### PR TITLE
Fix is_ascii check when determining next layer

### DIFF
--- a/mitmproxy/proxy/root_context.py
+++ b/mitmproxy/proxy/root_context.py
@@ -100,7 +100,7 @@ class RootContext(object):
         is_ascii = (
             len(d) == 3 and
             # expect A-Za-z
-            all(65 <= x <= 90 and 97 <= x <= 122 for x in six.iterbytes(d))
+            all(65 <= x <= 90 or 97 <= x <= 122 for x in six.iterbytes(d))
         )
         if self.config.rawtcp and not is_ascii:
             return protocol.RawTCPLayer(top_layer)


### PR DESCRIPTION
An ASCII character can't be both upper case and lower case. Fixing this, otherwise --raw-tcp option will assume innermost layer is always raw TCP.