### PR TITLE
Inline Scripts: Run click Scripts in Standalone Mode

### DIFF
--- a/mitmproxy/script/script.py
+++ b/mitmproxy/script/script.py
@@ -15,6 +15,11 @@ import warnings
 
 import six
 
+try:
+    import click
+except ImportError:
+    click = False
+
 from mitmproxy import exceptions
 
 
@@ -104,6 +109,9 @@ class Script(object):
             sys.path.pop()
 
         start_fn = self.ns.get("start")
+        if click and isinstance(start_fn, click.Command):
+            # click sys.exit()s by default, we explicitly disable that.
+            return self.run("start", standalone_mode=False)
         if start_fn and len(inspect.getargspec(start_fn).args) == 2:
             warnings.warn(
                 "The 'args' argument of the start() script hook is deprecated. "


### PR DESCRIPTION
As threatened in https://github.com/mitmproxy/mitmproxy/pull/1254#issuecomment-225755577, I'd still like to have a minimal `click` integration for the script module. I regularly run into click's `sys.exit()ing` behaviour while livereloading scripts, and this should make everything work out of the box. 

I'm happy to make this an undocumented feature so that we can remove it if it ever causes any issues (which I doubt).