### PR TITLE
Fix #846

### DIFF
--- a/libmproxy/flow.py
+++ b/libmproxy/flow.py
@@ -666,7 +666,7 @@ class FlowMaster(controller.Master):
         script.reloader.unwatch(script_obj)
         self.scripts.remove(script_obj)
 
-    def load_script(self, command, use_reloader=False):
+    def load_script(self, command, use_reloader=True):
         """
             Loads a script. Returns an error description if something went
             wrong.
@@ -1040,14 +1040,14 @@ class FlowMaster(controller.Master):
             s.unload()
         except script.ScriptException as e:
             ok = False
-            self.add_event('Error reloading "{}": {}'.format(s.filename, str(e)))
+            self.add_event('Error reloading "{}": {}'.format(s.filename, str(e)), 'error')
         try:
             s.load()
         except script.ScriptException as e:
             ok = False
-            self.add_event('Error reloading "{}": {}'.format(s.filename, str(e)))
+            self.add_event('Error reloading "{}": {}'.format(s.filename, str(e)), 'error')
         else:
-            self.add_event('"{}" reloaded.'.format(s.filename))
+            self.add_event('"{}" reloaded.'.format(s.filename), 'info')
         return ok
 
     def shutdown(self):

--- a/libmproxy/script/reloader.py
+++ b/libmproxy/script/reloader.py
@@ -38,7 +38,6 @@ class _ScriptModificationHandler(RegexMatchingEventHandler):
             regexes=['.*'+filename]
         )
         self.callback = callback
-        self.filename = filename 
 
     def on_modified(self, event):
         self.callback()

--- a/libmproxy/script/reloader.py
+++ b/libmproxy/script/reloader.py
@@ -5,7 +5,7 @@ if sys.platform == 'darwin':
     from watchdog.observers.polling import PollingObserver as Observer
 else:
     from watchdog.observers import Observer
-# The OSX reloader is watchdog 0.8.3 breaks when unobserving paths. 
+# The OSX reloader in watchdog 0.8.3 breaks when unobserving paths. 
 # We use the PollingObserver instead.
 
 _observers = {}

--- a/libmproxy/script/reloader.py
+++ b/libmproxy/script/reloader.py
@@ -27,9 +27,7 @@ def unwatch(script):
 
 class _ScriptModificationHandler(PatternMatchingEventHandler):
     def __init__(self, callback, filename='*'):
-        # We could enumerate all relevant *.py files (as werkzeug does it),
-        # but our case looks like it isn't as simple as enumerating sys.modules.
-        # This should be good enough for now.
+
         super(_ScriptModificationHandler, self).__init__(
             ignore_directories=True,
         )
@@ -38,7 +36,7 @@ class _ScriptModificationHandler(PatternMatchingEventHandler):
 
     def on_modified(self, event):
         if event.is_directory:
-            files_in_dir = [event.src_path + "/" + \
+            files_in_dir = [event.src_path + "/" + 
                     f for f in os.listdir(event.src_path)]
             if len(files_in_dir) > 0:
                 modified_filepath = max(files_in_dir, key=os.path.getmtime)
@@ -48,6 +46,10 @@ class _ScriptModificationHandler(PatternMatchingEventHandler):
             modified_filepath = event.src_path
 
         if fnmatch.fnmatch(os.path.basename(modified_filepath), self.filename):
+            self.callback()
+
+    def on_created(self, event):
+        if fnmatch.fnmatch(os.path.basename(event.src_path), self.filename):
             self.callback()
 
 __all__ = ["watch", "unwatch"]

--- a/libmproxy/script/reloader.py
+++ b/libmproxy/script/reloader.py
@@ -1,7 +1,7 @@
 import os
 import fnmatch
 from watchdog.events import PatternMatchingEventHandler
-from watchdog.observers import Observer
+from watchdog.observers.polling import PollingObserver 
 
 _observers = {}
 
@@ -12,7 +12,7 @@ def watch(script, callback):
     script_dir = os.path.dirname(os.path.abspath(script.args[0]))
     script_name = os.path.basename(script.args[0])
     event_handler = _ScriptModificationHandler(callback, filename=script_name)
-    observer = Observer()
+    observer = PollingObserver()
     observer.schedule(event_handler, script_dir)
     observer.start()
     _observers[script] = observer
@@ -37,7 +37,6 @@ class _ScriptModificationHandler(PatternMatchingEventHandler):
         self.filename = filename 
 
     def on_modified(self, event):
-        # super(_ScriptModificationHandler, self).on_modified(event)
         if event.is_directory:
             files_in_dir = [event.src_path + "/" + \
                     f for f in os.listdir(event.src_path)]
@@ -48,7 +47,7 @@ class _ScriptModificationHandler(PatternMatchingEventHandler):
         else:
             modified_filepath = event.src_path
 
-        if fnmatch.fnmatch(os.path.basename(modifiedFilename), self.filename):
+        if fnmatch.fnmatch(os.path.basename(modified_filepath), self.filename):
             self.callback()
 
 __all__ = ["watch", "unwatch"]

--- a/libmproxy/script/reloader.py
+++ b/libmproxy/script/reloader.py
@@ -1,4 +1,5 @@
 import os
+import fnmatch
 from watchdog.events import PatternMatchingEventHandler
 from watchdog.observers import Observer
 
@@ -24,17 +25,30 @@ def unwatch(script):
 
 
 class _ScriptModificationHandler(PatternMatchingEventHandler):
-    def __init__(self, callback):
+    def __init__(self, callback, pattern='*.py'):
         # We could enumerate all relevant *.py files (as werkzeug does it),
         # but our case looks like it isn't as simple as enumerating sys.modules.
         # This should be good enough for now.
         super(_ScriptModificationHandler, self).__init__(
             ignore_directories=True,
-            patterns=["*.py"]
         )
         self.callback = callback
+        self.pattern = pattern
 
     def on_modified(self, event):
-        self.callback()
+        super(_ScriptModificationHandler, self).on_modified(event)
+        if event.is_directory:
+            files_in_dir = [event.src_path + "/" + \
+                    f for f in os.listdir(event.src_path)]
+            if len(files_in_dir) > 0:
+                modifiedFilename = max(files_in_dir, key=os.path.getmtime)
+            else:
+                return
+        else:
+            modifiedFilename = event.src_path
+
+        if fnmatch.fnmatch(os.path.basename(modifiedFilename), self.pattern):
+            self.callback()
 
 __all__ = ["watch", "unwatch"]
+


### PR DESCRIPTION
Finally the script reloader works on both Linux and OS X!:tada:
1. I found that the reloader will crash if we load two scripts in same directory. Because we simply use `PatternMatchingEventHandler` to watch the all `*.py` file, when, say, two observer were set in the same, even the modification on the second script will hit the first observer. Then, the first observer will callback to reload the first script. So I pass the `filename` to `_ScriptModificationHandler` to make sure the modification will hit the corresponding observer.
2. The `Observer()` is kind of tricky. 
+ On OS X, `event.src_path` will only prints the path to the folder containing the file, not the path to the file itself. So I added some code to find out the script's real path. See: [Watchdog library in Python on OS X — not showing full event path](http://stackoverflow.com/questions/17537291/watchdog-library-in-python-on-os-x-not-showing-full-event-path)
+ For some reasons, multiple observers seem not work on OS X, typically will throw an exception when we stop them. So it need to be changed to `watchdog.observers.polling.PollingObserver()`, which will work on any platform.
+ On Linux, however, the `PollingObserver()` behave a little bit different than `Observer()`, it recognize all `modify` events as `creat` events. Therefore a `on_created` method need to be added to the `_ScriptModificationHandler`.

Already tested this on my Ubuntu 14.04 as well as OS X 10.10.