### PR TITLE
A humble pull request

### DIFF
--- a/libmproxy/platform/lsof.py
+++ b/libmproxy/platform/lsof.py
@@ -1,3 +1,4 @@
+import re
 
 def lookup(address, port, s):
     """
@@ -8,9 +9,9 @@ def lookup(address, port, s):
     """
     spec = "%s:%s"%(address, port)
     for i in s.split("\n"):
-        if "ESTABLISHED:ESTABLISHED" in i and spec in i:
-            s = i.split()
-            if len(s) > 4:
-                s = s[4].split(":")
+        if "ESTABLISHED" in i and spec in i:
+            m = re.match(".* (\S*)->%s" % spec, i)
+            if m:
+                s = m.group(1).split(":")
                 if len(s) == 2:
                     return s[0], int(s[1])

--- a/libmproxy/platform/osx.py
+++ b/libmproxy/platform/osx.py
@@ -1,16 +1,16 @@
 import subprocess
-import pf
+import lsof
 
 """
     Doing this the "right" way by using DIOCNATLOOK on the pf device turns out
     to be a pain. Apple has made a number of modifications to the data
     structures returned, and compiling userspace tools to test and work with
-    this turns out to be a pain in the ass. Parsing pfctl output is short,
+    this turns out to be a pain in the ass. Parsing lsof output is short,
     simple, and works.
 """
 
 class Resolver:
-    STATECMD = ("sudo", "-n", "/sbin/pfctl", "-s", "state")
+    STATECMD = ("sudo", "-n", "/usr/sbin/lsof", "-n", "-P", "-i", "TCP")
     def __init__(self):
         pass
 
@@ -20,4 +20,4 @@ class Resolver:
             stxt = subprocess.check_output(self.STATECMD, stderr=subprocess.STDOUT)
         except subprocess.CalledProcessError:
             return None
-        return pf.lookup(peer[0], peer[1], stxt)
+        return lsof.lookup(peer[0], peer[1], stxt)


### PR DESCRIPTION
Hi Aldo,

mitmproxy is an _amazing_ tool; I've had a really fun dozen hours this weekend playing with it.

This patch lets you use transparent proxy mode on Mac OS X versions before Lion. (My hacking machine is an old Snow Leopard macbook).

I think this is strictly better, because it still works on post-Lion machines... but let me know if you'd like me to change it in any way. Thanks!
