### PR TITLE
Show file not found error

### DIFF
--- a/libmproxy/console/__init__.py
+++ b/libmproxy/console/__init__.py
@@ -423,6 +423,7 @@ class ConsoleMaster(flow.FlowMaster):
         self.eventlog = options.eventlog
         self.eventlist = urwid.SimpleListWalker([])
 
+        self.statusbar = None
         if options.client_replay:
             self.client_playback_path(options.client_replay)
 

--- a/libmproxy/console/__init__.py
+++ b/libmproxy/console/__init__.py
@@ -599,7 +599,6 @@ class ConsoleMaster(flow.FlowMaster):
         self.ui.register_palette(self.palette)
         self.flow_list_walker = flowlist.FlowListWalker(self, self.state)
         self.view = None
-        self.statusbar = None
         self.header = None
         self.body = None
         self.help_context = None


### PR DESCRIPTION
Hi Max, 
Just another quick oneliner bugfix 
when starting mitmproxy (not mitmdump) with a replay file that do not exist (client or server replay) mitmproxy abort with an exception instead of showing not found error

```python
./mitmproxy -S notexisitingfile
Traceback (most recent call last):
  File "./mitmproxy", line 3, in <module>
    mitmproxy()
  File "/home/gato/trabajos/mitmproxy/libmproxy/main.py", line 97, in mitmproxy
    m = console.ConsoleMaster(server, console_options)
  File "/home/gato/trabajos/mitmproxy/libmproxy/console/__init__.py", line 430, in __init__
    self.server_playback_path(options.server_replay)
  File "/home/gato/trabajos/mitmproxy/libmproxy/console/__init__.py", line 524, in server_playback_path
    if not self.statusbar:
AttributeError: 'ConsoleMaster' object has no attribute 'statusbar'
```
same error when running ./mitmproxy -c notexisitingfile

I've found that statubar is initialized to None in ConsoleMaster.run() but flow reading is done first (when parsing parameters) I've just moved self.statusbar = None from  method run to init

Regards.
Marcelo