### PR TITLE
Show current filepath in status bar

### DIFF
--- a/libmproxy/console/__init__.py
+++ b/libmproxy/console/__init__.py
@@ -195,6 +195,9 @@ class StatusBar(common.WWrap):
         if self.master.stream:
             r.append("[W:%s]"%self.master.stream_path)
 
+        if self.master.state.last_saveload:
+            r.append("[%s]"%self.master.state.last_saveload)
+
         return r
 
     def redraw(self):


### PR DESCRIPTION
Showing the filename is useful when looking at multiple .mitm files
simultaneously.
