### PR TITLE
py.test: disable coverage collection by default

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -17,7 +17,7 @@ install:
   - "dev.bat"
   - "python -c \"from OpenSSL import SSL; print(SSL.SSLeay_version(SSL.SSLEAY_VERSION))\""
 test_script:
-  - "py.test"
+  - "py.test --cov netlib --cov mitmproxy --cov pathod"
 cache:
   - C:\Users\appveyor\AppData\Local\pip\cache
 deploy_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ before_script:
   - "python -c \"from OpenSSL import SSL; print(SSL.SSLeay_version(SSL.SSLEAY_VERSION))\""
 
 script:
-  - "py.test ./test/$SCOPE"
+  - "py.test --cov netlib --cov mitmproxy --cov pathod ./test/$SCOPE"
 
 after_success:
   - coveralls

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,7 +9,7 @@ ignore = E251
 
 [pytest]
 testpaths = test
-addopts = --timeout 30 -s --cov netlib --cov mitmproxy --cov pathod
+addopts = --timeout 30 -s
 
 [coverage:run]
 branch = True


### PR DESCRIPTION
I'd like to remove the coverage collection by default. I frequently use `py.test`'s looponfail mode, which has cluttered output and slow performance due to this.