### PR TITLE
Adding example which turns every reponse into an HTTP 500.

### DIFF
--- a/examples/README
+++ b/examples/README
@@ -7,6 +7,7 @@ add_header.py             Simple script that just adds a header to every request
 change_upstream_proxy.py  Dynamically change the upstream proxy
 dns_spoofing.py           Use mitmproxy in a DNS spoofing scenario.
 dup_and_replay.py         Duplicates each request, changes it, and then replays the modified request.
+fail_with_500.py          Turn every response into an Internal Server Error.
 filt.py                   Use mitmproxy's filter expressions in your script.
 flowwriter.py             Only write selected flows into a mitmproxy dumpfile.
 iframe_injector.py        Inject configurable iframe into pages.

--- a/examples/fail_with_500.py
+++ b/examples/fail_with_500.py
@@ -1,0 +1,3 @@
+def response(context, flow):
+    flow.response.status_code = 500
+    flow.response.content = None

--- a/examples/fail_with_500.py
+++ b/examples/fail_with_500.py
@@ -1,3 +1,3 @@
 def response(context, flow):
     flow.response.status_code = 500
-    flow.response.content = None
+    flow.response.content = b""


### PR DESCRIPTION
I love using mitmproxy to easily reproduce network failures against API's.  I think this example will help raise awareness of how easy it can be to use mitmproxy in this way.