### PR TITLE
Fix #1005

### DIFF
--- a/mitmproxy/console/__init__.py
+++ b/mitmproxy/console/__init__.py
@@ -58,6 +58,8 @@ class ConsoleState(flow.State):
         super(ConsoleState, self).update_flow(f)
         if self.focus is None:
             self.set_focus(0)
+        elif self.follow_focus:
+            self.set_focus(self.flow_count())
         return f
 
     def set_limit(self, limit):

--- a/mitmproxy/console/__init__.py
+++ b/mitmproxy/console/__init__.py
@@ -50,7 +50,7 @@ class ConsoleState(flow.State):
         if self.focus is None:
             self.set_focus(0)
         elif self.follow_focus:
-            self.set_focus(len(self.view) - 1)
+            self.update_focus()
         self.set_flow_marked(f, False)
         return f
 
@@ -59,7 +59,7 @@ class ConsoleState(flow.State):
         if self.focus is None:
             self.set_focus(0)
         elif self.follow_focus:
-            self.set_focus(self.flow_count())
+            self.update_focus()
         return f
 
     def set_limit(self, limit):
@@ -81,6 +81,9 @@ class ConsoleState(flow.State):
             self.focus = idx
         else:
             self.focus = None
+
+    def update_focus(self):
+        self.set_focus(len(self.view) - 1)
 
     def set_focus_flow(self, f):
         self.set_focus(self.view.index(f))


### PR DESCRIPTION
I traced the error for a while. The problem is on line 73 of ```console/__init__.py```:
```python
return self.view[self.focus], self.focus
```
When we turn on the following mode and apply the filter, see line 434 of ```flow.py```, the ```_update``` method of ```FlowView```:
```python
elif not self.filt(f):
    self._remove(f)
```
clearly, it will remove the filtered flows here, but the ```self.focus``` won't update, so it will throw a ```list index out of range``` error.
To fix this, I set the focus to the newest line after we update the flow in ```ConsoleState```.
Hope this help! :smiley: 