### PR TITLE
Fixed the missing encoding argument exception at flow.py (line 828)

### DIFF
--- a/libmproxy/flow.py
+++ b/libmproxy/flow.py
@@ -825,4 +825,4 @@ class FilteredFlowWriter:
         if self.filt and not f.match(self.filt):
             return
         d = f.get_state()
-        tnetstring.dump(d, self.fo)
+        tnetstring.dump(d, self.fo, 'utf-8')


### PR DESCRIPTION
Hi everyone,

I cloned https://github.com/mitmproxy/mitmproxy/commit/34d419ead8f4062818593916475f1af86db1ee2d and I got this exception. I fix it adding the missing encoding argument with "utf-8".

``` python

Traceback (most recent call last):
  File "/usr/local/bin/mitmdump", line 9, in <module>
    load_entry_point('mitmproxy==0.11', 'console_scripts', 'mitmdump')()
  File "/usr/local/lib/python2.7/dist-packages/mitmproxy-0.11-py2.7.egg/libmproxy/main.py", line 159, in mitmdump
    master.run()
  File "/usr/local/lib/python2.7/dist-packages/mitmproxy-0.11-py2.7.egg/libmproxy/dump.py", line 247, in run
    return flow.FlowMaster.run(self)
  File "/usr/local/lib/python2.7/dist-packages/mitmproxy-0.11-py2.7.egg/libmproxy/controller.py", line 111, in run
    self.tick(self.masterq, 0.01)
  File "/usr/local/lib/python2.7/dist-packages/mitmproxy-0.11-py2.7.egg/libmproxy/flow.py", line 613, in tick
    return controller.Master.tick(self, q, timeout)
  File "/usr/local/lib/python2.7/dist-packages/mitmproxy-0.11-py2.7.egg/libmproxy/controller.py", line 101, in tick
    self.handle(*msg)
  File "/usr/local/lib/python2.7/dist-packages/mitmproxy-0.11-py2.7.egg/libmproxy/controller.py", line 118, in handle
    m(obj)
  File "/usr/local/lib/python2.7/dist-packages/mitmproxy-0.11-py2.7.egg/libmproxy/dump.py", line 227, in handle_response
    flow.FlowMaster.handle_response(self, f)
  File "/usr/local/lib/python2.7/dist-packages/mitmproxy-0.11-py2.7.egg/libmproxy/flow.py", line 760, in handle_response
    self.stream.add(f)
  File "/usr/local/lib/python2.7/dist-packages/mitmproxy-0.11-py2.7.egg/libmproxy/flow.py", line 828, in add
    tnetstring.dump(d, self.fo)
  File "/usr/local/lib/python2.7/dist-packages/mitmproxy-0.11-py2.7.egg/libmproxy/tnetstring.py", line 103, in dump
    file.write(dumps(value,encoding))
  File "/usr/local/lib/python2.7/dist-packages/mitmproxy-0.11-py2.7.egg/libmproxy/tnetstring.py", line 93, in dumps
    _rdumpq(q,0,value,encoding)
  File "/usr/local/lib/python2.7/dist-packages/mitmproxy-0.11-py2.7.egg/libmproxy/tnetstring.py", line 175, in _rdumpq
    size = _rdumpq(q,size,v,encoding)
  File "/usr/local/lib/python2.7/dist-packages/mitmproxy-0.11-py2.7.egg/libmproxy/tnetstring.py", line 175, in _rdumpq
    size = _rdumpq(q,size,v,encoding)
  File "/usr/local/lib/python2.7/dist-packages/mitmproxy-0.11-py2.7.egg/libmproxy/tnetstring.py", line 166, in _rdumpq
    size = _rdumpq(q,size,item,encoding)
  File "/usr/local/lib/python2.7/dist-packages/mitmproxy-0.11-py2.7.egg/libmproxy/tnetstring.py", line 166, in _rdumpq
    size = _rdumpq(q,size,item,encoding)
  File "/usr/local/lib/python2.7/dist-packages/mitmproxy-0.11-py2.7.egg/libmproxy/tnetstring.py", line 183, in _rdumpq
    raise ValueError("must specify encoding to dump unicode strings")
ValueError: must specify encoding to dump unicode strings
```
