### PR TITLE
Make har_extractor.py output HAR 1.2 spec-compliant

### DIFF
--- a/examples/har_extractor.py
+++ b/examples/har_extractor.py
@@ -4,6 +4,7 @@
 """
 import six
 import sys
+import pytz
 from harparser import HAR
 
 from datetime import datetime
@@ -120,7 +121,7 @@ def response(context, flow):
     full_time = sum(v for v in timings.values() if v > -1)
 
     started_date_time = datetime.utcfromtimestamp(
-        flow.request.timestamp_start).isoformat()
+        flow.request.timestamp_start).replace(tzinfo=pytz.timezone("UTC")).isoformat()
 
     request_query_string = [{"name": k, "value": v}
                             for k, v in flow.request.query or {}]
@@ -174,6 +175,7 @@ def response(context, flow):
                 "startedDateTime": entry['startedDateTime'],
                 "id": page_id,
                 "title": flow.request.url,
+                "pageTimings": {}
             })
         )
         context.HARLog.set_page_ref(flow.request.url, page_id)

--- a/test/mitmproxy/data/har_extractor.har
+++ b/test/mitmproxy/data/har_extractor.har
@@ -10,15 +10,16 @@
             },
             "pages": [
                 {
-                    "startedDateTime": "1993-08-24T14:41:12",
+                    "startedDateTime": "1993-08-24T14:41:12+00:00",
                     "id": "autopage_1",
-                    "title": "http://address:22/path"
+                    "title": "http://address:22/path",
+                    "pageTimings": {}
                 }
             ],
             "entries": [
                 {
                     "pageref": "autopage_1",
-                    "startedDateTime": "1993-08-24T14:41:12",
+                    "startedDateTime": "1993-08-24T14:41:12+00:00",
                     "cache": {},
                     "request": {
                         "cookies": [],


### PR DESCRIPTION
HAR files were failing to load in harviewer (http://www.softwareishard.com/har/viewer/) due to:
- ISO 8601 dates for startedDateTime missing timezone (http://www.softwareishard.com/blog/har-12-spec/#pages)
-- Used UTC but could add detection of default system timezone if desired
- pages object missing pageTimings (http://www.softwareishard.com/blog/har-12-spec/#pageTimings)
-- Used null because all child fields are optional