### PR TITLE
Do not send Proxy-Agent in CONNECT responses

### DIFF
--- a/libmproxy/models/http.py
+++ b/libmproxy/models/http.py
@@ -456,14 +456,13 @@ def make_connect_request(address):
 
 
 def make_connect_response(http_version):
-    headers = Headers(
-        Proxy_Agent=version.NAMEVERSION
-    )
+    # Do not send any response headers as it breaks proxying non-80 ports on
+    # Android emulators using the -http-proxy option.
     return HTTPResponse(
         http_version,
         200,
         "Connection established",
-        headers,
+        Headers(),
         "",
     )
 


### PR DESCRIPTION
Sending any headers at all in response to a CONNECT request breaks
proxying Android emulators on all non-80 ports.

Issue: #783