### PR TITLE
Fixed a bug in format_flow in common.py.

### DIFF
--- a/libmproxy/console/common.py
+++ b/libmproxy/console/common.py
@@ -181,7 +181,7 @@ def format_flow(f, focus, extended=False, padding=2):
     d = dict(
         intercepting = f.intercepting,
 
-        req_timestamp = f.request.timestamp,
+        req_timestamp = f.request.timestamp_start,
         req_is_replay = f.request.is_replay(),
         req_method = f.request.method,
         req_acked = f.request.acked,


### PR DESCRIPTION
Fixed a bug in format_flow in common.py dealing with the new Request timestamp_start and timestamp_end.  Changed the reference from timestamp to timestamp_start.
