### PR TITLE
autocompletion using argcomplete

### DIFF
--- a/libmproxy/cmdline.py
+++ b/libmproxy/cmdline.py
@@ -5,6 +5,7 @@ import configargparse
 from netlib import http
 from . import filt, utils, version
 from .proxy import config
+from argcomplete.completers import FilesCompleter
 
 APP_HOST = "mitm.it"
 APP_PORT = 80
@@ -222,7 +223,7 @@ def common_options(parser):
         "--cadir",
         action="store", type=str, dest="cadir", default=config.CA_DIR,
         help="Location of the default mitmproxy CA files. (%s)"%config.CA_DIR
-    )
+    ).completer = FilesCompleter(allowednames=("",))
     parser.add_argument(
         "--host",
         action="store_true", dest="showhost", default=False,
@@ -237,7 +238,7 @@ def common_options(parser):
         "-r", "--read-flows",
         action="store", dest="rfile", default=None,
         help="Read flows from file."
-    )
+    ).completer = FilesCompleter()
     parser.add_argument(
         "-s", "--script",
         action="append", type=str, dest="scripts", default=[],
@@ -246,7 +247,7 @@ def common_options(parser):
             Run a script. Surround with quotes to pass script arguments. Can be
             passed multiple times.
         """
-    )
+    ).completer = FilesCompleter(allowednames=(".py",))
     parser.add_argument(
         "-t", "--stickycookie",
         action="store",
@@ -270,12 +271,12 @@ def common_options(parser):
         "-w", "--wfile",
         action="store", dest="outfile", type=lambda f: (f, "wb"),
         help="Write flows to file."
-    )
+    ).completer = FilesCompleter()
     outfile.add_argument(
         "-a", "--afile",
         action="store", dest="outfile", type=lambda f: (f, "ab"),
         help="Append flows to file."
-    )
+    ).completer = FilesCompleter()
     parser.add_argument(
         "-z", "--anticomp",
         action="store_true", dest="anticomp", default=False,
@@ -421,14 +422,14 @@ def common_options(parser):
         "-c", "--client-replay",
         action="append", dest="client_replay", default=None, metavar="PATH",
         help="Replay client requests from a saved file."
-    )
+    ).completer = FilesCompleter()
 
     group = parser.add_argument_group("Server Replay")
     group.add_argument(
         "-S", "--server-replay",
         action="append", dest="server_replay", default=None, metavar="PATH",
         help="Replay server responses from a saved file."
-    )
+    ).completer = FilesCompleter()
     group.add_argument(
         "-k", "--kill",
         action="store_true", dest="kill", default=False,
@@ -508,7 +509,7 @@ def common_options(parser):
             Replacement pattern, where the replacement clause is a path to a
             file.
         """
-    )
+    ).completer = FilesCompleter()
 
     group = parser.add_argument_group(
         "Set Headers",

--- a/libmproxy/main.py
+++ b/libmproxy/main.py
@@ -6,6 +6,7 @@ import netlib.version
 from . import version, cmdline
 from .proxy import process_proxy_options, ProxyServerError
 from .proxy.server import DummyServer, ProxyServer
+import argcomplete
 
 
 # This file is not included in coverage analysis or tests - anything that can be
@@ -82,6 +83,7 @@ def mitmproxy():  # pragma: nocover
     assert_utf8_env()
 
     parser = cmdline.mitmproxy()
+    argcomplete.autocomplete(parser)
     options = parser.parse_args()
     if options.quiet:
         options.verbose = 0
@@ -107,6 +109,7 @@ def mitmdump():  # pragma: nocover
     check_versions()
 
     parser = cmdline.mitmdump()
+    argcomplete.autocomplete(parser)    
     options = parser.parse_args()
     if options.quiet:
         options.verbose = 0
@@ -140,7 +143,8 @@ def mitmweb():  # pragma: nocover
 
     check_versions()
     parser = cmdline.mitmweb()
-
+    argcomplete.autocomplete(parser)
+    
     options = parser.parse_args()
     if options.quiet:
         options.verbose = 0

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ deps = {
     "pyOpenSSL>=0.14",
     "tornado>=4.0.2",
     "configargparse>=0.9.3",
-    "pyperclip>=1.5.8"
+    "pyperclip>=1.5.8",
     "argcomplete>=0.8.4"
 }
 script_deps = {

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ deps = {
     "tornado>=4.0.2",
     "configargparse>=0.9.3",
     "pyperclip>=1.5.8"
+    "argcomplete>=0.8.4"
 }
 script_deps = {
     "mitmproxy": {


### PR DESCRIPTION
Hi, 
I've implemented autocompletion using argcomplete (https://github.com/kislyuk/argcomplete) as @cortesi suggested in #512 
It's fully working but has 2 issues: 
1.- as "--conf" parameter is added to parser in construction time https://github.com/mitmproxy/mitmproxy/blob/master/libmproxy/cmdline.py#L566-L575  I couldn't add a FilesCompleter to it (so no file suggestion for this param, the param itself is suggested). I have some ideas on how to solve this but all of them are hacks.
2.- completion is slow: The main reasons for this is that argcomplete runs the script to generate the suggestions every time tab is pressed (there is an issue requesting static completions, but i don't think will be done any time soon https://github.com/kislyuk/argcomplete/issues/85 ) And mitmproxy loads lots of libraries before parsing args so expect a delay between 1.2 and 2 seconds between pressing tab and seen suggestions on screen.
Regards
Marcelo
