### PR TITLE
[web] gulp: log errors from buildScript/bundle

### DIFF
--- a/web/gulpfile.js
+++ b/web/gulpfile.js
@@ -96,6 +96,10 @@ function buildScript(bundler, filename, dev) {
 
     function rebundle() {
         return bundler.bundle()
+            .on('error', function(error) {
+                gutil.log(error + '\n' + error.codeFrame);
+                this.emit('end');
+            })
             .pipe(dev ? plumber(handleError) : gutil.noop())
             .pipe(source('bundle.js'))
             .pipe(buffer())


### PR DESCRIPTION
Gulp eats errors from watchify, which makes `scripts-app-dev` never finish when start up gulp with an error script.