### PR TITLE
TCPFlow Filters

### DIFF
--- a/mitmproxy/filt.py
+++ b/mitmproxy/filt.py
@@ -81,6 +81,24 @@ class FErr(_Action):
         return True if f.error else False
 
 
+class FHTTP(_Action):
+    code = "http"
+    help = "Match HTTP flows"
+
+    @only(HTTPFlow)
+    def __call__(self, f):
+        return True
+
+
+class FTCP(_Action):
+    code = "tcp"
+    help = "Match TCP flows"
+
+    @only(TCPFlow)
+    def __call__(self, f):
+        return True
+
+
 class FReq(_Action):
     code = "q"
     help = "Match request with no response"
@@ -384,7 +402,9 @@ filt_unary = [
     FReq,
     FResp,
     FAsset,
-    FErr
+    FErr,
+    FHTTP,
+    FTCP,
 ]
 filt_rex = [
     FHeadRequest,

--- a/mitmproxy/filt.py
+++ b/mitmproxy/filt.py
@@ -76,7 +76,6 @@ class FErr(_Action):
     code = "e"
     help = "Match error"
 
-    @only(HTTPFlow, TCPFlow)
     def __call__(self, f):
         return True if f.error else False
 
@@ -326,7 +325,6 @@ class FSrc(_Rex):
     help = "Match source address"
     is_binary = False
 
-    @only(HTTPFlow, TCPFlow)
     def __call__(self, f):
         return f.client_conn.address and self.re.search(repr(f.client_conn.address))
 
@@ -336,7 +334,6 @@ class FDst(_Rex):
     help = "Match destination address"
     is_binary = False
 
-    @only(HTTPFlow, TCPFlow)
     def __call__(self, f):
         return f.server_conn.address and self.re.search(repr(f.server_conn.address))
 

--- a/mitmproxy/filt.py
+++ b/mitmproxy/filt.py
@@ -193,12 +193,22 @@ class FBod(_Rex):
     help = "Body"
 
     def __call__(self, f):
-        if f.request and f.request.content:
-            if self.re.search(f.request.get_decoded_content()):
-                return True
-        if f.response and f.response.content:
-            if self.re.search(f.response.get_decoded_content()):
-                return True
+
+        # HTTPFlow
+        if hasattr(f, 'request'):
+            if f.request and f.request.content:
+                if self.re.search(f.request.get_decoded_content()):
+                    return True
+            if f.response and f.response.content:
+                if self.re.search(f.response.get_decoded_content()):
+                    return True
+
+        # TCPFlow
+        elif hasattr(f, 'messages'):
+            for msg in f.messages:
+                if self.re.search(msg.content):
+                    return True
+
         return False
 
 

--- a/mitmproxy/filt.py
+++ b/mitmproxy/filt.py
@@ -175,7 +175,7 @@ class FContentType(_Rex):
         return False
 
 
-class FRequestContentType(_Rex):
+class FContentTypeRequest(_Rex):
     code = "tq"
     help = "Request Content-Type header"
 
@@ -184,7 +184,7 @@ class FRequestContentType(_Rex):
         return _check_content_type(self.re, f.request)
 
 
-class FResponseContentType(_Rex):
+class FContentTypeResponse(_Rex):
     code = "ts"
     help = "Response Content-Type header"
 
@@ -399,28 +399,28 @@ class FNot(_Token):
 
 
 filt_unary = [
-    FReq,
-    FResp,
     FAsset,
     FErr,
     FHTTP,
+    FReq,
+    FResp,
     FTCP,
 ]
 filt_rex = [
-    FHeadRequest,
-    FHeadResponse,
-    FHead,
+    FBod,
     FBodRequest,
     FBodResponse,
-    FBod,
-    FMethod,
-    FDomain,
-    FUrl,
-    FRequestContentType,
-    FResponseContentType,
     FContentType,
-    FSrc,
+    FContentTypeRequest,
+    FContentTypeResponse,
+    FDomain,
     FDst,
+    FHead,
+    FHeadRequest,
+    FHeadResponse,
+    FMethod,
+    FSrc,
+    FUrl,
 ]
 filt_int = [
     FCode

--- a/mitmproxy/filt.py
+++ b/mitmproxy/filt.py
@@ -219,18 +219,14 @@ class FBod(_Rex):
 
     @only(HTTPFlow, TCPFlow)
     def __call__(self, f):
-
-        # HTTPFlow
-        if hasattr(f, 'request'):
+        if isinstance(f, HTTPFlow):
             if f.request and f.request.content:
                 if self.re.search(f.request.get_decoded_content()):
                     return True
             if f.response and f.response.content:
                 if self.re.search(f.response.get_decoded_content()):
                     return True
-
-        # TCPFlow
-        elif hasattr(f, 'messages'):
+        elif isinstance(f, TCPFlow):
             for msg in f.messages:
                 if self.re.search(msg.content):
                     return True
@@ -242,22 +238,32 @@ class FBodRequest(_Rex):
     code = "bq"
     help = "Request body"
 
-    @only(HTTPFlow)
+    @only(HTTPFlow, TCPFlow)
     def __call__(self, f):
-        if f.request and f.request.content:
-            if self.re.search(f.request.get_decoded_content()):
-                return True
+        if isinstance(f, HTTPFlow):
+            if f.request and f.request.content:
+                if self.re.search(f.request.get_decoded_content()):
+                    return True
+        elif isinstance(f, TCPFlow):
+            for msg in f.messages:
+                if msg.from_client and self.re.search(msg.content):
+                    return True
 
 
 class FBodResponse(_Rex):
     code = "bs"
     help = "Response body"
 
-    @only(HTTPFlow)
+    @only(HTTPFlow, TCPFlow)
     def __call__(self, f):
-        if f.response and f.response.content:
-            if self.re.search(f.response.get_decoded_content()):
-                return True
+        if isinstance(f, HTTPFlow):
+            if f.response and f.response.content:
+                if self.re.search(f.response.get_decoded_content()):
+                    return True
+        elif isinstance(f, TCPFlow):
+            for msg in f.messages:
+                if not msg.from_client and self.re.search(msg.content):
+                    return True
 
 
 class FMethod(_Rex):

--- a/mitmproxy/models/tcp.py
+++ b/mitmproxy/models/tcp.py
@@ -7,6 +7,8 @@ from typing import List
 import netlib.basetypes
 from mitmproxy.models.flow import Flow
 
+import six
+
 
 class TCPMessage(netlib.basetypes.Serializable):
 
@@ -53,3 +55,22 @@ class TCPFlow(Flow):
 
     def __repr__(self):
         return "<TCPFlow ({} messages)>".format(len(self.messages))
+
+    def match(self, f):
+        """
+            Match this flow against a compiled filter expression. Returns True
+            if matched, False if not.
+
+            If f is a string, it will be compiled as a filter expression. If
+            the expression is invalid, ValueError is raised.
+        """
+        if isinstance(f, six.string_types):
+            from .. import filt
+
+            f = filt.parse(f)
+            if not f:
+                raise ValueError("Invalid filter expression.")
+        if f:
+            return f(self)
+
+        return True

--- a/test/mitmproxy/test_filt.py
+++ b/test/mitmproxy/test_filt.py
@@ -1,6 +1,9 @@
 from six.moves import cStringIO as StringIO
-from mitmproxy import filt
 from mock import patch
+
+from mitmproxy import filt
+from mitmproxy.models.flow import Flow
+
 from . import tutils
 
 
@@ -374,6 +377,61 @@ class TestMatchingTCPFlow:
     def test_url(self):
         f = self.flow()
         assert not self.q("~u whatever", f)
+
+
+class DummyFlow(Flow):
+    """ A flow that is neither HTTP nor TCP. """
+
+    def __init__(self):
+        pass
+
+
+class TestMatchingDummyFlow:
+
+    def flow(self):
+        return DummyFlow()
+
+    def q(self, q, o):
+        return filt.parse(q)(o)
+
+    def test_filters(self):
+        f = self.flow()
+
+        assert not self.q("~a", f)
+
+        assert not self.q("~b whatever", f)
+        assert not self.q("~bq whatever", f)
+        assert not self.q("~bs whatever", f)
+
+        assert not self.q("~dst whatever", f)
+
+        assert not self.q("~c 0", f)
+
+        assert not self.q("~d whatever", f)
+
+        assert not self.q("~e", f)
+
+        assert not self.q("~http", f)
+
+        assert not self.q("~h whatever", f)
+        assert not self.q("~hq whatever", f)
+        assert not self.q("~hs whatever", f)
+
+        assert not self.q("~m whatever", f)
+
+        assert not self.q("~s", f)
+
+        assert not self.q("~src whatever", f)
+
+        assert not self.q("~tcp", f)
+
+        assert not self.q("~t whatever", f)
+        assert not self.q("~tq whatever", f)
+        assert not self.q("~ts whatever", f)
+
+        assert not self.q("~u whatever", f)
+
+        assert not self.q("~q", f)
 
 
 @patch('traceback.extract_tb')

--- a/test/mitmproxy/test_filt.py
+++ b/test/mitmproxy/test_filt.py
@@ -264,15 +264,21 @@ class TestMatchingTCPFlow:
 
     def test_body(self):
         f = self.flow()
-        assert not self.q("~b nonexistent", f)
+
+        # Messages sent by client or server
         assert self.q("~b hello", f)
         assert self.q("~b me", f)
+        assert not self.q("~b nonexistent", f)
 
-        # Request Body
-        assert not self.q("~bq whatever", f)
+        # Messages sent by client
+        assert self.q("~bq hello", f)
+        assert not self.q("~bq me", f)
+        assert not self.q("~bq nonexistent", f)
 
-        # Response Body
-        assert not self.q("~bs whatever", f)
+        # Messages sent by server
+        assert self.q("~bs me", f)
+        assert not self.q("~bs hello", f)
+        assert not self.q("~bs nonexistent", f)
 
     def test_src(self):
         f = self.flow()

--- a/test/mitmproxy/test_filt.py
+++ b/test/mitmproxy/test_filt.py
@@ -268,6 +268,12 @@ class TestMatchingTCPFlow:
         assert self.q("~b hello", f)
         assert self.q("~b me", f)
 
+        # Request Body
+        assert not self.q("~bq whatever", f)
+
+        # Response Body
+        assert not self.q("~bs whatever", f)
+
     def test_src(self):
         f = self.flow()
         assert self.q("~src address", f)
@@ -308,6 +314,50 @@ class TestMatchingTCPFlow:
         assert self.q("! ~src :99", f)
         assert self.q("!~src :99 !~src :99", f)
         assert not self.q("!~src :99 !~src :22", f)
+
+    def test_request(self):
+        f = self.flow()
+        assert not self.q("~q", f)
+
+    def test_response(self):
+        f = self.flow()
+        assert not self.q("~s", f)
+
+    def test_headers(self):
+        f = self.flow()
+        assert not self.q("~h whatever", f)
+
+        # Request headers
+        assert not self.q("~hq whatever", f)
+
+        # Response headers
+        assert not self.q("~hs whatever", f)
+
+    def test_content_type(self):
+        f = self.flow()
+        assert not self.q("~t whatever", f)
+
+        # Request content-type
+        assert not self.q("~tq whatever", f)
+
+        # Response content-type
+        assert not self.q("~ts whatever", f)
+
+    def test_code(self):
+        f = self.flow()
+        assert not self.q("~c 200", f)
+
+    def test_domain(self):
+        f = self.flow()
+        assert not self.q("~d whatever", f)
+
+    def test_method(self):
+        f = self.flow()
+        assert not self.q("~m whatever", f)
+
+    def test_url(self):
+        f = self.flow()
+        assert not self.q("~u whatever", f)
 
 
 @patch('traceback.extract_tb')

--- a/test/mitmproxy/test_filt.py
+++ b/test/mitmproxy/test_filt.py
@@ -285,6 +285,31 @@ class TestMatchingTCPFlow:
         assert not self.q("~dst :99", f)
         assert self.q("~dst address:22", f)
 
+    def test_and(self):
+        f = self.flow()
+        f.server_conn = tutils.tserver_conn()
+        assert self.q("~b hello & ~b me", f)
+        assert not self.q("~src wrongaddress & ~b hello", f)
+        assert self.q("(~src :22 & ~dst :22) & ~b hello", f)
+        assert not self.q("(~src address:22 & ~dst :22) & ~b nonexistent", f)
+        assert not self.q("(~src address:22 & ~dst :99) & ~b hello", f)
+
+    def test_or(self):
+        f = self.flow()
+        f.server_conn = tutils.tserver_conn()
+        assert self.q("~b hello | ~b me", f)
+        assert self.q("~src :22 | ~b me", f)
+        assert not self.q("~src :99 | ~dst :99", f)
+        assert self.q("(~src :22 | ~dst :22) | ~b me", f)
+
+    def test_not(self):
+        f = self.flow()
+        assert not self.q("! ~src :22", f)
+        assert self.q("! ~src :99", f)
+        assert self.q("!~src :99 !~src :99", f)
+        assert not self.q("!~src :99 !~src :22", f)
+
+
 @patch('traceback.extract_tb')
 def test_pyparsing_bug(extract_tb):
     """https://github.com/mitmproxy/mitmproxy/issues/1087"""

--- a/test/mitmproxy/test_filt.py
+++ b/test/mitmproxy/test_filt.py
@@ -262,6 +262,13 @@ class TestMatchingTCPFlow:
         e = self.err()
         assert self.q("~e", e)
 
+    def test_body(self):
+        f = self.flow()
+        assert not self.q("~b nonexistent", f)
+        assert self.q("~b hello", f)
+        assert self.q("~b me", f)
+
+
 @patch('traceback.extract_tb')
 def test_pyparsing_bug(extract_tb):
     """https://github.com/mitmproxy/mitmproxy/issues/1087"""

--- a/test/mitmproxy/test_filt.py
+++ b/test/mitmproxy/test_filt.py
@@ -87,6 +87,11 @@ class TestMatchingHTTPFlow:
     def q(self, q, o):
         return filt.parse(q)(o)
 
+    def test_http(self):
+        s = self.req()
+        assert self.q("~http", s)
+        assert not self.q("~tcp", s)
+
     def test_asset(self):
         s = self.resp()
         assert not self.q("~a", s)
@@ -257,6 +262,11 @@ class TestMatchingTCPFlow:
 
     def q(self, q, o):
         return filt.parse(q)(o)
+
+    def test_tcp(self):
+        f = self.flow()
+        assert self.q("~tcp", f)
+        assert not self.q("~http", f)
 
     def test_ferr(self):
         e = self.err()

--- a/test/mitmproxy/test_filt.py
+++ b/test/mitmproxy/test_filt.py
@@ -268,6 +268,22 @@ class TestMatchingTCPFlow:
         assert self.q("~b hello", f)
         assert self.q("~b me", f)
 
+    def test_src(self):
+        f = self.flow()
+        assert self.q("~src address", f)
+        assert not self.q("~src foobar", f)
+        assert self.q("~src :22", f)
+        assert not self.q("~src :99", f)
+        assert self.q("~src address:22", f)
+
+    def test_dst(self):
+        f = self.flow()
+        f.server_conn = tutils.tserver_conn()
+        assert self.q("~dst address", f)
+        assert not self.q("~dst foobar", f)
+        assert self.q("~dst :22", f)
+        assert not self.q("~dst :99", f)
+        assert self.q("~dst address:22", f)
 
 @patch('traceback.extract_tb')
 def test_pyparsing_bug(extract_tb):

--- a/test/mitmproxy/test_filt.py
+++ b/test/mitmproxy/test_filt.py
@@ -73,7 +73,7 @@ class TestParsing:
         self._dump(a)
 
 
-class TestMatching:
+class TestMatchingHTTPFlow:
 
     def req(self):
         return tutils.tflow()
@@ -246,6 +246,21 @@ class TestMatching:
         assert self.q("!~c 201 !~c 202", s)
         assert not self.q("!~c 201 !~c 200", s)
 
+
+class TestMatchingTCPFlow:
+
+    def flow(self):
+        return tutils.ttcpflow()
+
+    def err(self):
+        return tutils.ttcpflow(err=True)
+
+    def q(self, q, o):
+        return filt.parse(q)(o)
+
+    def test_ferr(self):
+        e = self.err()
+        assert self.q("~e", e)
 
 @patch('traceback.extract_tb')
 def test_pyparsing_bug(extract_tb):

--- a/test/mitmproxy/test_flow.py
+++ b/test/mitmproxy/test_flow.py
@@ -293,7 +293,7 @@ class TestServerPlaybackState:
         assert s._hash(r) == s._hash(r2)
 
 
-class TestFlow(object):
+class TestHTTPFlow(object):
 
     def test_copy(self):
         f = tutils.tflow(resp=True)
@@ -441,6 +441,20 @@ class TestFlow(object):
         assert f.response.content != b"abarb"
         f.response.decode()
         assert f.response.content == b"abarb"
+
+
+class TestTCPFlow:
+
+    def test_match(self):
+        f = tutils.ttcpflow()
+        assert not f.match("~b nonexistent")
+        assert f.match(None)
+        assert not f.match("~b nonexistent")
+
+        f = tutils.ttcpflow(err=True)
+        assert f.match("~e")
+
+        tutils.raises(ValueError, f.match, "~")
 
 
 class TestState:

--- a/test/mitmproxy/tutils.py
+++ b/test/mitmproxy/tutils.py
@@ -4,11 +4,10 @@ import tempfile
 import argparse
 import sys
 
-from mitmproxy.models.tcp import TCPMessage
-from six.moves import cStringIO as StringIO
 from contextlib import contextmanager
-
 from unittest.case import SkipTest
+
+from six.moves import cStringIO as StringIO
 
 import netlib.utils
 import netlib.tutils
@@ -16,6 +15,8 @@ from mitmproxy import controller
 from mitmproxy.models import (
     ClientConnection, ServerConnection, Error, HTTPRequest, HTTPResponse, HTTPFlow, TCPFlow
 )
+from mitmproxy.models.tcp import TCPMessage
+from mitmproxy.models.flow import Flow
 
 
 def _skip_windows(*args):
@@ -45,6 +46,27 @@ def skip_appveyor(fn):
         return _skip_appveyor
     else:
         return fn
+
+
+class DummyFlow(Flow):
+    """A flow that is neither HTTP nor TCP."""
+
+    def __init__(self, client_conn, server_conn, live=None):
+        super(DummyFlow, self).__init__("dummy", client_conn, server_conn, live)
+
+
+def tdummyflow(client_conn=True, server_conn=True, err=None):
+    if client_conn is True:
+        client_conn = tclient_conn()
+    if server_conn is True:
+        server_conn = tserver_conn()
+    if err is True:
+        err = terr()
+
+    f = DummyFlow(client_conn, server_conn)
+    f.error = err
+    f.reply = controller.DummyReply()
+    return f
 
 
 def ttcpflow(client_conn=True, server_conn=True, messages=True, err=None):


### PR DESCRIPTION
Filters that make sense for TCPFlows:

- [x] body: `~b`
- [x] client body:`~bq`
- [x] server body: `~bs`
- [x] src / dest address: `~src` `~dst`
- [x] error: `~e`
- [x] operators: `! & |`

Filters that will just return `False` for TCPFlows:

- [x] request/response: `~q`, `~s`
- [x] headers: `~h`, `~hq`, `hs`
- [x] content-type: `~t`, `~tq`, `~ts`
- [x] response code: `~c`
- [x] domain: `~d`
- [x] method: `~m`
- [x] url: `~u`

Other Tasks:

- [x] `@only` decorator
- [x] Add a [`match`](https://github.com/dufferzafar/mitmproxy/blob/15c0ccb306fa25f76ddcd17daa8d4f617dc68904/mitmproxy/models/http.py#L216-L233) function.
- [x] `~http` & `~tcp` filters
- [x] Tests for `TCPFlow.match`
- [x] Tests for a new type of flow: `TestFlow` 
