### PR TITLE
Addons cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,10 +20,10 @@ matrix:
   include:
     - python: 3.5
       env: TOXENV=lint
-    - os: osx
-      osx_image: xcode7.3
-      language: generic
-      env: TOXENV=py35
+#    - os: osx
+#      osx_image: xcode7.3
+#      language: generic
+#      env: TOXENV=py35
     - python: 3.5
       env: TOXENV=py35
     - python: 3.5

--- a/mitmproxy/console/common.py
+++ b/mitmproxy/console/common.py
@@ -38,7 +38,7 @@ def is_keypress(k):
     """
         Is this input event a keypress?
     """
-    if isinstance(k, basestring):
+    if isinstance(k, six.string_types):
         return True
 
 

--- a/mitmproxy/console/master.py
+++ b/mitmproxy/console/master.py
@@ -295,9 +295,6 @@ class ConsoleMaster(flow.FlowMaster):
         self.__dict__[name] = value
         signals.update_settings.send(self)
 
-    def set_stickyauth(self, txt):
-        self.options.stickyauth = txt
-
     def options_error(self, opts, exc):
         signals.status_message.send(
             message=str(exc),

--- a/mitmproxy/console/options.py
+++ b/mitmproxy/console/options.py
@@ -153,7 +153,6 @@ class Options(urwid.WidgetWrap):
 
     def clearall(self):
         self.master.anticache = False
-        self.master.anticomp = False
         self.master.killextra = False
         self.master.showhost = False
         self.master.refresh_server_playback = True
@@ -163,8 +162,11 @@ class Options(urwid.WidgetWrap):
         self.master.set_ignore_filter([])
         self.master.set_tcp_filter([])
         self.master.scripts = []
-        self.master.set_stickyauth(None)
         self.master.set_stickycookie(None)
+
+        self.master.options.stickyauth = None
+        self.master.options.anticomp = False
+
         self.master.state.default_body_view = contentviews.get("Auto")
 
         signals.update_settings.send(self)
@@ -263,7 +265,7 @@ class Options(urwid.WidgetWrap):
         signals.status_prompt.send(
             prompt = "Sticky auth filter",
             text = self.master.options.stickyauth,
-            callback = self.master.set_stickyauth
+            callback = self.master.options.setter("stickyauth")
         )
 
     def sticky_cookie(self):

--- a/mitmproxy/main.py
+++ b/mitmproxy/main.py
@@ -76,7 +76,11 @@ def mitmproxy(args=None):  # pragma: no cover
 
     server = get_server(console_options.no_server, proxy_config)
 
-    m = console.master.ConsoleMaster(server, console_options)
+    try:
+        m = console.master.ConsoleMaster(server, console_options)
+    except exceptions.OptionsError as e:
+        print("mitmproxy: %s" % e, file=sys.stderr)
+        sys.exit(1)
     try:
         m.run()
     except (KeyboardInterrupt, _thread.error):
@@ -109,7 +113,7 @@ def mitmdump(args=None):  # pragma: no cover
 
         signal.signal(signal.SIGTERM, cleankill)
         master.run()
-    except dump.DumpError as e:
+    except (dump.DumpError, exceptions.OptionsError) as e:
         print("mitmdump: %s" % e, file=sys.stderr)
         sys.exit(1)
     except (KeyboardInterrupt, _thread.error):
@@ -137,7 +141,11 @@ def mitmweb(args=None):  # pragma: no cover
 
     server = get_server(web_options.no_server, proxy_config)
 
-    m = web.master.WebMaster(server, web_options)
+    try:
+        m = web.master.WebMaster(server, web_options)
+    except exceptions.OptionsError as e:
+        print("mitmweb: %s" % e, file=sys.stderr)
+        sys.exit(1)
     try:
         m.run()
     except (KeyboardInterrupt, _thread.error):

--- a/mitmproxy/options.py
+++ b/mitmproxy/options.py
@@ -65,5 +65,10 @@ class Options(object):
             self._opts.update(kwargs)
             self.changed.send(self)
 
+    def setter(self, attr):
+        if attr not in self._opts:
+            raise KeyError("No such option: %s" % attr)
+        return lambda x: self.__setattr__(attr, x)
+
     def __repr__(self):
         return pprint.pformat(self._opts)

--- a/mitmproxy/web/app.py
+++ b/mitmproxy/web/app.py
@@ -344,7 +344,7 @@ class Settings(RequestHandler):
                 http2=self.master.server.config.http2,
                 anticache=self.master.options.anticache,
                 anticomp=self.master.options.anticomp,
-                stickyauth=self.master.stickyauth_txt,
+                stickyauth=self.master.options.stickyauth,
                 stickycookie=self.master.stickycookie_txt,
                 stream= self.master.stream_large_bodies.max_size if self.master.stream_large_bodies else False
             )
@@ -378,7 +378,7 @@ class Settings(RequestHandler):
                 self.master.set_stickycookie(v)
                 update[k] = v
             elif k == "stickyauth":
-                self.master.set_stickyauth(v)
+                self.master.options.stickyauth = v
                 update[k] = v
             elif k == "stream":
                 self.master.set_stream_large_bodies(v)

--- a/test/mitmproxy/test_options.py
+++ b/test/mitmproxy/test_options.py
@@ -3,7 +3,7 @@ import copy
 
 from mitmproxy import options
 from mitmproxy import exceptions
-from netlib.tutils import raises
+from netlib import tutils
 
 
 class TO(options.Options):
@@ -19,8 +19,8 @@ def test_options():
     assert o.two == "three"
     o.one = "one"
     assert o.one == "one"
-    raises("no such option", setattr, o, "nonexistent", "value")
-    raises("no such option", o.update, nonexistent = "value")
+    tutils.raises("no such option", setattr, o, "nonexistent", "value")
+    tutils.raises("no such option", o.update, nonexistent = "value")
 
     rec = []
 
@@ -36,6 +36,14 @@ def test_options():
     o.update(one="oink")
     assert len(rec) == 2
     assert rec[-1].one == "oink"
+
+
+def test_setter():
+    o = TO(two="three")
+    f = o.setter("two")
+    f("xxx")
+    assert o.two == "xxx"
+    tutils.raises("no such option", o.setter, "nonexistent")
 
 
 def test_rollback():


### PR DESCRIPTION
Minor addons cleanup: handle options errors on the command line, add a bit of convenience to options, and disable Travis while OSX tests are screwed up.