### PR TITLE
Allow reading scripts from an anonymous pipe

### DIFF
--- a/libmproxy/script.py
+++ b/libmproxy/script.py
@@ -83,7 +83,7 @@ class Script:
                  "If your script path contains spaces, "
                  "make sure to wrap it in additional quotes, e.g. -s \"'./foo bar/baz.py' --args\".") %
                 args[0])
-        elif not os.path.isfile(args[0]):
+        elif os.path.isdir(args[0]):
             raise ScriptError("Not a file: %s" % args[0])
         return args
 


### PR DESCRIPTION
Bash (and many other shells) provide a nifty feature in "anonymous pipe" or "anonymous fifo" whereby the output of a subshell may be treated as a simple file by the parent shell: http://unix.stackexchange.com/a/156088

Unfortunately, libmproxy complains because that "file" is not a regular file, as os.path.isfile checks, e.g. giving the error "Not a file: /dev/fd/11". This patch is intended to provide for the following use-case:

```
mitmdump -s <(echo "def response(context, flow):\n  flow.response.headers['newheader'] = [`hostname`]")
```

where `hostname` may be replaced with a more complicated lookup.