### PR TITLE
handles UnicodeDecodeError (#531)

### DIFF
--- a/libmproxy/console/common.py
+++ b/libmproxy/console/common.py
@@ -252,7 +252,7 @@ def copy_flow(part, scope, flow, master, state):
     try:
         master.add_event(str(len(data)))
         pyperclip.copy(data)
-    except RuntimeError:
+    except (RuntimeError, UnicodeDecodeError):
         def save(k):
             if k == "y":
                 ask_save_path("Save data", data, master, state)


### PR DESCRIPTION
Hi @cortesi 
this PR solves #531
When feature #334 was implemented i found a similar error once (a TypeError) but couldn't reproduce it again, so we removed the catch for these type of error. (see https://github.com/mitmproxy/mitmproxy/pull/448#discussion-diff-24215901R226) As pyperclip uses different base tools to do the actual copying depending on OS and installed libraries (gtk, xsel, pbpaste, etc) is hard to know in advance what exceptions can be thrown. I could reproduce the UnicodeDecodeError on a Mac running Yosemite (10.10.3) and this solve it. (well actually just catch the exception and offers to save the content as file instead)
Regards
Marcelo 