### PR TITLE
fixes crash pressing 'c':client-replay in mitmproxy

### DIFF
--- a/libmproxy/console/__init__.py
+++ b/libmproxy/console/__init__.py
@@ -248,7 +248,7 @@ class StatusBar(urwid.WidgetWrap):
         return True
 
     def get_edit_text(self):
-        return self.ab.w.get_edit_text()
+        return self.ab._w.get_edit_text()
 
     def path_prompt(self, prompt, text):
         return self.ab.path_prompt(prompt, text)


### PR DESCRIPTION
Checking bug #522 (which i can reproduce) found that presing "c" (client replay) mitmproxy crashes with this error: 
```
Traceback (most recent call last):
  File "/home/gato/trabajos/mitmproxy/libmproxy/console/__init__.py", line 805, in run
    self.loop.run()
  File "/home/gato/.local/lib/python2.7/site-packages/urwid/main_loop.py", line 278, in run
    self._run()
  File "/home/gato/.local/lib/python2.7/site-packages/urwid/main_loop.py", line 375, in _run
    self.event_loop.run()
  File "/home/gato/.local/lib/python2.7/site-packages/urwid/main_loop.py", line 678, in run
    self._loop()
  File "/home/gato/.local/lib/python2.7/site-packages/urwid/main_loop.py", line 715, in _loop
    self._watch_files[fd]()
  File "/home/gato/.local/lib/python2.7/site-packages/urwid/raw_display.py", line 392, in <lambda>
    event_loop, callback, self.get_available_raw_input())
  File "/home/gato/.local/lib/python2.7/site-packages/urwid/raw_display.py", line 492, in parse_input
    callback(processed, processed_codes)
  File "/home/gato/.local/lib/python2.7/site-packages/urwid/main_loop.py", line 396, in _update
    keys = self.input_filter(keys, raw)
  File "/home/gato/.local/lib/python2.7/site-packages/urwid/main_loop.py", line 535, in input_filter
    return self._input_filter(keys, raw)
  File "/home/gato/trabajos/mitmproxy/libmproxy/console/__init__.py", line 619, in input_filter
    self.prompt_execute()
  File "/home/gato/trabajos/mitmproxy/libmproxy/console/__init__.py", line 957, in prompt_execute
    txt = self.statusbar.get_edit_text()
  File "/home/gato/trabajos/mitmproxy/libmproxy/console/__init__.py", line 251, in get_edit_text
    return self.ab.w.get_edit_text()
  File "/home/gato/.local/lib/python2.7/site-packages/urwid/widget.py", line 1811, in _raise_old_name_error
    raise WidgetWrapError("The WidgetWrap.w member variable has "
WidgetWrapError: The WidgetWrap.w member variable has been renamed to WidgetWrap._w (not intended for use outside the class and its subclasses).  Please update your code to use self._w instead of self.w.

mitmproxy has crashed!
Please lodge a bug report at:
	https://github.com/mitmproxy/mitmproxy
Shutting down...
```
replaced 
```
return self.ab.w.get_edit_text()
```
with (as suggested by the exception)
```
return self.ab._w.get_edit_text()
```
and is working again.

Regards.
Marcelo