### PR TITLE
Export/Copy flow as...

### DIFF
--- a/libmproxy/console/common.py
+++ b/libmproxy/console/common.py
@@ -276,6 +276,10 @@ def copy_flow_format_data(part, scope, flow):
                     raise ValueError("Unknown part: {}".format(part))
     return data, False
 
+def export_prompt(k, flow):
+    if k == "c":
+        copy_as_curl_command(flow)
+
 def copy_as_curl_command(flow):
 
     if flow.request.content is None or flow.request.content == CONTENT_MISSING:

--- a/libmproxy/console/common.py
+++ b/libmproxy/console/common.py
@@ -242,7 +242,7 @@ def ask_save_path(prompt, data):
     signals.status_prompt_path.send(
         prompt = prompt,
         callback = ask_save_overwrite,
-        args = (data)
+        args =  (data, ) 
     )
 
 

--- a/libmproxy/console/common.py
+++ b/libmproxy/console/common.py
@@ -242,7 +242,7 @@ def ask_save_path(prompt, data):
     signals.status_prompt_path.send(
         prompt = prompt,
         callback = ask_save_overwrite,
-        args =  (data, ) 
+        args =  (data, )
     )
 
 
@@ -282,7 +282,7 @@ def copy_as_curl_command(flow):
         return None, "Request content is missing"
 
     headerString = ""
-    for k,v in flow.request.headers:
+    for k,v in flow.request.headers.fields:
       headerString += " -H '" + k + ":" + v + "' "
 
     data = "curl"

--- a/libmproxy/console/common.py
+++ b/libmproxy/console/common.py
@@ -287,10 +287,6 @@ def export_prompt(k, flow):
 
 
 def copy_as_curl_command(flow):
-    if flow.request.content is None or flow.request.content == CONTENT_MISSING:
-        signals.status_message.send(message="Request content is missing")
-        return
-
     data = "curl "
 
     for k, v in flow.request.headers.fields:
@@ -309,10 +305,6 @@ def copy_as_curl_command(flow):
 
 
 def copy_as_python_code(flow):
-    if flow.request.content is None or flow.request.content == CONTENT_MISSING:
-        signals.status_message.send(message="Request content is missing")
-        return
-
     if flow.request.method != "GET":
         signals.status_message.send(message="Currently, only GET methods are supported")
         return
@@ -334,12 +326,7 @@ def copy_as_python_code(flow):
 
 
 def copy_as_raw_request(flow):
-    if flow.request.content is None or flow.request.content == CONTENT_MISSING:
-        signals.status_message.send(message="Request content is missing")
-        return
-
     data = netlib.http.http1.assemble_request(flow.request)
-
     copy_to_clipboard_or_prompt(data)
 
 

--- a/libmproxy/console/common.py
+++ b/libmproxy/console/common.py
@@ -283,7 +283,7 @@ def copy_as_curl_command(flow):
 
     headerString = ""
     for k,v in flow.request.headers:
-      headerString += " -H \"" + k + ":" + v + "\" "
+      headerString += " -H '" + k + ":" + v + "' "
 
     data = "curl"
 
@@ -291,7 +291,7 @@ def copy_as_curl_command(flow):
       data += " -X " + flow.request.method
 
     full_url = flow.request.scheme + "://" + flow.request.host + flow.request.path
-    data += headerString + " \"" + full_url + "\""
+    data += " " + headerString + "'" + full_url + "'"
 
     if flow.request.content != None and flow.request.content != "":
       data += " --data-binary " + "'" + flow.request.content + "'"

--- a/libmproxy/console/common.py
+++ b/libmproxy/console/common.py
@@ -207,7 +207,7 @@ def raw_format_flow(f, focus, extended, padding):
 
 
 # Save file to disk
-def save_data(path, data, master, state):
+def save_data(path, data):
     if not path:
         return
     try:
@@ -217,32 +217,32 @@ def save_data(path, data, master, state):
         signals.status_message.send(message=v.strerror)
 
 
-def ask_save_overwite(path, data, master, state):
+def ask_save_overwrite(path, data):
     if not path:
         return
     path = os.path.expanduser(path)
     if os.path.exists(path):
-        def save_overwite(k):
+        def save_overwrite(k):
             if k == "y":
-                save_data(path, data, master, state)
+                save_data(path, data)
 
         signals.status_prompt_onekey.send(
-            prompt = "'" + path + "' already exists. Overwite?",
+            prompt = "'" + path + "' already exists. Overwrite?",
             keys = (
                 ("yes", "y"),
                 ("no", "n"),
             ),
-            callback = save_overwite
+            callback = save_overwrite
         )
     else:
-        save_data(path, data, master, state)
+        save_data(path, data)
 
 
-def ask_save_path(prompt, data, master, state):
+def ask_save_path(prompt, data):
     signals.status_prompt_path.send(
         prompt = prompt,
-        callback = ask_save_overwite,
-        args = (data, master, state)
+        callback = ask_save_overwrite,
+        args = (data)
     )
 
 
@@ -313,7 +313,7 @@ def copy_to_clipboard_or_prompt(data):
     except (RuntimeError, UnicodeDecodeError, AttributeError):
         def save(k):
             if k == "y":
-                ask_save_path("Save data", data, master, state)
+                ask_save_path("Save data", data)
         signals.status_prompt_onekey.send(
             prompt = "Cannot copy data to clipboard. Save as file?",
             keys = (
@@ -392,16 +392,12 @@ def ask_save_body(part, master, state, flow):
     elif part == "q" and request_has_content:
         ask_save_path(
             "Save request content",
-            flow.request.get_decoded_content(),
-            master,
-            state
+            flow.request.get_decoded_content()
         )
     elif part == "s" and response_has_content:
         ask_save_path(
             "Save response content",
-            flow.response.get_decoded_content(),
-            master,
-            state
+            flow.response.get_decoded_content()
         )
     else:
         signals.status_message.send(message="No content to save.")

--- a/libmproxy/console/common.py
+++ b/libmproxy/console/common.py
@@ -282,6 +282,8 @@ def export_prompt(k, flow):
         copy_as_curl_command(flow)
     elif k == "p":
         copy_as_python_code(flow)
+    elif k == "r":
+        copy_as_raw_request(flow)
 
 
 def copy_as_curl_command(flow):
@@ -327,6 +329,16 @@ def copy_as_python_code(flow):
     full_url = flow.request.scheme + "://" + flow.request.host + flow.request.path
 
     data = data % (headers, full_url)
+
+    copy_to_clipboard_or_prompt(data)
+
+
+def copy_as_raw_request(flow):
+    if flow.request.content is None or flow.request.content == CONTENT_MISSING:
+        signals.status_message.send(message="Request content is missing")
+        return
+
+    data = netlib.http.http1.assemble_request(flow.request)
 
     copy_to_clipboard_or_prompt(data)
 

--- a/libmproxy/console/common.py
+++ b/libmproxy/console/common.py
@@ -282,7 +282,8 @@ def export_prompt(k, flow):
 
 def copy_as_curl_command(flow):
     if flow.request.content is None or flow.request.content == CONTENT_MISSING:
-        return None, "Request content is missing"
+        signals.status_message.send(message="Request content is missing")
+        return
 
     data = "curl "
 

--- a/libmproxy/console/common.py
+++ b/libmproxy/console/common.py
@@ -281,24 +281,22 @@ def export_prompt(k, flow):
         copy_as_curl_command(flow)
 
 def copy_as_curl_command(flow):
-
     if flow.request.content is None or flow.request.content == CONTENT_MISSING:
         return None, "Request content is missing"
 
-    headerString = ""
-    for k,v in flow.request.headers.fields:
-      headerString += " -H '" + k + ":" + v + "' "
+    data = "curl "
 
-    data = "curl"
+    for k, v in flow.request.headers.fields:
+      data += "-H '%s:%s' " % (k, v)
 
     if flow.request.method != "GET":
-      data += " -X " + flow.request.method
+      data += "-X %s " % flow.request.method
 
     full_url = flow.request.scheme + "://" + flow.request.host + flow.request.path
-    data += " " + headerString + "'" + full_url + "'"
+    data += "'%s'" % full_url
 
-    if flow.request.content != None and flow.request.content != "":
-      data += " --data-binary " + "'" + flow.request.content + "'"
+    if flow.request.content:
+      data += " --data-binary '%s'" % flow.request.content
 
     copy_to_clipboard_or_prompt(data)
 

--- a/libmproxy/console/flowlist.py
+++ b/libmproxy/console/flowlist.py
@@ -13,10 +13,10 @@ def _mkhelp():
         ("A", "accept all intercepted flows"),
         ("a", "accept this intercepted flow"),
         ("b", "save request/response body"),
-        ("Z", "copy request as curl command"),
         ("C", "clear flow list or eventlog"),
         ("d", "delete flow"),
         ("D", "duplicate flow"),
+        ("E", "export"),
         ("e", "toggle eventlog"),
         ("F", "toggle follow flow list"),
         ("l", "set limit filter pattern"),
@@ -255,8 +255,16 @@ class ConnectionItem(urwid.WidgetWrap):
             )
         elif key == "P":
             common.ask_copy_part("a", self.flow, self.master, self.state)
-        elif key == "Z":
-            common.copy_as_curl_command(self.flow)
+        elif key == "E":
+            signals.status_prompt_onekey.send(
+                self,
+                prompt = "Export",
+                keys = (
+                    ("as curl command", "c"),
+                ),
+                callback = common.export_prompt,
+                args = (self.flow,)
+            )
         elif key == "b":
             common.ask_save_body(None, self.master, self.state, self.flow)
         else:

--- a/libmproxy/console/flowlist.py
+++ b/libmproxy/console/flowlist.py
@@ -261,6 +261,7 @@ class ConnectionItem(urwid.WidgetWrap):
                 prompt = "Export",
                 keys = (
                     ("as curl command", "c"),
+                    ("as python code", "p"),
                 ),
                 callback = common.export_prompt,
                 args = (self.flow,)

--- a/libmproxy/console/flowlist.py
+++ b/libmproxy/console/flowlist.py
@@ -262,6 +262,7 @@ class ConnectionItem(urwid.WidgetWrap):
                 keys = (
                     ("as curl command", "c"),
                     ("as python code", "p"),
+                    ("as raw request", "r"),
                 ),
                 callback = common.export_prompt,
                 args = (self.flow,)

--- a/libmproxy/console/flowlist.py
+++ b/libmproxy/console/flowlist.py
@@ -13,6 +13,7 @@ def _mkhelp():
         ("A", "accept all intercepted flows"),
         ("a", "accept this intercepted flow"),
         ("b", "save request/response body"),
+        ("Z", "copy request as curl command"),
         ("C", "clear flow list or eventlog"),
         ("d", "delete flow"),
         ("D", "duplicate flow"),
@@ -254,6 +255,8 @@ class ConnectionItem(urwid.WidgetWrap):
             )
         elif key == "P":
             common.ask_copy_part("a", self.flow, self.master, self.state)
+        elif key == "Z":
+            common.copy_as_curl_command(self.flow)
         elif key == "b":
             common.ask_save_body(None, self.master, self.state, self.flow)
         else:

--- a/libmproxy/console/flowview.py
+++ b/libmproxy/console/flowview.py
@@ -27,7 +27,7 @@ def _mkhelp():
         ("b", "save request/response body"),
         ("D", "duplicate flow"),
         ("d", "delete flow"),
-        ("E", "export"),        
+        ("E", "export"),
         ("e", "edit request/response"),
         ("f", "load full body data"),
         ("m", "change body display mode for this entity"),
@@ -581,6 +581,7 @@ class FlowView(tabs.Tabs):
                 prompt = "Export",
                 keys = (
                     ("as curl command", "c"),
+                    ("as python code", "p"),
                 ),
                 callback = common.export_prompt,
                 args = (self.flow,)

--- a/libmproxy/console/flowview.py
+++ b/libmproxy/console/flowview.py
@@ -25,6 +25,7 @@ def _mkhelp():
         ("A", "accept all intercepted flows"),
         ("a", "accept this intercepted flow"),
         ("b", "save request/response body"),
+        ("Z", "copy as curl command"),
         ("d", "delete flow"),
         ("D", "duplicate flow"),
         ("e", "edit request/response"),
@@ -574,6 +575,8 @@ class FlowView(tabs.Tabs):
                 callback = self.master.save_one_flow,
                 args = (self.flow,)
             )
+        elif key == "Z":
+            common.copy_as_curl_command(self.flow)
         elif key == "|":
             signals.status_prompt_path.send(
                 prompt = "Send flow to script",

--- a/libmproxy/console/flowview.py
+++ b/libmproxy/console/flowview.py
@@ -25,9 +25,9 @@ def _mkhelp():
         ("A", "accept all intercepted flows"),
         ("a", "accept this intercepted flow"),
         ("b", "save request/response body"),
-        ("Z", "copy as curl command"),
-        ("d", "delete flow"),
         ("D", "duplicate flow"),
+        ("d", "delete flow"),
+        ("E", "export"),        
         ("e", "edit request/response"),
         ("f", "load full body data"),
         ("m", "change body display mode for this entity"),
@@ -575,8 +575,16 @@ class FlowView(tabs.Tabs):
                 callback = self.master.save_one_flow,
                 args = (self.flow,)
             )
-        elif key == "Z":
-            common.copy_as_curl_command(self.flow)
+        elif key == "E":
+            signals.status_prompt_onekey.send(
+                self,
+                prompt = "Export",
+                keys = (
+                    ("as curl command", "c"),
+                ),
+                callback = common.export_prompt,
+                args = (self.flow,)
+            )
         elif key == "|":
             signals.status_prompt_path.send(
                 prompt = "Send flow to script",

--- a/libmproxy/console/flowview.py
+++ b/libmproxy/console/flowview.py
@@ -582,6 +582,7 @@ class FlowView(tabs.Tabs):
                 keys = (
                     ("as curl command", "c"),
                     ("as python code", "p"),
+                    ("as raw request", "r"),
                 ),
                 callback = common.export_prompt,
                 args = (self.flow,)


### PR DESCRIPTION
This pull supersedes #799 & #619. I've taken the code from pull #799 by @gato, rebased it and made my own changes.

Fixes #596 (export as curl) and #808 (export as python code)

~~I will also add support for exporting as raw http request - #807.~~ I've added code for copying raw requests (but am not sure if it is the right way.)

For the python code part, I've used the [requests](https://readthedocs.org/projects/requests) module as it has become quite a standard.
Currently, only GET methods are supported, but if you feel that the general implementation is correct then I can extend it to work for other methods as well.

While testing out export as curl, I felt having an option for exporting as [httpie](https://github.com/jkbrzt/httpie) might be nice too. Thoughts?