### PR TITLE
Add --replay-ignore-host option

### DIFF
--- a/libmproxy/cmdline.py
+++ b/libmproxy/cmdline.py
@@ -192,7 +192,8 @@ def get_common_options(options):
         nopop=options.nopop,
         replay_ignore_content = options.replay_ignore_content,
         replay_ignore_params = options.replay_ignore_params,
-        replay_ignore_payload_params = options.replay_ignore_payload_params
+        replay_ignore_payload_params = options.replay_ignore_payload_params,
+        replay_ignore_host = options.replay_ignore_host
     )
 
 
@@ -478,6 +479,11 @@ def common_options(parser):
             Request's parameters to be ignored while searching for a saved flow
             to replay. Can be passed multiple times.
         """
+    )
+    group.add_argument(
+        "--replay-ignore-host",
+        action="store_true", dest="replay_ignore_host", default=False,
+        help="Ignore request's destination host while searching for a saved flow to replay"
     )
 
     group = parser.add_argument_group(

--- a/libmproxy/console/__init__.py
+++ b/libmproxy/console/__init__.py
@@ -528,7 +528,10 @@ class ConsoleMaster(flow.FlowMaster):
                 flows,
                 self.killextra, self.rheaders,
                 False, self.nopop,
-                self.options.replay_ignore_params, self.options.replay_ignore_content, self.options.replay_ignore_payload_params
+                self.options.replay_ignore_params,
+                self.options.replay_ignore_content,
+                self.options.replay_ignore_payload_params,
+                self.options.replay_ignore_host
             )
 
     def spawn_editor(self, data):

--- a/libmproxy/console/flowlist.py
+++ b/libmproxy/console/flowlist.py
@@ -126,7 +126,8 @@ class ConnectionItem(common.WWrap):
                 self.master.killextra, self.master.rheaders,
                 False, self.master.nopop,
                 self.master.options.replay_ignore_params, self.master.options.replay_ignore_content,
-                self.master.options.replay_ignore_payload_params
+                self.master.options.replay_ignore_payload_params,
+                self.master.options.replay_ignore_host
             )
         elif k == "t":
             self.master.start_server_playback(
@@ -134,7 +135,8 @@ class ConnectionItem(common.WWrap):
                 self.master.killextra, self.master.rheaders,
                 False, self.master.nopop,
                 self.master.options.replay_ignore_params, self.master.options.replay_ignore_content,
-                self.master.options.replay_ignore_payload_params
+                self.master.options.replay_ignore_payload_params,
+                self.master.options.replay_ignore_host
             )
         else:
             self.master.path_prompt(

--- a/libmproxy/dump.py
+++ b/libmproxy/dump.py
@@ -40,6 +40,7 @@ class Options(object):
         "replay_ignore_content",
         "replay_ignore_params",
         "replay_ignore_payload_params",
+        "replay_ignore_host"
     ]
 
     def __init__(self, **kwargs):
@@ -78,6 +79,7 @@ class DumpMaster(flow.FlowMaster):
         self.showhost = options.showhost
         self.replay_ignore_params = options.replay_ignore_params
         self.replay_ignore_content = options.replay_ignore_content
+        self.replay_ignore_host = options.replay_ignore_host
         self.refresh_server_playback = options.refresh_server_playback
         self.replay_ignore_payload_params = options.replay_ignore_payload_params
 
@@ -119,6 +121,7 @@ class DumpMaster(flow.FlowMaster):
                 options.replay_ignore_params,
                 options.replay_ignore_content,
                 options.replay_ignore_payload_params,
+                options.replay_ignore_host
             )
 
         if options.client_replay:

--- a/test/test_flow.py
+++ b/test/test_flow.py
@@ -114,7 +114,7 @@ class TestClientPlaybackState:
 
 class TestServerPlaybackState:
     def test_hash(self):
-        s = flow.ServerPlaybackState(None, [], False, False, None, False, None)
+        s = flow.ServerPlaybackState(None, [], False, False, None, False, None, False)
         r = tutils.tflow()
         r2 = tutils.tflow()
 
@@ -126,7 +126,7 @@ class TestServerPlaybackState:
         assert s._hash(r) != s._hash(r2)
 
     def test_headers(self):
-        s = flow.ServerPlaybackState(["foo"], [], False, False, None, False, None)
+        s = flow.ServerPlaybackState(["foo"], [], False, False, None, False, None, False)
         r = tutils.tflow(resp=True)
         r.request.headers["foo"] = ["bar"]
         r2 = tutils.tflow(resp=True)
@@ -147,7 +147,7 @@ class TestServerPlaybackState:
         r2 = tutils.tflow(resp=True)
         r2.request.headers["key"] = ["two"]
 
-        s = flow.ServerPlaybackState(None, [r, r2], False, False, None, False, None)
+        s = flow.ServerPlaybackState(None, [r, r2], False, False, None, False, None, False)
         assert s.count() == 2
         assert len(s.fmap.keys()) == 1
 
@@ -168,7 +168,7 @@ class TestServerPlaybackState:
         r2 = tutils.tflow(resp=True)
         r2.request.headers["key"] = ["two"]
 
-        s = flow.ServerPlaybackState(None, [r, r2], False, True, None, False, None)
+        s = flow.ServerPlaybackState(None, [r, r2], False, True, None, False, None, False)
 
         assert s.count() == 2
         s.next_flow(r)
@@ -176,7 +176,7 @@ class TestServerPlaybackState:
 
 
     def test_ignore_params(self):
-        s = flow.ServerPlaybackState(None, [], False, False, ["param1", "param2"], False, None)
+        s = flow.ServerPlaybackState(None, [], False, False, ["param1", "param2"], False, None, False)
         r = tutils.tflow(resp=True)
         r.request.path="/test?param1=1"
         r2 = tutils.tflow(resp=True)
@@ -190,7 +190,7 @@ class TestServerPlaybackState:
         assert not s._hash(r) == s._hash(r2)
 
     def test_ignore_payload_params(self):
-        s = flow.ServerPlaybackState(None, [], False, False, None, False, ["param1", "param2"])
+        s = flow.ServerPlaybackState(None, [], False, False, None, False, ["param1", "param2"], False)
         r = tutils.tflow(resp=True)
         r.request.headers["Content-Type"] = ["application/x-www-form-urlencoded"]
         r.request.content = "paramx=x&param1=1"
@@ -216,7 +216,7 @@ class TestServerPlaybackState:
         assert not s._hash(r) == s._hash(r2)
 
     def test_ignore_payload_params_other_content_type(self):
-        s = flow.ServerPlaybackState(None, [], False, False, None, False, ["param1", "param2"])
+        s = flow.ServerPlaybackState(None, [], False, False, None, False, ["param1", "param2"], False)
         r = tutils.tflow(resp=True)
         r.request.headers["Content-Type"] = ["application/json"]
         r.request.content = '{"param1":"1"}'
@@ -231,7 +231,7 @@ class TestServerPlaybackState:
 
     def test_ignore_payload_wins_over_params(self):
         #NOTE: parameters are mutually exclusive in options
-        s = flow.ServerPlaybackState(None, [], False, False, None, True, ["param1", "param2"])
+        s = flow.ServerPlaybackState(None, [], False, False, None, True, ["param1", "param2"], False)
         r = tutils.tflow(resp=True)
         r.request.headers["Content-Type"] = ["application/x-www-form-urlencoded"]
         r.request.content = "paramx=y"
@@ -242,10 +242,10 @@ class TestServerPlaybackState:
         assert s._hash(r) == s._hash(r2)
 
     def test_ignore_content(self):
-        s = flow.ServerPlaybackState(None, [], False, False, None, False, None)
+        s = flow.ServerPlaybackState(None, [], False, False, None, False, None, False)
         r = tutils.tflow(resp=True)
         r2 = tutils.tflow(resp=True)
-        
+
         r.request.content = "foo"
         r2.request.content = "foo"
         assert s._hash(r) == s._hash(r2)
@@ -253,7 +253,7 @@ class TestServerPlaybackState:
         assert not s._hash(r) == s._hash(r2)
 
         #now ignoring content
-        s = flow.ServerPlaybackState(None, [], False, False, None, True, None)
+        s = flow.ServerPlaybackState(None, [], False, False, None, True, None, False)
         r = tutils.tflow(resp=True)
         r2 = tutils.tflow(resp=True)
         r.request.content = "foo"
@@ -264,6 +264,17 @@ class TestServerPlaybackState:
         r2.request.content = ""
         assert s._hash(r) == s._hash(r2)
         r2.request.content = None
+        assert s._hash(r) == s._hash(r2)
+
+    def test_ignore_host(self):
+        s = flow.ServerPlaybackState(None, [], False, False, None, False, None, True)
+        r = tutils.tflow(resp=True)
+        r2 = tutils.tflow(resp=True)
+
+        r.request.host="address"
+        r2.request.host="address"
+        assert s._hash(r) == s._hash(r2)
+        r2.request.host="wrong_address"
         assert s._hash(r) == s._hash(r2)
 
 
@@ -748,9 +759,8 @@ class TestFlowMaster:
 
         f = tutils.tflow(resp=True)
         pb = [tutils.tflow(resp=True), f]
-
         fm = flow.FlowMaster(DummyServer(ProxyConfig()), s)
-        assert not fm.start_server_playback(pb, False, [], False, False, None, False, None)
+        assert not fm.start_server_playback(pb, False, [], False, False, None, False, None, False)
         assert not fm.start_client_playback(pb, False)
         fm.client_playback.testing = True
 
@@ -773,16 +783,16 @@ class TestFlowMaster:
         fm.refresh_server_playback = True
         assert not fm.do_server_playback(tutils.tflow())
 
-        fm.start_server_playback(pb, False, [], False, False, None, False, None)
+        fm.start_server_playback(pb, False, [], False, False, None, False, None, False)
         assert fm.do_server_playback(tutils.tflow())
 
-        fm.start_server_playback(pb, False, [], True, False, None, False, None)
+        fm.start_server_playback(pb, False, [], True, False, None, False, None, False)
         r = tutils.tflow()
         r.request.content = "gibble"
         assert not fm.do_server_playback(r)
         assert fm.do_server_playback(tutils.tflow())
 
-        fm.start_server_playback(pb, False, [], True, False, None, False, None)
+        fm.start_server_playback(pb, False, [], True, False, None, False, None, False)
         q = Queue.Queue()
         fm.tick(q, 0)
         assert fm.should_exit.is_set()
@@ -797,7 +807,7 @@ class TestFlowMaster:
         pb = [f]
         fm = flow.FlowMaster(None, s)
         fm.refresh_server_playback = True
-        fm.start_server_playback(pb, True, [], False, False, None, False, None)
+        fm.start_server_playback(pb, True, [], False, False, None, False, None, False)
 
         f = tutils.tflow()
         f.request.host = "nonexistent"


### PR DESCRIPTION
Similar to the other --replay-ignore-* options, this prevents matching on the destination address while searching for flows to replay.

The use case necessitating this is replaying server responses (in transparent mode) for domains that use multiple IP addresses.