### PR TITLE
added support for specifying multiple files for flow playback (aka scenario support first dependencies) 

### DIFF
--- a/libmproxy/cmdline.py
+++ b/libmproxy/cmdline.py
@@ -418,14 +418,14 @@ def common_options(parser):
     group = parser.add_argument_group("Client Replay")
     group.add_argument(
         "-c", "--client-replay",
-        action="store", dest="client_replay", default=None, metavar="PATH",
+        action="append", dest="client_replay", default=None, metavar="PATH",
         help="Replay client requests from a saved file."
     )
 
     group = parser.add_argument_group("Server Replay")
     group.add_argument(
         "-S", "--server-replay",
-        action="store", dest="server_replay", default=None, metavar="PATH",
+        action="append", dest="server_replay", default=None, metavar="PATH",
         help="Replay server responses from a saved file."
     )
     group.add_argument(

--- a/libmproxy/console/__init__.py
+++ b/libmproxy/console/__init__.py
@@ -496,11 +496,13 @@ class ConsoleMaster(flow.FlowMaster):
         self.eventlog = not self.eventlog
         self.view_flowlist()
 
-    def _readflow(self, path):
-        path = os.path.expanduser(path)
+    def _readflow(self, paths):
         try:
-            f = file(path, "rb")
-            flows = list(flow.FlowReader(f).stream())
+            flows = []
+            for path in paths:
+                path = os.path.expanduser(path)
+                f = file(path, "rb")
+                flows.extend(list(flow.FlowReader(f).stream()))
         except (IOError, flow.FlowReadError), v:
             return True, v.strerror
         return False, flows
@@ -521,7 +523,7 @@ class ConsoleMaster(flow.FlowMaster):
                 ret,
                 self.killextra, self.rheaders,
                 False, self.nopop,
-                self.options.replay_ignore_params, self.options.replay_ignore_content
+                self.options.replay_ignore_params, self.options.replay_ignore_content, self.options.replay_ignore_payload_params
             )
 
     def spawn_editor(self, data):

--- a/libmproxy/console/__init__.py
+++ b/libmproxy/console/__init__.py
@@ -501,8 +501,8 @@ class ConsoleMaster(flow.FlowMaster):
             flows = []
             for path in paths:
                 path = os.path.expanduser(path)
-                f = file(path, "rb")
-                flows.extend(list(flow.FlowReader(f).stream()))
+                with file(path, "rb") as f:
+                    flows.extend(list(flow.FlowReader(f).stream()))
         except (IOError, flow.FlowReadError), v:
             return True, v.strerror
         return False, flows

--- a/libmproxy/dump.py
+++ b/libmproxy/dump.py
@@ -143,11 +143,13 @@ class DumpMaster(flow.FlowMaster):
         if self.o.app:
             self.start_app(self.o.app_host, self.o.app_port)
 
-    def _readflow(self, path):
-        path = os.path.expanduser(path)
+    def _readflow(self, paths):
         try:
-            f = file(path, "rb")
-            flows = list(flow.FlowReader(f).stream())
+            flows = []
+            for path in paths:
+                path = os.path.expanduser(path)
+                f = file(path, "rb")
+                flows.extend(list(flow.FlowReader(f).stream()))
         except (IOError, flow.FlowReadError), v:
             raise DumpError(v.strerror)
         return flows

--- a/libmproxy/dump.py
+++ b/libmproxy/dump.py
@@ -148,8 +148,8 @@ class DumpMaster(flow.FlowMaster):
             flows = []
             for path in paths:
                 path = os.path.expanduser(path)
-                f = file(path, "rb")
-                flows.extend(list(flow.FlowReader(f).stream()))
+                with file(path, "rb") as f:
+                    flows.extend(list(flow.FlowReader(f).stream()))
         except (IOError, flow.FlowReadError), v:
             raise DumpError(v.strerror)
         return flows

--- a/test/test_dump.py
+++ b/test/test_dump.py
@@ -82,17 +82,17 @@ class TestDumpMaster:
             p = os.path.join(t, "rep")
             self._flowfile(p)
 
-            o = dump.Options(server_replay=p, kill=True)
+            o = dump.Options(server_replay=[p], kill=True)
             m = dump.DumpMaster(None, o, outfile=cs)
 
             self._cycle(m, "content")
             self._cycle(m, "content")
 
-            o = dump.Options(server_replay=p, kill=False)
+            o = dump.Options(server_replay=[p], kill=False)
             m = dump.DumpMaster(None, o, outfile=cs)
             self._cycle(m, "nonexistent")
 
-            o = dump.Options(client_replay=p, kill=False)
+            o = dump.Options(client_replay=[p], kill=False)
             m = dump.DumpMaster(None, o, outfile=cs)
 
     def test_read(self):


### PR DESCRIPTION
Hi Max, 

As we agreed in https://github.com/mitmproxy/mitmproxy/pull/432 i'm PR you with (server|client)_replay supporting a list of files and modified _readflow to read all of them. 
I've done it in DumpMaster (dump.py) but also in cmdline.py (for mitmproxy to support it as well)
I've also fixed a bug (that i previously added), replay_ignore_payload_params was not been passed to start_server_playback when called in mitmproxy (it was ok in mitmdump) 

Regards.
Marcelo
