### PR TITLE
HTTP protocol refactoring

### DIFF
--- a/libmproxy/console/grideditor.py
+++ b/libmproxy/console/grideditor.py
@@ -5,9 +5,11 @@ import re
 import os
 import urwid
 
+from netlib import odict
+from netlib.http import user_agents
+
 from . import common, signals
 from .. import utils, filt, script
-from netlib import http_uastrings, http_cookies, odict
 
 
 FOOTER = [
@@ -516,7 +518,7 @@ class HeaderEditor(GridEditor):
         return text
 
     def set_user_agent(self, k):
-        ua = http_uastrings.get_by_shortcut(k)
+        ua = user_agents.get_by_shortcut(k)
         if ua:
             self.walker.add_value(
                 [
@@ -529,7 +531,7 @@ class HeaderEditor(GridEditor):
         if key == "U":
             signals.status_prompt_onekey.send(
                 prompt = "Add User-Agent header:",
-                keys = [(i[0], i[1]) for i in http_uastrings.UASTRINGS],
+                keys = [(i[0], i[1]) for i in user_agents.UASTRINGS],
                 callback = self.set_user_agent,
             )
             return True
@@ -592,7 +594,7 @@ class SetHeadersEditor(GridEditor):
         return text
 
     def set_user_agent(self, k):
-        ua = http_uastrings.get_by_shortcut(k)
+        ua = user_agents.get_by_shortcut(k)
         if ua:
             self.walker.add_value(
                 [
@@ -606,7 +608,7 @@ class SetHeadersEditor(GridEditor):
         if key == "U":
             signals.status_prompt_onekey.send(
                 prompt = "Add User-Agent header:",
-                keys = [(i[0], i[1]) for i in http_uastrings.UASTRINGS],
+                keys = [(i[0], i[1]) for i in user_agents.UASTRINGS],
                 callback = self.set_user_agent,
             )
             return True

--- a/libmproxy/flow.py
+++ b/libmproxy/flow.py
@@ -158,7 +158,7 @@ class StreamLargeBodies(object):
     def run(self, flow, is_request):
         r = flow.request if is_request else flow.response
         code = flow.response.code if flow.response else None
-        expected_size = netlib.http.expected_http_body_size(
+        expected_size = netlib.http.http1.expected_http_body_size(
             r.headers, is_request, flow.request.method, code
         )
         if not (0 <= expected_size <= self.max_size):

--- a/libmproxy/flow.py
+++ b/libmproxy/flow.py
@@ -158,7 +158,7 @@ class StreamLargeBodies(object):
     def run(self, flow, is_request):
         r = flow.request if is_request else flow.response
         code = flow.response.code if flow.response else None
-        expected_size = netlib.http.http1.expected_http_body_size(
+        expected_size = netlib.http.http1.HTTP1Protocol.expected_http_body_size(
             r.headers, is_request, flow.request.method, code
         )
         if not (0 <= expected_size <= self.max_size):

--- a/libmproxy/protocol/http.py
+++ b/libmproxy/protocol/http.py
@@ -1,14 +1,16 @@
 from __future__ import absolute_import
 import Cookie
+import copy
+import threading
+import time
 import urllib
 import urlparse
-import time
-import copy
 from email.utils import parsedate_tz, formatdate, mktime_tz
-import threading
-from netlib import http, tcp, http_status, http_cookies
-import netlib.utils
-from netlib import odict
+
+import netlib
+from netlib import http, tcp, odict, utils
+from netlib.http import cookies
+
 from .tcp import TCPHandler
 from .primitives import KILL, ProtocolHandler, Flow, Error
 from ..proxy.connection import ServerConnection
@@ -354,7 +356,7 @@ class HTTPRequest(HTTPMessage):
         if hasattr(rfile, "reset_timestamps"):
             rfile.reset_timestamps()
 
-        req = http.read_request(
+        req = http.http1.read_request(
             rfile,
             include_body = include_body,
             body_size_limit = body_size_limit,
@@ -642,7 +644,7 @@ class HTTPRequest(HTTPMessage):
         """
         ret = odict.ODict()
         for i in self.headers["cookie"]:
-            ret.extend(http_cookies.parse_cookie_header(i))
+            ret.extend(cookies.parse_cookie_header(i))
         return ret
 
     def set_cookies(self, odict):
@@ -650,7 +652,7 @@ class HTTPRequest(HTTPMessage):
             Takes an netlib.odict.ODict object. Over-writes any existing Cookie
             headers.
         """
-        v = http_cookies.format_cookie_header(odict)
+        v = cookies.format_cookie_header(odict)
         self.headers["Cookie"] = [v]
 
     def replace(self, pattern, repl, *args, **kwargs):
@@ -760,7 +762,7 @@ class HTTPResponse(HTTPMessage):
         if hasattr(rfile, "reset_timestamps"):
             rfile.reset_timestamps()
 
-        resp = http.read_response(
+        resp = http.http1.read_response(
             rfile,
             request_method,
             body_size_limit,
@@ -894,7 +896,7 @@ class HTTPResponse(HTTPMessage):
         """
         ret = []
         for header in self.headers["set-cookie"]:
-            v = http_cookies.parse_set_cookie_header(header)
+            v = http.cookies.parse_set_cookie_header(header)
             if v:
                 name, value, attrs = v
                 ret.append([name, [value, attrs]])
@@ -910,7 +912,7 @@ class HTTPResponse(HTTPMessage):
         values = []
         for i in odict.lst:
             values.append(
-                http_cookies.format_set_cookie_header(
+                http.cookies.format_set_cookie_header(
                     i[0],
                     i[1][0],
                     i[1][1]
@@ -1081,7 +1083,7 @@ class HTTPHandler(ProtocolHandler):
             if flow.response.stream:
                 flow.response.content = CONTENT_MISSING
             else:
-                flow.response.content = http.read_http_body(
+                flow.response.content = http.http1.read_http_body(
                     self.c.server_conn.rfile, flow.response.headers,
                     self.c.config.body_size_limit,
                     flow.request.method, flow.response.code, False
@@ -1231,7 +1233,7 @@ class HTTPHandler(ProtocolHandler):
             pass
 
     def send_error(self, code, message, headers):
-        response = http_status.RESPONSES.get(code, "Unknown")
+        response = http.status_codes.RESPONSES.get(code, "Unknown")
         html_content = """
             <html>
                 <head>
@@ -1364,7 +1366,7 @@ class HTTPHandler(ProtocolHandler):
         # We provide a mostly unified API to the user, which needs to be
         # unfiddled here
         # ( See also: https://github.com/mitmproxy/mitmproxy/issues/337 )
-        address = netlib.tcp.Address((flow.request.host, flow.request.port))
+        address = tcp.Address((flow.request.host, flow.request.port))
 
         ssl = (flow.request.scheme == "https")
 
@@ -1418,7 +1420,7 @@ class HTTPHandler(ProtocolHandler):
             h = flow.response._assemble_head(preserve_transfer_encoding=True)
             self.c.client_conn.send(h)
 
-            chunks = http.read_http_body_chunked(
+            chunks = http.http1.read_http_body_chunked(
                 self.c.server_conn.rfile,
                 flow.response.headers,
                 self.c.config.body_size_limit,
@@ -1441,11 +1443,11 @@ class HTTPHandler(ProtocolHandler):
             semantics. Returns True, if so.
         """
         close_connection = (
-            http.connection_close(
+            http.http1.connection_close(
                 flow.request.httpversion,
-                flow.request.headers) or http.connection_close(
+                flow.request.headers) or http.http1.connection_close(
                 flow.response.httpversion,
-                flow.response.headers) or http.expected_http_body_size(
+                flow.response.headers) or http.http1.expected_http_body_size(
                 flow.response.headers,
                 False,
                 flow.request.method,

--- a/libmproxy/protocol/http.py
+++ b/libmproxy/protocol/http.py
@@ -760,7 +760,7 @@ class HTTPResponse(HTTPMessage):
         if hasattr(rfile, "reset_timestamps"):
             rfile.reset_timestamps()
 
-        httpversion, code, msg, headers, content = http.read_response(
+        resp = http.read_response(
             rfile,
             request_method,
             body_size_limit,
@@ -776,11 +776,11 @@ class HTTPResponse(HTTPMessage):
             timestamp_end = None
 
         return HTTPResponse(
-            httpversion,
-            code,
-            msg,
-            headers,
-            content,
+            resp.httpversion,
+            resp.status_code,
+            resp.msg,
+            resp.headers,
+            resp.content,
             timestamp_start,
             timestamp_end
         )

--- a/libmproxy/proxy/config.py
+++ b/libmproxy/proxy/config.py
@@ -2,7 +2,11 @@ from __future__ import absolute_import
 import os
 import re
 from OpenSSL import SSL
-from netlib import http_auth, certutils, tcp
+
+import netlib
+from netlib import http, certutils, tcp
+from netlib.http import authentication
+
 from .. import utils, platform, version
 from .primitives import RegularProxyMode, SpoofMode, SSLSpoofMode, TransparentProxyMode, UpstreamProxyMode, ReverseProxyMode, Socks5ProxyMode
 
@@ -103,7 +107,7 @@ class ProxyConfig:
             self.openssl_method_server = ssl_version_server
         else:
             self.openssl_method_server = tcp.SSL_VERSIONS[ssl_version_server]
-        
+
         if ssl_verify_upstream_cert:
             self.openssl_verification_mode_server = SSL.VERIFY_PEER
         else:
@@ -164,18 +168,18 @@ def process_proxy_options(parser, options):
                 return parser.error(
                     "Invalid single-user specification. Please use the format username:password")
             username, password = options.auth_singleuser.split(':')
-            password_manager = http_auth.PassManSingleUser(username, password)
+            password_manager = authentication.PassManSingleUser(username, password)
         elif options.auth_nonanonymous:
-            password_manager = http_auth.PassManNonAnon()
+            password_manager = authentication.PassManNonAnon()
         elif options.auth_htpasswd:
             try:
-                password_manager = http_auth.PassManHtpasswd(
+                password_manager = authentication.PassManHtpasswd(
                     options.auth_htpasswd)
             except ValueError as v:
                 return parser.error(v.message)
-        authenticator = http_auth.BasicProxyAuth(password_manager, "mitmproxy")
+        authenticator = authentication.BasicProxyAuth(password_manager, "mitmproxy")
     else:
-        authenticator = http_auth.NullProxyAuth(None)
+        authenticator = authentication.NullProxyAuth(None)
 
     certs = []
     for i in options.certs:

--- a/test/test_protocol_http.py
+++ b/test/test_protocol_http.py
@@ -327,11 +327,11 @@ class TestInvalidRequests(tservers.HTTPProxTest):
         p = self.pathoc()
         r = p.request("connect:'%s:%s'" % ("127.0.0.1", self.server2.port))
         assert r.status_code == 400
-        assert "Must not CONNECT on already encrypted connection" in r.content
+        assert "Must not CONNECT on already encrypted connection" in r.body
 
     def test_relative_request(self):
         p = self.pathoc_raw()
         p.connect()
         r = p.request("get:/p/200")
         assert r.status_code == 400
-        assert "Invalid HTTP request form" in r.content
+        assert "Invalid HTTP request form" in r.body

--- a/test/test_proxy.py
+++ b/test/test_proxy.py
@@ -31,7 +31,9 @@ class TestServerConnection:
         f.server_conn = sc
         f.request.path = "/p/200:da"
         sc.send(f.request.assemble())
-        assert http.http1.read_response(sc.rfile, f.request.method, 1000)
+
+        protocol = http.http1.HTTP1Protocol(rfile=sc.rfile)
+        assert protocol.read_response(f.request.method, 1000)
         assert self.d.last_log()
 
         sc.finish()

--- a/test/test_proxy.py
+++ b/test/test_proxy.py
@@ -31,7 +31,7 @@ class TestServerConnection:
         f.server_conn = sc
         f.request.path = "/p/200:da"
         sc.send(f.request.assemble())
-        assert http.read_response(sc.rfile, f.request.method, 1000)
+        assert http.http1.read_response(sc.rfile, f.request.method, 1000)
         assert self.d.last_log()
 
         sc.finish()

--- a/test/test_server.py
+++ b/test/test_server.py
@@ -765,22 +765,16 @@ class TestStreamRequest(tservers.HTTPProxTest):
             (self.server.urlbase, spec))
         connection.send("\r\n")
 
-        httpversion, code, msg, headers, content = http.read_response(
-            fconn, "GET", None, include_body=False)
+        resp = http.read_response(fconn, "GET", None, include_body=False)
 
-        assert headers["Transfer-Encoding"][0] == 'chunked'
-        assert code == 200
+        assert resp.headers["Transfer-Encoding"][0] == 'chunked'
+        assert resp.status_code == 200
 
         chunks = list(
             content for _,
                         content,
                         _ in http.read_http_body_chunked(
-                fconn,
-                headers,
-                None,
-                "GET",
-                200,
-                False))
+                fconn, resp.headers, None, "GET", 200, False))
         assert chunks == ["this", "isatest", ""]
 
         connection.close()


### PR DESCRIPTION
This PR starts of a larger refactoring process to unify everything related to HTTP semantics and split the actual "on-the-wire" protocol from the overall flow behind it.

Mostly moving code around between projects, modules, and classes.

This PR requires mitmproxy/netlib#81 to work properly.
This PR requires mitmproxy/pathod#31 to work properly.