### PR TITLE
TLS verification warnings write to stderr

### DIFF
--- a/libmproxy/dump.py
+++ b/libmproxy/dump.py
@@ -150,7 +150,8 @@ class DumpMaster(flow.FlowMaster):
             self.echo(
                 e,
                 fg="red" if level == "error" else None,
-                dim=(level == "debug")
+                dim=(level == "debug"),
+                err=(level == "error")
             )
 
     @staticmethod


### PR DESCRIPTION
I tested this and warnings no longer corrupt the file when I run

`mitmdump -q -w /dev/stdout > out` then `mitmdump -n -r out`

cc @mhils 