### PR TITLE
Add click integration for inline scripts

### DIFF
--- a/docs/scripting/inlinescripts.rst
+++ b/docs/scripting/inlinescripts.rst
@@ -207,6 +207,8 @@ The arguments are then exposed in the start event:
    :caption: examples/modify_response_body.py
    :language: python
 
+Mitmproxy also supports `integration`_ with `click`_ for command line interfaces.
+
 Running scripts on saved flows
 ------------------------------
 
@@ -229,3 +231,5 @@ By default, spaces are interpreted as a separator between the inline script and 
 quotes if it contains spaces: ``-s '\'./foo bar/baz.py\' 42'``.
 
 .. _GitHub: https://github.com/mitmproxy/mitmproxy
+.. _integration: https://github.com/mitmproxy/mitmproxy/blob/master/test/mitmproxy/data/scripts/click_simple.py
+.. _click: http://click.pocoo.org/

--- a/mitmproxy/script/script.py
+++ b/mitmproxy/script/script.py
@@ -12,6 +12,11 @@ import sys
 
 import six
 
+try:
+    import click
+except ImportError:
+    click = False
+
 from mitmproxy import exceptions
 
 
@@ -89,6 +94,14 @@ class Script(object):
         finally:
             sys.path.pop()
             sys.path.pop()
+
+        start_fn = self.ns.get("start")
+        uses_click_cli = click and isinstance(start_fn, click.Command)
+        if uses_click_cli:
+            def cli_wrapper(context, argv):
+                return start_fn(args=argv[1:], prog_name=argv[0], standalone_mode=False, obj=context)
+            self.ns["start"] = cli_wrapper
+
         return self.run("start", self.args)
 
     def unload(self):

--- a/test/mitmproxy/data/scripts/click_context.py
+++ b/test/mitmproxy/data/scripts/click_context.py
@@ -1,0 +1,10 @@
+import click
+
+var = None
+
+
+@click.command()
+@click.pass_obj
+def start(context):
+    global var
+    var = context

--- a/test/mitmproxy/data/scripts/click_simple.py
+++ b/test/mitmproxy/data/scripts/click_simple.py
@@ -1,0 +1,10 @@
+import click
+
+var = None
+
+
+@click.command()
+@click.argument("x")
+def start(x):
+    global var
+    var = x

--- a/test/mitmproxy/script/test_script.py
+++ b/test/mitmproxy/script/test_script.py
@@ -81,3 +81,12 @@ def test_script_exception():
         s.load()
         with tutils.raises(ScriptException):
             s.unload()
+
+
+def test_click_integration():
+    with tutils.chdir(tutils.test_data.path("data/scripts")):
+        with Script("click_simple.py foo", None) as s:
+            assert s.ns["var"] == "foo"
+
+        with Script("click_context.py", "context") as s:
+            assert s.ns["var"] == "context"


### PR DESCRIPTION
Some developers in this community tend to write reasonably complex inline scripts (*hides*), which can be configured using additional arguments. This PR adds `click` support for the `start` script hook, so that we can use `click` to parse arguments:

```python
import click

@click.command()
@click.argument("outfile", type=click.File("wb"))
def start(outfile):
    # ...
```