### PR TITLE
Reenable pathod.language.writer tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,9 @@ matrix:
       git:
         depth: 9999999
     - python: 3.5
-      env: SCOPE="netlib test/mitmproxy/script test/pathod/test_utils.py test/pathod/test_log.py test/pathod/test_language_generators.py test/pathod/test_language_base.py test/pathod/test_language_http.py"
+      env: SCOPE="netlib test/mitmproxy/script test/pathod/test_utils.py test/pathod/test_log.py test/pathod/test_language_generators.py test/pathod/test_language_base.py test/pathod/test_language_http.py test/pathod/test_language_writer.py"
     - python: 3.5
-      env: SCOPE="netlib test/mitmproxy/script test/pathod/test_utils.py test/pathod/test_log.py test/pathod/test_language_generators.py test/pathod/test_language_base.py test/pathod/test_language_http.py" NO_ALPN=1
+      env: SCOPE="netlib test/mitmproxy/script test/pathod/test_utils.py test/pathod/test_log.py test/pathod/test_language_generators.py test/pathod/test_language_base.py test/pathod/test_language_http.py test/pathod/test_language_writer.py" NO_ALPN=1
     - python: 2.7
       env: DOCS=1
       script: 'cd docs && SPHINXOPTS="-W" make -e html'

--- a/test/pathod/test_language_writer.py
+++ b/test/pathod/test_language_writer.py
@@ -87,4 +87,4 @@ def test_write_values_after():
     s = BytesIO()
     r = next(language.parse_pathod("400:ia,'xx'"))
     language.serve(r, s, {})
-    assert s.getvalue().endswith('xx')
+    assert s.getvalue().endswith(b'xx')


### PR DESCRIPTION
@dufferzafar: I removed `test_language_writer` from `.travis.yml` until we fix the other language parts, that made `test_write_values_after` fail. Having travis fail on master makes reviewing all kinds of pull requests incredibly difficult.

This reverts commit 1e1b4fd88dd16b3b6b8c2cbf9337cba4dffa6c68.