### PR TITLE
Simplify Issue Template

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -100,29 +100,6 @@ The last command invokes `sphinx-autobuild`_, which watches the Sphinx directory
 the documentation when a change is detected.
 
 
-Contributing
-----
-
-Thank you for your interest in contributing to mitmproxy!
-
-* Bug Reports
-
-Bug Reports are very welcome - please file them on the GitHub issue_tracker_.
-Please make sure to fill out the template and provide as much information as
-possible.
-
-* Feature Requests
-
-We're happy to hear what you'd like to see in mitmproxy. Please file feature
-requests on the GitHub issue_tracker_.
-
-* Patches
-
-We're always happy to accept patches. Please submit them in the form of pull
-requests to the this repository. If you're working on something cool, please do
-not hesitate and get in touch!
-
-
 
 .. |mitmproxy_site| image:: https://shields.mitmproxy.org/api/https%3A%2F%2F-mitmproxy.org-blue.svg
     :target: https://mitmproxy.org/

--- a/issue_template.md
+++ b/issue_template.md
@@ -1,28 +1,19 @@
 ##### Steps to reproduce the problem:
-1. Launch mitmproxy
-2. Press X
-3. Click Y
+
+1. 
+2. 
+3. 
 
 ##### What is the expected behavior?
 
-It should display Z.
 
 ##### What went wrong?
 
-It crashed with this error/trace: ...
 
 ##### Any other comments?
 
-None.
 
 ---
 
-mitmproxy version: (e.g.: 0.16, git commit hash)
-
-mitmproxy installed from: (e.g.: pip, binary package, source)
-
-Operating System: (e.g.: Windows, OSX, Linux, with specific version)
-
-OpenSSL version: (e.g.: 1.0.2f, run `openssl version` in your shell)
-
-pyOpenSSL version: (e.g.: 0.15.1, run `import OpenSSL; print(OpenSSL.__version__)` in Python)
+Mitmproxy Version:
+Operating System:


### PR DESCRIPTION
I think the current version is a bit too verbose. Also, stuff like "run `import OpenSSL; print(OpenSSL.__version__)` in Python" etc. may be confusing to users that just take the binary.

@Kriechi, is that ok for you?