### PR TITLE
simplify virtualenv

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -64,8 +64,8 @@ checkouts will be reflected live in the virtualenv.
 To confirm that you're up and running, activate the virtualenv, and run the
 mitmproxy test suite:
 
-```
-$ ../venv.mitmproxy/bin/activate
+```shell
+$ source ../venv.mitmproxy/bin/activate # ..\venv.mitmproxy\Scripts\activate.bat on Windows
 $ nosetests ./test
 ```
 Note that the main executables for the project - **mitmdump**, **mitmproxy** and

--- a/README.mkd
+++ b/README.mkd
@@ -65,7 +65,7 @@ To confirm that you're up and running, activate the virtualenv, and run the
 mitmproxy test suite:
 
 ```
-$ source ../venv.mitmproxy/bin/activate
+$ ../venv.mitmproxy/bin/activate
 $ nosetests ./test
 ```
 Note that the main executables for the project - **mitmdump**, **mitmproxy** and

--- a/dev
+++ b/dev
@@ -1,16 +1,6 @@
 #!/bin/sh
 VENV=../venv.mitmproxy
-PIP="$VENV/bin/pip --cache-dir ~/.pipcache"
-
-echo "This script sets up the following:"
-echo "\t~/.pipcache - A pip cache directory"
-echo "\t$VENV - A development virtualenv"
-
-mkdir -p ~/.pipcache
 
 virtualenv $VENV
 source $VENV/bin/activate
-$PIP install -r ./requirements.txt
-# Re-install these to make them editable
-$PIP install --editable ../netlib
-$PIP install --editable ../pathod
+pip install --src .. -r requirements.txt

--- a/dev
+++ b/dev
@@ -4,3 +4,8 @@ VENV=../venv.mitmproxy
 virtualenv $VENV
 source $VENV/bin/activate
 pip install --src .. -r requirements.txt
+
+echo ""
+echo "* Created virtualenv environment in $VENV."
+echo "* Installed all dependencies into the virtualenv."
+echo "* Activated virtualenv environment."

--- a/dev.bat
+++ b/dev.bat
@@ -1,0 +1,6 @@
+@echo off
+set VENV=..\venv.mitmproxy
+
+virtualenv %VENV%
+call %VENV%\Scripts\activate.bat
+pip install --src .. -r requirements.txt

--- a/dev.bat
+++ b/dev.bat
@@ -4,3 +4,8 @@ set VENV=..\venv.mitmproxy
 virtualenv %VENV%
 call %VENV%\Scripts\activate.bat
 pip install --src .. -r requirements.txt
+
+echo.
+echo * Created virtualenv environment in %VENV%.
+echo * Installed all dependencies into the virtualenv.
+echo * Activated virtualenv environment.


### PR DESCRIPTION
- add dev.bat for Windows users
- remove superfluous pip install calls.
- remove `~/.pipcache` stuff.  
  If that causes issues with PyInstaller, we should use `pip --no-cache-dir` there or `rm -r pip.locations.USER_CACHE_DIR`.

@cortesi: third change works for you?