### PR TITLE
Add missing parser.add_option_group(group)

### DIFF
--- a/libmproxy/cmdline.py
+++ b/libmproxy/cmdline.py
@@ -263,6 +263,7 @@ def common_options(parser):
         help="Disable response pop from response flow. "
         "This makes it possible to replay same response multiple times."
     )
+    parser.add_option_group(group)
 
     group = optparse.OptionGroup(
         parser,


### PR DESCRIPTION
Just a small fix for beauty. Thanks for your great work, libmproxy is really a joy to use.

Thanks!

Max
