### PR TITLE
Remove Certforward Feature

### DIFF
--- a/libmproxy/proxy/config.py
+++ b/libmproxy/proxy/config.py
@@ -48,7 +48,6 @@ class ProxyConfig:
             ciphers_client=None,
             ciphers_server=None,
             certs=[],
-            certforward=False,
             ssl_version_client=tcp.SSL_DEFAULT_METHOD,
             ssl_version_server=tcp.SSL_DEFAULT_METHOD,
             ssl_ports=TRANSPARENT_SSL_PORTS,
@@ -91,7 +90,6 @@ class ProxyConfig:
             CONF_BASENAME)
         for spec, cert in certs:
             self.certstore.add_cert_file(spec, cert)
-        self.certforward = certforward
         self.ssl_ports = ssl_ports
 
         if isinstance(ssl_version_client, int):
@@ -202,7 +200,6 @@ def process_proxy_options(parser, options):
         ciphers_client=options.ciphers_client,
         ciphers_server=options.ciphers_server,
         certs=certs,
-        certforward=options.certforward,
         ssl_version_client=options.ssl_version_client,
         ssl_version_server=options.ssl_version_server,
         ssl_ports=ssl_ports,
@@ -225,11 +222,6 @@ def ssl_option_group(parser):
         'it is used, else the default key in the conf dir is used. '
         'The PEM file should contain the full certificate chain, with the leaf certificate as the first entry. '
         'Can be passed multiple times.')
-    group.add_argument(
-        "--cert-forward", action="store_true",
-        dest="certforward", default=False,
-        help="Simply forward SSL certificates from upstream."
-    )
     group.add_argument(
         "--ciphers-client", action="store",
         type=str, dest="ciphers_client", default=None,

--- a/test/test_server.py
+++ b/test/test_server.py
@@ -757,14 +757,6 @@ class TestIncompleteResponse(tservers.HTTPProxTest):
         assert self.pathod("200").status_code == 502
 
 
-class TestCertForward(tservers.HTTPProxTest):
-    certforward = True
-    ssl = True
-
-    def test_app_err(self):
-        tutils.raises("handshake error", self.pathod, "200:b@100")
-
-
 class TestUpstreamProxy(tservers.HTTPUpstreamProxTest, CommonMixin, AppMixin):
     ssl = False
 

--- a/test/tservers.py
+++ b/test/tservers.py
@@ -89,7 +89,6 @@ class ProxTestBase(object):
     no_upstream_cert = False
     authenticator = None
     masterclass = TestMaster
-    certforward = False
 
     @classmethod
     def setupAll(cls):
@@ -131,7 +130,6 @@ class ProxTestBase(object):
             no_upstream_cert = cls.no_upstream_cert,
             cadir = cls.cadir,
             authenticator = cls.authenticator,
-            certforward = cls.certforward,
             ssl_ports=([cls.server.port, cls.server2.port] if cls.ssl else []),
             clientcerts = tutils.test_data.path("data/clientcert") if cls.clientcerts else None
         )


### PR DESCRIPTION
The certforward feature was implemented to support #gotofail, which only works on unpatched iOS devices. Given that many apps don't support iOS 7 anymore, jailbreak+ssl killswitch is usually the better option. By removing certforward, we can make netlib a pure python module again, which significantly simplifies distribution.

depends on https://github.com/mitmproxy/netlib/pull/79

closes #360 
closes #471
closes #629
closes https://github.com/mitmproxy/netlib/issues/33
closes https://github.com/mitmproxy/netlib/issues/63
closes https://github.com/mitmproxy/netlib/issues/68