### PR TITLE
added time elapsed between request sent and response received

### DIFF
--- a/libmproxy/console/common.py
+++ b/libmproxy/console/common.py
@@ -162,7 +162,6 @@ def raw_format_flow(f, focus, extended, padding):
         if f["resp_ctype"]:
             resp.append(fcol(f["resp_ctype"], rc))
         resp.append(fcol(f["resp_clen"], rc))
-        resp.append(fcol(f["resp_rate"], rc))
         resp.append(fcol(f["roundtrip"], rc))
 
     elif f["err_msg"]:
@@ -347,21 +346,15 @@ def format_flow(f, focus, extended=False, hostheader=False, padding=2):
         else:
             contentdesc = "[no content]"
         duration = 0
-        if f.response.timestamp_end:
-            delta = f.response.timestamp_end - f.response.timestamp_start
-            if f.request.timestamp_end:
-                duration = f.response.timestamp_end - f.request.timestamp_end
-        else:
-            delta = 0
+        if f.response.timestamp_end and f.request.timestamp_start:
+            duration = f.response.timestamp_end - f.request.timestamp_start
         size = f.response.size()
-        rate = utils.pretty_size(size / ( delta if delta > 0 else 1 ) )
         roundtrip = utils.pretty_duration(duration)
 
         d.update(dict(
             resp_code = f.response.code,
             resp_is_replay = f.response.is_replay,
             resp_clen = contentdesc,
-            resp_rate = "{0}/s".format(rate),
             roundtrip = roundtrip,
         ))
         t = f.response.headers["content-type"]

--- a/libmproxy/console/common.py
+++ b/libmproxy/console/common.py
@@ -163,6 +163,7 @@ def raw_format_flow(f, focus, extended, padding):
             resp.append(fcol(f["resp_ctype"], rc))
         resp.append(fcol(f["resp_clen"], rc))
         resp.append(fcol(f["resp_rate"], rc))
+        resp.append(fcol(f["roundtrip"], rc))
 
     elif f["err_msg"]:
         resp.append(fcol(SYMBOL_RETURN, "error"))
@@ -345,19 +346,23 @@ def format_flow(f, focus, extended=False, hostheader=False, padding=2):
             contentdesc = "[content missing]"
         else:
             contentdesc = "[no content]"
-
+        duration = 0
         if f.response.timestamp_end:
             delta = f.response.timestamp_end - f.response.timestamp_start
+            if f.request.timestamp_end:
+                duration = f.response.timestamp_end - f.request.timestamp_end
         else:
             delta = 0
         size = f.response.size()
         rate = utils.pretty_size(size / ( delta if delta > 0 else 1 ) )
+        roundtrip = utils.pretty_duration(duration)
 
         d.update(dict(
             resp_code = f.response.code,
             resp_is_replay = f.response.is_replay,
             resp_clen = contentdesc,
             resp_rate = "{0}/s".format(rate),
+            roundtrip = roundtrip,
         ))
         t = f.response.headers["content-type"]
         if t:

--- a/libmproxy/utils.py
+++ b/libmproxy/utils.py
@@ -79,6 +79,18 @@ def pretty_size(size):
                 x = int(x)
             return str(x) + suf
 
+def pretty_duration(secs):
+    formatters = [
+        (100, "{:.0f}s"), 
+        (10, "{:2.1f}s"), 
+        (1, "{:1.2f}s"),         
+    ]
+
+    for limit, formatter in formatters:
+        if secs >= limit:
+            return formatter.format(secs)
+    #less than 1 sec 
+    return "{:.0f}ms".format(secs*1000)
 
 class Data:
     def __init__(self, name):

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -50,6 +50,19 @@ def test_urldecode():
     s = "one=two&three=four"
     assert len(utils.urldecode(s)) == 2
 
+def test_pretty_duration():
+    assert utils.pretty_duration(0.00001) == "0ms"
+    assert utils.pretty_duration(0.0001) == "0ms"
+    assert utils.pretty_duration(0.001) == "1ms"
+    assert utils.pretty_duration(0.01) == "10ms"
+    assert utils.pretty_duration(0.1) == "100ms"
+    assert utils.pretty_duration(1) == "1.00s"
+    assert utils.pretty_duration(10) == "10.0s"
+    assert utils.pretty_duration(100) == "100s"
+    assert utils.pretty_duration(1000) == "1000s"
+    assert utils.pretty_duration(10000) == "10000s"    
+    assert utils.pretty_duration(1.123) == "1.12s"
+    assert utils.pretty_duration(0.123) == "123ms"
 
 def test_LRUCache():
     class Foo:


### PR DESCRIPTION
Hi Max, 
i've added to flowview and flowlist time elapsed to handle request. I've used the difference between end of request and end of response but flow has timestamps for begin and end for both request and response so other combinations can be shown either. 
Just let me know if this approach seems ok or you want to calculate it differently. Or perhaps add to view more times (req time: xxx ms., resp time: yyy ms. , whole time: zzz ms.)
I created this PR for issue #487 
Regards
Marcelo