### PR TITLE
Fix external viewer function by using shlex

### DIFF
--- a/libmproxy/console/flowview.py
+++ b/libmproxy/console/flowview.py
@@ -343,7 +343,7 @@ class FlowView(common.WWrap):
         self.flow.backup()
         if part == "r":
             c = self.master.spawn_editor(conn.content or "")
-            conn.content = c.rstrip("\n")
+            conn.content = c.rstrip("\n") # what?
         elif part == "f":
             if not conn.get_form_urlencoded() and conn.content:
                 self.master.prompt_onekey(


### PR DESCRIPTION
This makes spawn_external_viewer not crash when $EDITOR or $PAGER have
spaces or multiple arguments.

In addition, spawn_external_viewer now chmods the file to read-only to
remind users who use only an $EDITOR that this function does not read
the file when the user returns.

Also, some of the redundant exception case handling for editing has been
consolidated.

fixes #79
