### PR TITLE
move CONTINUE checks into mitmproxy

### DIFF
--- a/libmproxy/proxy.py
+++ b/libmproxy/proxy.py
@@ -415,8 +415,9 @@ class ProxyHandler(tcp.BaseHandler):
             raise ProxyError(400, "Bad HTTP request line: %s"%repr(line))
         method, scheme, host, port, path, httpversion = r
         headers = self.read_headers(authenticate=True)
-        content = http.read_http_body_request(
-            self.rfile, self.wfile, headers, httpversion, self.config.body_size_limit
+        self.handle_expect_header(headers, httpversion)
+        content = http.read_http_body(
+            self.rfile, headers, self.config.body_size_limit, True
         )
         return flow.Request(
             client_conn, httpversion, host, port, scheme, method, path, headers, content,
@@ -446,13 +447,22 @@ class ProxyHandler(tcp.BaseHandler):
             raise ProxyError(400, "Bad HTTP request line: %s"%repr(line))
         method, path, httpversion = r
         headers = self.read_headers(authenticate=False)
-        content = http.read_http_body_request(
-            self.rfile, self.wfile, headers, httpversion, self.config.body_size_limit
+        self.handle_expect_header(headers, httpversion)
+        content = http.read_http_body(
+            self.rfile, headers, self.config.body_size_limit, True
         )
         return flow.Request(
             client_conn, httpversion, host, port, scheme, method, path, headers, content,
             self.rfile.first_byte_timestamp, utils.timestamp()
         )
+
+    def handle_expect_header(self, headers, httpversion):
+        if "expect" in headers:
+            if "100-continue" in headers['expect'] and httpversion >= (1, 1):
+                #FIXME: Check if content-length is over limit
+                self.wfile.write('HTTP/1.1 100 Continue\r\n'
+                                 '\r\n')
+                del headers['expect']
 
     def read_headers(self, authenticate=False):
         headers = http.read_headers(self.rfile)

--- a/test/test_server.py
+++ b/test/test_server.py
@@ -176,10 +176,10 @@ class TestHTTPAuth(tservers.HTTPProxTest):
 class TestHTTPConnectSSLError(tservers.HTTPProxTest):
     certfile = True
     def test_go(self):
-        p = self.pathoc()
-        req = "connect:'localhost:%s'"%self.proxy.port
-        assert p.request(req).status_code == 200
-        assert p.request(req).status_code == 400
+        p = self.pathoc_raw()
+        dst = ("localhost", self.proxy.port)
+        p.connect(connect_to=dst)
+        tutils.raises("400 - Bad Request", p.http_connect, dst)
 
 
 class TestHTTPS(tservers.HTTPProxTest, CommonMixin):


### PR DESCRIPTION
Main PR: https://github.com/mitmproxy/netlib/pull/26

This PR moves the handling of Expect-Headers into mitmproxy. The travis build fails as travis runs the tests against netlib master.
