### PR TITLE
response.msg -> response.reason

### DIFF
--- a/examples/har_extractor.py
+++ b/examples/har_extractor.py
@@ -143,7 +143,7 @@ def response(context, flow):
         },
         "response": {
             "status": flow.response.status_code,
-            "statusText": flow.response.msg,
+            "statusText": flow.response.reason,
             "httpVersion": flow.response.http_version,
             "cookies": format_cookies(flow.response.cookies),
             "headers": format_headers(flow.response.headers),

--- a/mitmproxy/models/flow.py
+++ b/mitmproxy/models/flow.py
@@ -28,7 +28,6 @@ class Error(stateobject.StateObject):
         @type msg: str
         @type timestamp: float
         """
-        self.flow = None  # will usually be set by the flow backref mixin
         self.msg = msg
         self.timestamp = timestamp or utils.timestamp()
 

--- a/netlib/http/response.py
+++ b/netlib/http/response.py
@@ -103,13 +103,3 @@ class Response(Message):
     def set_cookies(self, odict):  # pragma: no cover
         warnings.warn(".set_cookies is deprecated, use .cookies instead.", DeprecationWarning)
         self.cookies = odict
-
-    @property
-    def msg(self):  # pragma: no cover
-        warnings.warn(".msg is deprecated, use .reason instead.", DeprecationWarning)
-        return self.reason
-
-    @msg.setter
-    def msg(self, reason):  # pragma: no cover
-        warnings.warn(".msg is deprecated, use .reason instead.", DeprecationWarning)
-        self.reason = reason

--- a/pathod/pathoc.py
+++ b/pathod/pathoc.py
@@ -425,7 +425,7 @@ class Pathoc(tcp.TCPClient):
             finally:
                 if resp:
                     lg("<< %s %s: %s bytes" % (
-                        resp.status_code, utils.xrepr(resp.msg), len(resp.content)
+                        resp.status_code, utils.xrepr(resp.reason), len(resp.content)
                     ))
                     if resp.status_code in self.ignorecodes:
                         lg.suppress()

--- a/test/netlib/http/http2/test_connections.py
+++ b/test/netlib/http/http2/test_connections.py
@@ -417,7 +417,7 @@ class TestReadResponse(tservers.ServerTestBase):
 
         assert resp.http_version == "HTTP/2.0"
         assert resp.status_code == 200
-        assert resp.msg == ''
+        assert resp.reason == ''
         assert resp.headers.fields == [[b':status', b'200'], [b'etag', b'foobar']]
         assert resp.content == b'foobar'
         assert resp.timestamp_end
@@ -444,7 +444,7 @@ class TestReadEmptyResponse(tservers.ServerTestBase):
         assert resp.stream_id == 42
         assert resp.http_version == "HTTP/2.0"
         assert resp.status_code == 200
-        assert resp.msg == ''
+        assert resp.reason == ''
         assert resp.headers.fields == [[b':status', b'200'], [b'etag', b'foobar']]
         assert resp.content == b''
 


### PR DESCRIPTION
This PR replaces all (already deprecated) occurences of `Response.msg` with `Response.reason`.