### PR TITLE
Send URL to stderr when starting mitmweb

### DIFF
--- a/mitmproxy/web/__init__.py
+++ b/mitmproxy/web/__init__.py
@@ -184,6 +184,8 @@ class WebMaster(flow.FlowMaster):
         iol.add_callback(self.start)
         tornado.ioloop.PeriodicCallback(lambda: self.tick(timeout=0), 5).start()
         try:
+            print("Server listening at http://{}:{}".format(
+                self.options.wiface, self.options.wport), file=sys.stderr)
             iol.start()
         except (Stop, KeyboardInterrupt):
             self.shutdown()


### PR DESCRIPTION
Nothing major, just makes it a bit easier for opening it up in the browser.