### PR TITLE
Fix Debug Mode on Windows

### DIFF
--- a/netlib/debug.py
+++ b/netlib/debug.py
@@ -1,5 +1,6 @@
 from __future__ import (absolute_import, print_function, division)
 
+import os
 import sys
 import threading
 import signal
@@ -93,6 +94,7 @@ def dump_stacks(signal, frame, file=sys.stdout):
     print("\n".join(code), file=file)
 
 
-def register_info_dumpers():  # pragma: no cover
-    signal.signal(signal.SIGUSR1, dump_info)
-    signal.signal(signal.SIGUSR2, dump_stacks)
+def register_info_dumpers():
+    if os.name != "nt":
+        signal.signal(signal.SIGUSR1, dump_info)
+        signal.signal(signal.SIGUSR2, dump_stacks)

--- a/test/netlib/test_debug.py
+++ b/test/netlib/test_debug.py
@@ -18,3 +18,7 @@ def test_dump_stacks():
 
 def test_sysinfo():
     assert debug.sysinfo()
+
+
+def test_register_info_dumpers():
+    debug.register_info_dumpers()


### PR DESCRIPTION
`signal.SIGUSR1` is undefined on Windows. The test probably has terrible side effects, but better than not detecting errors.