### PR TITLE
Added new proxy option: invisible. 

### DIFF
--- a/libmproxy/cmdline.py
+++ b/libmproxy/cmdline.py
@@ -362,6 +362,11 @@ def proxy_options(parser):
         action="store", type=int, dest="port", default=8080,
         help="Proxy service port."
     )
+    group.add_argument(
+        "--invisible",
+        action="store_true", dest="invisible_proxy", default=False,
+        help="Make proxy invisible for the clients."
+    )
     http2 = group.add_mutually_exclusive_group()
     http2.add_argument("--http2", action="store_true", dest="http2")
     http2.add_argument("--no-http2", action="store_false", dest="http2",

--- a/libmproxy/protocol/http.py
+++ b/libmproxy/protocol/http.py
@@ -322,7 +322,8 @@ class HttpLayer(Layer):
                 # don't throw an error for disconnects that happen before/between requests.
                 return
             except NetlibException as e:
-                self.send_error_response(400, repr(e))
+		if not self.config.invisible:
+               	    self.send_error_response(400, repr(e))
                 six.reraise(ProtocolException, ProtocolException("Error in HTTP connection: %s" % repr(e)), sys.exc_info()[2])
 
             try:
@@ -369,7 +370,8 @@ class HttpLayer(Layer):
                     return
 
             except NetlibException as e:
-                self.send_error_response(502, repr(e))
+		if not self.config.invisible:
+                    self.send_error_response(502, repr(e))
 
                 if not flow.response:
                     flow.error = Error(str(e))

--- a/libmproxy/proxy/config.py
+++ b/libmproxy/proxy/config.py
@@ -50,6 +50,7 @@ class ProxyConfig:
             no_upstream_cert=False,
             body_size_limit=None,
             mode="regular",
+	    invisible=False,
             upstream_server=None,
             authenticator=None,
             ignore_hosts=tuple(),
@@ -73,6 +74,7 @@ class ProxyConfig:
         self.no_upstream_cert = no_upstream_cert
         self.body_size_limit = body_size_limit
         self.mode = mode
+        self.invisible = invisible
         if upstream_server:
             self.upstream_server = ServerSpec(upstream_server[0], Address.wrap(upstream_server[1]))
         else:
@@ -187,6 +189,7 @@ def process_proxy_options(parser, options):
         no_upstream_cert=options.no_upstream_cert,
         body_size_limit=body_size_limit,
         mode=mode,
+	invisible=options.invisible_proxy,
         upstream_server=upstream_server,
         ignore_hosts=options.ignore_hosts,
         tcp_hosts=options.tcp_hosts,

--- a/libmproxy/proxy/server.py
+++ b/libmproxy/proxy/server.py
@@ -133,14 +133,17 @@ class ConnectionHandler(object):
                 self.log(repr(e), "error")
 
                 self.log(traceback.format_exc(), "debug")
-            # If an error propagates to the topmost level,
-            # we send an HTTP error response, which is both
-            # understandable by HTTP clients and humans.
-            try:
-                error_response = make_error_response(502, repr(e))
-                self.client_conn.send(assemble_response(error_response))
-            except TcpException:
-                pass
+
+            if not self.config.invisible:
+	        # If an error propagates to the topmost level,
+                # we send an HTTP error response, which is both
+                # understandable by HTTP clients and humans.
+                try:
+		    self.log("VAR: sending error response 502", "info")
+                    error_response = make_error_response(502, repr(e))
+                    self.client_conn.send(assemble_response(error_response))
+                except TcpException:
+                    pass
         except Exception:
             self.log(traceback.format_exc(), "error")
             print(traceback.format_exc(), file=sys.stderr)


### PR DESCRIPTION
If this option is set, mitmproxy does not send any error messages to the clients, stays silent and does not reveal its existence in the network.

It is useful to monitor / reverse engineer applications which are probing for proxy (e.g., by sending malformed requests to analyze the response) and are changing their behavior depending on the results.
