### PR TITLE
Detect JSON API media type as a json content view

### DIFF
--- a/mitmproxy/contentviews.py
+++ b/mitmproxy/contentviews.py
@@ -226,7 +226,10 @@ class ViewXML(View):
 class ViewJSON(View):
     name = "JSON"
     prompt = ("json", "s")
-    content_types = ["application/json"]
+    content_types = [
+        "application/json",
+        "application/vnd.api+json"
+    ]
 
     def __call__(self, data, **metadata):
         pj = pretty_json(data)

--- a/test/mitmproxy/test_contentview.py
+++ b/test/mitmproxy/test_contentview.py
@@ -201,6 +201,13 @@ Larry
         )
         assert "Raw" in r[0]
 
+        r = cv.get_content_view(
+            cv.get("Auto"),
+            b"[1, 2, 3]",
+            headers=Headers(content_type="application/vnd.api+json")
+        )
+        assert r[0] == "JSON"
+
         tutils.raises(
             ContentViewException,
             cv.get_content_view,


### PR DESCRIPTION
In practice, Ember.js applications support JSON API out the box, so it would be awesome if HTTP requests with a `Content-Type: application/vnd.api+json` header (as defined in the spec) are detected and parsed as JSON 😃 

IANA assignment here:
https://www.iana.org/assignments/media-types/application/vnd.api+json

More about JSON API:
https://github.com/json-api/json-api