### PR TITLE
Fix urwid version parsing error when it's something like 0.9.10-pre

### DIFF
--- a/libmproxy/console.py
+++ b/libmproxy/console.py
@@ -114,7 +114,7 @@ def format_flow(f, focus, extended=False, padding=2):
 
 def int_version(v):
     SIG = 3
-    v = urwid.__version__.split(".")
+    v = urwid.__version__.split("-")[0].split(".")
     x = 0
     for i in range(min(SIG, len(v))):
         x += int(v[i]) * 10**(SIG-i)


### PR DESCRIPTION
mitmproxy will fail to parse a version like 0.9.10-pre, which is the version of urwid I'm currently using.
