### PR TITLE
remove clean_bin, clarify unicode handling

### DIFF
--- a/examples/tcp_message.py
+++ b/examples/tcp_message.py
@@ -17,9 +17,11 @@ def tcp_message(ctx, tcp_msg):
     is_modified = False if modified_msg == tcp_msg.message else True
     tcp_msg.message = modified_msg
 
-    print("[tcp_message{}] from {} {} to {} {}:\r\n{}".format(
-        " (modified)" if is_modified else "",
-        "client" if tcp_msg.sender == tcp_msg.client_conn else "server",
-        tcp_msg.sender.address,
-        "server" if tcp_msg.receiver == tcp_msg.server_conn else "client",
-        tcp_msg.receiver.address, strutils.clean_bin(tcp_msg.message)))
+    print(
+        "[tcp_message{}] from {} {} to {} {}:\r\n{}".format(
+            " (modified)" if is_modified else "",
+            "client" if tcp_msg.sender == tcp_msg.client_conn else "server",
+            tcp_msg.sender.address,
+            "server" if tcp_msg.receiver == tcp_msg.server_conn else "client",
+            tcp_msg.receiver.address, strutils.bytes_to_escaped_str(tcp_msg.message))
+    )

--- a/mitmproxy/contentviews.py
+++ b/mitmproxy/contentviews.py
@@ -160,7 +160,7 @@ class ViewRaw(View):
     content_types = []
 
     def __call__(self, data, **metadata):
-        return "Raw", format_text(strutils.bytes_to_escaped_str(data))
+        return "Raw", format_text(strutils.bytes_to_escaped_str(data, True))
 
 
 class ViewHex(View):
@@ -597,10 +597,9 @@ def safe_to_print(lines, encoding="utf8"):
     for line in lines:
         clean_line = []
         for (style, text) in line:
-            try:
-                text = strutils.clean_bin(text.decode(encoding, "strict"))
-            except UnicodeDecodeError:
-                text = strutils.clean_bin(text)
+            if isinstance(text, bytes):
+                text = text.decode(encoding, "replace")
+            text = strutils.escape_control_characters(text)
             clean_line.append((style, text))
         yield clean_line
 

--- a/netlib/websockets/frame.py
+++ b/netlib/websockets/frame.py
@@ -255,7 +255,7 @@ class Frame(object):
     def __repr__(self):
         ret = repr(self.header)
         if self.payload:
-            ret = ret + "\nPayload:\n" + strutils.clean_bin(self.payload)
+            ret = ret + "\nPayload:\n" + strutils.bytes_to_escaped_str(self.payload)
         return ret
 
     def human_readable(self):

--- a/pathod/log.py
+++ b/pathod/log.py
@@ -62,8 +62,9 @@ class LogCtx(object):
             for line in strutils.hexdump(data):
                 self("\t%s %s %s" % line)
         else:
-            for i in strutils.clean_bin(data).split("\n"):
-                self("\t%s" % i)
+            data = data.decode("ascii", "replace").replace(u"\ufffd", u".")
+            for i in strutils.escape_control_characters(data).split(u"\n"):
+                self(u"\t%s" % i)
 
     def __call__(self, line):
         self.lines.append(line)


### PR DESCRIPTION
This PR removes `strutils.clean_bin` and replaces it with the less obscure `escape_control_characters`. `escape_control_characters` does just one thing: It takes all unicode C1 control codes and replaces them with `"."`. We also had a bug in the raw display mode, where we escaped newlines and tabs, which made everything look weird. This has now been fixed by adding a `keep_spacing` parameter to `bytes_to_escaped_str`.