### PR TITLE
Accurately timestamp start of request

### DIFF
--- a/libmproxy/protocol/http.py
+++ b/libmproxy/protocol/http.py
@@ -344,6 +344,11 @@ class HTTPRequest(HTTPMessage):
             body_size_limit = body_size_limit,
             wfile = wfile
         )
+
+        if hasattr(rfile, "first_byte_timestamp"):
+            # more accurate timestamp_start
+            timestamp_start = rfile.first_byte_timestamp
+
         timestamp_end = utils.timestamp()
         return HTTPRequest(
             req.form_in,


### PR DESCRIPTION
When building a request from a stream, try to get an accurate
start timestamp from the Reader. This was already in the code
and also used when building response objects, but was omitted
in commit ddf458b330bf9fe200cb1dbc3ddb5ae1a5d2102a

Without his logic and when the client is reusing a connection
to send requests, the timestamp_start of subsequent requests
is early and equal to when the connection started read blocking