### PR TITLE
Show an error when $EDITOR/$PAGER are unset.

### DIFF
--- a/libmproxy/console/flowview.py
+++ b/libmproxy/console/flowview.py
@@ -542,7 +542,10 @@ class FlowView(common.WWrap):
             if conn and conn.content:
                 t = conn.headers["content-type"] or [None]
                 t = t[0]
-                self.master.spawn_external_viewer(conn.content, t)
+                if os.environ.has_key("EDITOR") or os.environ.has_key("PAGER"):
+                    self.master.spawn_external_viewer(conn.content, t)
+                else:
+                    self.master.statusbar.message("Error! Set $EDITOR or $PAGER.")
         elif key == "|":
             self.master.path_prompt(
                 "Send flow to script: ", self.state.last_script,


### PR DESCRIPTION
This catches an exception that otherwise crashes mitmproxy. Maybe a better solution would be to ask the user for which editor they want to use, instead of asking them to close mitmproxy and set it in their environment.

fixes cortesi/mitmproxy#71
