### PR TITLE
console: add command line flag to disable mouse interaction

### DIFF
--- a/libmproxy/cmdline.py
+++ b/libmproxy/cmdline.py
@@ -608,6 +608,11 @@ def mitmproxy():
         action="store_true", dest="eventlog",
         help="Show event log."
     )
+    parser.add_argument(
+        "--no-mouse",
+        action="store_true", dest="no_mouse",
+        help="Disable mouse interaction."
+    )
     group = parser.add_argument_group(
         "Filters",
         "See help in mitmproxy for filter expression syntax."

--- a/libmproxy/console/__init__.py
+++ b/libmproxy/console/__init__.py
@@ -154,7 +154,8 @@ class Options(object):
         "wfile",
         "nopop",
         "palette",
-        "palette_transparent"
+        "palette_transparent",
+        "no_mouse"
     ]
 
     def __init__(self, **kwargs):
@@ -455,12 +456,12 @@ class ConsoleMaster(flow.FlowMaster):
 
     def run(self):
         self.ui = urwid.raw_display.Screen()
-        self.ui.set_mouse_tracking()
         self.ui.set_terminal_properties(256)
         self.set_palette(self.palette)
         self.loop = urwid.MainLoop(
             urwid.SolidFill("x"),
             screen = self.ui,
+            handle_mouse = not self.options.no_mouse,
         )
 
         self.server.start_slave(

--- a/libmproxy/main.py
+++ b/libmproxy/main.py
@@ -55,6 +55,7 @@ def mitmproxy(args=None):  # pragma: nocover
     console_options.eventlog = options.eventlog
     console_options.intercept = options.intercept
     console_options.limit = options.limit
+    console_options.no_mouse = options.no_mouse
 
     server = get_server(console_options.no_server, proxy_config)
 


### PR DESCRIPTION
Adds the --no-mouse command line option to disable the mouse.

Fixes #685