### PR TITLE
update and move version information

### DIFF
--- a/mitmproxy/version.py
+++ b/mitmproxy/version.py
@@ -1,3 +1,6 @@
 from __future__ import (absolute_import, print_function, division)
 
-from netlib.version import *
+IVERSION = (0, 18)
+VERSION = ".".join(str(i) for i in IVERSION)
+NAME = "mitmproxy"
+NAMEVERSION = NAME + " " + VERSION

--- a/netlib/version.py
+++ b/netlib/version.py
@@ -1,6 +1,0 @@
-from __future__ import (absolute_import, print_function, division)
-
-IVERSION = (0, 18)
-VERSION = ".".join(str(i) for i in IVERSION)
-NAME = "netlib"
-NAMEVERSION = NAME + " " + VERSION

--- a/netlib/version_check.py
+++ b/netlib/version_check.py
@@ -1,5 +1,5 @@
 """
-Having installed a wrong version of pyOpenSSL or netlib is unfortunately a
+Having installed a wrong version of pyOpenSSL or mitmproxy is unfortunately a
 very common source of error. Check before every start that both versions
 are somewhat okay.
 """
@@ -10,7 +10,6 @@ import os.path
 import six
 
 import OpenSSL
-from . import version
 
 PYOPENSSL_MIN_VERSION = (0, 15)
 

--- a/pathod/version.py
+++ b/pathod/version.py
@@ -1,3 +1,3 @@
 from __future__ import (absolute_import, print_function, division)
 
-from netlib.version import *
+from mitmproxy.version import *

--- a/test/netlib/test_version_check.py
+++ b/test/netlib/test_version_check.py
@@ -1,6 +1,6 @@
 from io import StringIO
 import mock
-from netlib import version_check, version
+from netlib import version_check
 
 
 @mock.patch("sys.exit")


### PR DESCRIPTION
With this mitmproxy sets the correct headers: e.g. `Server: mitmproxy 0.18`, instead of using the netlib identifier.