### PR TITLE
--replay_ignore_payload_params added, to filter params in form posts

### DIFF
--- a/libmproxy/cmdline.py
+++ b/libmproxy/cmdline.py
@@ -183,7 +183,8 @@ def get_common_options(options):
         verbosity=options.verbose,
         nopop=options.nopop,
         replay_ignore_content = options.replay_ignore_content,
-        replay_ignore_params = options.replay_ignore_params
+        replay_ignore_params = options.replay_ignore_params,
+        replay_ignore_payload_params = options.replay_ignore_payload_params
     )
 
 
@@ -438,13 +439,24 @@ def common_options(parser):
         help="Disable response pop from response flow. "
              "This makes it possible to replay same response multiple times."
     )
-    group.add_argument(
+    payload = group.add_mutually_exclusive_group()
+    payload.add_argument(
         "--replay-ignore-content",
         action="store_true", dest="replay_ignore_content", default=False,
         help="""
             Ignore request's content while searching for a saved flow to replay
         """
     )
+    payload.add_argument(
+        "--replay-ignore-payload-param",
+        action="append", dest="replay_ignore_payload_params", type=str,
+        help="""
+            Request's payload parameters (application/x-www-form-urlencoded) to 
+            be ignored while searching for a saved flow to replay. 
+            Can be passed multiple times. 
+        """
+    )
+
     group.add_argument(
         "--replay-ignore-param",
         action="append", dest="replay_ignore_params", type=str,

--- a/libmproxy/dump.py
+++ b/libmproxy/dump.py
@@ -39,6 +39,7 @@ class Options(object):
         "outfile",
         "replay_ignore_content",
         "replay_ignore_params",
+        "replay_ignore_payload_params",
     ]
 
     def __init__(self, **kwargs):
@@ -78,6 +79,7 @@ class DumpMaster(flow.FlowMaster):
         self.replay_ignore_params = options.replay_ignore_params
         self.replay_ignore_content = options.replay_ignore_content
         self.refresh_server_playback = options.refresh_server_playback
+        self.replay_ignore_payload_params = options.replay_ignore_payload_params
 
         self.set_stream_large_bodies(options.stream_large_bodies)
 
@@ -115,7 +117,8 @@ class DumpMaster(flow.FlowMaster):
                 not options.keepserving,
                 options.nopop,
                 options.replay_ignore_params,
-                options.replay_ignore_content
+                options.replay_ignore_content,
+                options.replay_ignore_payload_params,
             )
 
         if options.client_replay:


### PR DESCRIPTION
Hi,
I've created a new replay parameter for ignoring selected parameters from a POST's payload (when payload is application/x-www-form-urlencoded) 
--replay-ignore-content is now mutually exclusive with the new parameter, so you can ignore the whole payload or just some parameters. 
