### PR TITLE
Preserve host header when modifying request path

### DIFF
--- a/netlib/netlib/http/request.py
+++ b/netlib/netlib/http/request.py
@@ -192,7 +192,8 @@ class Request(Message):
     def query(self, odict):
         query = utils.urlencode(odict.lst)
         scheme, netloc, path, params, _, fragment = urllib.parse.urlparse(self.url)
-        self.url = urllib.parse.urlunparse([scheme, netloc, path, params, query, fragment])
+        _, _, _, self.path = utils.parse_url(
+                urllib.parse.urlunparse([scheme, netloc, path, params, query, fragment]))
 
     @property
     def cookies(self):
@@ -223,7 +224,8 @@ class Request(Message):
         components = map(lambda x: urllib.parse.quote(x, safe=""), components)
         path = "/" + "/".join(components)
         scheme, netloc, _, params, query, fragment = urllib.parse.urlparse(self.url)
-        self.url = urllib.parse.urlunparse([scheme, netloc, path, params, query, fragment])
+        _, _, _, self.path = utils.parse_url(
+                urllib.parse.urlunparse([scheme, netloc, path, params, query, fragment]))
 
     def anticache(self):
         """
@@ -351,3 +353,4 @@ class Request(Message):
     def form_out(self, form_out):  # pragma: nocover
         warnings.warn(".form_out is deprecated, use .first_line_format instead.", DeprecationWarning)
         self.first_line_format = form_out
+

--- a/test/netlib/http/test_request.py
+++ b/test/netlib/http/test_request.py
@@ -136,8 +136,10 @@ class TestRequestUtils(object):
         assert request.query.lst == [("bar", "42")]
 
     def test_set_query(self):
-        request = treq()
+        request = treq(host=b"foo", headers = Headers(host=b"bar"))
         request.query = ODict([])
+        assert request.host == b"foo"
+        assert request.headers["host"] == b"bar"
 
     def test_get_cookies_none(self):
         request = treq()
@@ -180,11 +182,14 @@ class TestRequestUtils(object):
         assert request.path_components == ["foo", "bar"]
 
     def test_set_path_components(self):
-        request = treq()
+        request = treq(host=b"foo", headers = Headers(host=b"bar"))
         request.path_components = ["foo", "baz"]
         assert request.path == "/foo/baz"
         request.path_components = []
         assert request.path == "/"
+        request.query = ODict([])
+        assert request.host == b"foo"
+        assert request.headers["host"] == b"bar"
 
     def test_anticache(self):
         request = treq()


### PR DESCRIPTION
Currently the path_components and query setters of the Request object
use the url setter under the hood. The url setter updates all parts of
the URL including the host. If the host header and the host in the
request URL are different (as is common when making HTTPS requests)
then the host header will be updated to the value in the URL as a
result of modifying the path.

This change fixes this problem by modifying the query and
path_components setters to not use the url setter and instead directly
update the path field.