### PR TITLE
Update gamecenter.rst

### DIFF
--- a/docs/tutorials/gamecenter.rst
+++ b/docs/tutorials/gamecenter.rst
@@ -51,7 +51,7 @@ The contents of the submission are particularly interesting:
             <key>context</key>
             <integer>0</integer>
             <key>score-value</key>
-            <integer>0</integer>
+            <integer>55</integer>
             <key>timestamp</key>
             <integer>1363515361321</integer>
           </dict>


### PR DESCRIPTION
Typo fix: changed plist score value from '0' to '55', aligning with the subsequent explanatory text.