### PR TITLE
Fix XSS vulnerability in HTTP errors

### DIFF
--- a/mitmproxy/models/http.py
+++ b/mitmproxy/models/http.py
@@ -1,5 +1,6 @@
 from __future__ import (absolute_import, print_function, division)
 from six.moves import http_cookies as Cookie
+import cgi
 import copy
 import warnings
 from email.utils import parsedate_tz, formatdate, mktime_tz
@@ -429,7 +430,7 @@ def make_error_response(status_code, message, headers=None):
             </head>
             <body>%s</body>
         </html>
-    """.strip() % (status_code, response, message)
+    """.strip() % (status_code, response, cgi.escape(message))
     body = body.encode("utf8", "replace")
 
     if not headers:


### PR DESCRIPTION
The make_error_response method does not properly escape characters
that end up in the response body. Since the error code can contain
user supplied values this leads to a potential XSS vulnerability.

Example:

    echo '<script>alert(1)</script>' | nc localhost 8888