### PR TITLE
reverse proxy: adjust dst when reading flows, fix #346

### DIFF
--- a/libmproxy/flow.py
+++ b/libmproxy/flow.py
@@ -615,6 +615,11 @@ class FlowMaster(controller.Master):
         """
             Loads a flow, and returns a new flow object.
         """
+
+        if self.server and self.server.config.mode == "reverse":
+            f.request.host, f.request.port = self.server.config.mode.dst[2:]
+            f.request.scheme = "https" if self.server.config.mode.dst[1] else "http"
+
         f.reply = controller.DummyReply()
         if f.request:
             self.handle_request(f)

--- a/test/test_flow.py
+++ b/test/test_flow.py
@@ -5,8 +5,9 @@ import mock
 from libmproxy import filt, protocol, controller, utils, tnetstring, flow
 from libmproxy.protocol.primitives import Error, Flow
 from libmproxy.protocol.http import decoded, CONTENT_MISSING
-from libmproxy.proxy.connection import ClientConnection, ServerConnection
-from netlib import tcp
+from libmproxy.proxy import ProxyConfig
+from libmproxy.proxy.server import DummyServer
+from libmproxy.proxy.connection import ClientConnection
 import tutils
 
 
@@ -490,6 +491,14 @@ class TestSerialize:
         fm = flow.FlowMaster(None, s)
         fm.load_flows(r)
         assert len(s._flow_list) == 6
+
+    def test_load_flows_reverse(self):
+        r = self._treader()
+        s = flow.State()
+        conf = ProxyConfig(mode="reverse", upstream_server=[True,True,"use-this-domain",80])
+        fm = flow.FlowMaster(DummyServer(conf), s)
+        fm.load_flows(r)
+        assert s._flow_list[0].request.host == "use-this-domain"
 
     def test_filter(self):
         sio = StringIO()


### PR DESCRIPTION
As discussed earlier today:

Assuming someone starts mitmproxy in reverse proxy mode with recorded flows, e.g.
`mitmproxy -r recorded_flows -R http://127.0.0.1:80`, we now set the destination for each flow to the reverse proxy. This allows to record flows and replay them to a different server later on.

Your earlier comment <i>"there's always been a number of different places we could source the host from in the display."</i> doesn't apply anymore - it's always request.host now, or the host header if `--host' is set (#337). As we don't want to break that up again, we already modify the target when loading the flow.
