### PR TITLE
Add escape_single_quotes=False arg to bytes_to_escaped_str

### DIFF
--- a/netlib/strutils.py
+++ b/netlib/strutils.py
@@ -69,7 +69,7 @@ def escape_control_characters(text, keep_spacing=True):
     return text.translate(trans)
 
 
-def bytes_to_escaped_str(data, keep_spacing=False):
+def bytes_to_escaped_str(data, keep_spacing=False, escape_single_quotes=False):
     """
     Take bytes and return a safe string that can be displayed to the user.
 
@@ -86,6 +86,8 @@ def bytes_to_escaped_str(data, keep_spacing=False):
     # We always insert a double-quote here so that we get a single-quoted string back
     # https://stackoverflow.com/questions/29019340/why-does-python-use-different-quotes-for-representing-strings-depending-on-their
     ret = repr(b'"' + data).lstrip("b")[2:-1]
+    if not escape_single_quotes:
+        ret = re.sub(r"(?<!\\)(\\\\)*\\'", lambda m: (m.group(1) or "") + "'", ret)
     if keep_spacing:
         ret = re.sub(
             r"(?<!\\)(\\\\)*\\([nrt])",

--- a/pathod/language/base.py
+++ b/pathod/language/base.py
@@ -136,7 +136,7 @@ class TokValueLiteral(_TokValueLiteral):
 
     def spec(self):
         inner = strutils.bytes_to_escaped_str(self.val)
-        inner = inner.replace(r"\'", r"\x27")
+        inner = inner.replace(r"'", r"\x27")
         return "'" + inner + "'"
 
 
@@ -148,7 +148,7 @@ class TokValueNakedLiteral(_TokValueLiteral):
         return e.setParseAction(lambda x: cls(*x))
 
     def spec(self):
-        return strutils.bytes_to_escaped_str(self.val)
+        return strutils.bytes_to_escaped_str(self.val, escape_single_quotes=True)
 
 
 class TokValueGenerate(Token):
@@ -166,7 +166,7 @@ class TokValueGenerate(Token):
 
     def freeze(self, settings):
         g = self.get_generator(settings)
-        return TokValueLiteral(strutils.bytes_to_escaped_str(g[:]))
+        return TokValueLiteral(strutils.bytes_to_escaped_str(g[:], escape_single_quotes=True))
 
     @classmethod
     def expr(cls):
@@ -578,4 +578,4 @@ class NestedMessage(Token):
 
     def freeze(self, settings):
         f = self.parsed.freeze(settings).spec()
-        return self.__class__(TokValueLiteral(strutils.bytes_to_escaped_str(f.encode())))
+        return self.__class__(TokValueLiteral(strutils.bytes_to_escaped_str(f.encode(), escape_single_quotes=True)))

--- a/pathod/pathoc.py
+++ b/pathod/pathoc.py
@@ -444,7 +444,7 @@ class Pathoc(tcp.TCPClient):
             finally:
                 if resp:
                     lg("<< %s %s: %s bytes" % (
-                        resp.status_code, strutils.bytes_to_escaped_str(resp.reason.encode()), len(resp.content)
+                        resp.status_code, strutils.escape_control_characters(resp.reason) if resp.reason else "", len(resp.content)
                     ))
                     if resp.status_code in self.ignorecodes:
                         lg.suppress()

--- a/test/netlib/test_strutils.py
+++ b/test/netlib/test_strutils.py
@@ -48,8 +48,11 @@ def test_bytes_to_escaped_str():
     assert strutils.bytes_to_escaped_str(b"\b") == r"\x08"
     assert strutils.bytes_to_escaped_str(br"&!?=\)") == r"&!?=\\)"
     assert strutils.bytes_to_escaped_str(b'\xc3\xbc') == r"\xc3\xbc"
-    assert strutils.bytes_to_escaped_str(b"'") == r"\'"
+    assert strutils.bytes_to_escaped_str(b"'") == r"'"
     assert strutils.bytes_to_escaped_str(b'"') == r'"'
+
+    assert strutils.bytes_to_escaped_str(b"'", escape_single_quotes=True) == r"\'"
+    assert strutils.bytes_to_escaped_str(b'"', escape_single_quotes=True) == r'"'
 
     assert strutils.bytes_to_escaped_str(b"\r\n\t") == "\\r\\n\\t"
     assert strutils.bytes_to_escaped_str(b"\r\n\t", True) == "\r\n\t"


### PR DESCRIPTION
This fixes #1448. Without this change applied, we'd see `'` escaped as `\'` in a couple of places (especially the raw view), which might be confusing.