### PR TITLE
fixing queryString (python 2 and 3) and cookies value for latest mitm

### DIFF
--- a/examples/har_extractor.py
+++ b/examples/har_extractor.py
@@ -137,7 +137,7 @@ def response(flow):
         flow.request.timestamp_start).replace(tzinfo=pytz.timezone("UTC")).isoformat()
 
     request_query_string = [{"name": k, "value": v}
-                            for k, v in flow.request.query or {}]
+                            for k, v in flow.request.query.items() or {}]
 
     response_body_size = len(flow.response.content)
     response_body_decoded_size = len(flow.response.content)
@@ -240,7 +240,7 @@ def done():
 
 def format_cookies(obj):
     if obj:
-        return [{"name": k.strip(), "value": v[0]} for k, v in obj.items()]
+        return [{"name": k.strip(), "value": v} for k, v in obj.items()]
     return ""
 
 


### PR DESCRIPTION
* Regarding har_extractor

* queryString for param `id=aflon` was coming as 

```json
"queryString": [
            {
              "name": "i",
              "value": "d"
            }
          ],
```
(due to missing iteritems()  / items() .. i guess this was never working even in python 2)

* Cookies were coming as 

```json
"request": {
          "cookies": [
            {
              "name": "__cfduid",
              "value": "d"
            },
            {
              "name": "user",
              "value": "m"
            }
          ],
```

values have only one letter due to `v[0]` .. probably because it earlier used to an array? 

This fixes those two issues. Rest of the fields look good in python 3 unless someone finds a problem.