### PR TITLE
fix -r option, read file in binary mode

### DIFF
--- a/libmproxy/console/__init__.py
+++ b/libmproxy/console/__init__.py
@@ -649,7 +649,7 @@ class ConsoleMaster(flow.FlowMaster):
         self.state.last_saveload = path
         path = os.path.expanduser(path)
         try:
-            f = file(path, "r")
+            f = file(path, "rb")
             fr = flow.FlowReader(f)
         except IOError, v:
             return v.strerror

--- a/libmproxy/dump.py
+++ b/libmproxy/dump.py
@@ -121,7 +121,7 @@ class DumpMaster(flow.FlowMaster):
         if options.rfile:
             path = os.path.expanduser(options.rfile)
             try:
-                f = file(path, "r")
+                f = file(path, "rb")
                 freader = flow.FlowReader(f)
             except IOError, v:
                 raise DumpError(v.strerror)


### PR DESCRIPTION
Title says it all. While flows are already written to disk in binary mode, the don't get read in binary mode which makes mitmproxy complain about invalid tnetstrings.
