### PR TITLE
remove redundant codeline

### DIFF
--- a/libmproxy/console/__init__.py
+++ b/libmproxy/console/__init__.py
@@ -77,7 +77,6 @@ class PathEdit(urwid.Edit, _PathCompleter):
 class ActionBar(common.WWrap):
     def __init__(self):
         self.message("")
-        self.expire = None
 
     def selectable(self):
         return True


### PR DESCRIPTION
This line is redundant, because self.message("") sets up self.expire = None
