### PR TITLE
Changed argument name from confdir to cadir in flowbasic example

### DIFF
--- a/examples/flowbasic
+++ b/examples/flowbasic
@@ -36,7 +36,7 @@ class MyMaster(flow.FlowMaster):
 
 config = proxy.ProxyConfig(
     port=8080,
-    confdir="~/.mitmproxy/"  # use ~/.mitmproxy/mitmproxy-ca.pem as default CA file.
+    cadir="~/.mitmproxy/"  # use ~/.mitmproxy/mitmproxy-ca.pem as default CA file.
 )
 state = flow.State()
 server = ProxyServer(config)


### PR DESCRIPTION
Hi,

The flowbasic example was using an argument named confdir with ProxyConfig which appears to have been renamed to cadir. I changed this it to get the example to work again.
