### PR TITLE
remove compatible version specifiers

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -16,6 +16,9 @@ This was tested on a fully patched installation of Ubuntu 14.04.
 
 Once installation is complete you can run :ref:`mitmproxy` or :ref:`mitmdump` from a terminal.
 
+On **Ubuntu 12.04** (and other systems with an outdated version of pip),
+you may need to update pip using ``pip install -U pip`` before installing mitmproxy.
+
 Installation From Source (Ubuntu)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/setup.py
+++ b/setup.py
@@ -50,55 +50,55 @@ setup(
     # https://packaging.python.org/en/latest/requirements/#install-requires
     # It is not considered best practice to use install_requires to pin dependencies to specific versions.
     install_requires=[
-        "netlib~={}".format(version.VERSION),
-        "h2~=2.1.0",
-        "tornado~=4.3.0",
-        "configargparse~=0.10.0",
-        "pyperclip~=1.5.22",
-        "blinker~=1.4.0",
-        "pyparsing~=2.0.5",
-        "html2text~=2016.1.8",
-        "construct~=2.5.2",
-        "six~=1.10.0",
-        "Pillow~=3.0.0",
-        "watchdog~=0.8.3",
-        "click~=6.2",
-        "urwid~=1.3.1",
+        "netlib>={}, <{}".format(version.MINORVERSION, version.NEXT_MINORVERSION),
+        "h2>=2.1.0, <2.2",
+        "tornado>=4.3, <4.4",
+        "configargparse>=0.10, <0.11",
+        "pyperclip>=1.5.22, <1.6",
+        "blinker>=1.4, <1.5",
+        "pyparsing>=2.0.5, <2.1",
+        "html2text==2016.1.8",
+        "construct>=2.5.2, <2.6",
+        "six>=1.10, <1.11",
+        "Pillow>=3.1, <3.2",
+        "watchdog>=0.8.3, <0.9",
+        "click>=6.2, <7.0",
+        "urwid>=1.3.1, <1.4",
     ],
     extras_require={
         ':sys_platform == "win32"': [
-            "pydivert~=0.0.7",
+            "pydivert>=0.0.7, <0.1",
             "lxml==3.4.4",  # there are no Windows wheels for newer versions, so we pin this.
         ],
         ':sys_platform != "win32"': [
-            "lxml~=3.5.0",
+            "lxml>=3.5.0, <3.6",
         ],
         # Do not use a range operator here: https://bitbucket.org/pypa/setuptools/issues/380
         # Ubuntu Trusty and other still ship with setuptools < 17.1
         ':python_version == "2.7"': [
-            "enum34~=1.0.4",
+            "enum34>=1.0.4, <1.1",
         ],
         'dev': [
-            "mock~=1.0.1",
-            "pytest~=2.8.0",
-            "pytest-xdist~=1.13.1",
-            "pytest-cov~=2.1.0",
-            "pytest-timeout~=1.0.0",
-            "coveralls~=0.4.1",
-            "pathod~={}".format(version.VERSION),
-            "sphinx~=1.3.1",
-            "sphinx-autobuild~=0.5.2",
-            "sphinxcontrib-documentedlist~=0.2.0"
+            "mock>=1.3.0, <1.4",
+            "pytest>=2.8.7, <2.9",
+            "pytest-xdist>=1.14, <1.15",
+            "pytest-cov>=2.2.1, <2.3",
+            "pytest-timeout>=1.0.0, <1.1",
+            "coveralls>=1.1, <1.2",
+            "pathod>={}, <{}".format(version.MINORVERSION, version.NEXT_MINORVERSION),
+            "sphinx>=1.3.5, <1.4",
+            "sphinx-autobuild>=0.5.2, <0.6",
+            "sphinxcontrib-documentedlist>=0.2.0, <0.3"
         ],
         'contentviews': [
-            "pyamf~=0.7.2",
-            "protobuf~=2.6.1",
-            "cssutils~=1.0.1"
+            "pyamf>=0.7.2, <0.8",
+            "protobuf>=2.6.1, <2.7",
+            "cssutils>=1.0.1, <1.1"
         ],
         'examples': [
-            "pytz~=2015.7.0",
-            "harparser~=0.2",
-            "beautifulsoup4~=4.4.1",
+            "pytz==2015.7.0",
+            "harparser>=0.2, <0.3",
+            "beautifulsoup4>=4.4.1, <4.5",
         ]
     }
 )


### PR DESCRIPTION
This PR removes the compatible version specifiers again. This allows us to `pip install mitmproxy` on Ubuntu 14.04 out of the box. Also, I added a note for Ubuntu 12.04 that users need to update pip first.

FWIW, Ubuntu 12.04 is currently responsible for 2.5% of our PyPi installs (thx @dstufft!):
![](https://caremad.io/s/UfND1ybHoS/Screen-Shot-2016-02-05-09-51-52.png)

`null` means PyPi doesn't have that data available because of the version of the installer they used didn't include it in the information they send. 