### PR TITLE
move HTTPResponse.refresh into netlib

### DIFF
--- a/test/mitmproxy/test_flow.py
+++ b/test/mitmproxy/test_flow.py
@@ -1151,38 +1151,6 @@ class TestResponse:
         resp2 = resp.copy()
         assert resp2.get_state() == resp.get_state()
 
-    def test_refresh(self):
-        r = HTTPResponse.wrap(netlib.tutils.tresp())
-        n = time.time()
-        r.headers["date"] = email.utils.formatdate(n)
-        pre = r.headers["date"]
-        r.refresh(n)
-        assert pre == r.headers["date"]
-        r.refresh(n + 60)
-
-        d = email.utils.parsedate_tz(r.headers["date"])
-        d = email.utils.mktime_tz(d)
-        # Weird that this is not exact...
-        assert abs(60 - (d - n)) <= 1
-
-        r.headers["set-cookie"] = "MOO=BAR; Expires=Tue, 08-Mar-2011 00:20:38 GMT; Path=foo.com; Secure"
-        r.refresh()
-
-    def test_refresh_cookie(self):
-        r = HTTPResponse.wrap(netlib.tutils.tresp())
-
-        # Invalid expires format, sent to us by Reddit.
-        c = "rfoo=bar; Domain=reddit.com; expires=Thu, 31 Dec 2037 23:59:59 GMT; Path=/"
-        assert r._refresh_cookie(c, 60)
-
-        c = "MOO=BAR; Expires=Tue, 08-Mar-2011 00:20:38 GMT; Path=foo.com; Secure"
-        assert "00:21:38" in r._refresh_cookie(c, 60)
-
-        # https://github.com/mitmproxy/mitmproxy/issues/773
-        c = ">=A"
-        with tutils.raises(ValueError):
-            r._refresh_cookie(c, 60)
-
     def test_replace(self):
         r = HTTPResponse.wrap(netlib.tutils.tresp())
         r.headers["Foo"] = "fOo"

--- a/test/netlib/http/test_cookies.py
+++ b/test/netlib/http/test_cookies.py
@@ -1,4 +1,5 @@
 from netlib.http import cookies
+from netlib.tutils import raises
 
 
 def test_read_token():
@@ -216,3 +217,18 @@ def test_parse_set_cookie_header():
             assert ret2[2].lst == expected[2]
         else:
             assert ret is None
+
+
+def test_refresh_cookie():
+
+    # Invalid expires format, sent to us by Reddit.
+    c = "rfoo=bar; Domain=reddit.com; expires=Thu, 31 Dec 2037 23:59:59 GMT; Path=/"
+    assert cookies.refresh_set_cookie_header(c, 60)
+
+    c = "MOO=BAR; Expires=Tue, 08-Mar-2011 00:20:38 GMT; Path=foo.com; Secure"
+    assert "00:21:38" in cookies.refresh_set_cookie_header(c, 60)
+
+    # https://github.com/mitmproxy/mitmproxy/issues/773
+    c = ">=A"
+    with raises(ValueError):
+        cookies.refresh_set_cookie_header(c, 60)

--- a/test/netlib/http/test_response.py
+++ b/test/netlib/http/test_response.py
@@ -1,6 +1,9 @@
 from __future__ import absolute_import, print_function, division
 
+import email
+
 import six
+import time
 
 from netlib.http import Headers
 from netlib.odict import ODict, ODictCaseless
@@ -100,3 +103,23 @@ class TestResponseUtils(object):
         v = resp.cookies
         assert len(v) == 1
         assert v["foo"] == [["bar", ODictCaseless()]]
+
+    def test_refresh(self):
+        r = tresp()
+        n = time.time()
+        r.headers["date"] = email.utils.formatdate(n)
+        pre = r.headers["date"]
+        r.refresh(n)
+        assert pre == r.headers["date"]
+        r.refresh(n + 60)
+
+        d = email.utils.parsedate_tz(r.headers["date"])
+        d = email.utils.mktime_tz(d)
+        # Weird that this is not exact...
+        assert abs(60 - (d - n)) <= 1
+
+        cookie = "MOO=BAR; Expires=Tue, 08-Mar-2011 00:20:38 GMT; Path=foo.com; Secure"
+        r.headers["set-cookie"] = cookie
+        r.refresh()
+        # Cookie refreshing is tested in test_cookies, we just make sure that it's triggered here.
+        assert cookie != r.headers["set-cookie"]


### PR DESCRIPTION
This PR moves `HTTPResponse.refresh` into netlib.