### PR TITLE
Fix upstream_cert call in case of https2http

### DIFF
--- a/libmproxy/proxy/server.py
+++ b/libmproxy/proxy/server.py
@@ -226,7 +226,7 @@ class ConnectionHandler:
         else:
             host = self.server_conn.address.host
             sans = []
-            if not self.config.no_upstream_cert or not self.server_conn.ssl_established:
+            if not self.config.no_upstream_cert and self.server_conn.ssl_established:
                 upstream_cert = self.server_conn.cert
                 if upstream_cert.cn:
                     host = upstream_cert.cn.decode("utf8").encode("idna")


### PR DESCRIPTION
We should ask for upstream cert only if there is:
1) no no_upstream_cert option specified
2) ssl connection to server is established
