### PR TITLE
Add urwid stop prior to exception output so stack trace is not cleared

### DIFF
--- a/libmproxy/console/__init__.py
+++ b/libmproxy/console/__init__.py
@@ -599,6 +599,8 @@ class ConsoleMaster(flow.FlowMaster):
         try:
             self.ui.run_wrapper(self.loop)
         except Exception:
+            self.ui.stop()
+            sys.stdout.flush()
             print >> sys.stderr, traceback.format_exc()
             print >> sys.stderr, "mitmproxy has crashed!"
             print >> sys.stderr, "Please lodge a bug report at: https://github.com/mitmproxy/mitmproxy"


### PR DESCRIPTION
mitmproxy outputs into the "alternate" buffer via `urwid`
`urwid` clears the screen and reverts to the original buffer in it's final cleanup after a stack trace is printed. https://github.com/mitmproxy/mitmproxy/issues/330

This change finalises `urwid` before the stack trace.
