### PR TITLE
Use `ensure_ascii` in wep.app#broadcast

### DIFF
--- a/libmproxy/web/app.py
+++ b/libmproxy/web/app.py
@@ -81,7 +81,8 @@ class WebSocketEventBroadcaster(tornado.websocket.WebSocketHandler):
 
     @classmethod
     def broadcast(cls, **kwargs):
-        message = json.dumps(kwargs)
+        message = json.dumps(kwargs, ensure_ascii=False)
+
         for conn in cls.connections:
             try:
                 conn.write_message(message)


### PR DESCRIPTION
Otherwise, a non-unicode character in a flow cause mitmweb to crash.

```
Traceback (most recent call last):
  File "./mitmweb", line 4, in <module>
    mitmweb()
  File "/home/isra17/devel/mitmproxy/mitmproxy/libmproxy/main.py", line 120, in mitmweb
    m = web.WebMaster(server, web_options)
  File "/home/isra17/devel/mitmproxy/mitmproxy/libmproxy/web/__init__.py", line 131, in __init__
    self.load_flows_file(options.rfile)
  File "/home/isra17/devel/mitmproxy/mitmproxy/libmproxy/flow.py", line 884, in load_flows_file
    return self.load_flows(freader)
  File "/home/isra17/devel/mitmproxy/mitmproxy/libmproxy/flow.py", line 874, in load_flows
    self.load_flow(i)
  File "/home/isra17/devel/mitmproxy/mitmproxy/libmproxy/flow.py", line 859, in load_flow
    self.handle_request(f)
  File "/home/isra17/devel/mitmproxy/mitmproxy/libmproxy/web/__init__.py", line 167, in handle_request
    super(WebMaster, self).handle_request(f)
  File "/home/isra17/devel/mitmproxy/mitmproxy/libmproxy/flow.py", line 976, in handle_request
    self.state.add_flow(f)
  File "/home/isra17/devel/mitmproxy/mitmproxy/libmproxy/flow.py", line 556, in add_flow
    self.flows._add(f)
  File "/home/isra17/devel/mitmproxy/mitmproxy/libmproxy/flow.py", line 464, in _add
    view._add(f)
  File "/home/isra17/devel/mitmproxy/mitmproxy/libmproxy/web/__init__.py", line 23, in _add
    data=f.get_state(short=True)
  File "/home/isra17/devel/mitmproxy/mitmproxy/libmproxy/web/app.py", line 84, in broadcast
    message = json.dumps(kwargs)
  File "/usr/lib/python2.7/json/__init__.py", line 243, in dumps
    return _default_encoder.encode(obj)
  File "/usr/lib/python2.7/json/encoder.py", line 207, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/usr/lib/python2.7/json/encoder.py", line 270, in iterencode
    return _iterencode(o, 0)
UnicodeDecodeError: 'utf8' codec can't decode byte 0xe9 in position 26: invalid c
```