### PR TITLE
Fix being unable to export binary data in requests

### DIFF
--- a/mitmproxy/console/common.py
+++ b/mitmproxy/console/common.py
@@ -303,7 +303,7 @@ def copy_to_clipboard_or_prompt(data):
 
     try:
         pyperclip.copy(toclip)
-    except (RuntimeError, UnicodeDecodeError, AttributeError):
+    except (RuntimeError, UnicodeDecodeError, AttributeError, TypeError):
         def save(k):
             if k == "y":
                 ask_save_path("Save data", data)


### PR DESCRIPTION
On Ubuntu 15.10 and Python 2 with PyGTK, when exporting a large amount of binary data (with the E shortcut), `pyperclip` will fail with a `Gtk.Clipboard.set_text() must be string without null bytes, not str`.

The failure then proceeds to crash mitmproxy, losing your session. This patch allows us to recover from this.