### PR TITLE
Correct display mode highlight keys

### DIFF
--- a/libmproxy/console/contentview.py
+++ b/libmproxy/console/contentview.py
@@ -137,7 +137,7 @@ class ViewXML:
 
 class ViewJSON:
     name = "JSON"
-    prompt = ("json", "j")
+    prompt = ("json", "s")
     content_types = ["application/json"]
     def __call__(self, hdrs, content, limit):
         lines = utils.pretty_json(content)

--- a/libmproxy/console/flowview.py
+++ b/libmproxy/console/flowview.py
@@ -34,8 +34,12 @@ def _mkhelp():
                 [("text", ": automatic detection")]
             ),
             (None,
-                common.highlight_key("hex", "h") +
+                common.highlight_key("hex", "e") +
                 [("text", ": Hex")]
+            ),
+            (None,
+                common.highlight_key("html", "h") +
+                [("text", ": HTML")]
             ),
             (None,
                 common.highlight_key("image", "i") +

--- a/libmproxy/console/help.py
+++ b/libmproxy/console/help.py
@@ -57,8 +57,12 @@ class HelpView(urwid.ListBox):
                     [("text", ": automatic detection")]
                 ),
                 (None,
-                    common.highlight_key("hex", "h") +
+                    common.highlight_key("hex", "e") +
                     [("text", ": Hex")]
+                ),
+                (None,
+                    common.highlight_key("html", "h") +
+                    [("text", ": HTML")]
                 ),
                 (None,
                     common.highlight_key("image", "i") +


### PR DESCRIPTION
Add html display mode to the help documentation.
Correct html and hex display mode highlight keys (help used 'h' for hex).
Correct json display mode highlight keys.
