### PR TITLE
Fix divide by zero issue when timestamp start and end are the same

### DIFF
--- a/libmproxy/console/common.py
+++ b/libmproxy/console/common.py
@@ -190,7 +190,7 @@ def format_flow(f, focus, extended=False, hostheader=False, padding=2):
 
         delta = f.response.timestamp_end - f.response.timestamp_start
         size = len(f.response.content) + f.response.get_header_size()
-        rate = utils.pretty_size(size / delta)
+        rate = utils.pretty_size(size / ( delta if delta > 0 else 1 ) )
 
         d.update(dict(
             resp_code = f.response.code,


### PR DESCRIPTION
When timestamp_end and timestamp_start are the same, the console throws an exception as delta == 0.
