### PR TITLE
Fixed palette forced to light in mitmproxywrapper.py

### DIFF
--- a/examples/mitmproxywrapper.py
+++ b/examples/mitmproxywrapper.py
@@ -86,7 +86,6 @@ class Wrapper(object):
             cmd = ['mitmproxy', '-p', str(self.port)]
             if self.extra_arguments:
                 cmd.extend(self.extra_arguments)
-            cmd.extend(['--palette', 'light'])
             subprocess.check_call(cmd)
 
     def wrap_honeyproxy(self):


### PR DESCRIPTION
Simple yet useful fix when using mitmproxywrapper.py
