### PR TITLE
Fix failing protobuf contentview test

### DIFF
--- a/test/test_contentview.py
+++ b/test/test_contentview.py
@@ -233,7 +233,7 @@ if cv.ViewProtobuf.is_available():
         p = tutils.test_data.path("data/protobuf01")
         content_type, output = v(file(p, "rb").read())
         assert content_type == "Protobuf"
-        assert output[0].text == '1: "3bbc333c-e61c-433b-819a-0b9a8cc103b8"'
+        assert output.next()[0][1] == '1: "3bbc333c-e61c-433b-819a-0b9a8cc103b8"'
 
 
 def test_get_by_shortcut():


### PR DESCRIPTION
I think the test code should *probably* use odict stuff but this fixes the failing test case

```
================================================================================================================== FAILURES ==================================================================================================================
_________________________________________________________________________________________________________ test_view_protobuf_request _________________________________________________________________________________________________________

    def test_view_protobuf_request():
        v = cv.ViewProtobuf()

        p = tutils.test_data.path("data/protobuf01")
        content_type, output = v(file(p, "rb").read())
        assert content_type == "Protobuf"
>       assert output[0].text == '1: "3bbc333c-e61c-433b-819a-0b9a8cc103b8"'
E       TypeError: 'generator' object has no attribute '__getitem__'

test/test_contentview.py:236: TypeError
```