### PR TITLE
Handle HTTP responses with status line missing a message/reason phrase 

### DIFF
--- a/libmproxy/proxy.py
+++ b/libmproxy/proxy.py
@@ -214,6 +214,8 @@ class ServerConnection:
         if not line:
             raise ProxyError(502, "Blank server response.")
         parts = line.strip().split(" ", 2)
+        if len(parts) == 2: # handle missing message gracefully
+            parts.append("")
         if not len(parts) == 3:
             raise ProxyError(502, "Invalid server response: %s."%line)
         proto, code, msg = parts


### PR DESCRIPTION
Handle missing message/reason phrase in HTTP response status line gracefully by adding an empty one.

Without this patch HTTP responses with a status line consisting only of HTTP version and status code are discarded. According to [RFC 2616](http://www.w3.org/Protocols/rfc2616/rfc2616-sec6.html#sec6.1) the reason phrase may be empty, but a space before is necessary. In this way, mitmproxy conforms to the HTTP spec, but for reverse engineering purposes it might be useful also handling non-conformant responses gracefully.

An example of such a status line is:
<code>HTTP/1.0 200</code>
