### PR TITLE
Match all freebsd versions and not just freebsd10

### DIFF
--- a/libmproxy/platform/__init__.py
+++ b/libmproxy/platform/__init__.py
@@ -8,7 +8,7 @@ if sys.platform == "linux2":
 elif sys.platform == "darwin":
     from . import osx
     resolver = osx.Resolver
-elif sys.platform == "freebsd10":
+elif sys.platform.startswith("freebsd"):
     from . import osx
     resolver = osx.Resolver
 elif sys.platform == "win32":

--- a/libmproxy/platform/pf.py
+++ b/libmproxy/platform/pf.py
@@ -13,7 +13,7 @@ def lookup(address, port, s):
         if "ESTABLISHED:ESTABLISHED" in i and spec in i:
             s = i.split()
             if len(s) > 4:
-                if sys.platform == "freebsd10":
+                if sys.platform.startswith("freebsd"):
                     # strip parentheses for FreeBSD pfctl
                     s = s[3][1:-1].split(":")
                 else:


### PR DESCRIPTION
+ Use sys.platform.startswith("freebsd") instead of matching just freebs...
+ This means support for any freebsd version (note that I only tested 11-CURRENT and 9)