### PR TITLE
Fix crash when trying to see the content of a request/response before ack.

### DIFF
--- a/libmproxy/console/flowview.py
+++ b/libmproxy/console/flowview.py
@@ -210,7 +210,9 @@ class FlowView(common.WWrap):
         else:
             parts.append(self._tab(qt, "heading_inactive"))
 
-        if self.flow.intercepting and self.flow.response and not self.flow.response.acked:
+        if self.flow.intercepting and not self.flow.response:
+            st = "No response yet"
+        elif self.flow.intercepting and not self.flow.response.acked:
             st = "Response intercepted"
         else:
             st = "Response"

--- a/libmproxy/flow.py
+++ b/libmproxy/flow.py
@@ -298,6 +298,7 @@ class Request(HTTPMsg):
         self.timestamp_start = timestamp_start or utils.timestamp()
         self.timestamp_end = max(timestamp_end or utils.timestamp(), timestamp_start)
         self.close = False
+        self.acked = False
 
         # Have this request's cookies been modified by sticky cookies or auth?
         self.stickycookie = False
@@ -613,6 +614,7 @@ class Response(HTTPMsg):
         self.timestamp_start = timestamp_start or utils.timestamp()
         self.timestamp_end = max(timestamp_end or utils.timestamp(), timestamp_start)
         self.replay = False
+        self.acked = False
 
     def _refresh_cookie(self, c, delta):
         """


### PR DESCRIPTION
self.flow.{response,request}.acked did not exist before acknowledging the flow.
Also add a message when the response has not been received.
