### PR TITLE
[web] Fix eslint warnings about tests

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -5,6 +5,7 @@
     "test": "jest ./src/js"
   },
   "jest": {
+    "scriptPreprocessor": "<rootDir>/node_modules/babel-jest",
     "testPathDirs": [
       "./src/js"
     ],
@@ -25,6 +26,7 @@
   },
   "devDependencies": {
     "babel-core": "^6.5.2",
+    "babel-jest": "^6.0.1",
     "babel-preset-es2015": "^6.5.0",
     "babel-preset-react": "^6.5.0",
     "babelify": "^7.2.0",
@@ -41,6 +43,7 @@
     "gulp-rename": "^1.2.2",
     "gulp-sourcemaps": "^1.6.0",
     "gulp-util": "^3.0.7",
+    "jest": "^0.1.40",
     "lodash": "^4.5.1",
     "uglifyify": "^3.0.1",
     "vinyl-buffer": "^1.0.0",

--- a/web/src/js/tests/utils.js
+++ b/web/src/js/tests/utils.js
@@ -1,8 +1,9 @@
 jest.dontMock("jquery");
 jest.dontMock("../utils");
 
+import {formatSize} from "../utils.js"
+
 describe("utils", function () {
-    import {formatSize} from "../utils.js"
     it("formatSize", function(){
         expect(formatSize(1024)).toEqual("1kb");
         expect(formatSize(0)).toEqual("0");


### PR DESCRIPTION
Eslint complains about it all the time:

```
Parsing error: 'import' and 'export' may only appear at the top level
```

Anyway, I found our tests are completely broken. I think we should remove it now and add them sometime later :confused: 