### PR TITLE
Fix toggle eventlog

### DIFF
--- a/libmproxy/console/__init__.py
+++ b/libmproxy/console/__init__.py
@@ -299,7 +299,10 @@ class ConsoleMaster(flow.FlowMaster):
 
     def toggle_eventlog(self):
         self.eventlog = not self.eventlog
-        self.view_flowlist()
+        if not self.eventlog:
+            signals.pop_view_state.send(self)
+        else:
+            self.view_flowlist()
 
     def _readflows(self, path):
         """

--- a/libmproxy/console/flowlist.py
+++ b/libmproxy/console/flowlist.py
@@ -233,8 +233,6 @@ class ConnectionItem(urwid.WidgetWrap):
 class FlowListWalker(urwid.ListWalker):
     def __init__(self, master, state):
         self.master, self.state = master, state
-        if self.state.flow_count():
-            self.set_focus(0)
         signals.flowlist_change.connect(self.sig_flowlist_change)
 
     def sig_flowlist_change(self, sender):


### PR DESCRIPTION
There are two changes.

1. When we toggle eventlog, it makes new windows at every toggle.

   If we toggle eventlog 5 times, then we have to press 'q' 5 times to quit program.

   So, just pop the new window, when a user toggles eventlog again.

2. I'm not sure that it is better change.

   When we toggle eventlog, it resets cursor position.

   I think it is better to keep cursor position.