### PR TITLE
[console] always show connection info in Details tab

### DIFF
--- a/libmproxy/console/flowdetailview.py
+++ b/libmproxy/console/flowdetailview.py
@@ -20,7 +20,7 @@ def flowdetails(state, flow):
     req = flow.request
     resp = flow.response
 
-    if sc:
+    if sc is not None:
         text.append(urwid.Text([("head", "Server Connection:")]))
         parts = [
             ["Address", "%s:%s" % sc.address()],
@@ -76,7 +76,7 @@ def flowdetails(state, flow):
                 common.format_keyvals(parts, key="key", val="text", indent=4)
             )
 
-    if cc:
+    if cc is not None:
         text.append(urwid.Text([("head", "Client Connection:")]))
 
         parts = [


### PR DESCRIPTION
Connections become false values when it's `finished`. Check if it's
`None` when trying to show address info.

Fixes #886.