### PR TITLE
fixing bug: AttributeError: DumpMaster instance has no attribute 'unload...

### DIFF
--- a/libmproxy/dump.py
+++ b/libmproxy/dump.py
@@ -223,8 +223,7 @@ class DumpMaster(flow.FlowMaster):
 
     def run(self):  # pragma: no cover
         if self.o.rfile and not self.o.keepserving:
-            for script in self.scripts:
-                self.unload_script(script)
+            self.unload_scripts()
             return
         try:
             return flow.FlowMaster.run(self)


### PR DESCRIPTION
Without this fix, I kept getting this error when using mitmdump -s bla.py -r somefile:

Traceback (most recent call last):
  File "/usr/local/bin/mitmdump", line 55, in <module>
    m.run()
  File "/usr/local/lib/python2.7/dist-packages/libmproxy/dump.py", line 227, in run
    self.unload_script(script)
AttributeError: DumpMaster instance has no attribute 'unload_script'
