### PR TITLE
Color palettes

### DIFF
--- a/libmproxy/console/palettes.py
+++ b/libmproxy/console/palettes.py
@@ -67,7 +67,7 @@ dark = [
 light = [
     ('body', 'black', 'dark cyan'),
     ('foot', 'dark gray', 'default'),
-    ('title', 'white,bold', 'default',),
+    ('title', 'white,bold', 'light blue',),
     ('editline', 'white', 'default',),
 
     # Status bar & heading
@@ -161,7 +161,7 @@ solarized_dark = [
 solarized_light = [
     ('body', 'dark cyan', 'default'),
     ('foot', 'dark gray', 'default'),
-    ('title', 'white,bold', 'default',),
+    ('title', 'white,bold', 'light cyan',),
     ('editline', 'white', 'default',),
 
     # Status bar & heading


### PR DESCRIPTION
I've added some color palettes so mitmproxy can be used with different terminal color setups
- `light` which addresses #40 
- `solarized_light` and `solarized_dark` for people like me using [Solarized](http://ethanschoonover.com/solarized) colors
