### PR TITLE
Display host name instead of IP for https requests

### DIFF
--- a/libmproxy/proxy.py
+++ b/libmproxy/proxy.py
@@ -346,7 +346,8 @@ class ProxyHandler(tcp.BaseHandler):
                 content = http.read_http_body_request(
                     self.rfile, self.wfile, headers, httpversion, self.config.body_size_limit
                 )
-                return flow.Request(client_conn, httpversion, headers['Host'][0], port, "https", method, path, headers, content)
+                display_host = headers['Host'][0] if 'Host' in headers else host
+                return flow.Request(client_conn, httpversion, display_host, port, "https", method, path, headers, content)
             else:
                 r = http.parse_init_proxy(line)
                 if not r:


### PR DESCRIPTION
See issue #77. Before 9130cd6, the value of the `Host` header was displayed as part of the URL. The current version displays the IP it CONNECTs to which is less useful. This (very simple) patch reverts that behavior.
