### PR TITLE
Remove global should_exit and fix tests

### DIFF
--- a/libmproxy/console/__init__.py
+++ b/libmproxy/console/__init__.py
@@ -577,7 +577,7 @@ class ConsoleMaster(flow.FlowMaster):
 
         self.view_flowlist()
 
-        self.server.start_slave(controller.Slave, controller.Channel(self.masterq))
+        self.server.start_slave(controller.Slave, controller.Channel(self.masterq, self.should_exit))
 
         if self.options.rfile:
             ret = self.load_flows(self.options.rfile)
@@ -780,7 +780,7 @@ class ConsoleMaster(flow.FlowMaster):
     def loop(self):
         changed = True
         try:
-            while not controller.should_exit:
+            while not self.should_exit.is_set():
                 startloop = time.time()
                 if changed:
                     self.statusbar.redraw()

--- a/libmproxy/flow.py
+++ b/libmproxy/flow.py
@@ -654,6 +654,7 @@ class FlowMaster(controller.Master):
                     self.server.config,
                     f,
                     self.masterq,
+                    self.should_exit
                 )
             rt.start() # pragma: no cover
             if block:
@@ -792,8 +793,8 @@ class FilteredFlowWriter:
 class RequestReplayThread(threading.Thread):
     name="RequestReplayThread"
 
-    def __init__(self, config, flow, masterq):
-        self.config, self.flow, self.channel = config, flow, controller.Channel(masterq)
+    def __init__(self, config, flow, masterq, should_exit):
+        self.config, self.flow, self.channel = config, flow, controller.Channel(masterq, should_exit)
         threading.Thread.__init__(self)
 
     def run(self):

--- a/test/test_flow.py
+++ b/test/test_flow.py
@@ -672,7 +672,6 @@ class TestFlowMaster:
         fm.handle_error(f.error)
 
     def test_server_playback(self):
-        controller.should_exit = False
         s = flow.State()
 
         f = tutils.tflow()
@@ -695,7 +694,7 @@ class TestFlowMaster:
         fm.start_server_playback(pb, False, [], True, False)
         q = Queue.Queue()
         fm.tick(q)
-        assert controller.should_exit
+        assert fm.should_exit.is_set()
 
         fm.stop_server_playback()
         assert not fm.server_playback

--- a/test/tservers.py
+++ b/test/tservers.py
@@ -283,7 +283,7 @@ class ChainProxTest(ProxTestBase):
     def teardownAll(cls):
         super(ChainProxTest, cls).teardownAll()
         for p in cls.chain:
-            p.tmaster.server.shutdown()
+            p.tmaster.shutdown()
 
     def setUp(self):
         super(ChainProxTest, self).setUp()


### PR DESCRIPTION
I have a plan to integrate libmproxy in w3af https://github.com/andresriancho/w3af/issues/1269.
Current Master implementation depends on global variable `should_exit` for shutdown proxy server, it's bad for us, because we use many threads and different proxies. 
I've changed implementation by using threading.Event.
