### PR TITLE
PIL imports -- packaging

### DIFF
--- a/libmproxy/console/contentview.py
+++ b/libmproxy/console/contentview.py
@@ -1,7 +1,12 @@
 import re, cStringIO, traceback, json
 import urwid
-from PIL import Image
-from PIL.ExifTags import TAGS
+
+try: from PIL import Image
+except ImportError: import Image
+
+try: from PIL.ExifTags import TAGS
+except ImportError: from ExifTags import TAGS
+
 import lxml.html, lxml.etree
 import netlib.utils
 import common


### PR DESCRIPTION
PIL documents two different way to import it's modules:
- import Image [1]
- from PIL import Image [2]

I changed contentview so that it imports using one way then tries the other way. This is similar to what people do with simplejson vs json. Django users also noted the problem [3] and the fix was similar to what I propose here.

[1] http://www.pythonware.com/library/pil/handbook/introduction.htm
[2] http://www.pythonware.com/library/pil/handbook/image.htm
[3] https://code.djangoproject.com/ticket/6054
