### PR TITLE
Preserve the genenerated dummy certs directory

### DIFF
--- a/libmproxy/cmdline.py
+++ b/libmproxy/cmdline.py
@@ -279,4 +279,10 @@ def common_options(parser):
     )
     parser.add_option_group(group)
 
+    group.add_option(
+        "--dummy-certs", action="store",
+        type = "str", dest = "certdir", default=None,
+        help = "Generated dummy certs directory."
+    )
+
     proxy.certificate_option_group(parser)


### PR DESCRIPTION
Aldo, as we discussed on the mitmproxy@googlegroups.com list, this PR makes it possible to preserve the generated dummy certs. Please take a look and let me know if I am missing anything that belongs with this commit, or if there are any cosmetic/style changes that you'd like me to include. I suggest you pull this PR into a branch.

If --dummy-certs=CERTSDIR is provided, use CERTSDIR as the location
for generating/finding the dummy certs. And in this case, preserve
the CERTSDIR directory on exit.
