### PR TITLE
Add "tcp_message" Inline Script Hook

### DIFF
--- a/docs/scripting/inlinescripts.rst
+++ b/docs/scripting/inlinescripts.rst
@@ -36,14 +36,13 @@ We encourage you to either browse them locally or on `GitHub`_.
 Events
 ------
 
-.. TODO: Split this into Connection, HTTP and TCP events once we have TCP events.
-
 The ``context`` argument passed to each event method is always a
 :py:class:`~libmproxy.script.ScriptContext` instance. It is guaranteed to be the same object
 for the scripts lifetime and is not shared between multiple inline scripts. You can safely use it
 to store any form of state you require.
 
-Events are listed in the order they usually occur.
+Script Lifecycle Events
+^^^^^^^^^^^^^^^^^^^^^^^
 
 .. py:function:: start(context, argv)
 
@@ -51,6 +50,13 @@ Events are listed in the order they usually occur.
 
     :param List[str] argv: The inline scripts' arguments.
         For example, ``mitmproxy -s 'example.py --foo 42'`` sets argv to ``["--foo", "42"]``.
+
+.. py:function:: done(context)
+
+    Called once on script shutdown, after any other events.
+
+Connection Events
+^^^^^^^^^^^^^^^^^
 
 .. py:function:: clientconnect(context, root_layer)
 
@@ -64,14 +70,13 @@ Events are listed in the order they usually occur.
         :py:class:`~libmproxy.proxy.RootContext`. For example, ``root_layer.client_conn.address``
         gives the remote address of the connecting client.
 
+.. py:function:: clientdisconnect(context, root_layer)
 
-.. py:function:: request(context, flow)
+    Called when a client disconnects from the proxy.
 
-    Called when a client request has been received. The ``flow`` object is
-    guaranteed to have a non-None ``request`` attribute.
+    .. versionchanged:: 0.14
 
-    :param HTTPFlow flow: The flow containing the request which has been received.
-        The object is guaranteed to have a non-None ``request`` attribute.
+    :param Layer root_layer: see :py:func:`clientconnect`
 
 .. py:function:: serverconnect(context, server_conn)
 
@@ -80,6 +85,25 @@ Events are listed in the order they usually occur.
 
     :param ServerConnection server_conn: The server connection object. It is guaranteed to have a
         non-None ``address`` attribute.
+
+.. py:function:: serverdisconnect(context, server_conn)
+
+    Called when the proxy has closed the server connection.
+
+    .. versionadded:: 0.14
+
+    :param ServerConnection server_conn: see :py:func:`serverconnect`
+
+HTTP Events
+^^^^^^^^^^^
+
+.. py:function:: request(context, flow)
+
+    Called when a client request has been received. The ``flow`` object is
+    guaranteed to have a non-None ``request`` attribute.
+
+    :param HTTPFlow flow: The flow containing the request which has been received.
+        The object is guaranteed to have a non-None ``request`` attribute.
 
 .. py:function:: responseheaders(context, flow)
 
@@ -109,26 +133,19 @@ Events are listed in the order they usually occur.
     :param HTTPFlow flow: The flow containing the error.
         It is guaranteed to have non-None ``error`` attribute.
 
-.. py:function:: serverdisconnect(context, server_conn)
+TCP Events
+^^^^^^^^^^
 
-    Called when the proxy has closed the server connection.
+.. py:function:: tcp_message(context, tcp_msg)
 
-    .. versionadded:: 0.14
+    .. warning::  API is subject to change
 
-    :param ServerConnection server_conn: see :py:func:`serverconnect`
+    If the proxy is in :ref:`TCP mode <tcpproxy>`, this event is called when it
+    receives a TCP payload from the client or server.
 
-.. py:function:: clientdisconnect(context, root_layer)
+    The sender and receiver are identifiable. The message is user-modifiable.
 
-    Called when a client disconnects from the proxy.
-
-    .. versionchanged:: 0.14
-
-    :param Layer root_layer: see :py:func:`clientconnect`
-
-.. py:function:: done(context)
-
-    Called once on script shutdown, after any other events.
-
+    :param TcpMessage tcp_msg: see *examples/tcp_message.py*
 
 API
 ---

--- a/examples/tcp_message.py
+++ b/examples/tcp_message.py
@@ -1,0 +1,24 @@
+'''
+tcp_message Inline Script Hook API Demonstration
+------------------------------------------------
+
+* modifies packets containing "foo" to "bar"
+* prints various details for each packet.
+
+example cmdline invocation:
+mitmdump -T --host --tcp ".*" -q -s examples/tcp_message.py
+'''
+from netlib.utils import clean_bin
+
+def tcp_message(ctx, tcp_msg):
+    modified_msg = tcp_msg.message.replace("foo", "bar")
+
+    is_modified = False if modified_msg == tcp_msg.message else True
+    tcp_msg.message = modified_msg
+
+    print("[tcp_message{}] from {} {} to {} {}:\r\n{}".format(
+        " (modified)" if is_modified else "",
+        "client" if tcp_msg.sender == tcp_msg.client_conn else "server",
+        tcp_msg.sender.address,
+        "server" if tcp_msg.receiver == tcp_msg.server_conn else "client",
+        tcp_msg.receiver.address, clean_bin(tcp_msg.message)))

--- a/libmproxy/flow.py
+++ b/libmproxy/flow.py
@@ -1050,6 +1050,10 @@ class FlowMaster(controller.Master):
             self.add_event('"{}" reloaded.'.format(s.filename))
         return ok
 
+    def handle_tcp_message(self, m):
+        self.run_script_hook("tcp_message", m)
+        m.reply()
+
     def shutdown(self):
         self.unload_scripts()
         controller.Master.shutdown(self)

--- a/test/scripts/tcp_stream_modify.py
+++ b/test/scripts/tcp_stream_modify.py
@@ -1,0 +1,3 @@
+def tcp_message(ctx,tm):
+    if tm.sender == tm.server_conn:
+        tm.message = tm.message.replace("foo", "bar")

--- a/test/test_server.py
+++ b/test/test_server.py
@@ -502,6 +502,18 @@ class TestHttps2Http(tservers.ReverseProxTest):
 class TestTransparent(tservers.TransparentProxTest, CommonMixin, TcpMixin):
     ssl = False
 
+    def test_tcp_stream_modify(self):
+        self.master.load_script(
+            tutils.test_data.path("scripts/tcp_stream_modify.py"))
+
+        self._tcpproxy_on()
+        d = self.pathod('200:b"foo"')
+        self._tcpproxy_off()
+
+        assert d.content == "bar"
+
+        self.master.unload_scripts()
+
 
 class TestTransparentSSL(tservers.TransparentProxTest, CommonMixin, TcpMixin):
     ssl = True


### PR DESCRIPTION
:dancer:  This early PR is the beginning of advancement on #747

@mhils Specifically, regarding the removal of the `layer` attribute from TcpMessage, I took out the `layer` from class `TcpMessage` and now send the `client_conn` and `server_conn` explicitly to the initializer... Let me know if you had something else in mind, as far as getting the `client_conn` and `server_conn` into the TcpMessage. 

### Inline Script Example
This is not yet included, but I am working on an inline script using the new feature that might be able to serve as an example script. More details to come on this later.

### Questions
Do new inline script hooks need unit tests??

Do any docs need updating?

### Documentation

The following is a key point of `TcpMessage`:

`sender` and `receiver` are mirrors to `client_conn` or `server_conn`. Together, the four are used to identify the origin of the message. For example,

```
if sender == client_conn:
    # we now know the client sent this message
```

I didn't put this information in the code, but I feel that maybe it belongs there :question: 
Or perhaps, only in more formal documentation, or both!

Direction and encouragement are always welcome! :sweat_smile: 