### PR TITLE
implement a toggle for viewing marked flows only in console

### DIFF
--- a/mitmproxy/console/flowlist.py
+++ b/mitmproxy/console/flowlist.py
@@ -21,6 +21,7 @@ def _mkhelp():
         ("l", "set limit filter pattern"),
         ("L", "load saved flows"),
         ("m", "toggle flow mark"),
+        ("M", "toggle marked flow view"),
         ("n", "create a new request"),
         ("P", "copy flow to clipboard"),
         ("r", "replay request"),
@@ -196,6 +197,12 @@ class ConnectionItem(urwid.WidgetWrap):
                 self.state.set_flow_marked(self.flow, False)
             else:
                 self.state.set_flow_marked(self.flow, True)
+            signals.flowlist_change.send(self)
+        elif key == "M":
+            if self.state.mark_filter:
+                self.state.disable_marked_filter()
+            else:
+                self.state.enable_marked_filter()
             signals.flowlist_change.send(self)
         elif key == "r":
             r = self.master.replay_request(self.flow)

--- a/mitmproxy/console/statusbar.py
+++ b/mitmproxy/console/statusbar.py
@@ -163,6 +163,10 @@ class StatusBar(urwid.WidgetWrap):
             r.append("[")
             r.append(("heading_key", "l"))
             r.append(":%s]" % self.master.state.limit_txt)
+        if self.master.state.mark_filter:
+            r.append("[")
+            r.append(("heading_key", "Marked Flows"))
+            r.append("]")
         if self.master.stickycookie_txt:
             r.append("[")
             r.append(("heading_key", "t"))


### PR DESCRIPTION
Hi All, I've been using this capability a bit when wrangling a bit of traffic in mitmproxy. It's not implemented as a filter, as the 'marking' of flows is handled in the ConsoleState. The 'M' command will quickly change the view to either marked flows or not. If there was an existing filter in place, this will be temporarily stored, and then replaced.

I'm unsure if this is the 'best' way to do this (don't hack much in Python), but it seems to be working for me fine.