### PR TITLE
Explicit file flush in mitmdump

### DIFF
--- a/libmproxy/tnetstring.py
+++ b/libmproxy/tnetstring.py
@@ -101,6 +101,7 @@ def dump(value,file,encoding=None):
     the given file.
     """
     file.write(dumps(value,encoding))
+    file.flush()
 
 
 def _rdumpq(q,size,value,encoding=None):


### PR DESCRIPTION
The dump file would be end up corrupted sometimes when working with mitmdump in a VM.  Adding an explicit flush seems to have resolved the file sync issues.
