### PR TITLE
fixed client update event

### DIFF
--- a/mitmproxy/web/master.py
+++ b/mitmproxy/web/master.py
@@ -82,6 +82,9 @@ class WebState(flow.State):
             data=entry
         )
 
+    def update_flow(self, flow):
+        self.view._update(flow)
+
     def clear(self):
         super(WebState, self).clear()
         self.events.clear()


### PR DESCRIPTION
if a flow is modified and sent to the server, the server doesnt not send a client broadcast to update all clients, in the PR this issue is solved 
