### PR TITLE
replace PIL dependency with Pillow

### DIFF
--- a/examples/upsidedownternet.py
+++ b/examples/upsidedownternet.py
@@ -1,4 +1,6 @@
-import Image, cStringIO
+import cStringIO
+from PIL import Image
+
 def response(context, flow):
     if flow.response.headers["content-type"] == ["image/png"]:
         s = cStringIO.StringIO(flow.response.content)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 Flask>=0.9
 Jinja2>=2.7
 MarkupSafe>=0.18
-PIL>=1.1.7
+Pillow>=1.0
 Werkzeug>=0.8.3
 lxml>=3.2.1
 netlib>=0.9.2


### PR DESCRIPTION
mitmproxy depends on PIL but in pip 1.5 it won't install because of pypa/pip#1055

This pull request propose switching to Pillow, a pip friendly PIL fork well maintained.

a way to reproduce the error:

``` shcon
~$ mkvirtualenv mitmproxy-under-pip15
New python executable in /home/daniel/envs/mitmproxy-under-pip15/bin/python
Installing distribute.............................................................................................................................................................................................done.
Installing pip...............done.

mitmproxy-under-pip15 ~$ pip install -U setuptools
Downloading/unpacking distribute from https://pypi.python.org/packages/source/d/distribute/distribute-0.7.3.zip#md5=c6c59594a7b180af57af8a0cc0cf5b4a
Downloading/unpacking setuptools>=0.7 (from distribute)
Successfully installed distribute setuptools
Cleaning up...

mitmproxy-under-pip15 ~$ pip install -U pip
Downloading/unpacking pip from https://pypi.python.org/packages/source/p/pip/pip-1.5.tar.gz#md5=6969b8a8adc4c7f7c5eb1707118f0686
Successfully installed pip
Cleaning up...

mitmproxy-under-pip15 ~$ pip --version
pip 1.5 from /home/daniel/envs/mitmproxy-under-pip15/local/lib/python2.7/site-packages (python 2.7)

mitmproxy-under-pip15 ~$ pip install mitmproxy
Downloading/unpacking mitmproxy
  Using download cache from /home/daniel/.pip_download_cache/https%3A%2F%2Fpypi.python.org%2Fpackages%2Fsource%2Fm%2Fmitmproxy%2Fmitmproxy-0.9.2.tar.gz
  Running setup.py (path:/home/daniel/envs/mitmproxy-under-pip15/build/mitmproxy/setup.py) egg_info for package mitmproxy

Downloading/unpacking netlib>=0.9.2 (from mitmproxy)
  Using download cache from /home/daniel/.pip_download_cache/https%3A%2F%2Fpypi.python.org%2Fpackages%2Fsource%2Fn%2Fnetlib%2Fnetlib-0.9.2.tar.gz
  Running setup.py (path:/home/daniel/envs/mitmproxy-under-pip15/build/netlib/setup.py) egg_info for package netlib

Downloading/unpacking urwid>=1.1 (from mitmproxy)
  Using download cache from /home/daniel/.pip_download_cache/https%3A%2F%2Fpypi.python.org%2Fpackages%2Fsource%2Fu%2Furwid%2Furwid-1.1.2.tar.gz
  Running setup.py (path:/home/daniel/envs/mitmproxy-under-pip15/build/urwid/setup.py) egg_info for package urwid

    warning: no files found matching 'CHANGELOG'
Downloading/unpacking pyasn1>0.1.2 (from mitmproxy)
  Using download cache from /home/daniel/.pip_download_cache/https%3A%2F%2Fpypi.python.org%2Fpackages%2Fsource%2Fp%2Fpyasn1%2Fpyasn1-0.1.7.tar.gz
  Running setup.py (path:/home/daniel/envs/mitmproxy-under-pip15/build/pyasn1/setup.py) egg_info for package pyasn1

Downloading/unpacking pyopenssl>=0.13 (from mitmproxy)
  Using download cache from /home/daniel/.pip_download_cache/https%3A%2F%2Fpypi.python.org%2Fpackages%2Fsource%2Fp%2FpyOpenSSL%2FpyOpenSSL-0.13.1.tar.gz
  Running setup.py (path:/home/daniel/envs/mitmproxy-under-pip15/build/pyopenssl/setup.py) egg_info for package pyopenssl

    warning: no previously-included files matching '*.pyc' found anywhere in distribution
Downloading/unpacking PIL (from mitmproxy)
  Could not find any downloads that satisfy the requirement PIL (from mitmproxy)
  Some externally hosted files were ignored (use --allow-external PIL to allow).
Cleaning up...
No distributions at all found for PIL (from mitmproxy)
Storing debug log for failure in /home/daniel/.pip/pip.log
```
