### PR TITLE
fix #1396, fix #1205, fix #1374

### DIFF
--- a/mitmproxy/console/flowlist.py
+++ b/mitmproxy/console/flowlist.py
@@ -188,7 +188,8 @@ class ConnectionItem(urwid.WidgetWrap):
             self.flow.accept_intercept(self.master)
             signals.flowlist_change.send(self)
         elif key == "d":
-            self.flow.kill(self.master)
+            if not self.flow.reply.acked:
+                self.flow.kill(self.master)
             self.state.delete_flow(self.flow)
             signals.flowlist_change.send(self)
         elif key == "D":
@@ -255,7 +256,8 @@ class ConnectionItem(urwid.WidgetWrap):
                 callback = self.save_flows_prompt,
             )
         elif key == "X":
-            self.flow.kill(self.master)
+            if not self.flow.reply.acked:
+                self.flow.kill(self.master)
         elif key == "enter":
             if self.flow.request:
                 self.master.view_flow(self.flow)

--- a/mitmproxy/console/flowview.py
+++ b/mitmproxy/console/flowview.py
@@ -569,7 +569,8 @@ class FlowView(tabs.Tabs):
             else:
                 self.view_next_flow(self.flow)
             f = self.flow
-            f.kill(self.master)
+            if not f.reply.acked:
+                f.kill(self.master)
             self.state.delete_flow(f)
         elif key == "D":
             f = self.master.duplicate_flow(self.flow)

--- a/mitmproxy/web/app.py
+++ b/mitmproxy/web/app.py
@@ -230,7 +230,8 @@ class AcceptFlow(RequestHandler):
 class FlowHandler(RequestHandler):
 
     def delete(self, flow_id):
-        self.flow.kill(self.master)
+        if not self.flow.reply.acked:
+            self.flow.kill(self.master)
         self.state.delete_flow(self.flow)
 
     def put(self, flow_id):


### PR DESCRIPTION
In a nutshell, whenever a users requests to delete a flow, we need to check if we need to kill it as well. I kept the check out of `self.flow.kill`, so that calling this in the wrong setting does not become a no-op.

@cortesi: Looks good to you?