### PR TITLE
Updated readme docs with new PyOpenSSL dependency.

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -49,7 +49,7 @@ Requirements
 ------------
 
 * [Python](http://www.python.org) 2.6.x or 2.7.x.
-* [PyOpenSSL](http://pypi.python.org/pypi/pyOpenSSL) 0.12 or newer.
+* [PyOpenSSL](http://pypi.python.org/pypi/pyOpenSSL) 0.13 or newer.
 * [pyasn1](http://pypi.python.org/pypi/pyasn1) 0.1.2 or newer.
 * [urwid](http://excess.org/urwid/) version 0.9.8 or newer.
 * [PIL](http://www.pythonware.com/products/pil/) version 1.1 or newer.

--- a/README.txt
+++ b/README.txt
@@ -48,7 +48,7 @@ Requirements
 ------------
 
 * Python_ 2.6.x or 2.7.x.
-* PyOpenSSL_ 0.12 or newer.
+* PyOpenSSL_ 0.13 or newer.
 * pyasn1_ 0.1.2 or newer.
 * urwid_  version 0.9.8 or newer.
 * PIL_  version 1.1 or newer.


### PR DESCRIPTION
In netlib, tcp.convert_to_ssl calls set_tlsext_servername_callback on a OpenSSL.Context object.  This function was newly added to version 0.13 of PyOpenSSL, http://multani.info/projects/pyopenssl/doc/latex-conversion/index.html#SSL.Context.set_tlsext_servername_callback .  I've updated the readme docs accordingly as using version 0.12 of PyOpenSSL will cause and AttributeError to be thrown.
