### PR TITLE
Fixed a potential bug

### DIFF
--- a/netlib/certutils.py
+++ b/netlib/certutils.py
@@ -92,6 +92,8 @@ def dummy_cert(privkey, cacert, commonname, sans):
     """
     ss = []
     for i in sans:
+        if i is None:
+            continue
         try:
             ipaddress.ip_address(i.decode("ascii"))
         except ValueError:


### PR DESCRIPTION
In some cases, mitmproxy will crash.
I can not reproduce it, but It appeared many times at random in my mechine(ubuntu 14.04)

> Traceback (most recent call last):
    File "/home/xiaohy/mitmproxy/mitmproxy/proxy/server.py", line 121, in handle
        root_layer()
    File "/home/xiaohy/mitmproxy/mitmproxy/proxy/modes/http_proxy.py", line 11, in __call__
        layer()
    File "/home/xiaohy/mitmproxy/mitmproxy/protocol/tls.py", line 345, in__call__
        self._establish_tls_with_client_and_server()
    File "/home/xiaohy/mitmproxy/mitmproxy/protocol/tls.py", line 427, in _establish_tls_with_client_and_server
        six.reraise(*sys.exc_info())
    File "/home/xiaohy/mitmproxy/mitmproxy/protocol/tls.py", line 424, in _establish_tls_with_client_and_server
        self._establish_tls_with_client()
File "/home/xiaohy/mitmproxy/mitmproxy/protocol/tls.py", line 433, in _establish_tls_with_client
        cert, key, chain_file = self._find_cert()
File "/home/xiaohy/mitmproxy/mitmproxy/protocol/tls.py", line 566, in _find_cert
        return self.config.certstore.get_cert(host, list(sans))
File "/home/xiaohy/mitmproxy/netlib/certutils.py", line 341, in get_cert
        sans),
FIle "/home/xiaohy/mitmproxy/netlib/certutils.py", line 96, in dummy_cert
        ipaddress.ip_address(i.decode("ascii"))
AttributeError: 'NoneType' object has no attribute 'decode'

In File /home/xiaohy/mitmproxy/mitmproxy/protocol/tls.py line 539
>  # In normal operation, the server address should always be known at this point.
        # However, we may just want to establish TLS so that we can send an error message to the client,
        # in which case the address can be None.

But I found that in some case，the code "host = self.server_conn.address.host " is not running