### PR TITLE
Rename "Limit" feature to "Filter View"

### DIFF
--- a/mitmproxy/cmdline.py
+++ b/mitmproxy/cmdline.py
@@ -773,7 +773,7 @@ def mitmproxy():
         help="Show event log."
     )
     parser.add_argument(
-        "-f", "--follow",
+        "--follow",
         action="store_true", dest="follow",
         help="Follow flow list."
     )
@@ -792,9 +792,9 @@ def mitmproxy():
         help="Intercept filter expression."
     )
     group.add_argument(
-        "-l", "--limit", action="store",
-        type=str, dest="limit", default=None,
-        help="Limit filter expression."
+        "-f", "--filter", action="store",
+        type=str, dest="filter", default=None,
+        help="Filter view expression."
     )
     return parser
 

--- a/mitmproxy/console/flowlist.py
+++ b/mitmproxy/console/flowlist.py
@@ -18,8 +18,8 @@ def _mkhelp():
         ("d", "delete flow"),
         ("D", "duplicate flow"),
         ("e", "toggle eventlog"),
+        ("f", "filter view"),
         ("F", "toggle follow flow list"),
-        ("l", "set limit filter pattern"),
         ("L", "load saved flows"),
         ("m", "toggle flow mark"),
         ("M", "toggle marked flow view"),
@@ -367,11 +367,11 @@ class FlowListBox(urwid.ListBox):
         elif key == "G":
             self.master.state.set_focus(self.master.state.flow_count())
             signals.flowlist_change.send(self)
-        elif key == "l":
+        elif key == "f":
             signals.status_prompt.send(
-                prompt = "Limit",
-                text = self.master.state.limit_txt,
-                callback = self.master.set_limit
+                prompt = "Filter View",
+                text = self.master.state.filter_txt,
+                callback = self.master.set_view_filter
             )
         elif key == "L":
             signals.status_prompt_path.send(

--- a/mitmproxy/console/flowview.py
+++ b/mitmproxy/console/flowview.py
@@ -80,7 +80,7 @@ def _mkhelp():
         ("r", "replay request"),
         ("V", "revert changes to request"),
         ("v", "view body in external viewer"),
-        ("w", "save all flows matching current limit"),
+        ("w", "save all flows matching current view filter"),
         ("W", "save this flow"),
         ("x", "delete body"),
         ("z", "encode/decode a request/response"),

--- a/mitmproxy/console/master.py
+++ b/mitmproxy/console/master.py
@@ -75,8 +75,8 @@ class ConsoleState(flow.State):
         self.update_focus()
         return f
 
-    def set_limit(self, limit):
-        ret = super(ConsoleState, self).set_limit(limit)
+    def set_view_filter(self, txt):
+        ret = super(ConsoleState, self).set_view_filter(txt)
         self.set_focus(self.focus)
         return ret
 
@@ -153,8 +153,8 @@ class ConsoleState(flow.State):
         last_focus, _ = self.get_focus()
         nearest_marked = self.get_nearest_matching_flow(last_focus, marked_filter)
 
-        self.last_filter = self.limit_txt
-        self.set_limit(marked_filter)
+        self.last_filter = self.filter_txt
+        self.set_view_filter(marked_filter)
 
         # Restore Focus
         if last_focus.marked:
@@ -171,7 +171,7 @@ class ConsoleState(flow.State):
         last_focus, _ = self.get_focus()
         nearest_marked = self.get_nearest_matching_flow(last_focus, marked_filter)
 
-        self.set_limit(self.last_filter)
+        self.set_view_filter(self.last_filter)
         self.last_filter = ""
 
         # Restore Focus
@@ -203,7 +203,7 @@ class Options(mitmproxy.options.Options):
             eventlog=False,  # type: bool
             follow=False,  # type: bool
             intercept=False,  # type: bool
-            limit=None,  # type: Optional[str]
+            filter=None,  # type: Optional[str]
             palette=None,  # type: Optional[str]
             palette_transparent=False,  # type: bool
             no_mouse=False,  # type: bool
@@ -212,7 +212,7 @@ class Options(mitmproxy.options.Options):
         self.eventlog = eventlog
         self.follow = follow
         self.intercept = intercept
-        self.limit = limit
+        self.filter = filter
         self.palette = palette
         self.palette_transparent = palette_transparent
         self.no_mouse = no_mouse
@@ -234,8 +234,8 @@ class ConsoleMaster(flow.FlowMaster):
             print("Intercept error: {}".format(r), file=sys.stderr)
             sys.exit(1)
 
-        if options.limit:
-            self.set_limit(options.limit)
+        if options.filter:
+            self.set_view_filter(options.filter)
 
         self.set_stream_large_bodies(options.stream_large_bodies)
 
@@ -672,8 +672,8 @@ class ConsoleMaster(flow.FlowMaster):
     def accept_all(self):
         self.state.accept_all(self)
 
-    def set_limit(self, txt):
-        v = self.state.set_limit(txt)
+    def set_view_filter(self, txt):
+        v = self.state.set_view_filter(txt)
         signals.flowlist_change.send(self)
         return v
 

--- a/mitmproxy/console/statusbar.py
+++ b/mitmproxy/console/statusbar.py
@@ -167,10 +167,10 @@ class StatusBar(urwid.WidgetWrap):
             r.append("[")
             r.append(("heading_key", "i"))
             r.append(":%s]" % self.master.state.intercept_txt)
-        if self.master.state.limit_txt:
+        if self.master.state.filter_txt:
             r.append("[")
-            r.append(("heading_key", "l"))
-            r.append(":%s]" % self.master.state.limit_txt)
+            r.append(("heading_key", "f"))
+            r.append(":%s]" % self.master.state.filter_txt)
         if self.master.options.stickycookie:
             r.append("[")
             r.append(("heading_key", "t"))

--- a/mitmproxy/flow/state.py
+++ b/mitmproxy/flow/state.py
@@ -191,7 +191,7 @@ class State(object):
         self.intercept = None
 
     @property
-    def limit_txt(self):
+    def filter_txt(self):
         return getattr(self.view.filt, "pattern", None)
 
     def flow_count(self):
@@ -225,8 +225,8 @@ class State(object):
     def load_flows(self, flows):
         self.flows._extend(flows)
 
-    def set_limit(self, txt):
-        if txt == self.limit_txt:
+    def set_view_filter(self, txt):
+        if txt == self.filter_txt:
             return
         if txt:
             f = filt.parse(txt)

--- a/mitmproxy/main.py
+++ b/mitmproxy/main.py
@@ -68,7 +68,7 @@ def mitmproxy(args=None):  # pragma: no cover
         console_options.eventlog = args.eventlog
         console_options.follow = args.follow
         console_options.intercept = args.intercept
-        console_options.limit = args.limit
+        console_options.filter = args.filter
         console_options.no_mouse = args.no_mouse
 
         server = process_options(parser, console_options, args)

--- a/test/mitmproxy/console/test_master.py
+++ b/test/mitmproxy/console/test_master.py
@@ -76,7 +76,7 @@ class TestConsoleState:
         self._add_response(c)
         self._add_request(c)
         self._add_response(c)
-        assert not c.set_limit("~s")
+        assert not c.set_view_filter("~s")
         assert len(c.view) == 3
         assert c.focus == 0
 

--- a/test/mitmproxy/test_flow.py
+++ b/test/mitmproxy/test_flow.py
@@ -504,13 +504,13 @@ class TestState:
         c = flow.State()
         f = tutils.tflow()
         c.add_flow(f)
-        c.set_limit("~e")
+        c.set_view_filter("~e")
         assert not c.view
         f.error = tutils.terr()
         assert c.update_flow(f)
         assert c.view
 
-    def test_set_limit(self):
+    def test_set_view_filter(self):
         c = flow.State()
 
         f = tutils.tflow()
@@ -519,24 +519,24 @@ class TestState:
         c.add_flow(f)
         assert len(c.view) == 1
 
-        c.set_limit("~s")
-        assert c.limit_txt == "~s"
+        c.set_view_filter("~s")
+        assert c.filter_txt == "~s"
         assert len(c.view) == 0
         f.response = HTTPResponse.wrap(netlib.tutils.tresp())
         c.update_flow(f)
         assert len(c.view) == 1
-        c.set_limit(None)
+        c.set_view_filter(None)
         assert len(c.view) == 1
 
         f = tutils.tflow()
         c.add_flow(f)
         assert len(c.view) == 2
-        c.set_limit("~q")
+        c.set_view_filter("~q")
         assert len(c.view) == 1
-        c.set_limit("~s")
+        c.set_view_filter("~s")
         assert len(c.view) == 1
 
-        assert "Invalid" in c.set_limit("~")
+        assert "Invalid" in c.set_view_filter("~")
 
     def test_set_intercept(self):
         c = flow.State()


### PR DESCRIPTION
Fixes #542.

Two filter view related functionalities:

- [ ] Ability to save filtered flows from the flowview is [missing](https://github.com/dufferzafar/mitmproxy/blob/master/mitmproxy/console/flowview.py#L83).

- [ ] A hotkey that toggles between the last set filter. (similar to `M` for marked flows)