### PR TITLE
Osx transparentproxy diocnatlook

### DIFF
--- a/libmproxy/dump.py
+++ b/libmproxy/dump.py
@@ -193,7 +193,11 @@ class DumpMaster(flow.FlowMaster):
             print >> self.outfile, str_request(f.request, self.showhost)
             print >> self.outfile, self.indent(4, f.request.headers)
             if utils.isBin(f.request.content):
-                print >> self.outfile, self.indent(4, netlib.utils.hexdump(f.request.content))
+                d = netlib.utils.hexdump(f.request.content)
+                d = "\n".join("%s\t%s %s"%i for i in d)
+                cont = self.indent(4, d)
+
+                print >> self.outfile, cont
             elif f.request.content:
                 print >> self.outfile, self.indent(4, f.request.content)
             print >> self.outfile

--- a/libmproxy/platform/osx.py
+++ b/libmproxy/platform/osx.py
@@ -1,23 +1,39 @@
-import subprocess
-import pf
-
-"""
-    Doing this the "right" way by using DIOCNATLOOK on the pf device turns out
-    to be a pain. Apple has made a number of modifications to the data
-    structures returned, and compiling userspace tools to test and work with
-    this turns out to be a pain in the ass. Parsing pfctl output is short,
-    simple, and works.
-"""
+import struct
+import socket
+import os
+import fcntl
 
 class Resolver:
-    STATECMD = ("sudo", "-n", "/sbin/pfctl", "-s", "state")
+    DIOCNATLOOK=0xc0544417
+    PF_INOUT=0
     def __init__(self):
-        pass
+        self.natfd= os.open("/dev/pf", os.O_RDWR)
 
     def original_addr(self, csock):
         peer = csock.getpeername()
-        try:
-            stxt = subprocess.check_output(self.STATECMD, stderr=subprocess.STDOUT)
-        except subprocess.CalledProcessError:
-            return None
-        return pf.lookup(peer[0], peer[1], stxt)
+        sock = csock.getsockname()
+        nl= self.makenatlook(peer, sock)
+        rnl= fcntl.ioctl(self.natfd, Resolver.DIOCNATLOOK, nl)
+        orig= self.unpacknatlook(rnl)
+        return orig[0], orig[1]
+
+    def makenatlook(self,afrom, ato):
+        return struct.pack("!16s16s16s16s4s4s4s4sBBBB", 
+                self.makepfaddr(afrom[0]), self.makepfaddr(ato[0]), "", "",
+                self.makepfport(afrom[1]), self.makepfport(ato[1]), "", "",
+                socket.AF_INET, socket.IPPROTO_TCP, 0, Resolver.PF_INOUT)
+    def unpacknatlook(self,nl):
+        _, _, _, rdaddr, _, _, _, rdport, _, _, _, _= struct.unpack("!16s16s16s16s4s4s4s4sBBBB", nl)
+        return (self.unpackpfaddr(rdaddr), self.unpackpfport(rdport))
+
+    def makepfaddr(self,a):
+        return struct.pack("!BBBB", *[int(x) for x in a.split(".")])
+    def unpackpfaddr(self,a):
+        return "%d.%d.%d.%d" % struct.unpack("!BBBB", a[:4])
+
+    def makepfport(self,p):
+        return struct.pack("!H", p)
+    def unpackpfport(self,p):
+        return struct.unpack("!H", p[:2])[0]
+
+


### PR DESCRIPTION
Hi,

( 49b626a5b437e652fcf6e23ca84249fa9731c6b2 )
I implemented transparent proxy originaladdr resolving for osx using DIOCNATLOOK.

the original lsof solution did not work for me ( on mountain lion ), it went into an infinite loop,
as if each lsof was causing more connections.

( 07eec690287c4d3f6e35017c0ba6831542771f28 )
and i also fixed a bug in the hexdump output of POST contents
