### PR TITLE
Handle Transfer-Encoding header values case insensitive, fix chunked SSL requests

### DIFF
--- a/libmproxy/proxy.py
+++ b/libmproxy/proxy.py
@@ -184,10 +184,14 @@ class FileLike:
             result += data
         return result
 
-    def readline(self):
+    def readline(self, size = None):
         result = ''
+        bytes_read = 0
         while True:
+            if size is not None and bytes_read >= size:
+                break
             ch = self.read(1)
+            bytes_read += 1
             if not ch:
                 break
             else:


### PR DESCRIPTION
Transfer-Encoding header values should be treated case-insensitive as described in the HTTP/1.1 RFC in [Section 3.6](http://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.6).

After fixing this I noticed FileLike's readline method does not support the size parameter used by read_chunked. I implemented this in the second commit.
