### PR TITLE
support for setting/sending multiple cookies

### DIFF
--- a/test/mitmproxy/test_flow.py
+++ b/test/mitmproxy/test_flow.py
@@ -69,6 +69,25 @@ class TestStickyCookieState:
         s, f = self._response("SSID=mooo", "www.google.com")
         assert s.jar.keys()[0] == ('www.google.com', 80, '/')
 
+        # Test setting of multiple cookies
+        c1 = "somecookie=test; Path=/"
+        c2 = "othercookie=helloworld; Path=/"
+        s, f = self._response(c1, "www.google.com")
+        f.response.headers["Set-Cookie"] = c2
+        s.handle_response(f)
+        googlekey = s.jar.keys()[0]
+        assert len(s.jar[googlekey].keys()) == 2
+
+        # Test overwriting of a cookie value
+        c1 = "somecookie=helloworld; Path=/"
+        c2 = "somecookie=newvalue; Path=/"
+        s, f = self._response(c1, "www.google.com")
+        f.response.headers["Set-Cookie"] = c2
+        s.handle_response(f)
+        googlekey = s.jar.keys()[0]
+        assert len(s.jar[googlekey].keys()) == 1
+        assert s.jar[googlekey]["somecookie"].value == "newvalue"
+
     def test_handle_request(self):
         s, f = self._response("SSID=mooo", "www.google.com")
         assert "cookie" not in f.request.headers


### PR DESCRIPTION
This patch adds support for using multiple cookies set by the same server, when using stickycookies.
The original code only remembered the last cookie set.

Testcase through: mitmdump -t "."
visit https://httpbin.org/cookies/set?helloWWW=worldZZZ&xxx=yyy
then flush cookies from your browser
and finally visit https://httpbin.org/cookies