### PR TITLE
Fix #1120

### DIFF
--- a/mitmproxy/console/common.py
+++ b/mitmproxy/console/common.py
@@ -401,6 +401,15 @@ flowcache = utils.LRUCache(800)
 
 
 def format_flow(f, focus, extended=False, hostheader=False, marked=False):
+    if hostheader:
+        url = f.request.pretty_url
+        if url == "*":
+            url = "* ({})".format(f.request.pretty_host)
+    else:
+        url = f.request.url
+        if url == "*":
+            url = "* ({})".format(f.request.host)
+
     d = dict(
         intercepted = f.intercepted,
         acked = f.reply.acked,
@@ -408,7 +417,7 @@ def format_flow(f, focus, extended=False, hostheader=False, marked=False):
         req_timestamp = f.request.timestamp_start,
         req_is_replay = f.request.is_replay,
         req_method = f.request.method,
-        req_url = f.request.pretty_url if hostheader else f.request.url,
+        req_url = url,
         req_http_version = f.request.http_version,
 
         err_msg = f.error.msg if f.error else None,

--- a/mitmproxy/dump.py
+++ b/mitmproxy/dump.py
@@ -249,8 +249,13 @@ class DumpMaster(flow.FlowMaster):
         method = click.style(method, fg=method_color, bold=True)
         if self.showhost:
             url = flow.request.pretty_url
+            if url == "*":
+                url = "* ({})".format(flow.request.pretty_host)
         else:
             url = flow.request.url
+            if url == "*":
+                url = "* ({})".format(flow.request.host)
+
         url = click.style(url, bold=True)
 
         httpversion = ""

--- a/netlib/http/request.py
+++ b/netlib/http/request.py
@@ -162,7 +162,7 @@ class Request(Message):
     def path(self):
         """
         HTTP request path, e.g. "/index.html".
-        Guaranteed to start with a slash.
+        Guaranteed to start with a slash, except for OPTIONS requests, which may just be "*".
         """
         if self.data.path is None:
             return None
@@ -180,6 +180,8 @@ class Request(Message):
         """
         if self.first_line_format == "authority":
             return "%s:%d" % (self.host, self.port)
+        if self.first_line_format == "relative" and self.path == "*":
+            return "*"
         return utils.unparse_url(self.scheme, self.host, self.port, self.path)
 
     @url.setter
@@ -220,6 +222,8 @@ class Request(Message):
         """
         if self.first_line_format == "authority":
             return "%s:%d" % (self.pretty_host, self.port)
+        if self.first_line_format == "relative" and self.path == "*":
+            return "*"
         return utils.unparse_url(self.scheme, self.pretty_host, self.port, self.path)
 
     @property

--- a/test/netlib/http/test_request.py
+++ b/test/netlib/http/test_request.py
@@ -107,6 +107,14 @@ class TestRequestUtils(object):
         with raises(ValueError):
             request.url = "not-a-url"
 
+    def test_url_options(self):
+        request = treq(method=b"OPTIONS", path=b"*")
+        assert request.url == "*"
+
+    def test_url_authority(self):
+        request = treq(first_line_format="authority")
+        assert request.url == "address:22"
+
     def test_pretty_host(self):
         request = treq()
         # Without host header
@@ -139,6 +147,10 @@ class TestRequestUtils(object):
         # Different ports
         request.headers["host"] = "other"
         assert request.pretty_url == "http://address:22/path"
+
+    def test_pretty_url_options(self):
+        request = treq(method=b"OPTIONS", path=b"*")
+        assert request.pretty_url == "*"
 
     def test_pretty_url_authority(self):
         request = treq(first_line_format="authority")


### PR DESCRIPTION
Fixing #1120 turned out to be surprisingly difficult from a UI/UX perspective. The key problem is that if we just display `OPTIONS *`, a user cannot associate the request with a host in the flow list:

```
λ mitmdump
127.0.0.1:52407: clientconnect
127.0.0.1 OPTIONS *                   <- this goes where?
 << 200 OK 0B
```


To fix this, I'd like to display `OPTIONS * (example.com)` in the UI. There are two ways to accomplish this:

1. Let `request.url` return the stuff in the parantheses as well.(https://github.com/mitmproxy/mitmproxy/compare/issue-1120)
2. Manually add them in the UI part. (https://github.com/mitmproxy/mitmproxy/compare/issue-1120-alt)

I personally prefer the second solution even though it is way more verbose code-wise. Thoughts?