### PR TITLE
Response editing now usable again in light of previous encoding change 

### DIFF
--- a/libmproxy/console.py
+++ b/libmproxy/console.py
@@ -40,7 +40,7 @@ def highlight_key(s, k):
 
 def format_keyvals(lst, key="key", val="text", space=5, indent=0):
     """
-        Format a list of (key, value) tuples. 
+        Format a list of (key, value) tuples.
 
         If key is None, it's treated specially:
             - We assume a sub-value, and add an extra indent.
@@ -430,7 +430,16 @@ class ConnectionView(WWrap):
 
         self.flow.backup()
         if part == "b":
-            conn.content = self._spawn_editor(conn.content or "")
+            e = conn.headers["content-encoding"]
+            if e:
+                e = e[0]
+            else:
+                e = "identity"
+            content = encoding.decode(e, conn.content)
+            if content is None:
+                conn.content = self._spawn_editor(conn.content or "")
+            else:
+                conn.content = encoding.encode(e, self._spawn_editor(content or ""))
         elif part == "h":
             headertext = self._spawn_editor(repr(conn.headers))
             headers = utils.Headers()
@@ -1235,37 +1244,37 @@ class ConsoleMaster(flow.FlowMaster):
             ("L", "load saved flows"),
 
             ("m", "change body display mode"),
-            (None, 
+            (None,
                 highlight_key("raw", "r") +
                 [("text", ": raw data")]
             ),
-            (None, 
+            (None,
                 highlight_key("pretty", "p") +
                 [("text", ": pretty-print XML, HTML and JSON")]
             ),
-            (None, 
+            (None,
                 highlight_key("hex", "h") +
                 [("text", ": hex dump")]
             ),
 
             ("o", "toggle options:"),
-            (None, 
+            (None,
                 highlight_key("anticache", "a") +
                 [
-                    
+
                     ("text", ": modify requests to prevent cached responses")
-                    
+
                 ]
             ),
-            (None, 
+            (None,
                 highlight_key("anticomp", "c") +
                 [("text", ": modify requests to try to prevent compressed responses")]
             ),
-            (None, 
+            (None,
                 highlight_key("killextra", "k") +
                 [("text", ": kill requests not part of server replay")]
             ),
-            (None, 
+            (None,
                 highlight_key("norefresh", "n") +
                 [("text", ": disable server replay response refresh")]
             ),

--- a/test/test_encoding.py
+++ b/test/test_encoding.py
@@ -4,30 +4,28 @@ import libpry
 import cStringIO
 import gzip, zlib
 
-class udecode_identity(libpry.AutoTree):
-    def test_decode(self):
-        assert 'string' == encoding.decode('identity', 'string')
+class uidentity(libpry.AutoTree):
+    def test_simple(self):
+        assert "string" == encoding.decode("identity", "string")
+        assert "string" == encoding.encode("identity", "string")
 
     def test_fallthrough(self):
-        assert 'string' == encoding.decode('nonexistent encoding', 'string')
+        assert "string" == encoding.decode("nonexistent encoding", "string")
+        assert "string" == encoding.encode("nonexistent encoding", "string")
 
-class udecode_gzip(libpry.AutoTree):
+class ugzip(libpry.AutoTree):
     def test_simple(self):
-        s = cStringIO.StringIO()
-        gf = gzip.GzipFile(fileobj=s, mode='wb')
-        gf.write('string')
-        gf.close()
-        assert 'string' == encoding.decode('gzip', s.getvalue())
+        assert "string" == encoding.decode("gzip", encoding.encode("gzip", "string"))
         assert None == encoding.decode("gzip", "bogus")
 
-class udecode_deflate(libpry.AutoTree):
+class udeflate(libpry.AutoTree):
     def test_simple(self):
-        assert 'string' == encoding.decode('deflate', zlib.compress('string'))
-        assert 'string' == encoding.decode('deflate', zlib.compress('string')[2:-4])
+        assert "string" == encoding.decode("deflate", encoding.encode("deflate", "string"))
+        assert "string" == encoding.decode("deflate", encoding.encode("deflate", "string")[2:-4])
         assert None == encoding.decode("deflate", "bogus")
 
 tests = [
-    udecode_identity(),
-    udecode_gzip(),
-    udecode_deflate()
+    uidentity(),
+    ugzip(),
+    udeflate()
 ]


### PR DESCRIPTION
My change to permit gzip and deflate encodings did not take into account response body editing.  Writing gzipped data by hand is kind of hard, so this has been corrected.

When edited, the compressed response bodies are now decompressed, send to the editor, and then after editing finally compressed and used.

-stephen
