### PR TITLE
Make sudo pfctl error check Python 3 compatible

### DIFF
--- a/mitmproxy/platform/osx.py
+++ b/mitmproxy/platform/osx.py
@@ -23,12 +23,12 @@ class Resolver(object):
         try:
             stxt = subprocess.check_output(self.STATECMD, stderr=subprocess.STDOUT)
         except subprocess.CalledProcessError as e:
-            if "sudo: a password is required" in e.output:
+            if "sudo: a password is required" in e.output.decode(errors="replace"):
                 insufficient_priv = True
             else:
                 raise RuntimeError("Error getting pfctl state: " + repr(e))
         else:
-            insufficient_priv = "sudo: a password is required" in stxt
+            insufficient_priv = "sudo: a password is required" in stxt.decode(errors="replace")
 
         if insufficient_priv:
             raise RuntimeError(


### PR DESCRIPTION
In Python 3, subprocess.check_output() returns a sequence of bytes. This change ensures that it will be converted to a string, so the substring test for the sudo error message does not raise a TypeError. This fixes the code in Python 3 while remaining compatible with Python 2.