### PR TITLE
integer division for python 3 compatibility

### DIFF
--- a/mitmproxy/console/common.py
+++ b/mitmproxy/console/common.py
@@ -379,7 +379,7 @@ def raw_format_flow(f, focus, extended):
             4: "code_400",
             5: "code_500",
         }
-        ccol = codes.get(f["resp_code"] / 100, "code_other")
+        ccol = codes.get(f["resp_code"] // 100, "code_other")
         resp.append(fcol(SYMBOL_RETURN, ccol))
         if f["resp_is_replay"]:
             resp.append(fcol(SYMBOL_REPLAY, "replay"))


### PR DESCRIPTION
* Regarding color coding the response codes

The colors were not working in python 3. As 404/100 was coming out to be 4.04 instead of 4. 
