### PR TITLE
[RFC] Raise ValueError if content-encoding is invalid

### DIFF
--- a/mitmproxy/console/flowview.py
+++ b/mitmproxy/console/flowview.py
@@ -226,7 +226,7 @@ class FlowView(tabs.Tabs):
             description = description.replace("Raw", "Couldn't parse: falling back to Raw")
 
         if enc:
-            description = " ".join(enc, description)
+            description = " ".join([enc, description])
 
         # Give hint that you have to tab for the response.
         if description == "No content" and isinstance(message, models.HTTPRequest):

--- a/mitmproxy/dump.py
+++ b/mitmproxy/dump.py
@@ -187,15 +187,20 @@ class DumpMaster(flow.FlowMaster):
             )
             self.echo(headers, indent=4)
         if self.o.flow_detail >= 3:
-            if message.content is None:
+            try:
+                content = message.content
+            except ValueError:
+                content = message.raw_content
+
+            if content is None:
                 self.echo("(content missing)", indent=4)
-            elif message.content:
+            elif content:
                 self.echo("")
 
                 try:
                     type, lines = contentviews.get_content_view(
                         contentviews.get("Auto"),
-                        message.content,
+                        content,
                         headers=getattr(message, "headers", None)
                     )
                 except exceptions.ContentViewException:
@@ -203,7 +208,7 @@ class DumpMaster(flow.FlowMaster):
                     self.add_event(s, "debug")
                     type, lines = contentviews.get_content_view(
                         contentviews.get("Raw"),
-                        message.content,
+                        content,
                         headers=getattr(message, "headers", None)
                     )
 

--- a/mitmproxy/filt.py
+++ b/mitmproxy/filt.py
@@ -193,12 +193,18 @@ class FBod(_Rex):
     help = "Body"
 
     def __call__(self, f):
-        if f.request and f.request.content:
-            if self.re.search(f.request.content):
-                return True
-        if f.response and f.response.content:
-            if self.re.search(f.response.content):
-                return True
+        if f.request and f.request.raw_content:
+            try:
+                if self.re.search(f.request.content):
+                    return True
+            except ValueError:
+                pass
+        if f.response and f.response.raw_content:
+            try:
+                if self.re.search(f.response.content):
+                    return True
+            except ValueError:
+                pass
         return False
 
 
@@ -207,9 +213,12 @@ class FBodRequest(_Rex):
     help = "Request body"
 
     def __call__(self, f):
-        if f.request and f.request.content:
-            if self.re.search(f.request.content):
-                return True
+        if f.request and f.request.raw_content:
+            try:
+                if self.re.search(f.request.content):
+                    return True
+            except ValueError:
+                pass
 
 
 class FBodResponse(_Rex):
@@ -217,9 +226,12 @@ class FBodResponse(_Rex):
     help = "Response body"
 
     def __call__(self, f):
-        if f.response and f.response.content:
-            if self.re.search(f.response.content):
-                return True
+        if f.response and f.response.raw_content:
+            try:
+                if self.re.search(f.response.content):
+                    return True
+            except ValueError:
+                pass
 
 
 class FMethod(_Rex):

--- a/mitmproxy/flow/export.py
+++ b/mitmproxy/flow/export.py
@@ -19,17 +19,23 @@ def dictstr(items, indent):
 def curl_command(flow):
     data = "curl "
 
-    for k, v in flow.request.headers.fields:
+    request = flow.request.copy()
+    try:
+        request.decode()
+    except ValueError:
+        pass
+
+    for k, v in request.headers.fields:
         data += "-H '%s:%s' " % (k, v)
 
-    if flow.request.method != "GET":
-        data += "-X %s " % flow.request.method
+    if request.method != "GET":
+        data += "-X %s " % request.method
 
-    full_url = flow.request.scheme + "://" + flow.request.host + flow.request.path
+    full_url = request.scheme + "://" + request.host + request.path
     data += "'%s'" % full_url
 
-    if flow.request.content:
-        data += " --data-binary '%s'" % flow.request.content
+    if request.raw_content:
+        data += " --data-binary '%s'" % request.raw_content
 
     return data
 

--- a/netlib/http/request.py
+++ b/netlib/http/request.py
@@ -347,7 +347,10 @@ class Request(message.Message):
     def _get_urlencoded_form(self):
         is_valid_content_type = "application/x-www-form-urlencoded" in self.headers.get("content-type", "").lower()
         if is_valid_content_type:
-            return tuple(netlib.http.url.decode(self.content))
+            try:
+                return tuple(netlib.http.url.decode(self.content))
+            except ValueError:
+                pass
         return ()
 
     def _set_urlencoded_form(self, value):
@@ -356,7 +359,7 @@ class Request(message.Message):
         This will overwrite the existing content if there is one.
         """
         self.headers["content-type"] = "application/x-www-form-urlencoded"
-        self.content = netlib.http.url.encode(value)
+        self.content = netlib.http.url.encode(value).encode()
 
     @urlencoded_form.setter
     def urlencoded_form(self, value):
@@ -376,7 +379,10 @@ class Request(message.Message):
     def _get_multipart_form(self):
         is_valid_content_type = "multipart/form-data" in self.headers.get("content-type", "").lower()
         if is_valid_content_type:
-            return multipart.decode(self.headers, self.content)
+            try:
+                return multipart.decode(self.headers, self.content)
+            except ValueError:
+                pass
         return ()
 
     def _set_multipart_form(self, value):

--- a/netlib/wsgi.py
+++ b/netlib/wsgi.py
@@ -60,10 +60,14 @@ class WSGIAdaptor(object):
         else:
             path_info = path
             query = ''
+        try:
+            content = flow.request.content
+        except ValueError:
+            content = flow.request.raw_content
         environ = {
             'wsgi.version': (1, 0),
             'wsgi.url_scheme': strutils.native(flow.request.scheme, "latin-1"),
-            'wsgi.input': BytesIO(flow.request.content or b""),
+            'wsgi.input': BytesIO(content or b""),
             'wsgi.errors': errsoc,
             'wsgi.multithread': True,
             'wsgi.multiprocess': False,


### PR DESCRIPTION
@cortesi: As we discussed, this makes `.content` raise a ValueError if decoding the Content-Encoding fails instead of returning our best guess. Unfortunately, after implementing this I'm back at my opinion that we probably should not do this. `Request` is supposed to provide an API that favors simplicity, and wrapping every call to `.content` with
```
try:
    content = request.content
except ValueError:
    content = request.raw_content  # well, let's do a best guess...
```
really does not improve things :confused: . 

I believe we should document our graceful degradation approach, and add a proper UI indicator for mitmproxy if we ever encounter an unknown/invalid content encoding. Alternatively, I suggest we implement `get_content(strict=False)` and make `.content` a shorthand for this. Anyone who should ever be interested in content-encoding correctness (I still can't come up with a convincing use case), is free to use `.data` directly. Again - `Request` should put simplicity first. We're not failing on weird stuff in HTTP headers either.

I know that we agreed on the ValueError approach, but after implementing these changes I feel this puts such a dent in the API usability that we should not go forward with it.

-----------

To provide some context for others: #1306 changes `Request.content` to automatically remove gzip/deflate content encoding, which was previously realized using `with decoded(request)`. This discussion is about what should happen in the rare event where we fail to decode the content, either because we don't know the content-encoding or because the content is malformed.
The original implementation in #1306 tries to decode the content, but returns the raw content if that fails. The advantage of that approach is that it is guaranteed to return a valid value, the disadvantage is that it makes those 0.01% of cases where the content-encoding is invalid harder to debug. The alternative to this is raising an error when accessing the content, which however means that `.content` is not safe to use anymore and we must expect it to raise a ValueError. In a nutshell, the question is whether it's worth sacrificing usability for this 0.01% error case or if we would rather document our graceful degradation behaviour.


Comments are welcome. :-)