### PR TITLE
External webapp

### DIFF
--- a/libmproxy/cmdline.py
+++ b/libmproxy/cmdline.py
@@ -4,8 +4,8 @@ import argparse
 import shlex
 import os
 
-APP_DOMAIN = "mitm"
-APP_IP = "1.1.1.1"
+APP_HOST = "mitm"
+APP_PORT = 80
 
 class ParseException(Exception): pass
 class OptionException(Exception): pass
@@ -130,8 +130,9 @@ def get_common_options(options):
 
     return dict(
         app = options.app,
-        app_ip = options.app_ip,
-        app_domain = options.app_domain,
+        app_host = options.app_host,
+        app_port = options.app_port,
+        app_external = options.app_external,
 
         anticache = options.anticache,
         anticomp = options.anticomp,
@@ -263,15 +264,19 @@ def common_options(parser):
         help="Enable the mitmproxy web app."
     )
     group.add_argument(
-        "--appdomain",
-        action="store", dest="app_domain", default=APP_DOMAIN, metavar="domain",
-        help="Domain to serve the app from."
+        "--app-host",
+        action="store", dest="app_host", default=APP_HOST, metavar="host",
+        help="Domain to serve the app from. For transparent mode, use an IP when a DNS entry for the app domain is not present."
     )
     group.add_argument(
-        "--appip",
-        action="store", dest="app_ip", default=APP_IP, metavar="ip",
-        help="""IP to serve the app from. Useful for transparent mode, when a DNS
-        entry for the app domain is not present."""
+        "--app-port",
+        action="store", dest="app_port", default=APP_PORT, type=int, metavar="80",
+        help="Port to serve the app from."
+    )
+    group.add_argument(
+        "--app-external",
+        action="store_true", dest="app_external",
+        help="Serve the app outside of the proxy."
     )
 
     group = parser.add_argument_group("Client Replay")

--- a/libmproxy/console/__init__.py
+++ b/libmproxy/console/__init__.py
@@ -423,7 +423,7 @@ class ConsoleMaster(flow.FlowMaster):
                 sys.exit(1)
 
         if options.app:
-            self.start_app(options.app_domain, options.app_ip)
+            self.start_app(self.o.app_host, self.o.app_port, self.o.app_external)
 
     def start_stream(self, path):
         path = os.path.expanduser(path)

--- a/libmproxy/dump.py
+++ b/libmproxy/dump.py
@@ -128,7 +128,7 @@ class DumpMaster(flow.FlowMaster):
                 self.add_event("Flow file corrupted. Stopped loading.")
 
         if self.o.app:
-            self.start_app(self.o.app_domain, self.o.app_ip)
+            self.start_app(self.o.app_host, self.o.app_port, self.o.app_external)
 
     def _readflow(self, path):
         path = os.path.expanduser(path)

--- a/libmproxy/flow.py
+++ b/libmproxy/flow.py
@@ -2,7 +2,7 @@
     This module provides more sophisticated flow tracking. These match requests
     with their responses, and provide filtering and interception facilities.
 """
-import hashlib, Cookie, cookielib, copy, re, urlparse, os
+import hashlib, Cookie, cookielib, copy, re, urlparse, os, threading
 import time, urllib
 import tnetstring, filt, script, utils, encoding, proxy
 from email.utils import parsedate_tz, formatdate, mktime_tz
@@ -1367,17 +1367,19 @@ class FlowMaster(controller.Master):
         self.stream = None
         app.mapp.config["PMASTER"] = self
 
-    def start_app(self, domain, ip):
-        self.server.apps.add(
-            app.mapp,
-            domain,
-            80
-        )
-        self.server.apps.add(
-            app.mapp,
-            ip,
-            80
-        )
+    def start_app(self, host, port, external):
+        if not external:
+            self.server.apps.add(
+                app.mapp,
+                host,
+                port
+            )
+        else:
+            print host
+            threading.Thread(target=app.mapp.run,kwargs={
+                "use_reloader": False,
+                "host": host,
+                "port": port}).start()
 
     def add_event(self, e, level="info"):
         """

--- a/test/tservers.py
+++ b/test/tservers.py
@@ -2,10 +2,8 @@ import threading, Queue
 import flask
 import libpathod.test, libpathod.pathoc
 from libmproxy import proxy, flow, controller
+from libmproxy.cmdline import APP_HOST, APP_PORT
 import tutils
-
-APP_DOMAIN = "mitm"
-APP_IP = "1.1.1.1"
 
 testapp = flask.Flask(__name__)
 
@@ -31,7 +29,7 @@ class TestMaster(flow.FlowMaster):
         flow.FlowMaster.__init__(self, s, state)
         self.testq = testq
         self.clear_log()
-        self.start_app(APP_DOMAIN, APP_IP)
+        self.start_app(APP_HOST, APP_PORT, False)
 
     def handle_request(self, m):
         flow.FlowMaster.handle_request(self, m)


### PR DESCRIPTION
Hey Aldo,

three suggested changes to the webapp architecture:
1. Remove distinct `app_ip` setting. Is there a special use case for this I am missing? Specifying an ip as domain/host should do the job for these cases, shouldn't it? I added an explanatory comment to the host command line flag.
2. Add an option to expose the web app externally (outside of the proxy). The implementation just spawns a second thread and heavily employs the Ostrich algorithm. Any smarter ideas? Is there an easy way open a second socket and bend the requests over to the Masterqueue? I'm not happy with the implementation, but I'd love to have that included. 
