### PR TITLE
Use ctrl+f and ctrl+b to scroll a page

### DIFF
--- a/libmproxy/console/common.py
+++ b/libmproxy/console/common.py
@@ -96,6 +96,10 @@ def format_keyvals(lst, key="key", val="text", indent=0):
 def shortcuts(k):
     if k == " ":
         k = "page down"
+    elif k == "ctrl f":
+        k = "page down"
+    elif k == "ctrl b":
+        k = "page up"
     elif k == "j":
         k = "down"
     elif k == "k":

--- a/libmproxy/console/help.py
+++ b/libmproxy/console/help.py
@@ -31,6 +31,7 @@ class HelpView(urwid.ListBox):
             ("g, G", "go to beginning, end"),
             ("space", "page down"),
             ("pg up/down", "page up/down"),
+            ("ctrl+b/ctrl+f", "page up/down"),
             ("arrows", "up, down, left, right"),
         ]
         text.extend(


### PR DESCRIPTION
I want to use ctrl+f/b to scroll down/up one page, just like `less` and `vi(m)`.

Since b (save request/response body) and f (load full body data) are used as other commands, I only implemented ctrl+f/b, unlike `less`.