### PR TITLE
New option: Add server certs to client chain

### DIFF
--- a/mitmproxy/cmdline.py
+++ b/mitmproxy/cmdline.py
@@ -434,13 +434,14 @@ def proxy_ssl_options(parser):
         action="store_true", dest="no_upstream_cert",
         help="Don't connect to upstream server to look up certificate details."
     )
-    group.add_argument(
+    subgroup = group.add_mutually_exclusive_group()
+    subgroup.add_argument(
         "--add-server-certs-to-client-chain", default=False,
         action="store_true", dest="add_server_certs_to_client_chain",
         help="Add all the certificates of the server to the certificate chain "
              "that will be served to the client, as extras."
     )
-    group.add_argument(
+    subgroup.add_argument(
         "--verify-upstream-cert", default=False,
         action="store_true", dest="ssl_verify_upstream_cert",
         help="Verify upstream server SSL/TLS certificates and fail if invalid "

--- a/mitmproxy/cmdline.py
+++ b/mitmproxy/cmdline.py
@@ -434,14 +434,13 @@ def proxy_ssl_options(parser):
         action="store_true", dest="no_upstream_cert",
         help="Don't connect to upstream server to look up certificate details."
     )
-    subgroup = group.add_mutually_exclusive_group()
-    subgroup.add_argument(
+    group.add_argument(
         "--add-upstream-certs-to-client-chain", default=False,
         action="store_true", dest="add_upstream_certs_to_client_chain",
         help="Add all certificates of the upstream server to the certificate chain "
              "that will be served to the proxy client, as extras."
     )
-    subgroup.add_argument(
+    group.add_argument(
         "--verify-upstream-cert", default=False,
         action="store_true", dest="ssl_verify_upstream_cert",
         help="Verify upstream server SSL/TLS certificates and fail if invalid "

--- a/mitmproxy/cmdline.py
+++ b/mitmproxy/cmdline.py
@@ -436,10 +436,10 @@ def proxy_ssl_options(parser):
     )
     subgroup = group.add_mutually_exclusive_group()
     subgroup.add_argument(
-        "--add-server-certs-to-client-chain", default=False,
-        action="store_true", dest="add_server_certs_to_client_chain",
-        help="Add all the certificates of the server to the certificate chain "
-             "that will be served to the client, as extras."
+        "--add-upstream-certs-to-client-chain", default=False,
+        action="store_true", dest="add_upstream_certs_to_client_chain",
+        help="Add all certificates of the upstream server to the certificate chain "
+             "that will be served to the proxy client, as extras."
     )
     subgroup.add_argument(
         "--verify-upstream-cert", default=False,

--- a/mitmproxy/cmdline.py
+++ b/mitmproxy/cmdline.py
@@ -435,6 +435,12 @@ def proxy_ssl_options(parser):
         help="Don't connect to upstream server to look up certificate details."
     )
     group.add_argument(
+        "--add-server-certs-to-client-chain", default=False,
+        action="store_true", dest="add_server_certs_to_client_chain",
+        help="Add all the certificates of the server to the certificate chain "
+             "that will be served to the client, as extras."
+    )
+    group.add_argument(
         "--verify-upstream-cert", default=False,
         action="store_true", dest="ssl_verify_upstream_cert",
         help="Verify upstream server SSL/TLS certificates and fail if invalid "

--- a/mitmproxy/protocol/tls.py
+++ b/mitmproxy/protocol/tls.py
@@ -432,7 +432,7 @@ class TlsLayer(Layer):
         self.log("Establish TLS with client", "debug")
         cert, key, chain_file = self._find_cert()
 
-        if self.config.add_server_certs_to_client_chain:
+        if self.config.add_upstream_certs_to_client_chain:
            extra_certs = self.server_conn.server_certs
         else:
            extra_certs = None

--- a/mitmproxy/protocol/tls.py
+++ b/mitmproxy/protocol/tls.py
@@ -432,6 +432,11 @@ class TlsLayer(Layer):
         self.log("Establish TLS with client", "debug")
         cert, key, chain_file = self._find_cert()
 
+        if self.config.add_server_certs_to_client_chain:
+           extra_certs = self.server_conn.server_certs
+        else:
+           extra_certs = None
+
         try:
             self.client_conn.convert_to_ssl(
                 cert, key,
@@ -441,6 +446,7 @@ class TlsLayer(Layer):
                 dhparams=self.config.certstore.dhparams,
                 chain_file=chain_file,
                 alpn_select_callback=self.__alpn_select_callback,
+                extra_chain_certs = extra_certs,
             )
             # Some TLS clients will not fail the handshake,
             # but will immediately throw an "unexpected eof" error on the first read.

--- a/mitmproxy/proxy/config.py
+++ b/mitmproxy/proxy/config.py
@@ -138,14 +138,26 @@ def process_proxy_options(parser, options):
             "Transparent, SOCKS5, reverse and upstream proxy mode "
             "are mutually exclusive. Read the docs on proxy modes to understand why."
         )
-
+    if options.add_upstream_certs_to_client_chain and options.no_upstream_cert:
+        return parser.error(
+            "The no-upstream-cert and add-upstream-certs-to-client-chain "
+            "options are mutually exclusive. If no-upstream-cert is enabled "
+            "then the upstream certificate is not retrieved before generating "
+            "the client certificate chain."
+        )
+    if options.add_upstream_certs_to_client_chain and options.ssl_verify_upstream_cert:
+        return parser.error(
+            "The verify-upstream-cert and add-upstream-certs-to-client-chain "
+            "options are mutually exclusive. If upstream certificates are verified "
+            "then extra upstream certificates are not available for inclusion "
+            "to the client chain."
+        )
     if options.clientcerts:
         options.clientcerts = os.path.expanduser(options.clientcerts)
         if not os.path.exists(options.clientcerts):
             return parser.error(
-                "Client certificate path does not exist: %s" % options.clientcerts
+                    "Client certificate path does not exist: %s" % options.clientcerts
             )
-
     if options.auth_nonanonymous or options.auth_singleuser or options.auth_htpasswd:
 
         if options.transparent_proxy:

--- a/mitmproxy/proxy/config.py
+++ b/mitmproxy/proxy/config.py
@@ -67,6 +67,7 @@ class ProxyConfig:
             ssl_verify_upstream_cert=False,
             ssl_verify_upstream_trusted_cadir=None,
             ssl_verify_upstream_trusted_ca=None,
+            add_server_certs_to_client_chain=False,
     ):
         self.host = host
         self.port = port
@@ -107,6 +108,7 @@ class ProxyConfig:
             self.openssl_verification_mode_server = SSL.VERIFY_NONE
         self.openssl_trusted_cadir_server = ssl_verify_upstream_trusted_cadir
         self.openssl_trusted_ca_server = ssl_verify_upstream_trusted_ca
+        self.add_server_certs_to_client_chain = add_server_certs_to_client_chain
 
 
 def process_proxy_options(parser, options):
@@ -206,5 +208,6 @@ def process_proxy_options(parser, options):
         ssl_version_server=options.ssl_version_server,
         ssl_verify_upstream_cert=options.ssl_verify_upstream_cert,
         ssl_verify_upstream_trusted_cadir=options.ssl_verify_upstream_trusted_cadir,
-        ssl_verify_upstream_trusted_ca=options.ssl_verify_upstream_trusted_ca
+        ssl_verify_upstream_trusted_ca=options.ssl_verify_upstream_trusted_ca,
+        add_server_certs_to_client_chain=options.add_server_certs_to_client_chain,
     )

--- a/mitmproxy/proxy/config.py
+++ b/mitmproxy/proxy/config.py
@@ -67,7 +67,7 @@ class ProxyConfig:
             ssl_verify_upstream_cert=False,
             ssl_verify_upstream_trusted_cadir=None,
             ssl_verify_upstream_trusted_ca=None,
-            add_server_certs_to_client_chain=False,
+            add_upstream_certs_to_client_chain=False,
     ):
         self.host = host
         self.port = port
@@ -108,7 +108,7 @@ class ProxyConfig:
             self.openssl_verification_mode_server = SSL.VERIFY_NONE
         self.openssl_trusted_cadir_server = ssl_verify_upstream_trusted_cadir
         self.openssl_trusted_ca_server = ssl_verify_upstream_trusted_ca
-        self.add_server_certs_to_client_chain = add_server_certs_to_client_chain
+        self.add_upstream_certs_to_client_chain = add_upstream_certs_to_client_chain
 
 
 def process_proxy_options(parser, options):
@@ -209,5 +209,5 @@ def process_proxy_options(parser, options):
         ssl_verify_upstream_cert=options.ssl_verify_upstream_cert,
         ssl_verify_upstream_trusted_cadir=options.ssl_verify_upstream_trusted_cadir,
         ssl_verify_upstream_trusted_ca=options.ssl_verify_upstream_trusted_ca,
-        add_server_certs_to_client_chain=options.add_server_certs_to_client_chain,
+        add_upstream_certs_to_client_chain=options.add_upstream_certs_to_client_chain,
     )

--- a/pathod/pathoc.py
+++ b/pathod/pathoc.py
@@ -42,7 +42,8 @@ class SSLInfo(object):
             "Cipher: %s, %s bit, %s" % self.cipher,
             "SSL certificate chain:"
         ]
-        for i in self.certchain:
+        for n,i in enumerate(self.certchain):
+            parts.append("  Certificate [%s]" % n)
             parts.append("\tSubject: ")
             for cn in i.get_subject().get_components():
                 parts.append("\t\t%s=%s" % cn)
@@ -69,7 +70,7 @@ class SSLInfo(object):
             s = certutils.SSLCert(i)
             if s.altnames:
                 parts.append("\tSANs: %s" % " ".join(s.altnames))
-            return "\n".join(parts)
+        return "\n".join(parts)
 
 
 

--- a/test/mitmproxy/test_server.py
+++ b/test/mitmproxy/test_server.py
@@ -1001,61 +1001,48 @@ class TestProxyChainingSSLReconnect(tservers.HTTPUpstreamProxyTest):
         assert self.chain[1].tmaster.state.flow_count() == 2
 
 
-class TestHTTPSAddServerCertsToClientChainTrue(tservers.HTTPProxyTest):
-    ssl = True
+class AddServerCertsToClientChainMixin:
+
+    def test_add_server_certs_to_client_chain(self):
+        with open(self.servercert, "rb") as f:
+            d = f.read()
+        c1 = SSLCert.from_pem(d)
+        p = self.pathoc()
+        server_cert_found_in_client_chain = False
+        for cert in p.server_certs:
+            if cert.digest('sha256') == c1.digest('sha256'):
+                server_cert_found_in_client_chain = True
+                break
+        assert(server_cert_found_in_client_chain == self.add_server_certs_to_client_chain)
+
+
+class TestHTTPSAddServerCertsToClientChainTrue(tservers.HTTPProxyTest, AddServerCertsToClientChainMixin):
+
+    """
+    If --add-server-certs-to-client-chain is True, then the client should receive the server's certificates
+    """
     add_server_certs_to_client_chain = True
-    servercert = tutils.test_data.path("data/trusted-server.crt")
-    ssloptions = pathod.SSLOptions(
-            cn="trusted-cert",
-            certs=[
-                ("trusted-cert", servercert)
-            ]
-    )
-
-    def test_add_server_certs_to_client_chain_true(self):
-        """
-        If --add-server-certs-to-client-chain is True, then the client should receive the server's certificates
-        """
-        with open(self.servercert, "rb") as f:
-            d = f.read()
-        c1 = SSLCert.from_pem(d)
-        p = self.pathoc()
-        print("digest of p.cert[1]: %s"%p.server_certs[1].digest('sha256'))
-        print("digest of c1.cert[1]: %s"%c1.digest('sha256'))
-        server_cert_found_in_client_chain = False
-
-        for cert in p.server_certs:
-            if cert.digest('sha256') == c1.digest('sha256'):
-                server_cert_found_in_client_chain = True
-                break
-
-        assert(server_cert_found_in_client_chain == True)
-
-
-class TestHTTPSAddServerCertsToClientChainFalse(tservers.HTTPProxyTest):
     ssl = True
-    add_server_certs_to_client_chain = False
     servercert = tutils.test_data.path("data/trusted-server.crt")
     ssloptions = pathod.SSLOptions(
-            cn="trusted-cert",
-            certs=[
-                ("trusted-cert", servercert)
-            ]
+        cn="trusted-cert",
+        certs=[
+            ("trusted-cert", servercert)
+        ]
     )
 
-    def test_add_server_certs_to_client_chain_false(self):
-        """
-        If --add-server-certs-to-client-chain is False, then the client should not receive the server's certificates
-        """
-        with open(self.servercert, "rb") as f:
-            d = f.read()
-        c1 = SSLCert.from_pem(d)
-        p = self.pathoc()
-        server_cert_found_in_client_chain = False
 
-        for cert in p.server_certs:
-            if cert.digest('sha256') == c1.digest('sha256'):
-                server_cert_found_in_client_chain = True
-                break
+class TestHTTPSAddServerCertsToClientChainFalse(tservers.HTTPProxyTest, AddServerCertsToClientChainMixin):
 
-        assert(server_cert_found_in_client_chain == False)
+    """
+    If --add-server-certs-to-client-chain is False, then the client should not receive the server's certificates
+    """
+    add_server_certs_to_client_chain = False
+    ssl = True
+    servercert = tutils.test_data.path("data/trusted-server.crt")
+    ssloptions = pathod.SSLOptions(
+        cn="trusted-cert",
+        certs=[
+            ("trusted-cert", servercert)
+        ]
+    )

--- a/test/mitmproxy/test_server.py
+++ b/test/mitmproxy/test_server.py
@@ -1001,7 +1001,7 @@ class TestProxyChainingSSLReconnect(tservers.HTTPUpstreamProxyTest):
         assert self.chain[1].tmaster.state.flow_count() == 2
 
 
-class AddServerCertsToClientChainMixin:
+class AddUpstreamCertsToClientChainMixin:
 
     ssl = True
     servercert = tutils.test_data.path("data/trusted-server.crt")
@@ -1012,30 +1012,30 @@ class AddServerCertsToClientChainMixin:
             ]
     )
 
-    def test_add_server_certs_to_client_chain(self):
+    def test_add_upstream_certs_to_client_chain(self):
         with open(self.servercert, "rb") as f:
             d = f.read()
-        c1 = SSLCert.from_pem(d)
+        upstreamCert = SSLCert.from_pem(d)
         p = self.pathoc()
-        server_cert_found_in_client_chain = False
-        for cert in p.server_certs:
-            if cert.digest('sha256') == c1.digest('sha256'):
-                server_cert_found_in_client_chain = True
+        upstream_cert_found_in_client_chain = False
+        for receivedCert in p.server_certs:
+            if receivedCert.digest('sha256') == upstreamCert.digest('sha256'):
+                upstream_cert_found_in_client_chain = True
                 break
-        assert(server_cert_found_in_client_chain == self.add_server_certs_to_client_chain)
+        assert(upstream_cert_found_in_client_chain == self.add_upstream_certs_to_client_chain)
 
 
-class TestHTTPSAddServerCertsToClientChainTrue(AddServerCertsToClientChainMixin, tservers.HTTPProxyTest):
+class TestHTTPSAddUpstreamCertsToClientChainTrue(AddUpstreamCertsToClientChainMixin, tservers.HTTPProxyTest):
 
     """
     If --add-server-certs-to-client-chain is True, then the client should receive the upstream server's certificates
     """
-    add_server_certs_to_client_chain = True
+    add_upstream_certs_to_client_chain = True
 
 
-class TestHTTPSAddServerCertsToClientChainFalse(AddServerCertsToClientChainMixin, tservers.HTTPProxyTest):
+class TestHTTPSAddUpstreamCertsToClientChainFalse(AddUpstreamCertsToClientChainMixin, tservers.HTTPProxyTest):
 
     """
     If --add-server-certs-to-client-chain is False, then the client should not receive the upstream server's certificates
     """
-    add_server_certs_to_client_chain = False
+    add_upstream_certs_to_client_chain = False

--- a/test/mitmproxy/test_server.py
+++ b/test/mitmproxy/test_server.py
@@ -1003,6 +1003,15 @@ class TestProxyChainingSSLReconnect(tservers.HTTPUpstreamProxyTest):
 
 class AddServerCertsToClientChainMixin:
 
+    ssl = True
+    servercert = tutils.test_data.path("data/trusted-server.crt")
+    ssloptions = pathod.SSLOptions(
+            cn="trusted-cert",
+            certs=[
+                ("trusted-cert", servercert)
+            ]
+    )
+
     def test_add_server_certs_to_client_chain(self):
         with open(self.servercert, "rb") as f:
             d = f.read()
@@ -1016,33 +1025,17 @@ class AddServerCertsToClientChainMixin:
         assert(server_cert_found_in_client_chain == self.add_server_certs_to_client_chain)
 
 
-class TestHTTPSAddServerCertsToClientChainTrue(tservers.HTTPProxyTest, AddServerCertsToClientChainMixin):
+class TestHTTPSAddServerCertsToClientChainTrue(AddServerCertsToClientChainMixin, tservers.HTTPProxyTest):
 
     """
-    If --add-server-certs-to-client-chain is True, then the client should receive the server's certificates
+    If --add-server-certs-to-client-chain is True, then the client should receive the upstream server's certificates
     """
     add_server_certs_to_client_chain = True
-    ssl = True
-    servercert = tutils.test_data.path("data/trusted-server.crt")
-    ssloptions = pathod.SSLOptions(
-        cn="trusted-cert",
-        certs=[
-            ("trusted-cert", servercert)
-        ]
-    )
 
 
-class TestHTTPSAddServerCertsToClientChainFalse(tservers.HTTPProxyTest, AddServerCertsToClientChainMixin):
+class TestHTTPSAddServerCertsToClientChainFalse(AddServerCertsToClientChainMixin, tservers.HTTPProxyTest):
 
     """
-    If --add-server-certs-to-client-chain is False, then the client should not receive the server's certificates
+    If --add-server-certs-to-client-chain is False, then the client should not receive the upstream server's certificates
     """
     add_server_certs_to_client_chain = False
-    ssl = True
-    servercert = tutils.test_data.path("data/trusted-server.crt")
-    ssloptions = pathod.SSLOptions(
-        cn="trusted-cert",
-        certs=[
-            ("trusted-cert", servercert)
-        ]
-    )

--- a/test/mitmproxy/tservers.py
+++ b/test/mitmproxy/tservers.py
@@ -86,7 +86,7 @@ class ProxyTestBase(object):
     no_upstream_cert = False
     authenticator = None
     masterclass = TestMaster
-    add_server_certs_to_client_chain = False
+    add_upstream_certs_to_client_chain = False
 
     @classmethod
     def setup_class(cls):
@@ -130,7 +130,7 @@ class ProxyTestBase(object):
             no_upstream_cert = cls.no_upstream_cert,
             cadir = cls.cadir,
             authenticator = cls.authenticator,
-            add_server_certs_to_client_chain = cls.add_server_certs_to_client_chain,
+            add_upstream_certs_to_client_chain = cls.add_upstream_certs_to_client_chain,
         )
 
 

--- a/test/mitmproxy/tservers.py
+++ b/test/mitmproxy/tservers.py
@@ -86,6 +86,7 @@ class ProxyTestBase(object):
     no_upstream_cert = False
     authenticator = None
     masterclass = TestMaster
+    add_server_certs_to_client_chain = False
 
     @classmethod
     def setup_class(cls):
@@ -129,6 +130,7 @@ class ProxyTestBase(object):
             no_upstream_cert = cls.no_upstream_cert,
             cadir = cls.cadir,
             authenticator = cls.authenticator,
+            add_server_certs_to_client_chain = cls.add_server_certs_to_client_chain,
         )
 
 


### PR DESCRIPTION
If enabled, append all server certificates to the certificate chain
served to the client, as extras. Can be used to test/bypass certain
certificate pinning impementations.