### PR TITLE
--replay-ignore-content & --replay-ignore-param ported from branch 0.10

### DIFF
--- a/libmproxy/cmdline.py
+++ b/libmproxy/cmdline.py
@@ -176,6 +176,8 @@ def get_common_options(options):
         wfile=options.wfile,
         verbosity=options.verbose,
         nopop=options.nopop,
+        replay_ignore_content = options.replay_ignore_content,
+        replay_ignore_params = options.replay_ignore_params
     )
 
 
@@ -369,6 +371,17 @@ def common_options(parser):
         help="Disable response pop from response flow. "
              "This makes it possible to replay same response multiple times."
     )
+    group.add_argument(
+        "--replay-ignore-content",
+        action="store_true", dest="replay_ignore_content", default=False,
+        help="Ignore request's content while searching for a saved flow to replay"
+    )
+    group.add_argument(
+        "--replay-ignore-param",
+        action="append", dest="replay_ignore_params", type=str,
+        help="Request's parameters to be ignored while searching for a saved flow to replay"
+           "Can be passed multiple times."
+    )    
 
     group = parser.add_argument_group(
         "Replacements",

--- a/libmproxy/dump.py
+++ b/libmproxy/dump.py
@@ -34,6 +34,8 @@ class Options(object):
         "stream_large_bodies",
         "verbosity",
         "wfile",
+        "replay_ignore_content",
+        "replay_ignore_params",
     ]
     def __init__(self, **kwargs):
         for k, v in kwargs.items():
@@ -69,6 +71,8 @@ class DumpMaster(flow.FlowMaster):
         self.anticache = options.anticache
         self.anticomp = options.anticomp
         self.showhost = options.showhost
+        self.replay_ignore_params = options.replay_ignore_params    
+        self.replay_ignore_content = options.replay_ignore_content
         self.refresh_server_playback = options.refresh_server_playback
 
         self.set_stream_large_bodies(options.stream_large_bodies)
@@ -106,7 +110,9 @@ class DumpMaster(flow.FlowMaster):
                 self._readflow(options.server_replay),
                 options.kill, options.rheaders,
                 not options.keepserving,
-                options.nopop
+                options.nopop,
+                options.replay_ignore_params,
+                options.replay_ignore_content
             )
 
         if options.client_replay:


### PR DESCRIPTION
Hi!
As talked in pull request https://github.com/mitmproxy/mitmproxy/pull/368 I've ported changes to master. 
for now only  replay-ignore-content and replay-ignore-param were ported as no functionality changed. 
It will take more time to rewire kill for use filters, so i've split changes and worked on this two first.
Regards.
Marcelo
