### PR TITLE
Remove upper bound for Pillow in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -103,7 +103,7 @@ setup(
             "urwid>=1.1",
             "pyasn1>0.1.2",
             "pyopenssl>=0.13",
-            "Pillow>=2.3.0,<2.4",
+            "Pillow>=2.3.0",
             "lxml",
             "flask"
         ],


### PR DESCRIPTION
Hi,

I think it is better to remove upper bound for Pillow in setup.py. Being defensive is good in requirements.txt, but having `Pillow < 2.4` in `install_requires` may disallow some valid setups (mitmproxy 0.10 and Pillow > 2.4) even if they will work fine. I think it may also cause Pillow to be downgraded for some users.
