### PR TITLE
Fix #835 , can display unicode character correctly

### DIFF
--- a/libmproxy/contentviews.py
+++ b/libmproxy/contentviews.py
@@ -228,7 +228,8 @@ class ViewHTML(View):
             s = lxml.etree.tostring(
                 d,
                 pretty_print=True,
-                doctype=docinfo.doctype
+                doctype=docinfo.doctype,
+                encoding='utf8'
             )
             return "HTML", format_text(s)
 


### PR DESCRIPTION
Fix this by myself! :smiley:  
Simply set encoding type to utf8 in ```lxml.etree.tostring``` function.