### PR TITLE
WIP: Distinguish between CI and interactive versions of tox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,15 +14,15 @@ matrix:
   fast_finish: true
   include:
     - python: 2.7
-      env: TOXENV=py27
+      env: TOXENV=py27-ci
     - python: 2.7
-      env: TOXENV=py27 NO_ALPN=1
+      env: TOXENV=py27-ci NO_ALPN=1
     - python: 3.5
-      env: TOXENV=py35
+      env: TOXENV=py35-ci
     - python: 3.5
-      env: TOXENV=py35 NO_ALPN=1
+      env: TOXENV=py35-ci NO_ALPN=1
     - language: generic
-      env: TOXENV=py27
+      env: TOXENV=py27-ci
       os: osx
       osx_image: xcode7.1
       git:
@@ -45,7 +45,7 @@ install:
 before_script:
   - "tox -e lint"
 
-script: tox -e py27-ci,py35-ci,docs
+script: tox
 
 after_success:
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,12 +40,12 @@ install:
       brew outdated openssl || brew upgrade openssl
       brew install python
     fi
+  - pip install tox tox-travis
 
 before_script:
-  - "pip install tox"
   - "tox -e lint"
 
-script: tox
+script: tox -e py27-ci,py35-ci,docs
 
 after_success:
   - |

--- a/tox.ini
+++ b/tox.ini
@@ -18,12 +18,14 @@ commands =
   bash -c 'set -o pipefail ; py.test -n 8 --color=yes --timeout 60 test/netlib test/mitmproxy/script test/pathod/test_utils.py test/pathod/test_log.py test/pathod/test_language_generators.py test/pathod/test_language_writer.py test/pathod/test_language_base.py test/pathod/test_language_http.py test/pathod/test_language_websocket.py test/pathod/test_language_http2.py 2>&1 | grep -v Cryptography_locking_cb'
 
 [testenv:py27-ci]
+basepython = python2.7
 commands =
   py.test --cov netlib --cov mitmproxy --cov pathod --color=yes --timeout 60 ./test
   codecov -e TOXENV
 
 [testenv:py35-ci]
 # remove bash & pipe & grep hack after cryptography ships with openssl 1.1.0
+basepython = python3.5
 whitelist_externals = bash
 commands =
   bash -c 'set -o pipefail ; py.test --cov netlib --cov mitmproxy --cov pathod --color=yes --timeout 60 test/netlib test/mitmproxy/script test/pathod/test_utils.py test/pathod/test_log.py test/pathod/test_language_generators.py test/pathod/test_language_writer.py test/pathod/test_language_base.py test/pathod/test_language_http.py test/pathod/test_language_websocket.py test/pathod/test_language_http2.py 2>&1 | grep -v Cryptography_locking_cb'

--- a/tox.ini
+++ b/tox.ini
@@ -9,18 +9,18 @@ passenv = CI TRAVIS_BUILD_ID TRAVIS TRAVIS_BRANCH TRAVIS_JOB_NUMBER TRAVIS_PULL_
 
 [testenv:py27]
 commands =
-  py.test -n 8 --color=yes --timeout 60 ./test
-
-[testenv:py27-ci]
-commands =
-  py.test --cov netlib --cov mitmproxy --cov pathod --color=yes --timeout 60 ./test
-  codecov -e TOXENV
+  py.test -n 8 --color=yes --timeout 60 []
 
 [testenv:py35]
 # remove bash & pipe & grep hack after cryptography ships with openssl 1.1.0
 whitelist_externals = bash
 commands =
   bash -c 'set -o pipefail ; py.test -n 8 --color=yes --timeout 60 test/netlib test/mitmproxy/script test/pathod/test_utils.py test/pathod/test_log.py test/pathod/test_language_generators.py test/pathod/test_language_writer.py test/pathod/test_language_base.py test/pathod/test_language_http.py test/pathod/test_language_websocket.py test/pathod/test_language_http2.py 2>&1 | grep -v Cryptography_locking_cb'
+
+[testenv:py27-ci]
+commands =
+  py.test --cov netlib --cov mitmproxy --cov pathod --color=yes --timeout 60 ./test
+  codecov -e TOXENV
 
 [testenv:py35-ci]
 # remove bash & pipe & grep hack after cryptography ships with openssl 1.1.0

--- a/tox.ini
+++ b/tox.ini
@@ -9,10 +9,20 @@ passenv = CI TRAVIS_BUILD_ID TRAVIS TRAVIS_BRANCH TRAVIS_JOB_NUMBER TRAVIS_PULL_
 
 [testenv:py27]
 commands =
+  py.test -n 8 --color=yes --timeout 60 ./test
+
+[testenv:py27-ci]
+commands =
   py.test --cov netlib --cov mitmproxy --cov pathod --color=yes --timeout 60 ./test
   codecov -e TOXENV
 
 [testenv:py35]
+# remove bash & pipe & grep hack after cryptography ships with openssl 1.1.0
+whitelist_externals = bash
+commands =
+  bash -c 'set -o pipefail ; py.test -n 8 --color=yes --timeout 60 test/netlib test/mitmproxy/script test/pathod/test_utils.py test/pathod/test_log.py test/pathod/test_language_generators.py test/pathod/test_language_writer.py test/pathod/test_language_base.py test/pathod/test_language_http.py test/pathod/test_language_websocket.py test/pathod/test_language_http2.py 2>&1 | grep -v Cryptography_locking_cb'
+
+[testenv:py35-ci]
 # remove bash & pipe & grep hack after cryptography ships with openssl 1.1.0
 whitelist_externals = bash
 commands =


### PR DESCRIPTION
- When testing locally, run just "tox". This runs the tests with paralellism,
coverage disabled, and without attempting to report coverage upstream.
- In Travis, we invoke the *-ci variants explicitly