### PR TITLE
Fix cert generation if confdir is relative

### DIFF
--- a/libmproxy/certutils.py
+++ b/libmproxy/certutils.py
@@ -41,7 +41,7 @@ def dummy_ca(path):
     if not os.path.exists(dirname):
         os.makedirs(dirname)
     if path.endswith(".pem"):
-        basename = os.path.splitext(path)
+        basename, _ = os.path.splitext(path)
         basename = os.path.basename(basename)
     else:
         basename = os.path.basename(path)


### PR DESCRIPTION
Hi cortesi,

once again thank you for your great work here. I am currently working on HoneyProxy (my Google Summer of Code Project), a HTTP(S) traffic visualization tool. Under the hood, we are using libmproxy for everything related to the proxy part HoneyProxy comes with. libmproxy handles all the SSL stuff easily so that I can fully concentrate on the GUI/visualization part - great, because this is the part where we want to develop something innovative. 

In the spirit of open source software, I'd like to fix the bugs I find an merge them back into the original project. So let's continue with this one:

_When providing a relative confdir, the path is not concatenated correctly._

mitmproxy --confdir ./ca-cert/

File "/usr/local/lib/python2.7/dist-packages/libmproxy/proxy.py", line 553, in process_proxy_options
certutils.dummy_ca(cacert)
File "/usr/local/lib/python2.7/dist-packages/libmproxy/certutils.py", line 57, in dummy_ca
f = open(os.path.join(dirname, basename + "-cert.pem"), "w")
IOError: [Errno 2] No such file or directory:
'./ca-cert/./ca-cert/mitmproxy-ca-cert.pem'

Fixed by removing the directories from the basename variable.

Thanks!
