### PR TITLE
Make the Websocket's connection header value case-insensitive

### DIFF
--- a/examples/ignore_websocket.py
+++ b/examples/ignore_websocket.py
@@ -26,7 +26,8 @@ def done(context):
 
 @concurrent
 def response(context, flow):
-    if flow.response.headers.get_first("Connection", None) == "Upgrade":
+    value = flow.response.headers.get_first("Connection", None)
+    if value and value.upper() == "UPGRADE":
         # We need to send the response manually now...
         flow.client_conn.send(flow.response.assemble())
         # ...and then delegate to tcp passthrough.


### PR DESCRIPTION
Some servers respond with `"upgrade"`; so just normalize the field value.

(Just I realized that maybe, should also be done for the header name? I dunno..)