### PR TITLE
Handling for EOF reading error in gzipped content

### DIFF
--- a/libmproxy/encoding.py
+++ b/libmproxy/encoding.py
@@ -54,7 +54,7 @@ def decode_gzip(content):
     gfile = gzip.GzipFile(fileobj=cStringIO.StringIO(content))
     try:
         return gfile.read()
-    except IOError:
+    except (IOError, EOFError):
         return None
 
 def encode_gzip(content):


### PR DESCRIPTION
Hi!
Today I had a crash in mitmproxy when I tried viewing some failed response. It was an unhandled EOFException in libmproxy/encoding.py, decode_gzip function.
Adding it to the except block seems the right thing to do.
Unfortunately, mitmproxy hanged the terminal as well, and I could not collect the session for further use/testing.
