### PR TITLE
improve cookie parsing

### DIFF
--- a/mitmproxy/console/flowview.py
+++ b/mitmproxy/console/flowview.py
@@ -364,12 +364,11 @@ class FlowView(tabs.Tabs):
             self.edit_form(conn)
 
     def set_cookies(self, lst, conn):
-        od = odict.ODict(lst)
-        conn.set_cookies(od)
+        conn.cookies = odict.ODict(lst)
         signals.flow_change.send(self, flow = self.flow)
 
     def set_setcookies(self, data, conn):
-        conn.set_cookies(data)
+        conn.cookies = data
         signals.flow_change.send(self, flow = self.flow)
 
     def edit(self, part):
@@ -389,7 +388,7 @@ class FlowView(tabs.Tabs):
             self.master.view_grideditor(
                 grideditor.CookieEditor(
                     self.master,
-                    message.get_cookies().lst,
+                    message.cookies.lst,
                     self.set_cookies,
                     message
                 )
@@ -398,7 +397,7 @@ class FlowView(tabs.Tabs):
             self.master.view_grideditor(
                 grideditor.SetCookieEditor(
                     self.master,
-                    message.get_cookies(),
+                    message.cookies,
                     self.set_setcookies,
                     message
                 )

--- a/netlib/http/cookies.py
+++ b/netlib/http/cookies.py
@@ -209,7 +209,7 @@ def refresh_set_cookie_header(c, delta):
         raise ValueError("Invalid Cookie")
 
     if "expires" in attrs:
-        e = parsedate_tz(attrs["expires"][0])
+        e = parsedate_tz(attrs["expires"][-1])
         if e:
             f = mktime_tz(e) + delta
             attrs["expires"] = [formatdate(f)]

--- a/netlib/http/cookies.py
+++ b/netlib/http/cookies.py
@@ -1,5 +1,6 @@
 from six.moves import http_cookies as Cookie
 import re
+import string
 from email.utils import parsedate_tz, formatdate, mktime_tz
 
 from .. import odict
@@ -26,7 +27,6 @@ variants. Serialization follows RFC6265.
 """
 
 # TODO: Disallow LHS-only Cookie values
-
 
 def _read_until(s, start, term):
     """
@@ -203,25 +203,26 @@ def refresh_set_cookie_header(c, delta):
     Returns:
         A refreshed Set-Cookie string
     """
-    try:
-        c = Cookie.SimpleCookie(str(c))
-    except Cookie.CookieError:
+
+    name, value, attrs = parse_set_cookie_header(c)
+    if not name or not value:
         raise ValueError("Invalid Cookie")
-    for i in c.values():
-        if "expires" in i:
-            d = parsedate_tz(i["expires"])
-            if d:
-                d = mktime_tz(d) + delta
-                i["expires"] = formatdate(d)
-            else:
-                # This can happen when the expires tag is invalid.
-                # reddit.com sends a an expires tag like this: "Thu, 31 Dec
-                # 2037 23:59:59 GMT", which is valid RFC 1123, but not
-                # strictly correct according to the cookie spec. Browsers
-                # appear to parse this tolerantly - maybe we should too.
-                # For now, we just ignore this.
-                del i["expires"]
-    ret = c.output(header="").strip()
+
+    if "expires" in attrs:
+        e = parsedate_tz(attrs["expires"][0])
+        if e:
+            f = mktime_tz(e) + delta
+            attrs["expires"] = [formatdate(f)]
+        else:
+            # This can happen when the expires tag is invalid.
+            # reddit.com sends a an expires tag like this: "Thu, 31 Dec
+            # 2037 23:59:59 GMT", which is valid RFC 1123, but not
+            # strictly correct according to the cookie spec. Browsers
+            # appear to parse this tolerantly - maybe we should too.
+            # For now, we just ignore this.
+            del attrs["expires"]
+
+    ret = format_set_cookie_header(name, value, attrs)
     if not ret:
         raise ValueError("Invalid Cookie")
     return ret

--- a/netlib/http/request.py
+++ b/netlib/http/request.py
@@ -343,14 +343,6 @@ class Request(Message):
 
     # Legacy
 
-    def get_cookies(self):  # pragma: no cover
-        warnings.warn(".get_cookies is deprecated, use .cookies instead.", DeprecationWarning)
-        return self.cookies
-
-    def set_cookies(self, odict):  # pragma: no cover
-        warnings.warn(".set_cookies is deprecated, use .cookies instead.", DeprecationWarning)
-        self.cookies = odict
-
     def get_query(self):  # pragma: no cover
         warnings.warn(".get_query is deprecated, use .query instead.", DeprecationWarning)
         return self.query or ODict([])

--- a/netlib/http/response.py
+++ b/netlib/http/response.py
@@ -127,13 +127,3 @@ class Response(Message):
             c.append(refreshed)
         if c:
             self.headers.set_all("set-cookie", c)
-
-    # Legacy
-
-    def get_cookies(self):  # pragma: no cover
-        warnings.warn(".get_cookies is deprecated, use .cookies instead.", DeprecationWarning)
-        return self.cookies
-
-    def set_cookies(self, odict):  # pragma: no cover
-        warnings.warn(".set_cookies is deprecated, use .cookies instead.", DeprecationWarning)
-        self.cookies = odict

--- a/test/netlib/http/test_cookies.py
+++ b/test/netlib/http/test_cookies.py
@@ -228,7 +228,16 @@ def test_refresh_cookie():
     c = "MOO=BAR; Expires=Tue, 08-Mar-2011 00:20:38 GMT; Path=foo.com; Secure"
     assert "00:21:38" in cookies.refresh_set_cookie_header(c, 60)
 
-    # https://github.com/mitmproxy/mitmproxy/issues/773
-    c = ">=A"
+    c = "foo,bar"
     with raises(ValueError):
         cookies.refresh_set_cookie_header(c, 60)
+
+    # https://github.com/mitmproxy/mitmproxy/issues/773
+    c = ">=A"
+    assert cookies.refresh_set_cookie_header(c, 60)
+
+    # https://github.com/mitmproxy/mitmproxy/issues/1118
+    c = "foo:bar=bla"
+    assert cookies.refresh_set_cookie_header(c, 0)
+    c = "foo/bar=bla"
+    assert cookies.refresh_set_cookie_header(c, 0)

--- a/test/netlib/http/test_request.py
+++ b/test/netlib/http/test_request.py
@@ -172,7 +172,7 @@ class TestRequestUtils(object):
     def test_get_cookies_none(self):
         request = treq()
         request.headers = Headers()
-        assert len(request.cookies) == 0
+        assert not request.cookies
 
     def test_get_cookies_single(self):
         request = treq()

--- a/test/netlib/http/test_response.py
+++ b/test/netlib/http/test_response.py
@@ -98,7 +98,7 @@ class TestResponseUtils(object):
         resp = tresp()
         v = resp.cookies
         v.add("foo", ["bar", ODictCaseless()])
-        resp.set_cookies(v)
+        resp.cookies = v
 
         v = resp.cookies
         assert len(v) == 1


### PR DESCRIPTION
allows `/` to be within a cookie name, e.g. `_csrf/link=foobar`
backport: `:` character to be within a cookie name from python 3.3
removes deprecated cookie getter/setter
fixes #1118 

This introduces a minor API change for sticky cookies.