### PR TITLE
h2: move header parsing to netlib

### DIFF
--- a/netlib/http/http2/__init__.py
+++ b/netlib/http/http2/__init__.py
@@ -1,6 +1,8 @@
 from __future__ import absolute_import, print_function, division
 from netlib.http.http2 import framereader
+from netlib.http.http2.utils import parse_headers
 
 __all__ = [
     "framereader",
+    "parse_headers",
 ]

--- a/netlib/http/http2/utils.py
+++ b/netlib/http/http2/utils.py
@@ -1,0 +1,37 @@
+from netlib.http import url
+
+
+def parse_headers(headers):
+    authority = headers.get(':authority', b'')
+    method = headers.get(':method', b'GET')
+    scheme = headers.get(':scheme', b'https')
+    path = headers.get(':path', b'/')
+
+    headers.clear(":method")
+    headers.clear(":scheme")
+    headers.clear(":path")
+
+    host = None
+    port = None
+
+    if path == b'*' or path.startswith(b"/"):
+        first_line_format = "relative"
+    elif method == b'CONNECT':  # pragma: no cover
+        raise NotImplementedError("CONNECT over HTTP/2 is not implemented.")
+    else:  # pragma: no cover
+        first_line_format = "absolute"
+        # FIXME: verify if path or :host contains what we need
+        scheme, host, port, _ = url.parse(path)
+
+    if authority:
+        host, _, port = authority.partition(b':')
+
+    if not host:
+        host = b'localhost'
+
+    if not port:
+        port = 443 if scheme == b'https' else 80
+
+    port = int(port)
+
+    return first_line_format, method, scheme, host, port, path

--- a/test/pathod/test_protocols_http2.py
+++ b/test/pathod/test_protocols_http2.py
@@ -367,37 +367,6 @@ class TestReadRequestAbsolute(netlib_tservers.ServerTestBase):
             assert req.port == 22
 
 
-class TestReadRequestConnect(netlib_tservers.ServerTestBase):
-    class handler(tcp.BaseHandler):
-        def handle(self):
-            self.wfile.write(
-                codecs.decode('00001b0105000000014287bdab4e9c17b7ff44871c92585422e08541871c92585422e085', 'hex_codec'))
-            self.wfile.write(
-                codecs.decode('00001d0105000000014287bdab4e9c17b7ff44882f91d35d055c87a741882f91d35d055c87a7', 'hex_codec'))
-            self.wfile.flush()
-
-    ssl = True
-
-    def test_connect(self):
-        c = tcp.TCPClient(("127.0.0.1", self.port))
-        with c.connect():
-            c.convert_to_ssl()
-            protocol = HTTP2StateProtocol(c, is_server=True)
-            protocol.connection_preface_performed = True
-
-            req = protocol.read_request(NotImplemented)
-            assert req.first_line_format == "authority"
-            assert req.method == "CONNECT"
-            assert req.host == "address"
-            assert req.port == 22
-
-            req = protocol.read_request(NotImplemented)
-            assert req.first_line_format == "authority"
-            assert req.method == "CONNECT"
-            assert req.host == "example.com"
-            assert req.port == 443
-
-
 class TestReadResponse(netlib_tservers.ServerTestBase):
     class handler(tcp.BaseHandler):
         def handle(self):


### PR DESCRIPTION
[One of the pathod tests](https://github.com/dufferzafar/mitmproxy/blob/h2-refactor/test/pathod/test_protocols_http2.py#L370-L398) is failing...