### PR TITLE
Keep blank URL parameters

### DIFF
--- a/libmproxy/utils.py
+++ b/libmproxy/utils.py
@@ -67,7 +67,7 @@ def urldecode(s):
     """
         Takes a urlencoded string and returns a list of (key, value) tuples.
     """
-    return cgi.parse_qsl(s)
+    return cgi.parse_qsl(s, keep_blank_values=True)
 
 
 def urlencode(s):

--- a/test/test_console_contentview.py
+++ b/test/test_console_contentview.py
@@ -58,7 +58,9 @@ class TestContentView:
         d = utils.urlencode([("one", "two"), ("three", "four")])
         v = cv.ViewURLEncoded()
         assert v([], d, 100)
-        assert not v([], "foo", 100)
+        d = utils.urlencode([("adsfa", "")])
+        v = cv.ViewURLEncoded()
+        assert v([], d, 100)
 
     def test_view_html(self):
         v = cv.ViewHTML()

--- a/test/test_flow.py
+++ b/test/test_flow.py
@@ -807,7 +807,7 @@ class TestRequest:
 
         r = flow.Request(None, (1, 1), "host", 22, "https", "GET", "/?adsfa", h, "content")
         q = r.get_query()
-        assert not q
+        assert q.lst == [("adsfa", "")]
 
         r = flow.Request(None, (1, 1), "host", 22, "https", "GET", "/foo?x=y&a=b", h, "content")
         assert r.get_query()


### PR DESCRIPTION
I'm using mitmproxy in a situation where blank URL parameters are required (similar to this [older, rejected PR](https://github.com/cortesi/mitmproxy/pull/41)).  

This change does the "dumbest thing that could possibly work":
- Are you open to adding this, and
- Assuming this should be configurable, any thoughts on how the option should be exposed? A command-line option seems like overkill.
