### PR TITLE
Check if server connection hasn't yet been initiated

### DIFF
--- a/libmproxy/models/connections.py
+++ b/libmproxy/models/connections.py
@@ -135,8 +135,8 @@ class ServerConnection(tcp.TCPClient, stateobject.StateObject):
     def get_state(self, short=False):
         d = super(ServerConnection, self).get_state(short)
         d.update(
-            address={"address": self.address(),
-                     "use_ipv6": self.address.use_ipv6},
+            address=({"address": self.address(),
+                     "use_ipv6": self.address.use_ipv6} if self.address else None), 
             source_address=({"address": self.source_address(),
                              "use_ipv6": self.source_address.use_ipv6} if self.source_address else None),
             cert=self.cert.to_pem() if self.cert else None


### PR DESCRIPTION
This fixes #761 when NoneType error is thrown when non-TLS requests initiate a client request but the server connection hasn't yet been initiated.