### PR TITLE
Removed imports left unused after Py{OpenSSL,ASN1}

### DIFF
--- a/libmproxy/certutils.py
+++ b/libmproxy/certutils.py
@@ -1,4 +1,4 @@
-import subprocess, os, tempfile, ssl, hashlib, socket, re
+import subprocess, os, ssl, hashlib, socket
 from pyasn1.type import univ, constraint, char, namedtype, tag
 from pyasn1.codec.der.decoder import decode
 import OpenSSL

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,4 +1,4 @@
-import textwrap, os, re, json
+import textwrap, re, json
 import libpry
 from libmproxy import utils
 


### PR DESCRIPTION
Commits 533f61f67aab38f5bce882ad0dc03b7b5f292956 and 8b841bc9e370370716b473f26e001c65e2eee2af left some imports unused while swithing to PyOpenSSL and PyASN1 -- this commit removes these imports.
