### PR TITLE
Test Implementation of Immutable Options

### DIFF
--- a/mitmproxy/cmdline.py
+++ b/mitmproxy/cmdline.py
@@ -184,9 +184,9 @@ def get_common_options(options):
             )
 
     return dict(
-        app=options.app,
-        app_host=options.app_host,
-        app_port=options.app_port,
+        onboarding_app=options.onboarding_app,
+        onboarding_app_host=options.onboarding_app_host,
+        onboarding_app_port=options.onboarding_app_port,
 
         anticache=options.anticache,
         anticomp=options.anticomp,
@@ -502,12 +502,12 @@ def onboarding_app(parser):
     group = parser.add_argument_group("Onboarding App")
     group.add_argument(
         "--noapp",
-        action="store_false", dest="app", default=True,
+        action="store_false", dest="onboarding_app", default=True,
         help="Disable the mitmproxy onboarding app."
     )
     group.add_argument(
         "--app-host",
-        action="store", dest="app_host", default=APP_HOST, metavar="host",
+        action="store", dest="onboarding_app_host", default=APP_HOST, metavar="host",
         help="""
             Domain to serve the onboarding app from. For transparent mode, use
             an IP when a DNS entry for the app domain is not present. Default:
@@ -517,7 +517,7 @@ def onboarding_app(parser):
     group.add_argument(
         "--app-port",
         action="store",
-        dest="app_port",
+        dest="onboarding_app_port",
         default=APP_PORT,
         type=int,
         metavar="80",

--- a/mitmproxy/console/master.py
+++ b/mitmproxy/console/master.py
@@ -222,9 +222,9 @@ class ConsoleMaster(flow.FlowMaster):
     palette = []
 
     def __init__(self, server, options):
-        flow.FlowMaster.__init__(self, server, ConsoleState())
+        super(ConsoleMaster, self).__init__(server, ConsoleState(), options)
         self.stream_path = None
-        self.options = options
+        self.options = self.options  # FIXME
 
         if options.replacements:
             for i in options.replacements:

--- a/mitmproxy/flow/__init__.py
+++ b/mitmproxy/flow/__init__.py
@@ -8,6 +8,7 @@ from mitmproxy.flow.modules import (
     ServerPlaybackState, StickyCookieState, StickyAuthState
 )
 from mitmproxy.flow.state import State, FlowView
+from mitmproxy.flow.options import Options
 
 # TODO: We may want to remove the imports from .modules and just expose "modules"
 
@@ -18,4 +19,5 @@ __all__ = [
     "AppRegistry", "ReplaceHooks", "SetHeaders", "StreamLargeBodies", "ClientPlaybackState",
     "ServerPlaybackState", "StickyCookieState", "StickyAuthState",
     "State", "FlowView",
+    "Options",
 ]

--- a/mitmproxy/flow/master.py
+++ b/mitmproxy/flow/master.py
@@ -13,6 +13,7 @@ from mitmproxy import models
 from mitmproxy import script
 from mitmproxy.flow import io
 from mitmproxy.flow import modules
+from mitmproxy.flow import options as foptions  # noqa
 from mitmproxy.onboarding import app
 from mitmproxy.protocol import http_replay
 from mitmproxy.proxy.config import HostMatcher
@@ -27,8 +28,19 @@ class FlowMaster(controller.Master):
         if len(self.servers) > 0:
             return self.servers[0]
 
-    def __init__(self, server, state):
-        super(FlowMaster, self).__init__()
+    def __init__(
+            self,
+            server,
+            state,
+            options=None,  # type: foptions.Options
+    ):
+        if options is None:
+            options = foptions.Options()
+        super(FlowMaster, self).__init__(options)
+
+        # Type Hinting
+        self.options = self.options  # type: foptions.Options
+
         if server:
             self.add_server(server)
         self.state = state

--- a/mitmproxy/flow/options.py
+++ b/mitmproxy/flow/options.py
@@ -1,0 +1,68 @@
+from __future__ import absolute_import, print_function, division
+from mitmproxy import controller
+from typing import Tuple, Optional, Sequence  # noqa
+
+APP_HOST = "mitm.it"
+APP_PORT = 80
+
+
+class Options(controller.Options):
+    def __init__(
+            self,
+            onboarding_app=True,  # type: bool
+            onboarding_app_host=APP_HOST,  # type: str
+            onboarding_app_port=APP_PORT,  # type: int
+            anticache=False,  # type: bool
+            anticomp=False,  # type: bool
+            client_replay=None,  # type: Optional[str]
+            kill=False,  # type: bool
+            no_server=False,  # type: bool
+            nopop=False,  # type: bool
+            refresh_server_playback=False,  # type: bool
+            rfile=None,  # type: Optional[str]
+            scripts=(),  # type: Sequence[str]
+            showhost=False,  # type: bool
+            replacements=(),  # type: Sequence[Tuple[str, str, str]]
+            rheaders=(),  # type: Sequence[str]
+            setheaders=(),  # type: Sequence[Tuple[str, str, str]]
+            server_replay=None,  # type: Optional[str]
+            stickycookie=None,  # type: Optional[str]
+            stickyauth=None,  # type: Optional[str]
+            stream_large_bodies=None,  # type: Optional[str]
+            verbosity=1,  # type: int
+            outfile=None,  # type: Optional[str]
+            replay_ignore_content=False,  # type: bool
+            replay_ignore_params=(),  # type: Sequence[str]
+            replay_ignore_payload_params=(),  # type: Sequence[str]
+            replay_ignore_host=False,  # type: bool
+    ):
+        # We could replace all assignments with clever metaprogramming,
+        # but type hints are a much more valueable asset.
+
+        self.onboarding_app = onboarding_app
+        self.onboarding_app_host = onboarding_app_host
+        self.onboarding_app_port = onboarding_app_port
+        self.anticache = anticache
+        self.anticomp = anticomp
+        self.client_replay = client_replay
+        self.kill = kill
+        self.no_server = no_server
+        self.nopop = nopop
+        self.refresh_server_playback = refresh_server_playback
+        self.rfile = rfile
+        self.scripts = scripts
+        self.showhost = showhost
+        self.replacements = replacements
+        self.rheaders = rheaders
+        self.setheaders = setheaders
+        self.server_replay = server_replay
+        self.stickycookie = stickycookie
+        self.stickyauth = stickyauth
+        self.stream_large_bodies = stream_large_bodies
+        self.verbosity = verbosity
+        self.outfile = outfile
+        self.replay_ignore_content = replay_ignore_content
+        self.replay_ignore_params = replay_ignore_params
+        self.replay_ignore_payload_params = replay_ignore_payload_params
+        self.replay_ignore_host = replay_ignore_host
+        super(Options, self).__init__()

--- a/mitmproxy/web/master.py
+++ b/mitmproxy/web/master.py
@@ -153,8 +153,8 @@ class Options(object):
 class WebMaster(flow.FlowMaster):
 
     def __init__(self, server, options):
-        self.options = options
-        super(WebMaster, self).__init__(server, WebState())
+        super(WebMaster, self).__init__(server, WebState(), options)
+        self.options = options  # type: Options
         self.app = app.Application(self, self.options.wdebug, self.options.wauthenticator)
         if options.rfile:
             try:

--- a/test/mitmproxy/test_controller.py
+++ b/test/mitmproxy/test_controller.py
@@ -25,7 +25,7 @@ class TestMaster(object):
                 # Speed up test
                 super(DummyMaster, self).tick(0)
 
-        m = DummyMaster()
+        m = DummyMaster(None)
         assert not m.should_exit.is_set()
         msg = TMsg()
         msg.reply = controller.DummyReply()
@@ -34,7 +34,7 @@ class TestMaster(object):
         assert m.should_exit.is_set()
 
     def test_server_simple(self):
-        m = controller.Master()
+        m = controller.Master(None)
         s = DummyServer(None)
         m.add_server(s)
         m.start()

--- a/test/mitmproxy/test_dump.py
+++ b/test/mitmproxy/test_dump.py
@@ -14,11 +14,11 @@ def test_strfuncs():
     m = dump.DumpMaster(None, o)
 
     m.outfile = StringIO()
-    m.o.flow_detail = 0
+    m.update_options(flow_detail=0)
     m.echo_flow(tutils.tflow())
     assert not m.outfile.getvalue()
 
-    m.o.flow_detail = 4
+    m.update_options(flow_detail=4)
     m.echo_flow(tutils.tflow())
     assert m.outfile.getvalue()
 
@@ -153,7 +153,7 @@ class TestDumpMaster(mastertest.MasterTest):
         )
 
     def test_app(self):
-        o = dump.Options(app=True)
+        o = dump.Options(onboarding_app=True)
         s = mock.MagicMock()
         m = dump.DumpMaster(s, o)
         assert len(m.apps.apps) == 1


### PR DESCRIPTION
I had a bit of a headache with the blinker Signals in the refactor branch. This is an experimental PR which brings immutable options. The idea is that options can only be changed  by calling `Master.update_options(new_options)`, which then calls `configure(new_options)` for all Addons. If any of these calls raises an exeception, we call `configure(old_options)` to roll back the existing changes. Compared to the refactor approach, we force a stricter chain of command here - not anybody can subscribe to updates anymore.
One direct advantage of this is that we can compare the current options with `new_options` in each configure call. This may also be very useful if we want to include the ProxyConfig in the options, as we can ensure that ProxyConfig does not change for existing connections.

@cortesi: This is still very exploratory here. Thoughts?