### PR TITLE
Fix platform import, substitute "~" with user's home

### DIFF
--- a/mitmproxy/onboarding/app.py
+++ b/mitmproxy/onboarding/app.py
@@ -48,6 +48,7 @@ class PEM(tornado.web.RequestHandler):
 
     def get(self):
         p = os.path.join(self.request.master.options.cadir, self.filename)
+        p = os.path.expanduser(p)
         self.set_header("Content-Type", "application/x-x509-ca-cert")
         self.set_header(
             "Content-Disposition",

--- a/mitmproxy/platform/__init__.py
+++ b/mitmproxy/platform/__init__.py
@@ -1,8 +1,9 @@
 import sys
+import re
 
 resolver = None
 
-if sys.platform == "linux2":
+if re.match(r"linux(?:2)?", sys.platform):
     from . import linux
     resolver = linux.Resolver
 elif sys.platform == "darwin":


### PR DESCRIPTION
Fixes two small bugs:

1. Fix platform import on Linux using python3 

```sh
$ mitmproxy -T --host
mitmproxy: Transparent mode not supported on this platform.
```

Using Python3 `sys.platform` returns `linux` instead of `linux2` (Python2). This causes the platform import to fail on python3.

2. Substitute tilde with user's home.

Delivering the cert `~/.mitmproxy/mitmproxy-ca-cert.pem` using `mitm.it` fails because the tilde is not replaced with the user's home directory.