### PR TITLE
Add error checking to ViewProtobuf

### DIFF
--- a/libmproxy/console/contentview.py
+++ b/libmproxy/console/contentview.py
@@ -389,8 +389,11 @@ class ViewProtobuf:
                              stdin=subprocess.PIPE,
                              stdout=subprocess.PIPE,
                              stderr=subprocess.PIPE)
-        out, _ = p.communicate(input=content)
-        return out
+        out, err = p.communicate(input=content)
+        if out:
+            return out
+        else:
+            return err
 
     def __call__(self, hdrs, content, limit):
         decoded = self.decode_protobuf(content)


### PR DESCRIPTION
There are protobufs that protoc can't parse.  When protoc --decode_raw
fails, it returns nothing to stdin, and writes "Failed to parse input."
to stderr. Before this commit, if protoc --decode_raw can't parse
the protobuf, the blank stdout output would get returned to the view;
with this commit stderr gets caught and returned to the view.
