### PR TITLE
improve autoenv script

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,5 @@
-DIR=`dirname $0`
-if [ -z "$VIRTUAL_ENV" ] && [ -f $DIR/../venv.mitmproxy/bin/activate ]; then
+DIR="${0%/*}"
+if [ -z "$VIRTUAL_ENV" ] && [ -f "$DIR/../venv.mitmproxy/bin/activate" ]; then
     echo "Activating mitmproxy virtualenv..."
-    source $DIR/../venv.mitmproxy/bin/activate
+    source "$DIR/../venv.mitmproxy/bin/activate"
 fi


### PR DESCRIPTION
* properly quote DIR variable
  (it might contain spaces)
* use builtin string magic instead of `dirname`