### PR TITLE
 Verify upstream certificates by default. #1111

### DIFF
--- a/mitmproxy/cmdline.py
+++ b/mitmproxy/cmdline.py
@@ -466,10 +466,9 @@ def proxy_ssl_options(parser):
              "that will be served to the proxy client, as extras."
     )
     group.add_argument(
-        "--verify-upstream-cert", default=False,
-        action="store_true", dest="ssl_verify_upstream_cert",
-        help="Verify upstream server SSL/TLS certificates and fail if invalid "
-             "or not present."
+        "--insecure", default=False,
+        action="store_true", dest="ssl_insecure",
+        help="Do not verify upstream server SSL/TLS certificates."
     )
     group.add_argument(
         "--upstream-trusted-cadir", default=None, action="store",

--- a/mitmproxy/console/options.py
+++ b/mitmproxy/console/options.py
@@ -93,7 +93,7 @@ class Options(urwid.WidgetWrap):
                 ),
                 select.Option(
                     "Don't Verify Upstream Certs",
-                    "K",
+                    "V",
                     lambda: master.server.config.ssl_insecure,
                     self.toggle_ssl_insecure
                 ),
@@ -198,7 +198,7 @@ class Options(urwid.WidgetWrap):
         signals.update_settings.send(self)
 
     def toggle_ssl_insecure(self):
-        self.master.server.config.ssl_insecure = not self.master.server.config.ssl_insecure
+        self.master.server.config.openssl_verification_mode_server = VERIFY_PEER if self.master.server.config.openssl_verification_mode_server is VERIFY_NONE else VERIFY_NONE
         signals.update_settings.send(self)
 
     def setheaders(self):

--- a/mitmproxy/console/options.py
+++ b/mitmproxy/console/options.py
@@ -198,7 +198,8 @@ class Options(urwid.WidgetWrap):
         signals.update_settings.send(self)
 
     def toggle_ssl_insecure(self):
-        self.master.server.config.openssl_verification_mode_server = VERIFY_PEER if self.master.server.config.openssl_verification_mode_server is VERIFY_NONE else VERIFY_NONE
+        self.master.server.config.ssl_insecure = not self.master.server.config.ssl_insecure
+        self.master.server.config.openssl_verification_mode_server = VERIFY_NONE if self.master.server.config.ssl_insecure else VERIFY_PEER
         signals.update_settings.send(self)
 
     def setheaders(self):

--- a/mitmproxy/console/options.py
+++ b/mitmproxy/console/options.py
@@ -8,6 +8,7 @@ from mitmproxy.console import grideditor
 from mitmproxy.console import palettes
 from mitmproxy.console import select
 from mitmproxy.console import signals
+from OpenSSL import SSL
 
 footer = [
     ('heading_key', "enter/space"), ":toggle ",
@@ -199,7 +200,7 @@ class Options(urwid.WidgetWrap):
 
     def toggle_ssl_insecure(self):
         self.master.server.config.ssl_insecure = not self.master.server.config.ssl_insecure
-        self.master.server.config.openssl_verification_mode_server = VERIFY_NONE if self.master.server.config.ssl_insecure else VERIFY_PEER
+        self.master.server.config.openssl_verification_mode_server = SSL.VERIFY_NONE if self.master.server.config.ssl_insecure else SSL.VERIFY_PEER
         signals.update_settings.send(self)
 
     def setheaders(self):

--- a/mitmproxy/console/options.py
+++ b/mitmproxy/console/options.py
@@ -200,7 +200,8 @@ class Options(urwid.WidgetWrap):
 
     def toggle_ssl_insecure(self):
         self.master.server.config.ssl_insecure = not self.master.server.config.ssl_insecure
-        self.master.server.config.openssl_verification_mode_server = SSL.VERIFY_NONE if self.master.server.config.ssl_insecure else SSL.VERIFY_PEER
+        self.master.server.config.openssl_verification_mode_server = SSL.VERIFY_NONE \
+            if self.master.server.config.ssl_insecure else SSL.VERIFY_PEER
         signals.update_settings.send(self)
 
     def setheaders(self):

--- a/mitmproxy/console/options.py
+++ b/mitmproxy/console/options.py
@@ -91,6 +91,12 @@ class Options(urwid.WidgetWrap):
                     lambda: master.server.config.check_tcp,
                     self.tcp_proxy
                 ),
+                select.Option(
+                    "Verify Upstream Certs",
+                    "K",
+                    lambda: master.server.config.ssl_insecure,
+                    self.toggle_ssl_insecure
+                ),
 
                 select.Heading("Utility"),
                 select.Option(
@@ -189,6 +195,10 @@ class Options(urwid.WidgetWrap):
 
     def toggle_upstream_cert(self):
         self.master.server.config.no_upstream_cert = not self.master.server.config.no_upstream_cert
+        signals.update_settings.send(self)
+
+    def toggle_ssl_insecure(self):
+        self.master.server.config.ssl_insecure = not self.master.server.config.ssl_insecure
         signals.update_settings.send(self)
 
     def setheaders(self):

--- a/mitmproxy/console/options.py
+++ b/mitmproxy/console/options.py
@@ -92,7 +92,7 @@ class Options(urwid.WidgetWrap):
                     self.tcp_proxy
                 ),
                 select.Option(
-                    "Verify Upstream Certs",
+                    "Don't Verify Upstream Certs",
                     "K",
                     lambda: master.server.config.ssl_insecure,
                     self.toggle_ssl_insecure

--- a/mitmproxy/proxy/config.py
+++ b/mitmproxy/proxy/config.py
@@ -78,7 +78,7 @@ class ProxyConfig:
             certs=tuple(),
             ssl_version_client="secure",
             ssl_version_server="secure",
-            ssl_verify_upstream_cert=False,
+            ssl_insecure=False,
             ssl_verify_upstream_trusted_cadir=None,
             ssl_verify_upstream_trusted_ca=None,
             add_upstream_certs_to_client_chain=False,
@@ -116,10 +116,10 @@ class ProxyConfig:
         self.openssl_method_server, self.openssl_options_server = \
             tcp.sslversion_choices[ssl_version_server]
 
-        if ssl_verify_upstream_cert:
-            self.openssl_verification_mode_server = SSL.VERIFY_PEER
-        else:
+        if ssl_insecure:
             self.openssl_verification_mode_server = SSL.VERIFY_NONE
+        else:
+            self.openssl_verification_mode_server = SSL.VERIFY_PEER
         self.openssl_trusted_cadir_server = ssl_verify_upstream_trusted_cadir
         self.openssl_trusted_ca_server = ssl_verify_upstream_trusted_ca
         self.add_upstream_certs_to_client_chain = add_upstream_certs_to_client_chain
@@ -161,12 +161,12 @@ def process_proxy_options(parser, options):
             "then the upstream certificate is not retrieved before generating "
             "the client certificate chain."
         )
-    if options.add_upstream_certs_to_client_chain and options.ssl_verify_upstream_cert:
+    if options.add_upstream_certs_to_client_chain and not options.ssl_insecure:
         return parser.error(
-            "The verify-upstream-cert and add-upstream-certs-to-client-chain "
-            "options are mutually exclusive. If upstream certificates are verified "
-            "then extra upstream certificates are not available for inclusion "
-            "to the client chain."
+            "Extra upstream certificates are not available for inclusion to the "
+            "client chain as upstream certificates are verified by default. "
+            "Please use the insecure option with the add-upstream-certs-to-client-chain "
+            "option to stop verifying the upstream certificates. "
         )
     if options.clientcerts:
         options.clientcerts = os.path.expanduser(options.clientcerts)
@@ -234,7 +234,7 @@ def process_proxy_options(parser, options):
         certs=tuple(certs),
         ssl_version_client=options.ssl_version_client,
         ssl_version_server=options.ssl_version_server,
-        ssl_verify_upstream_cert=options.ssl_verify_upstream_cert,
+        ssl_insecure=options.ssl_insecure,
         ssl_verify_upstream_trusted_cadir=options.ssl_verify_upstream_trusted_cadir,
         ssl_verify_upstream_trusted_ca=options.ssl_verify_upstream_trusted_ca,
         add_upstream_certs_to_client_chain=options.add_upstream_certs_to_client_chain,

--- a/mitmproxy/proxy/config.py
+++ b/mitmproxy/proxy/config.py
@@ -89,6 +89,7 @@ class ProxyConfig:
         self.ciphers_server = ciphers_server
         self.clientcerts = clientcerts
         self.no_upstream_cert = no_upstream_cert
+        self.ssl_insecure = ssl_insecure
         self.body_size_limit = body_size_limit
         self.mode = mode
         if upstream_server:

--- a/test/mitmproxy/test_protocol_http2.py
+++ b/test/mitmproxy/test_protocol_http2.py
@@ -98,6 +98,7 @@ class _Http2TestBase(object):
             no_upstream_cert = False,
             cadir = cls.cadir,
             authenticator = None,
+            ssl_insecure = True,
         )
 
     def setup(self):

--- a/test/mitmproxy/test_proxy.py
+++ b/test/mitmproxy/test_proxy.py
@@ -138,9 +138,9 @@ class TestProcessProxyOptions:
             "--singleuser",
             "test")
 
-    def test_verify_upstream_cert(self):
-        p = self.assert_noerr("--verify-upstream-cert")
-        assert p.openssl_verification_mode_server == SSL.VERIFY_PEER
+    def test_insecure(self):
+        p = self.assert_noerr("--insecure")
+        assert p.openssl_verification_mode_server == SSL.VERIFY_NONE
 
     def test_upstream_trusted_cadir(self):
         expected_dir = "/path/to/a/ca/dir"

--- a/test/mitmproxy/tservers.py
+++ b/test/mitmproxy/tservers.py
@@ -122,6 +122,7 @@ class ProxyTestBase(object):
             cadir = cls.cadir,
             authenticator = cls.authenticator,
             add_upstream_certs_to_client_chain = cls.add_upstream_certs_to_client_chain,
+            ssl_insecure = True,
         )
 
 


### PR DESCRIPTION
This adds the `--insecure` option and enables certificate verification by default. The tests fail and I need help in knowing how to fix them.