### PR TITLE
Now keeps header capitalization

### DIFF
--- a/netlib/multidict.py
+++ b/netlib/multidict.py
@@ -105,7 +105,7 @@ class _MultiDict(MutableMapping, basetypes.Serializable):
             if self._kconv(field[0]) == key_kconv:
                 if values:
                     new_fields.append(
-                        (key, values.pop(0))
+                        (field[0], values.pop(0))
                     )
             else:
                 new_fields.append(field)

--- a/test/netlib/test_multidict.py
+++ b/test/netlib/test_multidict.py
@@ -120,7 +120,7 @@ class TestMultiDict(object):
             ("a", "b"),
             ("x", "x"),
             ("c", "d"),
-            ("X", "x"),
+            ("X", "X"),
             ("e", "f"),
         ))
         md.set_all("x", ["1", "2", "3"])
@@ -128,7 +128,7 @@ class TestMultiDict(object):
             ("a", "b"),
             ("x", "1"),
             ("c", "d"),
-            ("x", "2"),
+            ("X", "2"),
             ("e", "f"),
             ("x", "3"),
         )


### PR DESCRIPTION
Fixes #1214
Some servers don't fully respect RFC 2616 (Headers should be case-insensitive). This makes it so that the capitalization of the header fields stay the same, even if (for example) the `Content-Length` changes.