### PR TITLE
Model Cleanup

### DIFF
--- a/libmproxy/flow_format_compat.py
+++ b/libmproxy/flow_format_compat.py
@@ -29,6 +29,7 @@ def convert_015_016(data):
             data[m]["http_version"] = data[m].pop("httpversion")
     if "msg" in data["response"]:
         data["response"]["reason"] = data["response"].pop("msg")
+    data["request"].pop("form_out", None)
     data["version"] = (0, 16)
     return data
 

--- a/libmproxy/flow_format_compat.py
+++ b/libmproxy/flow_format_compat.py
@@ -21,9 +21,22 @@ def convert_014_015(data):
     return data
 
 
+def convert_015_016(data):
+    for m in ("request", "response"):
+        if "body" in data[m]:
+            data[m]["content"] = data[m].pop("body")
+        if "httpversion" in data[m]:
+            data[m]["http_version"] = data[m].pop("httpversion")
+    if "msg" in data["response"]:
+        data["response"]["reason"] = data["response"].pop("msg")
+    data["version"] = (0, 16)
+    return data
+
+
 converters = {
     (0, 13): convert_013_014,
     (0, 14): convert_014_015,
+    (0, 15): convert_015_016,
 }
 
 

--- a/libmproxy/models/connections.py
+++ b/libmproxy/models/connections.py
@@ -48,8 +48,8 @@ class ClientConnection(tcp.BaseHandler, stateobject.StateObject):
         timestamp_ssl_setup=float
     )
 
-    def get_state(self, short=False):
-        d = super(ClientConnection, self).get_state(short)
+    def get_state(self):
+        d = super(ClientConnection, self).get_state()
         d.update(
             address=({
                 "address": self.address(),
@@ -130,10 +130,9 @@ class ServerConnection(tcp.TCPClient, stateobject.StateObject):
         ssl_established=bool,
         sni=str
     )
-    _stateobject_long_attributes = {"cert"}
 
-    def get_state(self, short=False):
-        d = super(ServerConnection, self).get_state(short)
+    def get_state(self):
+        d = super(ServerConnection, self).get_state()
         d.update(
             address=({"address": self.address(),
                       "use_ipv6": self.address.use_ipv6} if self.address else {}),

--- a/libmproxy/models/flow.py
+++ b/libmproxy/models/flow.py
@@ -86,14 +86,11 @@ class Flow(stateobject.StateObject):
         intercepted=bool
     )
 
-    def get_state(self, short=False):
-        d = super(Flow, self).get_state(short)
+    def get_state(self):
+        d = super(Flow, self).get_state()
         d.update(version=version.IVERSION)
         if self._backup and self._backup != d:
-            if short:
-                d.update(modified=True)
-            else:
-                d.update(backup=self._backup)
+            d.update(backup=self._backup)
         return d
 
     def __eq__(self, other):

--- a/libmproxy/models/flow.py
+++ b/libmproxy/models/flow.py
@@ -45,7 +45,7 @@ class Error(stateobject.StateObject):
         # the default implementation assumes an empty constructor. Override
         # accordingly.
         f = cls(None)
-        f.load_state(state)
+        f.set_state(state)
         return f
 
     def copy(self):
@@ -93,6 +93,12 @@ class Flow(stateobject.StateObject):
             d.update(backup=self._backup)
         return d
 
+    def set_state(self, state):
+        state.pop("version")
+        if "backup" in state:
+            self._backup = state.pop("backup")
+        super(Flow, self).set_state(state)
+
     def __eq__(self, other):
         return self is other
 
@@ -130,7 +136,7 @@ class Flow(stateobject.StateObject):
             Revert to the last backed up state.
         """
         if self._backup:
-            self.load_state(self._backup)
+            self.set_state(self._backup)
             self._backup = None
 
     def kill(self, master):

--- a/libmproxy/stateobject.py
+++ b/libmproxy/stateobject.py
@@ -13,24 +13,20 @@ class StateObject(object):
     # should be serialized. If the attribute is a class, it must implement the
     # StateObject protocol.
     _stateobject_attributes = None
-    # A set() of attributes that should be ignored for short state
-    _stateobject_long_attributes = frozenset([])
 
     def from_state(self, state):
         raise NotImplementedError()
 
-    def get_state(self, short=False):
+    def get_state(self):
         """
             Retrieve object state. If short is true, return an abbreviated
             format with long data elided.
         """
         state = {}
         for attr, cls in self._stateobject_attributes.iteritems():
-            if short and attr in self._stateobject_long_attributes:
-                continue
             val = getattr(self, attr)
             if hasattr(val, "get_state"):
-                state[attr] = val.get_state(short)
+                state[attr] = val.get_state()
             else:
                 state[attr] = val
         return state

--- a/libmproxy/stateobject.py
+++ b/libmproxy/stateobject.py
@@ -1,26 +1,25 @@
 from __future__ import absolute_import
+from netlib.utils import Serializable
 
 
-class StateObject(object):
-
+class StateObject(Serializable):
     """
-        An object with serializable state.
+    An object with serializable state.
 
-        State attributes can either be serializable types(str, tuple, bool, ...)
-        or StateObject instances themselves.
+    State attributes can either be serializable types(str, tuple, bool, ...)
+    or StateObject instances themselves.
     """
-    # An attribute-name -> class-or-type dict containing all attributes that
-    # should be serialized. If the attribute is a class, it must implement the
-    # StateObject protocol.
+
     _stateobject_attributes = None
-
-    def from_state(self, state):
-        raise NotImplementedError()
+    """
+    An attribute-name -> class-or-type dict containing all attributes that
+    should be serialized. If the attribute is a class, it must implement the
+    Serializable protocol.
+    """
 
     def get_state(self):
         """
-            Retrieve object state. If short is true, return an abbreviated
-            format with long data elided.
+        Retrieve object state.
         """
         state = {}
         for attr, cls in self._stateobject_attributes.iteritems():
@@ -31,18 +30,22 @@ class StateObject(object):
                 state[attr] = val
         return state
 
-    def load_state(self, state):
+    def set_state(self, state):
         """
-            Load object state from data returned by a get_state call.
+        Load object state from data returned by a get_state call.
         """
+        state = state.copy()
         for attr, cls in self._stateobject_attributes.iteritems():
-            if state.get(attr, None) is None:
-                setattr(self, attr, None)
+            if state.get(attr) is None:
+                setattr(self, attr, state.pop(attr))
             else:
                 curr = getattr(self, attr)
-                if hasattr(curr, "load_state"):
-                    curr.load_state(state[attr])
+                if hasattr(curr, "set_state"):
+                    curr.set_state(state.pop(attr))
                 elif hasattr(cls, "from_state"):
-                    setattr(self, attr, cls.from_state(state[attr]))
-                else:
-                    setattr(self, attr, cls(state[attr]))
+                    obj = cls.from_state(state.pop(attr))
+                    setattr(self, attr, obj)
+                else:  # primitive types such as int, str, ...
+                    setattr(self, attr, cls(state.pop(attr)))
+        if state:
+            raise RuntimeWarning("Unexpected State in __setstate__: {}".format(state))

--- a/libmproxy/version.py
+++ b/libmproxy/version.py
@@ -1,6 +1,6 @@
 from __future__ import (absolute_import, print_function, division)
 
-IVERSION = (0, 15)
+IVERSION = (0, 16)
 VERSION = ".".join(str(i) for i in IVERSION)
 MINORVERSION = ".".join(str(i) for i in IVERSION[:2])
 NAME = "mitmproxy"

--- a/libmproxy/web/__init__.py
+++ b/libmproxy/web/__init__.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, print_function
 import collections
 import tornado.ioloop
 import tornado.httpserver
+
 from .. import controller, flow
 from . import app
 
@@ -20,7 +21,7 @@ class WebFlowView(flow.FlowView):
         app.ClientConnection.broadcast(
             type="flows",
             cmd="add",
-            data=f.get_state(short=True)
+            data=app._strip_content(f.get_state())
         )
 
     def _update(self, f):
@@ -28,7 +29,7 @@ class WebFlowView(flow.FlowView):
         app.ClientConnection.broadcast(
             type="flows",
             cmd="update",
-            data=f.get_state(short=True)
+            data=app._strip_content(f.get_state())
         )
 
     def _remove(self, f):

--- a/libmproxy/web/app.py
+++ b/libmproxy/web/app.py
@@ -4,7 +4,36 @@ import tornado.web
 import tornado.websocket
 import logging
 import json
+
+from netlib.http import CONTENT_MISSING
 from .. import version, filt
+
+
+def _strip_content(flow_state):
+    """
+    Remove flow message content and cert to save transmission space.
+
+    Args:
+        flow_state: The original flow state. Will be left unmodified
+    """
+    for attr in ("request", "response"):
+        if attr in flow_state:
+            message = flow_state[attr]
+            if message["content"]:
+                message["contentLength"] = len(message["content"])
+            elif message["content"] == CONTENT_MISSING:
+                message["contentLength"] = None
+            else:
+                message["contentLength"] = 0
+            del message["content"]
+
+    if "backup" in flow_state:
+        del flow_state["backup"]
+        flow_state["modified"] = True
+
+    flow_state.get("server_conn", {}).pop("cert", None)
+
+    return flow_state
 
 
 class APIError(tornado.web.HTTPError):
@@ -100,7 +129,7 @@ class Flows(RequestHandler):
 
     def get(self):
         self.write(dict(
-            data=[f.get_state(short=True) for f in self.state.flows]
+            data=[_strip_content(f.get_state()) for f in self.state.flows]
         ))
 
 

--- a/libmproxy/web/app.py
+++ b/libmproxy/web/app.py
@@ -170,7 +170,7 @@ class FlowHandler(RequestHandler):
                     elif k == "port":
                         request.port = int(v)
                     elif k == "headers":
-                        request.headers.load_state(v)
+                        request.headers.set_state(v)
                     else:
                         print "Warning: Unknown update {}.{}: {}".format(a, k, v)
 
@@ -184,7 +184,7 @@ class FlowHandler(RequestHandler):
                     elif k == "http_version":
                         response.http_version = str(v)
                     elif k == "headers":
-                        response.headers.load_state(v)
+                        response.headers.set_state(v)
                     else:
                         print "Warning: Unknown update {}.{}: {}".format(a, k, v)
             else:

--- a/test/test_flow.py
+++ b/test/test_flow.py
@@ -422,7 +422,7 @@ class TestFlow(object):
         assert not f == f2
         f2.error = Error("e2")
         assert not f == f2
-        f.load_state(f2.get_state())
+        f.set_state(f2.get_state())
         assert f.get_state() == f2.get_state()
 
     def test_kill(self):
@@ -1204,7 +1204,7 @@ class TestError:
 
         e2 = Error("bar")
         assert not e == e2
-        e.load_state(e2.get_state())
+        e.set_state(e2.get_state())
         assert e.get_state() == e2.get_state()
 
         e3 = e.copy()
@@ -1224,7 +1224,7 @@ class TestClientConnection:
         assert not c == c2
 
         c2.timestamp_start = 42
-        c.load_state(c2.get_state())
+        c.set_state(c2.get_state())
         assert c.timestamp_start == 42
 
         c3 = c.copy()

--- a/test/tutils.py
+++ b/test/tutils.py
@@ -76,7 +76,11 @@ def tclient_conn():
     """
     c = ClientConnection.from_state(dict(
         address=dict(address=("address", 22), use_ipv6=True),
-        clientcert=None
+        clientcert=None,
+        ssl_established=False,
+        timestamp_start=1,
+        timestamp_ssl_setup=2,
+        timestamp_end=3,
     ))
     c.reply = controller.DummyReply()
     return c
@@ -88,9 +92,15 @@ def tserver_conn():
     """
     c = ServerConnection.from_state(dict(
         address=dict(address=("address", 22), use_ipv6=True),
-        state=[],
         source_address=dict(address=("address", 22), use_ipv6=True),
-        cert=None
+        cert=None,
+        timestamp_start=1,
+        timestamp_tcp_setup=2,
+        timestamp_ssl_setup=3,
+        timestamp_end=4,
+        ssl_established=False,
+        sni="address",
+        via=None
     ))
     c.reply = controller.DummyReply()
     return c


### PR DESCRIPTION
This PR introduces some changes to serialization within mitmproxy:

- Check if there are any leftover or missing attributes when restoring state and raise an exception if so. This already caught a few subtle bugs.
- Remove the `short` argument from `.get_state()`, which is replaced by `_strip_content` in mitmweb. This should not have been part of the serialization API in the first place.
- `s/load_state/set_state/`
- Simplify serialization based on the changes in mitmproxy/netlib/pull/120.

I needed to increase the version number so that the convert function corrects serialized data. This is a first attempt and simplifying libmproxy.models.http as much as possible.