### PR TITLE
Improve script loading

### DIFF
--- a/mitmproxy/console/grideditor.py
+++ b/mitmproxy/console/grideditor.py
@@ -642,8 +642,8 @@ class ScriptEditor(GridEditor):
     def is_error(self, col, val):
         try:
             script.Script.parse_command(val)
-        except script.ScriptException as v:
-            return str(v)
+        except script.ScriptException as e:
+            return str(e)
 
 
 class HostPatternEditor(GridEditor):

--- a/mitmproxy/dump.py
+++ b/mitmproxy/dump.py
@@ -7,7 +7,7 @@ import itertools
 from netlib import tcp
 import netlib.utils
 from . import flow, filt, contentviews
-from .exceptions import ContentViewException, FlowReadException
+from .exceptions import ContentViewException, FlowReadException, ScriptException
 
 
 class DumpError(Exception):
@@ -125,9 +125,10 @@ class DumpMaster(flow.FlowMaster):
 
         scripts = options.scripts or []
         for command in scripts:
-            err = self.load_script(command, use_reloader=True)
-            if err:
-                raise DumpError(err)
+            try:
+                self.load_script(command, use_reloader=True)
+            except ScriptException as e:
+                raise DumpError(str(e))
 
         if options.rfile:
             try:

--- a/mitmproxy/exceptions.py
+++ b/mitmproxy/exceptions.py
@@ -7,6 +7,10 @@ See also: http://lucumr.pocoo.org/2014/10/16/on-error-handling/
 """
 from __future__ import (absolute_import, print_function, division)
 
+import traceback
+
+import sys
+
 
 class ProxyException(Exception):
     """
@@ -59,7 +63,23 @@ class ReplayException(ProxyException):
 
 
 class ScriptException(ProxyException):
-    pass
+    @classmethod
+    def from_exception_context(cls, cut_tb=1):
+        """
+        Must be called while the current stack handles an exception.
+
+        Args:
+            cut_tb: remove N frames from the stack trace to hide internal calls.
+        """
+        exc_type, exc_value, exc_traceback = sys.exc_info()
+
+        while cut_tb > 0:
+            exc_traceback = exc_traceback.tb_next
+            cut_tb -= 1
+
+        tb = "".join(traceback.format_exception(exc_type, exc_value, exc_traceback))
+
+        return cls(tb)
 
 
 class FlowReadException(ProxyException):

--- a/mitmproxy/flow.py
+++ b/mitmproxy/flow.py
@@ -695,14 +695,13 @@ class FlowMaster(controller.ServerMaster):
 
     def load_script(self, command, use_reloader=False):
         """
-            Loads a script. Returns an error description if something went
-            wrong.
+            Loads a script.
+
+            Raises:
+                ScriptException
         """
-        try:
-            s = script.Script(command, script.ScriptContext(self))
-            s.load()
-        except script.ScriptException as e:
-            return traceback.format_exc(e)
+        s = script.Script(command, script.ScriptContext(self))
+        s.load()
         if use_reloader:
             script.reloader.watch(s, lambda: self.event_queue.put(("script_change", s)))
         self.scripts.append(s)
@@ -712,7 +711,7 @@ class FlowMaster(controller.ServerMaster):
             try:
                 script_obj.run(name, *args, **kwargs)
             except script.ScriptException as e:
-                self.add_event("Script error:\n" + str(e), "error")
+                self.add_event("Script error:\n{}".format(e), "error")
 
     def run_script_hook(self, name, *args, **kwargs):
         for script_obj in self.scripts:
@@ -1069,12 +1068,12 @@ class FlowMaster(controller.ServerMaster):
             s.unload()
         except script.ScriptException as e:
             ok = False
-            self.add_event('Error reloading "{}": {}'.format(s.filename, str(e)), 'error')
+            self.add_event('Error reloading "{}":\n{}'.format(s.filename, e), 'error')
         try:
             s.load()
         except script.ScriptException as e:
             ok = False
-            self.add_event('Error reloading "{}": {}'.format(s.filename, str(e)), 'error')
+            self.add_event('Error reloading "{}":\n{}'.format(s.filename, e), 'error')
         else:
             self.add_event('"{}" reloaded.'.format(s.filename), 'info')
         return ok

--- a/mitmproxy/script/script.py
+++ b/mitmproxy/script/script.py
@@ -79,10 +79,10 @@ class Script(object):
             with open(self.filename) as f:
                 code = compile(f.read(), self.filename, 'exec')
                 exec (code, self.ns, self.ns)
-        except Exception as e:
+        except Exception:
             six.reraise(
                 ScriptException,
-                ScriptException(str(e)),
+                ScriptException.from_exception_context(),
                 sys.exc_info()[2]
             )
         finally:
@@ -113,10 +113,10 @@ class Script(object):
         if f:
             try:
                 return f(self.ctx, *args, **kwargs)
-            except Exception as e:
+            except Exception:
                 six.reraise(
                     ScriptException,
-                    ScriptException(str(e)),
+                    ScriptException.from_exception_context(),
                     sys.exc_info()[2]
                 )
         else:

--- a/test/mitmproxy/test_examples.py
+++ b/test/mitmproxy/test_examples.py
@@ -106,8 +106,8 @@ def test_modify_querystring():
 
 def test_modify_response_body():
     with tutils.raises(script.ScriptException):
-        with example("modify_response_body.py") as ex:
-            pass
+        with example("modify_response_body.py"):
+            assert True
 
     flow = tutils.tflow(resp=netutils.tresp(content="I <3 mitmproxy"))
     with example("modify_response_body.py mitmproxy rocks") as ex:
@@ -125,7 +125,7 @@ def test_redirect_requests():
 
 def test_har_extractor():
     with tutils.raises(script.ScriptException):
-        with example("har_extractor.py") as ex:
+        with example("har_extractor.py"):
             pass
 
     times = dict(

--- a/test/mitmproxy/test_server.py
+++ b/test/mitmproxy/test_server.py
@@ -285,8 +285,7 @@ class TestHTTP(tservers.HTTPProxyTest, CommonMixin, AppMixin):
         self.master.set_stream_large_bodies(None)
 
     def test_stream_modify(self):
-        self.master.load_script(
-            tutils.test_data.path("scripts/stream_modify.py"))
+        self.master.load_script(tutils.test_data.path("scripts/stream_modify.py"))
         d = self.pathod('200:b"foo"')
         assert d.content == "bar"
         self.master.unload_scripts()
@@ -511,8 +510,7 @@ class TestTransparent(tservers.TransparentProxyTest, CommonMixin, TcpMixin):
     ssl = False
 
     def test_tcp_stream_modify(self):
-        self.master.load_script(
-            tutils.test_data.path("scripts/tcp_stream_modify.py"))
+        self.master.load_script(tutils.test_data.path("scripts/tcp_stream_modify.py"))
 
         self._tcpproxy_on()
         d = self.pathod('200:b"foo"')


### PR DESCRIPTION
This PR improves mitmproxy's script loading:

- Return an error string in Python is an anti pattern. In particular, we swallowed errors regarding script loading in the mitmproxy UI when loading scripts.
- Add traceback to script exceptions. That greatly helps with debugging.