### PR TITLE
Speed up TLS handshake if SNI is present

### DIFF
--- a/mitmproxy/protocol/base.py
+++ b/mitmproxy/protocol/base.py
@@ -133,24 +133,15 @@ class ServerConnectionMixin(object):
                     "The proxy shall not connect to itself.".format(repr(address))
                 )
 
-    def set_server(self, address, server_tls=None, sni=None):
+    def set_server(self, address):
         """
         Sets a new server address. If there is an existing connection, it will be closed.
-
-        Raises:
-            ~mitmproxy.exceptions.ProtocolException:
-                if ``server_tls`` is ``True``, but there was no TLS layer on the
-                protocol stack which could have processed this.
         """
         if self.server_conn:
             self.disconnect()
         self.log("Set new server address: " + repr(address), "debug")
         self.server_conn.address = address
         self.__check_self_connect()
-        if server_tls:
-            raise ProtocolException(
-                "Cannot upgrade to TLS, no TLS layer on the protocol stack."
-            )
 
     def disconnect(self):
         """

--- a/mitmproxy/protocol/http.py
+++ b/mitmproxy/protocol/http.py
@@ -144,7 +144,7 @@ class HttpLayer(Layer):
 
     def __call__(self):
         if self.mode == "transparent":
-            self.__initial_server_tls = self._server_tls
+            self.__initial_server_tls = self.server_tls
             self.__initial_server_conn = self.server_conn
         while True:
             try:

--- a/mitmproxy/protocol/http.py
+++ b/mitmproxy/protocol/http.py
@@ -120,18 +120,13 @@ class UpstreamConnectLayer(Layer):
         if address != self.server_conn.via.address:
             self.ctx.set_server(address)
 
-    def set_server(self, address, server_tls=None, sni=None):
+    def set_server(self, address):
         if self.ctx.server_conn:
             self.ctx.disconnect()
         address = tcp.Address.wrap(address)
         self.connect_request.host = address.host
         self.connect_request.port = address.port
         self.server_conn.address = address
-
-        if server_tls:
-            raise ProtocolException(
-                "Cannot upgrade to TLS, no TLS layer on the protocol stack."
-            )
 
 
 class HttpLayer(Layer):
@@ -355,8 +350,9 @@ class HttpLayer(Layer):
 
         if self.mode == "regular" or self.mode == "transparent":
             # If there's an existing connection that doesn't match our expectations, kill it.
-            if address != self.server_conn.address or tls != self.server_conn.tls_established:
-                self.set_server(address, tls, address.host)
+            if address != self.server_conn.address or tls != self.server_tls:
+                self.set_server(address)
+                self.set_server_tls(tls, address.host)
             # Establish connection is neccessary.
             if not self.server_conn:
                 self.connect()

--- a/mitmproxy/protocol/tls.py
+++ b/mitmproxy/protocol/tls.py
@@ -308,7 +308,7 @@ class TlsClientHello(object):
 
     def __repr__(self):
         return "TlsClientHello( sni: %s alpn_protocols: %s,  cipher_suites: %s)" % \
-            (self._client_hello.sni, self.alpn_protocols, self.cipher_suites)
+            (self.sni, self.alpn_protocols, self.cipher_suites)
 
 
 class TlsLayer(Layer):

--- a/mitmproxy/protocol/tls.py
+++ b/mitmproxy/protocol/tls.py
@@ -341,13 +341,15 @@ class TlsLayer(Layer):
               https://www.openssl.org/docs/ssl/SSL_CTX_set_cert_cb.html
             - The original mitmproxy issue is https://github.com/mitmproxy/mitmproxy/issues/427
         """
-
-        client_tls_requires_server_cert = (
-            self._client_tls and self._server_tls and not self.config.no_upstream_cert
-        )
-
         if self._client_tls:
             self._parse_client_hello()
+
+        # First, this requires that we have TLS on both the client and the server connection.
+        # Second, this must be disabled if the user specified --no-upstream-cert
+        # Third, if the client sends a SNI value, we can be reasonably sure that this is the actual target host.
+        client_tls_requires_server_cert = (
+            self._client_tls and self._server_tls and not self.config.no_upstream_cert and not self.client_sni
+        )
 
         if client_tls_requires_server_cert:
             self._establish_tls_with_client_and_server()

--- a/mitmproxy/proxy/root_context.py
+++ b/mitmproxy/proxy/root_context.py
@@ -63,7 +63,7 @@ class RootContext(object):
                 except TlsProtocolException as e:
                     self.log("Cannot parse Client Hello: %s" % repr(e), "error")
                 else:
-                    ignore = self.config.check_ignore((client_hello.client_sni, 443))
+                    ignore = self.config.check_ignore((client_hello.sni, 443))
             if ignore:
                 return RawTCPLayer(top_layer, logging=False)
 


### PR DESCRIPTION
This is an experimental PR that speeds up mitmproxy's TLS handshake. The assumption is as follows: If the client sends a SNI value in the handshake, we can be reasonably sure that this is actually the server the client is requesting. Thus, we can just mirror the SNI value in the cert and don't need to an upstream connection.

I really don't see a case where this could be failing. @cortesi, any concerns with this? If we all agree that this should be implemented, I'll adjust the tests.