### PR TITLE
Support Comma Separated Cookies

### DIFF
--- a/netlib/http/cookies.py
+++ b/netlib/http/cookies.py
@@ -185,8 +185,7 @@ def parse_set_cookie_headers(headers):
     for header in headers:
         cookies = parse_set_cookie_header(header)
         if cookies:
-            for cookie in cookies:
-                name, value, attrs = cookie
+            for name, value, attrs in cookies:
                 ret.append((name, SetCookie(value, attrs)))
     return ret
 
@@ -221,6 +220,8 @@ def parse_set_cookie_header(line):
 
     if cookies:
         return cookies
+    else:
+        return None
 
 
 def format_set_cookie_header(name, value, attrs):

--- a/netlib/http/cookies.py
+++ b/netlib/http/cookies.py
@@ -128,6 +128,15 @@ def _read_cookie_pairs(s, off=0):
             break
 
     return pairs, off
+
+
+def _read_set_cookie_pairs(s, off=0):
+    """
+        Read pairs of lhs=rhs values from SetCookie headers while handling multiple cookies.
+
+        off: start offset
+        specials: attributes that are treated specially
+    """
     cookies = []
     pairs = []
 
@@ -140,10 +149,12 @@ def _read_cookie_pairs(s, off=0):
             if off < len(s) and s[off] == "=":
                 rhs, off = _read_value(s, off + 1, ";,")
 
-                # expires values can contain commas in them so they need to
-                # be handled separately.
+                # Special handliing of attributes
                 if lhs.lower() == "expires":
-                    # This is a heuristic we use to determine whether we've
+                    # 'expires' values can contain commas in them so they need to
+                    # be handled separately.
+
+                    # '3' is just a heuristic we use to determine whether we've
                     # only read a part of the datetime and should read more.
                     if len(rhs) <= 3:
                         trail, off = _read_value(s, off + 1, ";,")
@@ -163,6 +174,7 @@ def _read_cookie_pairs(s, off=0):
 
     if pairs or not cookies:
         cookies.append(pairs)
+
     return cookies, off
 
 

--- a/netlib/http/cookies.py
+++ b/netlib/http/cookies.py
@@ -103,12 +103,31 @@ def _read_value(s, start, delims):
         return _read_until(s, start, delims)
 
 
-def _read_pairs(s, off=0):
+def _read_cookie_pairs(s, off=0):
     """
-        Read pairs of lhs=rhs values while handling multiple cookies.
+        Read pairs of lhs=rhs values from Cookie headers.
 
         off: start offset
     """
+    pairs = []
+
+    while True:
+        lhs, off = _read_key(s, off)
+        lhs = lhs.lstrip()
+
+        if lhs:
+            rhs = None
+            if off < len(s) and s[off] == "=":
+                rhs, off = _read_value(s, off + 1, ";")
+
+            pairs.append([lhs, rhs])
+
+        off += 1
+
+        if not off < len(s):
+            break
+
+    return pairs, off
     cookies = []
     pairs = []
 
@@ -185,7 +204,7 @@ def _parse_set_cookie_pairs(s):
         For Set-Cookie, we support multiple cookies as described in RFC2109.
         This function therefore returns a list of lists.
     """
-    pairs, off_ = _read_pairs(s)
+    pairs, off_ = _read_cookie_pairs(line)
     return pairs
 
 

--- a/netlib/http/cookies.py
+++ b/netlib/http/cookies.py
@@ -154,8 +154,11 @@ def _read_set_cookie_pairs(s, off=0):
                     # 'expires' values can contain commas in them so they need to
                     # be handled separately.
 
+                    # We actually bank on the fact that the expires value WILL
+                    # contain a comma. Things will fail, if they don't.
+
                     # '3' is just a heuristic we use to determine whether we've
-                    # only read a part of the datetime and should read more.
+                    # only read a part of the expires value and we should read more.
                     if len(rhs) <= 3:
                         trail, off = _read_value(s, off + 1, ";,")
                         rhs = rhs + "," + trail

--- a/netlib/http/cookies.py
+++ b/netlib/http/cookies.py
@@ -223,7 +223,7 @@ def parse_cookie_header(line):
 def parse_cookie_headers(cookie_headers):
     cookie_list = []
     for header in cookie_headers:
-        cookie_list.extend(parse_cookie_header(header)[0])
+        cookie_list.extend(parse_cookie_header(header))
     return cookie_list
 
 

--- a/netlib/http/cookies.py
+++ b/netlib/http/cookies.py
@@ -57,13 +57,6 @@ def _read_until(s, start, term):
     return s[start:i + 1], i + 1
 
 
-def _read_token(s, start):
-    """
-        Read a token - the LHS of a token/value pair in a cookie.
-    """
-    return _read_until(s, start, ",;=")
-
-
 def _read_quoted_string(s, start):
     """
         start: offset to the first quote of the string to be read
@@ -91,6 +84,13 @@ def _read_quoted_string(s, start):
     return "".join(ret), i + 1
 
 
+def _read_key(s, start, delims=";="):
+    """
+        Read a key - the LHS of a token/value pair in a cookie.
+    """
+    return _read_until(s, start, delims)
+
+
 def _read_value(s, start, delims):
     """
         Reads a value - the RHS of a token/value pair in a cookie.
@@ -113,7 +113,7 @@ def _read_pairs(s, off=0):
     pairs = []
 
     while True:
-        lhs, off = _read_token(s, off)
+        lhs, off = _read_key(s, off, ";=,")
         lhs = lhs.lstrip()
 
         if lhs:

--- a/netlib/http/cookies.py
+++ b/netlib/http/cookies.py
@@ -28,8 +28,21 @@ _cookie_params = set((
     'secure', 'httponly', 'version',
 ))
 
+ESCAPE = re.compile(r"([\"\\])")
 
-# TODO: Disallow LHS-only Cookie values
+
+class CookieAttrs(multidict.ImmutableMultiDict):
+    @staticmethod
+    def _kconv(key):
+        return key.lower()
+
+    @staticmethod
+    def _reduce_values(values):
+        # See the StickyCookieTest for a weird cookie that only makes sense
+        # if we take the last part.
+        return values[-1]
+
+SetCookie = collections.namedtuple("SetCookie", ["value", "attrs"])
 
 
 def _read_until(s, start, term):
@@ -90,7 +103,6 @@ def _read_value(s, start, delims):
         return _read_until(s, start, delims)
 
 
-# TODO: Disallow LHS-only Cookie values
 def _read_pairs(s, off=0):
     """
         Read pairs of lhs=rhs values while handling multiple cookies.
@@ -145,9 +157,6 @@ def _has_special(s):
     return False
 
 
-ESCAPE = re.compile(r"([\"\\])")
-
-
 def _format_pairs(lst, specials=(), sep="; "):
     """
         specials: A lower-cased list of keys that will not be quoted.
@@ -190,19 +199,6 @@ def parse_set_cookie_headers(headers):
     return ret
 
 
-class CookieAttrs(multidict.ImmutableMultiDict):
-    @staticmethod
-    def _kconv(key):
-        return key.lower()
-
-    @staticmethod
-    def _reduce_values(values):
-        # See the StickyCookieTest for a weird cookie that only makes sense
-        # if we take the last part.
-        return values[-1]
-
-
-SetCookie = collections.namedtuple("SetCookie", ["value", "attrs"])
 
 
 def parse_set_cookie_header(line):

--- a/netlib/http/response.py
+++ b/netlib/http/response.py
@@ -155,7 +155,7 @@ class Response(message.Message):
     def _set_cookies(self, value):
         cookie_headers = []
         for k, v in value:
-            header = cookies.format_set_cookie_header(k, v[0], v[1])
+            header = cookies.format_set_cookie_header([(k, v[0], v[1])])
             cookie_headers.append(header)
         self.headers.set_all("set-cookie", cookie_headers)
 

--- a/test/mitmproxy/builtins/test_stickycookie.py
+++ b/test/mitmproxy/builtins/test_stickycookie.py
@@ -92,7 +92,6 @@ class TestStickyCookie(mastertest.MasterTest):
             "foo/bar=hello",
             "foo:bar=world",
             "foo@bar=fizz",
-            "foo,bar=buzz",
         ]
         for c in cs:
             f.response.headers["Set-Cookie"] = c

--- a/test/netlib/http/test_cookies.py
+++ b/test/netlib/http/test_cookies.py
@@ -5,51 +5,51 @@ from netlib.tutils import raises
 
 import mock
 
-pairs = [
+cookie_pairs = [
     [
         "",
-        [[]]
+        []
     ],
     [
         "one=uno",
-        [[["one", "uno"]]]
+        [["one", "uno"]]
     ],
     [
         "one",
-        [[["one", None]]]
+        [["one", None]]
     ],
     [
         "one=uno; two=due",
-        [[["one", "uno"], ["two", "due"]]]
+        [["one", "uno"], ["two", "due"]]
     ],
     [
         'one="uno"; two="\due"',
-        [[["one", "uno"], ["two", "due"]]]
+        [["one", "uno"], ["two", "due"]]
     ],
     [
         'one="un\\"o"',
-        [[["one", 'un"o']]]
+        [["one", 'un"o']]
     ],
     [
         'one="uno,due"',
-        [[["one", 'uno,due']]]
+        [["one", 'uno,due']]
     ],
     [
         "one=uno; two; three=tre",
-        [[["one", "uno"], ["two", None], ["three", "tre"]]]
+        [["one", "uno"], ["two", None], ["three", "tre"]]
     ],
     [
         "_lvs2=zHai1+Hq+Tc2vmc2r4GAbdOI5Jopg3EwsdUT9g=; "
         "_rcc2=53VdltWl+Ov6ordflA==;",
-        [[
+        [
             ["_lvs2", "zHai1+Hq+Tc2vmc2r4GAbdOI5Jopg3EwsdUT9g="],
             ["_rcc2", "53VdltWl+Ov6ordflA=="]
-        ]]
+        ]
     ]
 ]
 
 
-def test_read_token():
+def test_read_key():
     tokens = [
         [("foo", 0), ("foo", 3)],
         [("foo", 1), ("oo", 3)],
@@ -60,7 +60,7 @@ def test_read_token():
         [(" foo=bar", 1), ("foo", 4)],
     ]
     for q, a in tokens:
-        assert cookies._read_token(*q) == a
+        assert cookies._read_key(*q) == a
 
 
 def test_read_quoted_string():
@@ -76,56 +76,58 @@ def test_read_quoted_string():
         assert cookies._read_quoted_string(*q) == a
 
 
-def test_read_pairs():
+def test_read_cookie_pairs():
     vals = [
         [
             "one",
-            [[["one", None]]]
+            [["one", None]]
         ],
         [
             "one=two",
-            [[["one", "two"]]]
+            [["one", "two"]]
         ],
         [
             "one=",
-            [[["one", ""]]]
+            [["one", ""]]
         ],
         [
             'one="two"',
-            [[["one", "two"]]]
+            [["one", "two"]]
         ],
         [
             'one="two"; three=four',
-            [[["one", "two"], ["three", "four"]]]
+            [["one", "two"], ["three", "four"]]
         ],
         [
             'one="two"; three=four; five',
-            [[["one", "two"], ["three", "four"], ["five", None]]]
+            [["one", "two"], ["three", "four"], ["five", None]]
         ],
         [
             'one="\\"two"; three=four',
-            [[["one", '"two'], ["three", "four"]]]
+            [["one", '"two'], ["three", "four"]]
         ],
     ]
     for s, lst in vals:
-        ret, off = cookies._read_pairs(s)
+        ret, off = cookies._read_cookie_pairs(s)
         assert ret == lst
 
 
 def test_pairs_roundtrips():
-    for s, expected in pairs:
-        ret, off = cookies._read_pairs(s)
+    for s, expected in cookie_pairs:
+        ret, off = cookies._read_cookie_pairs(s)
         assert ret == expected
-        s2 = cookies._format_pairs(expected[0])
-        ret, off = cookies._read_pairs(s2)
+
+        s2 = cookies._format_pairs(expected)
+        ret, off = cookies._read_cookie_pairs(s2)
         assert ret == expected
 
 
 def test_cookie_roundtrips():
-    for s, expected in pairs:
+    for s, expected in cookie_pairs:
         ret = cookies.parse_cookie_header(s)
         assert ret == expected
-        s2 = cookies.format_cookie_header(expected[0])
+
+        s2 = cookies.format_cookie_header(expected)
         ret = cookies.parse_cookie_header(s2)
         assert ret == expected
 
@@ -176,11 +178,11 @@ def test_parse_set_cookie_pairs():
         ],
     ]
     for s, expected in pairs:
-        ret = cookies._parse_set_cookie_pairs(s)
+        ret, off = cookies._read_set_cookie_pairs(s)
         assert ret == expected
 
         s2 = cookies._format_set_cookie_pairs(expected[0])
-        ret2 = cookies._parse_set_cookie_pairs(s2)
+        ret2, off = cookies._read_set_cookie_pairs(s2)
         assert ret2 == expected
 
 
@@ -211,6 +213,7 @@ def test_parse_set_cookie_header():
             assert ret[0][0] == expected[0][0]
             assert ret[0][1] == expected[0][1]
             assert ret[0][2].items(multi=True) == expected[0][2]
+
             s2 = cookies.format_set_cookie_header(*ret[0])
             ret2 = cookies.parse_set_cookie_header(s2)
             assert ret2[0][0] == expected[0][0]

--- a/test/netlib/http/test_cookies.py
+++ b/test/netlib/http/test_cookies.py
@@ -5,11 +5,55 @@ from netlib.tutils import raises
 
 import mock
 
+pairs = [
+    [
+        "",
+        [[]]
+    ],
+    [
+        "one=uno",
+        [[["one", "uno"]]]
+    ],
+    [
+        "one",
+        [[["one", None]]]
+    ],
+    [
+        "one=uno; two=due",
+        [[["one", "uno"], ["two", "due"]]]
+    ],
+    [
+        'one="uno"; two="\due"',
+        [[["one", "uno"], ["two", "due"]]]
+    ],
+    [
+        'one="un\\"o"',
+        [[["one", 'un"o']]]
+    ],
+    [
+        'one="uno,due"',
+        [[["one", 'uno,due']]]
+    ],
+    [
+        "one=uno; two; three=tre",
+        [[["one", "uno"], ["two", None], ["three", "tre"]]]
+    ],
+    [
+        "_lvs2=zHai1+Hq+Tc2vmc2r4GAbdOI5Jopg3EwsdUT9g=; "
+        "_rcc2=53VdltWl+Ov6ordflA==;",
+        [[
+            ["_lvs2", "zHai1+Hq+Tc2vmc2r4GAbdOI5Jopg3EwsdUT9g="],
+            ["_rcc2", "53VdltWl+Ov6ordflA=="]
+        ]]
+    ]
+]
+
 
 def test_read_token():
     tokens = [
         [("foo", 0), ("foo", 3)],
         [("foo", 1), ("oo", 3)],
+        [(" foo", 0), (" foo", 4)],
         [(" foo", 1), ("foo", 4)],
         [(" foo;", 1), ("foo", 4)],
         [(" foo=", 1), ("foo", 4)],
@@ -36,31 +80,31 @@ def test_read_pairs():
     vals = [
         [
             "one",
-            [["one", None]]
+            [[["one", None]]]
         ],
         [
             "one=two",
-            [["one", "two"]]
+            [[["one", "two"]]]
         ],
         [
             "one=",
-            [["one", ""]]
+            [[["one", ""]]]
         ],
         [
             'one="two"',
-            [["one", "two"]]
+            [[["one", "two"]]]
         ],
         [
             'one="two"; three=four',
-            [["one", "two"], ["three", "four"]]
+            [[["one", "two"], ["three", "four"]]]
         ],
         [
             'one="two"; three=four; five',
-            [["one", "two"], ["three", "four"], ["five", None]]
+            [[["one", "two"], ["three", "four"], ["five", None]]]
         ],
         [
             'one="\\"two"; three=four',
-            [["one", '"two'], ["three", "four"]]
+            [[["one", '"two'], ["three", "four"]]]
         ],
     ]
     for s, lst in vals:
@@ -69,126 +113,75 @@ def test_read_pairs():
 
 
 def test_pairs_roundtrips():
-    pairs = [
-        [
-            "",
-            []
-        ],
-        [
-            "one=uno",
-            [["one", "uno"]]
-        ],
-        [
-            "one",
-            [["one", None]]
-        ],
-        [
-            "one=uno; two=due",
-            [["one", "uno"], ["two", "due"]]
-        ],
-        [
-            'one="uno"; two="\due"',
-            [["one", "uno"], ["two", "due"]]
-        ],
-        [
-            'one="un\\"o"',
-            [["one", 'un"o']]
-        ],
-        [
-            'one="uno,due"',
-            [["one", 'uno,due']]
-        ],
-        [
-            "one=uno; two; three=tre",
-            [["one", "uno"], ["two", None], ["three", "tre"]]
-        ],
-        [
-            "_lvs2=zHai1+Hq+Tc2vmc2r4GAbdOI5Jopg3EwsdUT9g=; "
-            "_rcc2=53VdltWl+Ov6ordflA==;",
-            [
-                ["_lvs2", "zHai1+Hq+Tc2vmc2r4GAbdOI5Jopg3EwsdUT9g="],
-                ["_rcc2", "53VdltWl+Ov6ordflA=="]
-            ]
-        ]
-    ]
-    for s, lst in pairs:
+    for s, expected in pairs:
         ret, off = cookies._read_pairs(s)
-        assert ret == lst
-        s2 = cookies._format_pairs(lst)
+        assert ret == expected
+        s2 = cookies._format_pairs(expected[0])
         ret, off = cookies._read_pairs(s2)
-        assert ret == lst
+        assert ret == expected
 
 
 def test_cookie_roundtrips():
-    pairs = [
-        [
-            "one=uno",
-            [["one", "uno"]]
-        ],
-        [
-            "one=uno; two=due",
-            [["one", "uno"], ["two", "due"]]
-        ],
-    ]
-    for s, lst in pairs:
+    for s, expected in pairs:
         ret = cookies.parse_cookie_header(s)
-        assert ret == lst
-        s2 = cookies.format_cookie_header(ret)
+        assert ret == expected
+        s2 = cookies.format_cookie_header(expected[0])
         ret = cookies.parse_cookie_header(s2)
-        assert ret == lst
+        assert ret == expected
 
 
 def test_parse_set_cookie_pairs():
     pairs = [
         [
             "one=uno",
-            [
+            [[
                 ["one", "uno"]
-            ]
+            ]]
         ],
         [
             "one=un\x20",
-            [
+            [[
                 ["one", "un\x20"]
-            ]
+            ]]
         ],
         [
             "one=uno; foo",
-            [
+            [[
                 ["one", "uno"],
                 ["foo", None]
-            ]
+            ]]
         ],
         [
             "mun=1.390.f60; "
             "expires=sun, 11-oct-2015 12:38:31 gmt; path=/; "
             "domain=b.aol.com",
-            [
+            [[
                 ["mun", "1.390.f60"],
                 ["expires", "sun, 11-oct-2015 12:38:31 gmt"],
                 ["path", "/"],
                 ["domain", "b.aol.com"]
-            ]
+            ]]
         ],
         [
             r'rpb=190%3d1%2616726%3d1%2634832%3d1%2634874%3d1; '
             'domain=.rubiconproject.com; '
             'expires=mon, 11-may-2015 21:54:57 gmt; '
             'path=/',
-            [
+            [[
                 ['rpb', r'190%3d1%2616726%3d1%2634832%3d1%2634874%3d1'],
                 ['domain', '.rubiconproject.com'],
                 ['expires', 'mon, 11-may-2015 21:54:57 gmt'],
                 ['path', '/']
-            ]
+            ]]
         ],
     ]
-    for s, lst in pairs:
+    for s, expected in pairs:
         ret = cookies._parse_set_cookie_pairs(s)
-        assert ret == lst
-        s2 = cookies._format_set_cookie_pairs(ret)
+        assert ret == expected
+
+        s2 = cookies._format_set_cookie_pairs(expected[0])
         ret2 = cookies._parse_set_cookie_pairs(s2)
-        assert ret2 == lst
+        assert ret2 == expected
 
 
 def test_parse_set_cookie_header():
@@ -201,28 +194,28 @@ def test_parse_set_cookie_header():
         ],
         [
             "one=uno",
-            ("one", "uno", ())
+            [("one", "uno", ())]
         ],
         [
             "one=uno; foo=bar",
-            ("one", "uno", (("foo", "bar"),))
+            [("one", "uno", (("foo", "bar"),))]
         ],
         [
             "one=uno; foo=bar; foo=baz",
-            ("one", "uno", (("foo", "bar"), ("foo", "baz")))
+            [("one", "uno", (("foo", "bar"), ("foo", "baz")))]
         ],
     ]
     for s, expected in vals:
         ret = cookies.parse_set_cookie_header(s)
         if expected:
-            assert ret[0] == expected[0]
-            assert ret[1] == expected[1]
-            assert ret[2].items(multi=True) == expected[2]
-            s2 = cookies.format_set_cookie_header(*ret)
+            assert ret[0][0] == expected[0][0]
+            assert ret[0][1] == expected[0][1]
+            assert ret[0][2].items(multi=True) == expected[0][2]
+            s2 = cookies.format_set_cookie_header(*ret[0])
             ret2 = cookies.parse_set_cookie_header(s2)
-            assert ret2[0] == expected[0]
-            assert ret2[1] == expected[1]
-            assert ret2[2].items(multi=True) == expected[2]
+            assert ret2[0][0] == expected[0][0]
+            assert ret2[0][1] == expected[0][1]
+            assert ret2[0][2].items(multi=True) == expected[0][2]
         else:
             assert ret is None
 

--- a/test/netlib/http/test_cookies.py
+++ b/test/netlib/http/test_cookies.py
@@ -187,6 +187,11 @@ def test_parse_set_cookie_pairs():
 
 
 def test_parse_set_cookie_header():
+    def set_cookie_equal(obs, exp):
+        assert obs[0] == exp[0]
+        assert obs[1] == exp[1]
+        assert obs[2].items(multi=True) == exp[2]
+
     vals = [
         [
             "", None
@@ -196,29 +201,61 @@ def test_parse_set_cookie_header():
         ],
         [
             "one=uno",
-            [("one", "uno", ())]
+            [
+                ("one", "uno", ())
+            ]
         ],
         [
             "one=uno; foo=bar",
-            [("one", "uno", (("foo", "bar"),))]
+            [
+                ("one", "uno", (("foo", "bar"),))
+            ]
         ],
         [
             "one=uno; foo=bar; foo=baz",
-            [("one", "uno", (("foo", "bar"), ("foo", "baz")))]
+            [
+                ("one", "uno", (("foo", "bar"), ("foo", "baz")))
+            ]
+        ],
+        # Comma Separated Variant of Set-Cookie Headers
+        [
+            "foo=bar, doo=dar",
+            [
+                ("foo", "bar", ()),
+                ("doo", "dar", ()),
+            ]
+        ],
+        [
+            "foo=bar; path=/, doo=dar; roo=rar; zoo=zar",
+            [
+                ("foo", "bar", (("path", "/"),)),
+                ("doo", "dar", (("roo", "rar"), ("zoo", "zar"))),
+            ]
+        ],
+        [
+            "foo=bar; expires=Mon, 24 Aug 2037",
+            [
+                ("foo", "bar", (("expires", "Mon, 24 Aug 2037"),)),
+            ]
+        ],
+        [
+            "foo=bar; expires=Mon, 24 Aug 2037 00:00:00 GMT, doo=dar",
+            [
+                ("foo", "bar", (("expires", "Mon, 24 Aug 2037 00:00:00 GMT"),)),
+                ("doo", "dar", ()),
+            ]
         ],
     ]
     for s, expected in vals:
         ret = cookies.parse_set_cookie_header(s)
         if expected:
-            assert ret[0][0] == expected[0][0]
-            assert ret[0][1] == expected[0][1]
-            assert ret[0][2].items(multi=True) == expected[0][2]
+            for i in range(len(expected)):
+                set_cookie_equal(ret[i], expected[i])
 
-            s2 = cookies.format_set_cookie_header(*ret[0])
+            s2 = cookies.format_set_cookie_header(ret)
             ret2 = cookies.parse_set_cookie_header(s2)
-            assert ret2[0][0] == expected[0][0]
-            assert ret2[0][1] == expected[0][1]
-            assert ret2[0][2].items(multi=True) == expected[0][2]
+            for i in range(len(expected)):
+                set_cookie_equal(ret2[i], expected[i])
         else:
             assert ret is None
 


### PR DESCRIPTION
Fixes #1434

Todo:

- [x] Rebased with master
- [x] The `_read_pairs` change should only affect `SetCookie` and not `Cookie`
- [x] Update `format_set_cookie_header` to take in a list of `SetCookie`s & return the comma separated list.
- [x] Add new tests for multi-cookies