### PR TITLE
send self to scripts so they can call methods

### DIFF
--- a/libmproxy/script.py
+++ b/libmproxy/script.py
@@ -96,7 +96,7 @@ class Script:
         f = self.ns.get(name)
         if f:
             try:
-                return (True, f(self.ctx, *args, **kwargs))
+                return (True, f(self, *args, **kwargs))
             except Exception, v:
                 return (False, (v, traceback.format_exc(v)))
         else:


### PR DESCRIPTION
this is probably not the best way to accomplish this, but would it be possible to also send `self` to the [inline scripts](http://mitmproxy.org/doc/scripting/inlinescripts.html) so that scripts could access methods and config options? Or perhaps even adding it as an optional third argument?
