### PR TITLE
add resolved IP address in "Details" tab

### DIFF
--- a/mitmproxy/console/flowdetailview.py
+++ b/mitmproxy/console/flowdetailview.py
@@ -23,6 +23,7 @@ def flowdetails(state, flow):
         text.append(urwid.Text([("head", "Server Connection:")]))
         parts = [
             ["Address", repr(sc.address)],
+            ["Resolved", repr(sc.sock_address)],
         ]
 
         text.extend(

--- a/mitmproxy/console/flowdetailview.py
+++ b/mitmproxy/console/flowdetailview.py
@@ -23,7 +23,7 @@ def flowdetails(state, flow):
         text.append(urwid.Text([("head", "Server Connection:")]))
         parts = [
             ["Address", repr(sc.address)],
-            ["Resolved", repr(sc.sock_address)],
+            ["Peer Address", repr(sc.peer_address)],
         ]
 
         text.extend(

--- a/mitmproxy/flow_format_compat.py
+++ b/mitmproxy/flow_format_compat.py
@@ -35,7 +35,7 @@ def convert_015_016(data):
 
 
 def convert_016_017(data):
-    data["server_conn"]["sock_address"] = None
+    data["server_conn"]["peer_address"] = None
     data["version"] = (0, 17)
     return data
 

--- a/mitmproxy/flow_format_compat.py
+++ b/mitmproxy/flow_format_compat.py
@@ -35,6 +35,7 @@ def convert_015_016(data):
 
 
 def convert_016_017(data):
+    data["server_conn"]["sock_address"] = None
     data["version"] = (0, 17)
     return data
 

--- a/mitmproxy/models/connections.py
+++ b/mitmproxy/models/connections.py
@@ -120,7 +120,7 @@ class ServerConnection(tcp.TCPClient, stateobject.StateObject):
         timestamp_tcp_setup=float,
         timestamp_ssl_setup=float,
         address=tcp.Address,
-        sock_address=tcp.Address,
+        peer_address=tcp.Address,
         source_address=tcp.Address,
         cert=certutils.SSLCert,
         ssl_established=bool,

--- a/mitmproxy/models/connections.py
+++ b/mitmproxy/models/connections.py
@@ -120,6 +120,7 @@ class ServerConnection(tcp.TCPClient, stateobject.StateObject):
         timestamp_tcp_setup=float,
         timestamp_ssl_setup=float,
         address=tcp.Address,
+        sock_address=tcp.Address,
         source_address=tcp.Address,
         cert=certutils.SSLCert,
         ssl_established=bool,

--- a/netlib/tcp.py
+++ b/netlib/tcp.py
@@ -458,9 +458,11 @@ class _Connection(object):
     def __init__(self, connection):
         if connection:
             self.connection = connection
+            self.sock_address = Address(connection.getpeername())
             self._makefile()
         else:
             self.connection = None
+            self.sock_address = None
             self.rfile = None
             self.wfile = None
 
@@ -701,6 +703,7 @@ class TCPClient(_Connection):
                 'Error connecting to "%s": %s' %
                 (self.address.host, err))
         self.connection = connection
+        self.sock_address = Address(connection.getpeername())
         self._makefile()
 
     def settimeout(self, n):

--- a/netlib/tcp.py
+++ b/netlib/tcp.py
@@ -458,11 +458,11 @@ class _Connection(object):
     def __init__(self, connection):
         if connection:
             self.connection = connection
-            self.sock_address = Address(connection.getpeername())
+            self.peer_address = Address(connection.getpeername())
             self._makefile()
         else:
             self.connection = None
-            self.sock_address = None
+            self.peer_address = None
             self.rfile = None
             self.wfile = None
 
@@ -703,7 +703,7 @@ class TCPClient(_Connection):
                 'Error connecting to "%s": %s' %
                 (self.address.host, err))
         self.connection = connection
-        self.sock_address = Address(connection.getpeername())
+        self.peer_address = Address(connection.getpeername())
         self._makefile()
 
     def settimeout(self, n):

--- a/test/mitmproxy/tutils.py
+++ b/test/mitmproxy/tutils.py
@@ -93,7 +93,7 @@ def tserver_conn():
     c = ServerConnection.from_state(dict(
         address=dict(address=("address", 22), use_ipv6=True),
         source_address=dict(address=("address", 22), use_ipv6=True),
-        sock_address=None,
+        peer_address=None,
         cert=None,
         timestamp_start=1,
         timestamp_tcp_setup=2,

--- a/test/mitmproxy/tutils.py
+++ b/test/mitmproxy/tutils.py
@@ -93,6 +93,7 @@ def tserver_conn():
     c = ServerConnection.from_state(dict(
         address=dict(address=("address", 22), use_ipv6=True),
         source_address=dict(address=("address", 22), use_ipv6=True),
+        sock_address=None,
         cert=None,
         timestamp_start=1,
         timestamp_tcp_setup=2,


### PR DESCRIPTION
It's useful to know the peer address when the domain has several IP addresses and you need to know where the request has gone.