### PR TITLE
Changes replace logic to function in both Python 2.6.x and 2.7.x

### DIFF
--- a/libmproxy/flow.py
+++ b/libmproxy/flow.py
@@ -323,16 +323,16 @@ class Flow:
                 self.response.ack()
             self.intercepting = False
 
-    def replace(self, pattern, repl, count=0, flags=0):
+    def replace(self, pattern, repl, *args, **kwargs):
         """
             Replaces a regular expression pattern with repl in all parts of the
-            flow . Returns the number of replacements made. 
+            flow . Returns the number of replacements made.
         """
-        c = self.request.replace(pattern, repl, count, flags)
+        c = self.request.replace(pattern, repl, *args, **kwargs)
         if self.response:
-            c += self.response.replace(pattern, repl, count, flags)
+            c += self.response.replace(pattern, repl, *args, **kwargs)
         if self.error:
-            c += self.error.replace(pattern, repl, count, flags)
+            c += self.error.replace(pattern, repl, *args, **kwargs)
         return c
 
 

--- a/libmproxy/proxy.py
+++ b/libmproxy/proxy.py
@@ -280,16 +280,16 @@ class Request(controller.Msg):
         else:
             return self.FMT_PROXY % (self.method, self.scheme, self.host, self.port, self.path, str(headers), content)
 
-    def replace(self, pattern, repl, count=0, flags=0):
+    def replace(self, pattern, repl, *args, **kwargs):
         """
             Replaces a regular expression pattern with repl in both the headers
             and the body of the request. Returns the number of replacements
-            made. 
+            made.
         """
-        self.content, c = re.subn(pattern, repl, self.content, count, flags)
-        self.path, pc = re.subn(pattern, repl, self.path, count, flags)
+        self.content, c = re.subn(pattern, repl, self.content, *args, **kwargs)
+        self.path, pc = re.subn(pattern, repl, self.path, *args, **kwargs)
         c += pc
-        c += self.headers.replace(pattern, repl, count, flags)
+        c += self.headers.replace(pattern, repl, *args, **kwargs)
         return c
 
 
@@ -418,14 +418,14 @@ class Response(controller.Msg):
         data = (proto, str(headers), content)
         return self.FMT%data
 
-    def replace(self, pattern, repl, count=0, flags=0):
+    def replace(self, pattern, repl, *args, **kwargs):
         """
             Replaces a regular expression pattern with repl in both the headers
             and the body of the response. Returns the number of replacements
-            made. 
+            made.
         """
-        self.content, c = re.subn(pattern, repl, self.content, count, flags)
-        c += self.headers.replace(pattern, repl, count, flags)
+        self.content, c = re.subn(pattern, repl, self.content, *args, **kwargs)
+        c += self.headers.replace(pattern, repl, *args, **kwargs)
         return c
 
 
@@ -497,13 +497,13 @@ class Error(controller.Msg):
     def __eq__(self, other):
         return self.get_state() == other.get_state()
 
-    def replace(self, pattern, repl, count=0, flags=0):
+    def replace(self, pattern, repl, *args, **kwargs):
         """
             Replaces a regular expression pattern with repl in both the headers
             and the body of the request. Returns the number of replacements
-            made. 
+            made.
         """
-        self.msg, c = re.subn(pattern, repl, self.msg, count, flags)
+        self.msg, c = re.subn(pattern, repl, self.msg, *args, **kwargs)
         return c
 
 

--- a/libmproxy/utils.py
+++ b/libmproxy/utils.py
@@ -1,15 +1,15 @@
 # Copyright (C) 2010  Aldo Cortesi
-# 
+#
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-# 
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import re, os, subprocess, datetime, textwrap, errno
@@ -67,7 +67,7 @@ def cleanBin(s):
             if i not in "\n\r\t":
                 parts.append(".")
     return "".join(parts)
-    
+
 
 TAG = r"""
         <\s*
@@ -279,16 +279,16 @@ class Headers:
                     ret.append([name, value])
         self.lst = ret
 
-    def replace(self, pattern, repl, count=0, flags=0):
+    def replace(self, pattern, repl, *args, **kwargs):
         """
             Replaces a regular expression pattern with repl in both header keys
-            and values. Returns the number of replacements made. 
+            and values. Returns the number of replacements made.
         """
         nlst, count = [], 0
         for i in self.lst:
-            k, c = re.subn(pattern, repl, i[0], count, flags)
+            k, c = re.subn(pattern, repl, i[0], *args, **kwargs)
             count += c
-            v, c = re.subn(pattern, repl, i[1], count, flags)
+            v, c = re.subn(pattern, repl, i[1], *args, **kwargs)
             count += c
             nlst.append([k, v])
         self.lst = nlst

--- a/test/test_proxy.py
+++ b/test/test_proxy.py
@@ -133,7 +133,7 @@ class uRequest(libpry.AutoTree):
         r.path = "path/foo"
         r.headers["Foo"] = ["fOo"]
         r.content = "afoob"
-        assert r.replace("foo", "boo", flags=re.I) == 4
+        assert r.replace("foo(?i)", "boo") == 4
         assert r.path == "path/boo"
         assert not "foo" in r.content
         assert r.headers["boo"] == ["boo"]
@@ -199,7 +199,7 @@ class uResponse(libpry.AutoTree):
         r = tutils.tresp()
         r.headers["Foo"] = ["fOo"]
         r.content = "afoob"
-        assert r.replace("foo", "boo", flags=re.I) == 3
+        assert r.replace("foo(?i)", "boo") == 3
         assert not "foo" in r.content
         assert r.headers["boo"] == ["boo"]
 


### PR DESCRIPTION
The recently added replace methods did not function in Python 2.6, and the testsuite wouldn't run in that version either.

re.subn takes only 4 arguments in Python 2.6. The fifth argument, flags, was added in Python 2.7. Both versions support appending regex patterns with filters (e.g. (?i) for case insensitivity).

By changing all .replace methods to accept pattern, replacement, _args, and *_kwargs, we assure compatibility for the two versions. Python 2.7 users will be able to pass a flag kwarg to replace, and it will function.

Flag kwargs were removed from the tests and instead the regex had a filter appended, which is supported in both versions.
