### PR TITLE
mitmproxy/models: missed comma in __all__

### DIFF
--- a/mitmproxy/models/__init__.py
+++ b/mitmproxy/models/__init__.py
@@ -20,6 +20,6 @@ __all__ = [
     "make_connect_response", "expect_continue_response",
     "ClientConnection", "ServerConnection",
     "Flow", "Error",
-    "TCPFlow"
-    "FLOW_TYPES"
+    "TCPFlow",
+    "FLOW_TYPES",
 ]


### PR DESCRIPTION
Spotted by Landscape (thanks @Kriechi for pointing out the site).  Add a
comma to the last item too, to prevent this from happening in the future
and reduce messing up blame later.