### PR TITLE
Force 0px height on main-view to restrain height to viewport

### DIFF
--- a/libmproxy/web/static/app.css
+++ b/libmproxy/web/static/app.css
@@ -61,6 +61,7 @@ body,
   flex: 1 1 auto;
   display: flex;
   flex-direction: row;
+  height: 0px;
 }
 .main-view.vertical {
   flex-direction: column;


### PR DESCRIPTION
Looks like the problem is down to the height of main-view not being restrained to the viewport, I've attached a hacky fix to resolve #615 (theres probably a React way of fixing this).

The height with a build from master is larger than the viewport (depends on the size of the table or detail, whichever is bigger).  (see the size in the bottom right)
![mitmweb_invalid_height](https://cloud.githubusercontent.com/assets/83862/8026528/a1ef0a7c-0d71-11e5-8ff1-ae40ba5e1cbf.png)

And with the hacky fix you can see its constrained to the view port
![mitmweb_0px_height](https://cloud.githubusercontent.com/assets/83862/8026526/9db42bb8-0d71-11e5-8800-d190957748bf.png)