### PR TITLE
Add a content view for query parameters

### DIFF
--- a/mitmproxy/mitmproxy/console/flowview.py
+++ b/mitmproxy/mitmproxy/console/flowview.py
@@ -193,8 +193,11 @@ class FlowView(tabs.Tabs):
     def _get_content_view(self, viewmode, message, max_lines, _):
 
         try:
+            query = None
+            if isinstance(message, HTTPRequest):
+                query = message.query
             description, lines = contentviews.get_content_view(
-                viewmode, message.content, headers=message.headers
+                viewmode, message.content, headers=message.headers, query=query
             )
         except ContentViewException:
             s = "Content viewer failed: \n" + traceback.format_exc()

--- a/test/mitmproxy/test_contentview.py
+++ b/test/mitmproxy/test_contentview.py
@@ -1,5 +1,6 @@
 from mitmproxy.exceptions import ContentViewException
 from netlib.http import Headers
+from netlib.odict import ODict
 import netlib.utils
 from netlib import encoding
 
@@ -44,6 +45,19 @@ class TestContentView:
             headers=Headers(content_type="text/flibble")
         )
         assert f[0].startswith("XML")
+
+        f = v(
+            "",
+            headers=Headers()
+        )
+        assert f[0] == "No content"
+
+        f = v(
+            "",
+            headers=Headers(),
+            query=ODict([("foo", "bar")]),
+        )
+        assert f[0] == "Query"
 
     def test_view_urlencoded(self):
         d = netlib.utils.urlencode([("one", "two"), ("three", "four")])
@@ -157,6 +171,13 @@ Larry
 
         h = Headers(content_type="unparseable")
         assert not view(v, headers=h)
+
+    def test_view_query(self):
+        d = ""
+        v = cv.ViewQuery()
+        f = v(d, query=ODict([("foo", "bar")]))
+        assert f[0] == "Query"
+        assert [x for x in f[1]] == [[("header", "foo: "), ("text", "bar")]]
 
     def test_get_content_view(self):
         r = cv.get_content_view(


### PR DESCRIPTION
The query content view uses format_dict to display a table of query
parameters and is made the default content view for requests with
query parameters and no request body.

To facilitate this the query parameter dictionary of HTTPRequests is
added to the metadata content view parameter under the "query" key.

Additionally, the logic for handling "no content" messages is moved
from contentviews.get_content_view to ViewAuto. This is necessary as
it allows the query content view to be displayed when there is no
request body.