### PR TITLE
Re-add deletion of stickycookies

### DIFF
--- a/mitmproxy/builtins/stickycookie.py
+++ b/mitmproxy/builtins/stickycookie.py
@@ -46,10 +46,20 @@ class StickyCookie:
             for name, (value, attrs) in flow.response.cookies.items(multi=True):
                 # FIXME: We now know that Cookie.py screws up some cookies with
                 # valid RFC 822/1123 datetime specifications for expiry. Sigh.
-                a = ckey(attrs, flow)
-                if domain_match(flow.request.host, a[0]):
-                    b = attrs.with_insert(0, name, value)
-                    self.jar[a][name] = b
+                dom_port_path = ckey(attrs, flow)
+
+                if domain_match(flow.request.host, dom_port_path[0]):
+                    if cookies.is_expired(attrs):
+                        # Remove the cookie from jar
+                        self.jar[dom_port_path].pop(name, None)
+
+                        # If all cookies of a dom_port_path have been removed
+                        # then remove it from the jar itself
+                        if not self.jar[dom_port_path]:
+                            self.jar.pop(dom_port_path, None)
+                    else:
+                        b = attrs.with_insert(0, name, value)
+                        self.jar[dom_port_path][name] = b
 
     def request(self, flow):
         if self.flt:

--- a/test/mitmproxy/builtins/test_stickycookie.py
+++ b/test/mitmproxy/builtins/test_stickycookie.py
@@ -112,6 +112,16 @@ class TestStickyCookie(mastertest.MasterTest):
         assert len(sc.jar[googlekey].keys()) == 1
         assert list(sc.jar[googlekey]["somecookie"].items())[0][1] == "newvalue"
 
+    def test_response_delete(self):
+        s, m, sc = self.mk()
+
+        # Test that a cookie is be deleted
+        # by setting the expire time in the past
+        f = self._response(s, m, sc, "duffer=zafar; Path=/", "www.google.com")
+        f.response.headers["Set-Cookie"] = "duffer=; Expires=Thu, 01-Jan-1970 00:00:00 GMT"
+        self.invoke(m, "response", f)
+        assert not sc.jar.keys()
+
     def test_request(self):
         s, m, sc = self.mk()
 


### PR DESCRIPTION
This was originally added in #1324 (fixing issue #1096)
but got lost during "the big refactor" (#1352)