### PR TITLE
First steps to solidifying the core

### DIFF
--- a/examples/flowbasic
+++ b/examples/flowbasic
@@ -8,7 +8,7 @@
     Note that request and response messages are not automatically replied to,
     so we need to implement handlers to do this.
 """
-from mitmproxy import flow
+from mitmproxy import flow, controller
 from mitmproxy.proxy import ProxyServer, ProxyConfig
 
 
@@ -19,18 +19,15 @@ class MyMaster(flow.FlowMaster):
         except KeyboardInterrupt:
             self.shutdown()
 
+    @controller.handler
     def handle_request(self, f):
         f = flow.FlowMaster.handle_request(self, f)
-        if f:
-            f.reply()
-        return f
+        print(f)
 
+    @controller.handler
     def handle_response(self, f):
         f = flow.FlowMaster.handle_response(self, f)
-        if f:
-            f.reply()
         print(f)
-        return f
 
 
 config = ProxyConfig(

--- a/examples/stickycookies
+++ b/examples/stickycookies
@@ -21,19 +21,19 @@ class StickyMaster(controller.Master):
         except KeyboardInterrupt:
             self.shutdown()
 
-    def handle_request(self, flow):
+    @controller.handler
+    def request(self, flow):
         hid = (flow.request.host, flow.request.port)
         if "cookie" in flow.request.headers:
             self.stickyhosts[hid] = flow.request.headers.get_all("cookie")
         elif hid in self.stickyhosts:
             flow.request.headers.set_all("cookie", self.stickyhosts[hid])
-        flow.reply()
 
-    def handle_response(self, flow):
+    @controller.handler
+    def response(self, flow):
         hid = (flow.request.host, flow.request.port)
         if "set-cookie" in flow.response.headers:
             self.stickyhosts[hid] = flow.response.headers.get_all("set-cookie")
-        flow.reply()
 
 
 config = proxy.ProxyConfig(port=8080)

--- a/mitmproxy/console/__init__.py
+++ b/mitmproxy/console/__init__.py
@@ -713,14 +713,15 @@ class ConsoleMaster(flow.FlowMaster):
             )
 
     def process_flow(self, f):
-        if self.state.intercept and f.match(self.state.intercept) and not f.request.is_replay:
+        should_intercept = any(
+            [
+                self.state.intercept and f.match(self.state.intercept) and not f.request.is_replay,
+                f.intercepted,
+            ]
+        )
+        if should_intercept:
             f.intercept(self)
-        else:
-            # check if flow was intercepted within an inline script by flow.intercept()
-            if f.intercepted:
-                f.intercept(self)
-            else:
-                f.reply()
+            f.reply.take()
         signals.flowlist_change.send(self)
         signals.flow_change.send(self, flow = f)
 
@@ -728,24 +729,29 @@ class ConsoleMaster(flow.FlowMaster):
         self.eventlist[:] = []
 
     # Handlers
+    @controller.handler
     def handle_error(self, f):
         f = flow.FlowMaster.handle_error(self, f)
         if f:
             self.process_flow(f)
         return f
 
+    @controller.handler
     def handle_request(self, f):
         f = flow.FlowMaster.handle_request(self, f)
+        self.add_event(f.reply.acked, "info")
         if f:
             self.process_flow(f)
         return f
 
+    @controller.handler
     def handle_response(self, f):
         f = flow.FlowMaster.handle_response(self, f)
         if f:
             self.process_flow(f)
         return f
 
+    @controller.handler
     def handle_script_change(self, script):
         if super(ConsoleMaster, self).handle_script_change(script):
             signals.status_message.send(message='"{}" reloaded.'.format(script.filename))

--- a/mitmproxy/console/__init__.py
+++ b/mitmproxy/console/__init__.py
@@ -739,7 +739,6 @@ class ConsoleMaster(flow.FlowMaster):
     @controller.handler
     def handle_request(self, f):
         f = flow.FlowMaster.handle_request(self, f)
-        self.add_event(f.reply.acked, "info")
         if f:
             self.process_flow(f)
         return f

--- a/mitmproxy/console/__init__.py
+++ b/mitmproxy/console/__init__.py
@@ -16,7 +16,7 @@ import weakref
 
 from netlib import tcp
 
-from .. import flow, script, contentviews
+from .. import flow, script, contentviews, controller
 from . import flowlist, flowview, help, window, signals, options
 from . import grideditor, palettes, statusbar, palettepicker
 from ..exceptions import FlowReadException, ScriptException

--- a/mitmproxy/console/__init__.py
+++ b/mitmproxy/console/__init__.py
@@ -730,28 +730,28 @@ class ConsoleMaster(flow.FlowMaster):
 
     # Handlers
     @controller.handler
-    def handle_error(self, f):
+    def error(self, f):
         f = flow.FlowMaster.handle_error(self, f)
         if f:
             self.process_flow(f)
         return f
 
     @controller.handler
-    def handle_request(self, f):
+    def request(self, f):
         f = flow.FlowMaster.handle_request(self, f)
         if f:
             self.process_flow(f)
         return f
 
     @controller.handler
-    def handle_response(self, f):
+    def response(self, f):
         f = flow.FlowMaster.handle_response(self, f)
         if f:
             self.process_flow(f)
         return f
 
     @controller.handler
-    def handle_script_change(self, script):
+    def script_change(self, script):
         if super(ConsoleMaster, self).handle_script_change(script):
             signals.status_message.send(message='"{}" reloaded.'.format(script.filename))
         else:

--- a/mitmproxy/controller.py
+++ b/mitmproxy/controller.py
@@ -36,10 +36,18 @@ class Master(object):
     """
         The master handles mitmproxy's main event loop.
     """
-    def __init__(self):
+    def __init__(self, *servers):
         self.event_queue = queue.Queue()
         self.should_exit = threading.Event()
         self.servers = []
+        for i in servers:
+            self.add_server(i)
+
+    def add_server(self, server):
+        # We give a Channel to the server which can be used to communicate with the master
+        channel = Channel(self.event_queue, self.should_exit)
+        server.set_channel(channel)
+        self.servers.append(server)
 
     def start(self):
         self.should_exit.clear()
@@ -86,12 +94,6 @@ class Master(object):
         for server in self.servers:
             server.shutdown()
         self.should_exit.set()
-
-    def add_server(self, server):
-        # We give a Channel to the server which can be used to communicate with the master
-        channel = Channel(self.event_queue, self.should_exit)
-        server.set_channel(channel)
-        self.servers.append(server)
 
 
 class ServerThread(threading.Thread):

--- a/mitmproxy/controller.py
+++ b/mitmproxy/controller.py
@@ -161,7 +161,13 @@ NO_REPLY = object()
 def handler(f):
     @functools.wraps(f)
     def wrapper(*args, **kwargs):
-        message = args[-1]
+        if len(args) == 1:
+            message = args[0]
+        elif len(args) == 2:
+            message = args[1]
+        else:
+            raise ControlError("Handler takes one argument: a message")
+
         if not hasattr(message, "reply"):
             raise ControlError("Message %s has no reply attribute"%message)
 

--- a/mitmproxy/controller.py
+++ b/mitmproxy/controller.py
@@ -66,8 +66,10 @@ class Master(object):
                 mtype, obj = self.event_queue.get(timeout=timeout)
                 if mtype not in Events:
                     raise ControlError("Unknown event %s"%repr(mtype))
-                handle_func = getattr(self, "handle_" + mtype)
-                if not handle_func.func_dict.get("handler"):
+                handle_func = getattr(self, mtype)
+                if not hasattr(handle_func, "func_dict"):
+                    raise ControlError("Handler %s not a function"%mtype)
+                if not handle_func.func_dict.get("__handler"):
                     raise ControlError(
                         "Handler function %s is not decorated with controller.handler"%(
                             handle_func
@@ -187,7 +189,7 @@ def handler(f):
         if handling and not message.reply.acked and not message.reply.taken:
             message.reply()
         return ret
-    wrapper.func_dict["handler"] = True
+    wrapper.func_dict["__handler"] = True
     return wrapper
 
 

--- a/mitmproxy/controller.py
+++ b/mitmproxy/controller.py
@@ -6,6 +6,27 @@ import sys
 
 from . import exceptions
 
+Events = frozenset([
+    "clientconnect",
+    "clientdisconnect",
+    "serverconnect",
+    "serverdisconnect",
+
+    "tcp_open",
+    "tcp_message",
+    "tcp_error",
+    "tcp_close",
+
+    "request",
+    "response",
+    "responseheaders",
+
+    "next_layer",
+
+    "error",
+    "log",
+])
+
 
 class ControlError(Exception):
     pass
@@ -43,6 +64,8 @@ class Master(object):
             # exception is thrown.
             while True:
                 mtype, obj = self.event_queue.get(timeout=timeout)
+                if mtype not in Events:
+                    raise ControlError("Unknown event %s"%repr(mtype))
                 handle_func = getattr(self, "handle_" + mtype)
                 if not handle_func.func_dict.get("handler"):
                     raise ControlError(

--- a/mitmproxy/dump.py
+++ b/mitmproxy/dump.py
@@ -6,8 +6,9 @@ import itertools
 
 from netlib import tcp
 from netlib.utils import bytes_to_escaped_str, pretty_size
-from . import flow, filt, contentviews
+from . import flow, filt, contentviews, controller
 from .exceptions import ContentViewException, FlowReadException, ScriptException
+
 
 
 class DumpError(Exception):

--- a/mitmproxy/dump.py
+++ b/mitmproxy/dump.py
@@ -10,7 +10,6 @@ from . import flow, filt, contentviews, controller
 from .exceptions import ContentViewException, FlowReadException, ScriptException
 
 
-
 class DumpError(Exception):
     pass
 
@@ -326,22 +325,25 @@ class DumpMaster(flow.FlowMaster):
 
         self.echo_flow(f)
 
-    def handle_request(self, f):
-        flow.FlowMaster.handle_request(self, f)
+    @controller.handler
+    def request(self, f):
+        flow.FlowMaster.request(self, f)
         self.state.delete_flow(f)
         if f:
             f.reply()
         return f
 
-    def handle_response(self, f):
-        flow.FlowMaster.handle_response(self, f)
+    @controller.handler
+    def response(self, f):
+        flow.FlowMaster.response(self, f)
         if f:
             f.reply()
             self._process_flow(f)
         return f
 
-    def handle_error(self, f):
-        flow.FlowMaster.handle_error(self, f)
+    @controller.handler
+    def error(self, f):
+        flow.FlowMaster.error(self, f)
         if f:
             self._process_flow(f)
         return f

--- a/mitmproxy/flow.py
+++ b/mitmproxy/flow.py
@@ -638,7 +638,7 @@ class State(object):
         self.flows.kill_all(master)
 
 
-class FlowMaster(controller.ServerMaster):
+class FlowMaster(controller.Master):
 
     @property
     def server(self):

--- a/mitmproxy/flow.py
+++ b/mitmproxy/flow.py
@@ -985,36 +985,36 @@ class FlowMaster(controller.ServerMaster):
             if block:
                 rt.join()
 
+    @controller.handler
     def handle_log(self, l):
         self.add_event(l.msg, l.level)
-        l.reply()
 
+    @controller.handler
     def handle_clientconnect(self, root_layer):
         self.run_script_hook("clientconnect", root_layer)
-        root_layer.reply()
 
+    @controller.handler
     def handle_clientdisconnect(self, root_layer):
         self.run_script_hook("clientdisconnect", root_layer)
-        root_layer.reply()
 
+    @controller.handler
     def handle_serverconnect(self, server_conn):
         self.run_script_hook("serverconnect", server_conn)
-        server_conn.reply()
 
+    @controller.handler
     def handle_serverdisconnect(self, server_conn):
         self.run_script_hook("serverdisconnect", server_conn)
-        server_conn.reply()
 
+    @controller.handler
     def handle_next_layer(self, top_layer):
         self.run_script_hook("next_layer", top_layer)
-        top_layer.reply()
 
+    @controller.handler
     def handle_error(self, f):
         self.state.update_flow(f)
         self.run_script_hook("error", f)
         if self.client_playback:
             self.client_playback.clear(f)
-        f.reply()
         return f
 
     def handle_request(self, f):

--- a/mitmproxy/flow.py
+++ b/mitmproxy/flow.py
@@ -546,7 +546,8 @@ class FlowStore(FlowList):
 
     def kill_all(self, master):
         for f in self._list:
-            f.kill(master)
+            if not f.reply.acked:
+                f.kill(master)
 
 
 class State(object):

--- a/mitmproxy/models/flow.py
+++ b/mitmproxy/models/flow.py
@@ -152,7 +152,7 @@ class Flow(stateobject.StateObject):
         self.error = Error("Connection killed")
         self.intercepted = False
         self.reply(Kill)
-        master.handle_error(self)
+        master.error(self)
 
     def intercept(self, master):
         """

--- a/mitmproxy/proxy/root_context.py
+++ b/mitmproxy/proxy/root_context.py
@@ -132,7 +132,6 @@ class RootContext(object):
 
 
 class Log(object):
-
     def __init__(self, msg, level="info"):
         self.msg = msg
         self.level = level

--- a/mitmproxy/web/__init__.py
+++ b/mitmproxy/web/__init__.py
@@ -197,17 +197,17 @@ class WebMaster(flow.FlowMaster):
             f.reply.take()
 
     @controller.handler
-    def handle_request(self, f):
+    def request(self, f):
         super(WebMaster, self).handle_request(f)
         self._process_flow(f)
 
     @controller.handler
-    def handle_response(self, f):
+    def response(self, f):
         super(WebMaster, self).handle_response(f)
         self._process_flow(f)
 
     @controller.handler
-    def handle_error(self, f):
+    def error(self, f):
         super(WebMaster, self).handle_error(f)
         self._process_flow(f)
 

--- a/mitmproxy/web/__init__.py
+++ b/mitmproxy/web/__init__.py
@@ -211,7 +211,6 @@ class WebMaster(flow.FlowMaster):
         super(WebMaster, self).handle_error(f)
         self._process_flow(f)
 
-    @controller.handler
     def add_event(self, e, level="info"):
         super(WebMaster, self).add_event(e, level)
         self.state.add_event(e, level)

--- a/mitmproxy/web/__init__.py
+++ b/mitmproxy/web/__init__.py
@@ -6,7 +6,7 @@ import sys
 
 from netlib.http import authentication
 
-from .. import flow
+from .. import flow, controller
 from ..exceptions import FlowReadException
 from . import app
 
@@ -194,21 +194,24 @@ class WebMaster(flow.FlowMaster):
         if self.state.intercept and self.state.intercept(
                 f) and not f.request.is_replay:
             f.intercept(self)
-        else:
-            f.reply()
+            f.reply.take()
 
+    @controller.handler
     def handle_request(self, f):
         super(WebMaster, self).handle_request(f)
         self._process_flow(f)
 
+    @controller.handler
     def handle_response(self, f):
         super(WebMaster, self).handle_response(f)
         self._process_flow(f)
 
+    @controller.handler
     def handle_error(self, f):
         super(WebMaster, self).handle_error(f)
         self._process_flow(f)
 
+    @controller.handler
     def add_event(self, e, level="info"):
         super(WebMaster, self).add_event(e, level)
         self.state.add_event(e, level)

--- a/netlib/tcp.py
+++ b/netlib/tcp.py
@@ -900,7 +900,7 @@ class TCPServer(object):
         """
         # If a thread has persisted after interpreter exit, the module might be
         # none.
-        if traceback:
+        if traceback and six:
             exc = six.text_type(traceback.format_exc())
             print(u'-' * 40, file=fp)
             print(

--- a/netlib/utils.py
+++ b/netlib/utils.py
@@ -438,7 +438,7 @@ def bytes_to_escaped_str(data):
         raise ValueError("data must be bytes")
     # We always insert a double-quote here so that we get a single-quoted string back
     # https://stackoverflow.com/questions/29019340/why-does-python-use-different-quotes-for-representing-strings-depending-on-their
-    return repr('"' + data).lstrip("b")[2:-1]
+    return repr(b'"' + data).lstrip("b")[2:-1]
 
 
 def escaped_str_to_bytes(data):

--- a/test/mitmproxy/test_controller.py
+++ b/test/mitmproxy/test_controller.py
@@ -16,7 +16,6 @@ class TMsg:
 
 class TestMaster(object):
     def test_simple(self):
-
         class DummyMaster(controller.Master):
             @controller.handler
             def handle_panic(self, _):
@@ -34,10 +33,8 @@ class TestMaster(object):
         m.run()
         assert m.should_exit.is_set()
 
-
-class TestServerMaster(object):
-    def test_simple(self):
-        m = controller.ServerMaster()
+    def test_server_simple(self):
+        m = controller.Master()
         s = DummyServer(None)
         m.add_server(s)
         m.start()

--- a/test/mitmproxy/test_controller.py
+++ b/test/mitmproxy/test_controller.py
@@ -18,7 +18,7 @@ class TestMaster(object):
     def test_simple(self):
         class DummyMaster(controller.Master):
             @controller.handler
-            def handle_panic(self, _):
+            def handle_log(self, _):
                 m.should_exit.set()
 
             def tick(self, timeout):
@@ -29,7 +29,7 @@ class TestMaster(object):
         assert not m.should_exit.is_set()
         msg = TMsg()
         msg.reply = controller.DummyReply()
-        m.event_queue.put(("panic", msg))
+        m.event_queue.put(("log", msg))
         m.run()
         assert m.should_exit.is_set()
 

--- a/test/mitmproxy/test_controller.py
+++ b/test/mitmproxy/test_controller.py
@@ -2,7 +2,7 @@ from threading import Thread, Event
 
 from mock import Mock
 
-from mitmproxy.controller import Reply, DummyReply, Channel, ServerThread, ServerMaster, Master
+from mitmproxy import controller
 from six.moves import queue
 
 from mitmproxy.exceptions import Kill
@@ -10,10 +10,15 @@ from mitmproxy.proxy import DummyServer
 from netlib.tutils import raises
 
 
+class TMsg:
+    pass
+
+
 class TestMaster(object):
     def test_simple(self):
 
-        class DummyMaster(Master):
+        class DummyMaster(controller.Master):
+            @controller.handler
             def handle_panic(self, _):
                 m.should_exit.set()
 
@@ -23,14 +28,16 @@ class TestMaster(object):
 
         m = DummyMaster()
         assert not m.should_exit.is_set()
-        m.event_queue.put(("panic", 42))
+        msg = TMsg()
+        msg.reply = controller.DummyReply()
+        m.event_queue.put(("panic", msg))
         m.run()
         assert m.should_exit.is_set()
 
 
 class TestServerMaster(object):
     def test_simple(self):
-        m = ServerMaster()
+        m = controller.ServerMaster()
         s = DummyServer(None)
         m.add_server(s)
         m.start()
@@ -42,7 +49,7 @@ class TestServerMaster(object):
 class TestServerThread(object):
     def test_simple(self):
         m = Mock()
-        t = ServerThread(m)
+        t = controller.ServerThread(m)
         t.run()
         assert m.serve_forever.called
 
@@ -50,7 +57,7 @@ class TestServerThread(object):
 class TestChannel(object):
     def test_tell(self):
         q = queue.Queue()
-        channel = Channel(q, Event())
+        channel = controller.Channel(q, Event())
         m = Mock()
         channel.tell("test", m)
         assert q.get() == ("test", m)
@@ -66,21 +73,21 @@ class TestChannel(object):
 
         Thread(target=reply).start()
 
-        channel = Channel(q, Event())
+        channel = controller.Channel(q, Event())
         assert channel.ask("test", Mock()) == 42
 
     def test_ask_shutdown(self):
         q = queue.Queue()
         done = Event()
         done.set()
-        channel = Channel(q, done)
+        channel = controller.Channel(q, done)
         with raises(Kill):
             channel.ask("test", Mock())
 
 
 class TestDummyReply(object):
     def test_simple(self):
-        reply = DummyReply()
+        reply = controller.DummyReply()
         assert not reply.acked
         reply()
         assert reply.acked
@@ -88,18 +95,18 @@ class TestDummyReply(object):
 
 class TestReply(object):
     def test_simple(self):
-        reply = Reply(42)
+        reply = controller.Reply(42)
         assert not reply.acked
         reply("foo")
         assert reply.acked
         assert reply.q.get() == "foo"
 
     def test_default(self):
-        reply = Reply(42)
+        reply = controller.Reply(42)
         reply()
         assert reply.q.get() == 42
 
     def test_reply_none(self):
-        reply = Reply(42)
+        reply = controller.Reply(42)
         reply(None)
         assert reply.q.get() is None

--- a/test/mitmproxy/test_controller.py
+++ b/test/mitmproxy/test_controller.py
@@ -18,7 +18,7 @@ class TestMaster(object):
     def test_simple(self):
         class DummyMaster(controller.Master):
             @controller.handler
-            def handle_log(self, _):
+            def log(self, _):
                 m.should_exit.set()
 
             def tick(self, timeout):

--- a/test/mitmproxy/test_dump.py
+++ b/test/mitmproxy/test_dump.py
@@ -64,14 +64,14 @@ class TestDumpMaster:
         f = tutils.tflow(req=netlib.tutils.treq(content=content))
         l = Log("connect")
         l.reply = mock.MagicMock()
-        m.handle_log(l)
-        m.handle_clientconnect(f.client_conn)
-        m.handle_serverconnect(f.server_conn)
-        m.handle_request(f)
+        m.log(l)
+        m.clientconnect(f.client_conn)
+        m.serverconnect(f.server_conn)
+        m.request(f)
         if not f.error:
             f.response = HTTPResponse.wrap(netlib.tutils.tresp(content=content))
-            f = m.handle_response(f)
-        m.handle_clientdisconnect(f.client_conn)
+            f = m.response(f)
+        m.clientdisconnect(f.client_conn)
         return f
 
     def _dummy_cycle(self, n, filt, content, **options):
@@ -95,8 +95,8 @@ class TestDumpMaster:
         o = dump.Options(flow_detail=1)
         m = dump.DumpMaster(None, o, outfile=cs)
         f = tutils.tflow(err=True)
-        m.handle_request(f)
-        assert m.handle_error(f)
+        m.request(f)
+        assert m.error(f)
         assert "error" in cs.getvalue()
 
     def test_missing_content(self):
@@ -105,10 +105,10 @@ class TestDumpMaster:
         m = dump.DumpMaster(None, o, outfile=cs)
         f = tutils.tflow()
         f.request.content = None
-        m.handle_request(f)
+        m.request(f)
         f.response = HTTPResponse.wrap(netlib.tutils.tresp())
         f.response.content = None
-        m.handle_response(f)
+        m.response(f)
         assert "content missing" in cs.getvalue()
 
     def test_replay(self):
@@ -160,7 +160,7 @@ class TestDumpMaster:
         assert o.verbosity == 2
 
     def test_filter(self):
-        assert not "GET" in self._dummy_cycle(1, "~u foo", "", verbosity=1)
+        assert "GET" not in self._dummy_cycle(1, "~u foo", "", verbosity=1)
 
     def test_app(self):
         o = dump.Options(app=True)

--- a/test/mitmproxy/test_flow.py
+++ b/test/mitmproxy/test_flow.py
@@ -461,9 +461,9 @@ class TestFlow(object):
         fm = flow.FlowMaster(None, s)
         f = tutils.tflow()
         f.intercept(mock.Mock())
-        assert not f.reply.acked
         f.kill(fm)
-        assert f.reply.acked
+        for i in s.view:
+            assert "killed" in str(i.error)
 
     def test_killall(self):
         s = flow.State()
@@ -475,11 +475,9 @@ class TestFlow(object):
         f = tutils.tflow()
         fm.handle_request(f)
 
-        for i in s.view:
-            assert not i.reply.acked
         s.killall(fm)
         for i in s.view:
-            assert i.reply.acked
+            assert "killed" in str(i.error)
 
     def test_accept_intercept(self):
         f = tutils.tflow()

--- a/test/mitmproxy/test_flow.py
+++ b/test/mitmproxy/test_flow.py
@@ -53,7 +53,7 @@ class TestStickyCookieState:
         assert s.domain_match("www.google.com", ".google.com")
         assert s.domain_match("google.com", ".google.com")
 
-    def test_handle_response(self):
+    def test_response(self):
         c = "SSID=mooo; domain=.google.com, FOO=bar; Domain=.google.com; Path=/; "\
             "Expires=Wed, 13-Jan-2021 22:23:01 GMT; Secure; "
 
@@ -100,7 +100,7 @@ class TestStickyCookieState:
         assert len(s.jar[googlekey].keys()) == 1
         assert s.jar[googlekey]["somecookie"].items()[0][1] == "newvalue"
 
-    def test_handle_request(self):
+    def test_request(self):
         s, f = self._response("SSID=mooo", "www.google.com")
         assert "cookie" not in f.request.headers
         s.handle_request(f)
@@ -109,7 +109,7 @@ class TestStickyCookieState:
 
 class TestStickyAuthState:
 
-    def test_handle_response(self):
+    def test_response(self):
         s = flow.StickyAuthState(filt.parse(".*"))
         f = tutils.tflow(resp=True)
         f.request.headers["authorization"] = "foo"
@@ -798,8 +798,8 @@ class TestFlowMaster:
         fm = flow.FlowMaster(None, s)
         fm.load_script(tutils.test_data.path("scripts/reqerr.py"))
         f = tutils.tflow()
-        fm.handle_clientconnect(f.client_conn)
-        assert fm.handle_request(f)
+        fm.clientconnect(f.client_conn)
+        assert fm.request(f)
 
     def test_script(self):
         s = flow.State()
@@ -807,18 +807,18 @@ class TestFlowMaster:
         fm.load_script(tutils.test_data.path("scripts/all.py"))
         f = tutils.tflow(resp=True)
 
-        fm.handle_clientconnect(f.client_conn)
+        fm.clientconnect(f.client_conn)
         assert fm.scripts[0].ns["log"][-1] == "clientconnect"
-        fm.handle_serverconnect(f.server_conn)
+        fm.serverconnect(f.server_conn)
         assert fm.scripts[0].ns["log"][-1] == "serverconnect"
-        fm.handle_request(f)
+        fm.request(f)
         assert fm.scripts[0].ns["log"][-1] == "request"
-        fm.handle_response(f)
+        fm.response(f)
         assert fm.scripts[0].ns["log"][-1] == "response"
         # load second script
         fm.load_script(tutils.test_data.path("scripts/all.py"))
         assert len(fm.scripts) == 2
-        fm.handle_clientdisconnect(f.server_conn)
+        fm.clientdisconnect(f.server_conn)
         assert fm.scripts[0].ns["log"][-1] == "clientdisconnect"
         assert fm.scripts[1].ns["log"][-1] == "clientdisconnect"
 
@@ -828,7 +828,7 @@ class TestFlowMaster:
         fm.load_script(tutils.test_data.path("scripts/all.py"))
 
         f.error = tutils.terr()
-        fm.handle_error(f)
+        fm.error(f)
         assert fm.scripts[0].ns["log"][-1] == "error"
 
     def test_duplicate_flow(self):
@@ -853,20 +853,20 @@ class TestFlowMaster:
         fm.anticache = True
         fm.anticomp = True
         f = tutils.tflow(req=None)
-        fm.handle_clientconnect(f.client_conn)
+        fm.clientconnect(f.client_conn)
         f.request = HTTPRequest.wrap(netlib.tutils.treq())
-        fm.handle_request(f)
+        fm.request(f)
         assert s.flow_count() == 1
 
         f.response = HTTPResponse.wrap(netlib.tutils.tresp())
-        fm.handle_response(f)
+        fm.response(f)
         assert s.flow_count() == 1
 
-        fm.handle_clientdisconnect(f.client_conn)
+        fm.clientdisconnect(f.client_conn)
 
         f.error = Error("msg")
         f.error.reply = controller.DummyReply()
-        fm.handle_error(f)
+        fm.error(f)
 
         fm.load_script(tutils.test_data.path("scripts/a.py"))
         fm.shutdown()
@@ -895,7 +895,7 @@ class TestFlowMaster:
         assert fm.state.flow_count()
 
         f.error = Error("error")
-        fm.handle_error(f)
+        fm.error(f)
 
     def test_server_playback(self):
         s = flow.State()
@@ -976,12 +976,12 @@ class TestFlowMaster:
         fm.set_stickycookie(".*")
         f = tutils.tflow(resp=True)
         f.response.headers["set-cookie"] = "foo=bar"
-        fm.handle_request(f)
-        fm.handle_response(f)
+        fm.request(f)
+        fm.response(f)
         assert fm.stickycookie_state.jar
         assert not "cookie" in f.request.headers
         f = f.copy()
-        fm.handle_request(f)
+        fm.request(f)
         assert f.request.headers["cookie"] == "foo=bar"
 
     def test_stickyauth(self):
@@ -996,12 +996,12 @@ class TestFlowMaster:
         fm.set_stickyauth(".*")
         f = tutils.tflow(resp=True)
         f.request.headers["authorization"] = "foo"
-        fm.handle_request(f)
+        fm.request(f)
 
         f = tutils.tflow(resp=True)
         assert fm.stickyauth_state.hosts
         assert not "authorization" in f.request.headers
-        fm.handle_request(f)
+        fm.request(f)
         assert f.request.headers["authorization"] == "foo"
 
     def test_stream(self):
@@ -1017,15 +1017,15 @@ class TestFlowMaster:
             f = tutils.tflow(resp=True)
 
             fm.start_stream(file(p, "ab"), None)
-            fm.handle_request(f)
-            fm.handle_response(f)
+            fm.request(f)
+            fm.response(f)
             fm.stop_stream()
 
             assert r()[0].response
 
             f = tutils.tflow()
             fm.start_stream(file(p, "ab"), None)
-            fm.handle_request(f)
+            fm.request(f)
             fm.shutdown()
 
             assert not r()[1].response

--- a/test/mitmproxy/test_flow.py
+++ b/test/mitmproxy/test_flow.py
@@ -470,10 +470,7 @@ class TestFlow(object):
         fm = flow.FlowMaster(None, s)
 
         f = tutils.tflow()
-        fm.handle_request(f)
-
-        f = tutils.tflow()
-        fm.handle_request(f)
+        f.intercept(fm)
 
         s.killall(fm)
         for i in s.view:

--- a/test/mitmproxy/test_flow.py
+++ b/test/mitmproxy/test_flow.py
@@ -866,7 +866,6 @@ class TestFlowMaster:
 
         f.response = HTTPResponse.wrap(netlib.tutils.tresp())
         fm.handle_response(f)
-        assert not fm.handle_response(None)
         assert s.flow_count() == 1
 
         fm.handle_clientdisconnect(f.client_conn)

--- a/test/mitmproxy/test_script.py
+++ b/test/mitmproxy/test_script.py
@@ -7,7 +7,7 @@ def test_duplicate_flow():
     fm = flow.FlowMaster(None, s)
     fm.load_script(tutils.test_data.path("scripts/duplicate_flow.py"))
     f = tutils.tflow()
-    fm.handle_request(f)
+    fm.request(f)
     assert fm.state.flow_count() == 2
     assert not fm.state.view[0].request.is_replay
     assert fm.state.view[1].request.is_replay

--- a/test/mitmproxy/test_server.py
+++ b/test/mitmproxy/test_server.py
@@ -12,6 +12,7 @@ from netlib.http import authentication, http1
 from netlib.tutils import raises
 from pathod import pathoc, pathod
 
+from mitmproxy import controller
 from mitmproxy.proxy.config import HostMatcher
 from mitmproxy.exceptions import Kill
 from mitmproxy.models import Error, HTTPResponse, HTTPFlow
@@ -623,6 +624,7 @@ class TestProxySSL(tservers.HTTPProxyTest):
 class MasterRedirectRequest(tservers.TestMaster):
     redirect_port = None  # Set by TestRedirectRequest
 
+    @controller.handler
     def handle_request(self, f):
         if f.request.path == "/p/201":
 
@@ -636,6 +638,7 @@ class MasterRedirectRequest(tservers.TestMaster):
             f.request.port = self.redirect_port
         super(MasterRedirectRequest, self).handle_request(f)
 
+    @controller.handler
     def handle_response(self, f):
         f.response.content = str(f.client_conn.address.port)
         f.response.headers["server-conn-id"] = str(f.server_conn.source_address.port)
@@ -689,10 +692,9 @@ class MasterStreamRequest(tservers.TestMaster):
     """
         Enables the stream flag on the flow for all requests
     """
-
+    @controller.handler
     def handle_responseheaders(self, f):
         f.response.stream = True
-        f.reply()
 
 
 class TestStreamRequest(tservers.HTTPProxyTest):
@@ -739,7 +741,7 @@ class TestStreamRequest(tservers.HTTPProxyTest):
 
 
 class MasterFakeResponse(tservers.TestMaster):
-
+    @controller.handler
     def handle_request(self, f):
         resp = HTTPResponse.wrap(netlib.tutils.tresp())
         f.reply(resp)
@@ -767,6 +769,7 @@ class TestServerConnect(tservers.HTTPProxyTest):
 
 class MasterKillRequest(tservers.TestMaster):
 
+    @controller.handler
     def handle_request(self, f):
         f.reply(Kill)
 
@@ -783,6 +786,7 @@ class TestKillRequest(tservers.HTTPProxyTest):
 
 class MasterKillResponse(tservers.TestMaster):
 
+    @controller.handler
     def handle_response(self, f):
         f.reply(Kill)
 
@@ -812,6 +816,7 @@ class TestTransparentResolveError(tservers.TransparentProxyTest):
 
 class MasterIncomplete(tservers.TestMaster):
 
+    @controller.handler
     def handle_request(self, f):
         resp = HTTPResponse.wrap(netlib.tutils.tresp())
         resp.content = None
@@ -930,7 +935,9 @@ class TestProxyChainingSSLReconnect(tservers.HTTPUpstreamProxyTest):
             k = [0]  # variable scope workaround: put into array
             _func = getattr(master, attr)
 
-            def handler(f):
+            @controller.handler
+            def handler(*args):
+                f = args[-1]
                 k[0] += 1
                 if not (k[0] in exclude):
                     f.client_conn.finish()
@@ -940,11 +947,14 @@ class TestProxyChainingSSLReconnect(tservers.HTTPUpstreamProxyTest):
 
             setattr(master, attr, handler)
 
-        kill_requests(self.chain[1].tmaster, "handle_request",
-                      exclude=[
-                          # fail first request
-                          2,  # allow second request
-        ])
+        kill_requests(
+            self.chain[1].tmaster,
+            "handle_request",
+            exclude = [
+                # fail first request
+                2,  # allow second request
+            ]
+        )
 
         kill_requests(self.chain[0].tmaster, "handle_request",
                       exclude=[
@@ -1004,10 +1014,10 @@ class AddUpstreamCertsToClientChainMixin:
     ssl = True
     servercert = tutils.test_data.path("data/trusted-server.crt")
     ssloptions = pathod.SSLOptions(
-            cn="trusted-cert",
-            certs=[
-                ("trusted-cert", servercert)
-            ]
+        cn="trusted-cert",
+        certs=[
+            ("trusted-cert", servercert)
+        ]
     )
 
     def test_add_upstream_certs_to_client_chain(self):

--- a/test/mitmproxy/tservers.py
+++ b/test/mitmproxy/tservers.py
@@ -39,13 +39,13 @@ class TestMaster(flow.FlowMaster):
         self.apps.add(errapp, "errapp", 80)
         self.clear_log()
 
+    @controller.handler
     def handle_request(self, f):
         flow.FlowMaster.handle_request(self, f)
-        f.reply()
 
+    @controller.handler
     def handle_response(self, f):
         flow.FlowMaster.handle_response(self, f)
-        f.reply()
 
     def clear_log(self):
         self.log = []

--- a/test/mitmproxy/tservers.py
+++ b/test/mitmproxy/tservers.py
@@ -39,19 +39,11 @@ class TestMaster(flow.FlowMaster):
         self.apps.add(errapp, "errapp", 80)
         self.clear_log()
 
-    @controller.handler
-    def handle_request(self, f):
-        flow.FlowMaster.handle_request(self, f)
-
-    @controller.handler
-    def handle_response(self, f):
-        flow.FlowMaster.handle_response(self, f)
-
     def clear_log(self):
-        self.log = []
+        self.tlog = []
 
     def add_event(self, message, level=None):
-        self.log.append(message)
+        self.tlog.append(message)
 
 
 class ProxyThread(threading.Thread):
@@ -68,8 +60,8 @@ class ProxyThread(threading.Thread):
         return self.tmaster.server.address.port
 
     @property
-    def log(self):
-        return self.tmaster.log
+    def tlog(self):
+        return self.tmaster.tlog
 
     def run(self):
         self.tmaster.run()


### PR DESCRIPTION
This is a hefty patch that takes some first steps towards solidifying our core comms mechanism. Highlights include:

- Introduce a @controller.handler decorator that automatically replys() to messages
- Introduce a reply.take() method to take control of a message and prevent automatic reply
- Handers are no longer named handle_message. The decorator makes clear what is a handler, so it's just "message" now.
- Add an explicit list of permitted messages. This clarifies our mechanisms, and will be the start of better message documentation and more sophisticated handling mechanisms down the track.
- Add a bunch of sanity checks for messages that are acked twice, or never, or are given invalid arguments. Use this to catch numerous occurrences throughout the codebase.
- Simplify the class hierarchy in controller by merging Master and ServerMaster. 




