### PR TITLE
hotfix to mitmproxy missing start_server_playback() parameter added. 

### DIFF
--- a/libmproxy/console/__init__.py
+++ b/libmproxy/console/__init__.py
@@ -529,7 +529,7 @@ class ConsoleMaster(flow.FlowMaster):
                 ret,
                 self.killextra, self.rheaders,
                 False, self.nopop,
-                self.options.replay_ignore_params, self.options.replay_ignore_content
+                self.options.replay_ignore_params, self.options.replay_ignore_content, self.options.replay_ignore_payload_params
             )
 
     def spawn_editor(self, data):


### PR DESCRIPTION
Hi Max, 
I've just backported the fix in mitmproxy's start_server_playback() from PR [#439] to add the missing parameter (replay_ignore_payload_params) which is present in mitmdump but was missing in mitmproxy.
Regards
Marcelo