### PR TITLE
Prevent flowview from creating duplicated windows

### DIFF
--- a/libmproxy/console/flowview.py
+++ b/libmproxy/console/flowview.py
@@ -519,12 +519,10 @@ class FlowView(tabs.Tabs):
             self._w.keypress(size, key)
         elif key == "a":
             self.flow.accept_intercept(self.master)
-            signals.pop_view_state.send(self)
-            self.master.view_flow(self.flow)
+            signals.flow_change.send(self, flow = self.flow)
         elif key == "A":
             self.master.accept_all()
-            signals.pop_view_state.send(self)
-            self.master.view_flow(self.flow)
+            signals.flow_change.send(self, flow = self.flow)
         elif key == "d":
             if self.state.flow_count() == 1:
                 self.master.view_flowlist()

--- a/libmproxy/console/flowview.py
+++ b/libmproxy/console/flowview.py
@@ -519,9 +519,11 @@ class FlowView(tabs.Tabs):
             self._w.keypress(size, key)
         elif key == "a":
             self.flow.accept_intercept(self.master)
+            signals.pop_view_state.send(self)
             self.master.view_flow(self.flow)
         elif key == "A":
             self.master.accept_all()
+            signals.pop_view_state.send(self)
             self.master.view_flow(self.flow)
         elif key == "d":
             if self.state.flow_count() == 1:


### PR DESCRIPTION
When accepting intercepted flows with 'a' or 'A' command in flowview, mitmproxy makes new window every time. So, I need to press 'q' button several times to return the flow list.