### PR TITLE
Make sure proxy returns the httpversion specified in the request

### DIFF
--- a/libmproxy/protocol/http.py
+++ b/libmproxy/protocol/http.py
@@ -1248,7 +1248,8 @@ class HTTPHandler(ProtocolHandler):
                 flow.server_conn = self.c.server_conn
                 self.c.establish_server_connection()
                 self.c.client_conn.send(
-                    'HTTP/1.1 200 Connection established\r\n' +
+                    ('HTTP/%s.%s 200 ' % (request.httpversion[0],request.httpversion[1])) +
+		    'Connection established\r\n' +
                     'Content-Length: 0\r\n' +
                     ('Proxy-agent: %s\r\n' % self.c.config.server_version) +
                     '\r\n'


### PR DESCRIPTION
rather than hardcoding to 1.1.

This helped me to work around the scenario where I was testing some old code that broke because it was expecting to receive 'HTTP/1.0 200 Connection established'
 