### PR TITLE
Add mitmproxy icon for binaries

### DIFF
--- a/release/specs/mitmdump.spec
+++ b/release/specs/mitmdump.spec
@@ -19,4 +19,5 @@ exe = EXE(pyz,
           debug=False,
           strip=None,
           upx=True,
-          console=True )
+          console=True,
+          icon='icon.ico' )

--- a/release/specs/mitmproxy.spec
+++ b/release/specs/mitmproxy.spec
@@ -19,4 +19,5 @@ exe = EXE(pyz,
           debug=False,
           strip=None,
           upx=True,
-          console=True )
+          console=True,
+          icon='icon.ico' )

--- a/release/specs/mitmweb.spec
+++ b/release/specs/mitmweb.spec
@@ -19,4 +19,5 @@ exe = EXE(pyz,
           debug=False,
           strip=None,
           upx=True,
-          console=True )
+          console=True,
+          icon='icon.ico' )

--- a/release/specs/pathoc.spec
+++ b/release/specs/pathoc.spec
@@ -19,4 +19,5 @@ exe = EXE(pyz,
           debug=False,
           strip=None,
           upx=True,
-          console=True )
+          console=True,
+          icon='icon.ico' )

--- a/release/specs/pathod.spec
+++ b/release/specs/pathod.spec
@@ -19,4 +19,5 @@ exe = EXE(pyz,
           debug=False,
           strip=None,
           upx=True,
-          console=True )
+          console=True,
+          icon='icon.ico' )


### PR DESCRIPTION
The executables created earlier used the default PyInstaller icon.
Now, the mitmproxy icon is used. 