### PR TITLE
Show tracebacks on mitmproxy error pages

### DIFF
--- a/mitmproxy/models/http.py
+++ b/mitmproxy/models/http.py
@@ -251,10 +251,11 @@ def make_error_response(status_code, message, headers=None):
             <head>
                 <title>%d %s</title>
             </head>
-            <body>%s</body>
+            <body><pre>%s</pre></body>
         </html>
     """.strip() % (status_code, response, cgi.escape(message))
-    body = body.encode("utf8", "replace")
+    # Remove the .decode('unicode_escape') when converting to py3
+    body = body.decode('unicode_escape').encode("utf8", "replace")
 
     if not headers:
         headers = Headers(

--- a/mitmproxy/protocol/http.py
+++ b/mitmproxy/protocol/http.py
@@ -161,7 +161,7 @@ class HttpLayer(base.Layer):
                 # don't throw an error for disconnects that happen before/between requests.
                 return
             except netlib.exceptions.NetlibException as e:
-                self.send_error_response(400, repr(e))
+                self.send_error_response(400, traceback.format_exc())
                 six.reraise(exceptions.ProtocolException, exceptions.ProtocolException(
                     "Error in HTTP connection: %s" % repr(e)), sys.exc_info()[2])
 
@@ -202,7 +202,7 @@ class HttpLayer(base.Layer):
                     return
 
             except (exceptions.ProtocolException, netlib.exceptions.NetlibException) as e:
-                self.send_error_response(502, repr(e))
+                self.send_error_response(502, traceback.format_exc())
 
                 if not flow.response:
                     flow.error = models.Error(str(e))


### PR DESCRIPTION
Instead of the repr of the exception, which is basically useless, show
the full traceback on the error page.