### PR TITLE
Simplify contentview logic

### DIFF
--- a/mitmproxy/addons.py
+++ b/mitmproxy/addons.py
@@ -20,7 +20,7 @@ class Addons(object):
 
     def add(self, options, *addons):
         if not addons:
-            raise ValueError("No adons specified.")
+            raise ValueError("No addons specified.")
         self.chain.extend(addons)
         for i in addons:
             self.invoke_with_context(i, "start")

--- a/mitmproxy/builtins/dumper.py
+++ b/mitmproxy/builtins/dumper.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, print_function, division
 
 import itertools
-import traceback
 
 import click
 

--- a/mitmproxy/builtins/dumper.py
+++ b/mitmproxy/builtins/dumper.py
@@ -63,30 +63,12 @@ class Dumper(object):
             )
             self.echo(headers, ident=4)
         if self.flow_detail >= 3:
-            try:
-                content = message.content
-            except ValueError:
-                content = message.get_content(strict=False)
-
-            if content is None:
-                self.echo("(content missing)", ident=4)
-            elif content:
-                self.echo("")
-
-                try:
-                    _, lines = contentviews.get_content_view(
-                        contentviews.get("Auto"),
-                        content,
-                        headers=getattr(message, "headers", None)
-                    )
-                except exceptions.ContentViewException:
-                    s = "Content viewer failed: \n" + traceback.format_exc()
-                    ctx.log.debug(s)
-                    _, lines = contentviews.get_content_view(
-                        contentviews.get("Raw"),
-                        content,
-                        headers=getattr(message, "headers", None)
-                    )
+                _, lines, error = contentviews.get_message_content_view(
+                    contentviews.get("Auto"),
+                    message
+                )
+                if error:
+                    ctx.log.debug(error)
 
                 styles = dict(
                     highlight=dict(bold=True),
@@ -105,13 +87,13 @@ class Dumper(object):
                 else:
                     lines_to_echo = lines
 
-                lines_to_echo = list(lines_to_echo)
-
                 content = u"\r\n".join(
                     u"".join(colorful(line)) for line in lines_to_echo
                 )
+                if content:
+                    self.echo("")
+                    self.echo(content)
 
-                self.echo(content)
                 if next(lines, None):
                     self.echo("(cut off)", ident=4, dim=True)
 

--- a/mitmproxy/console/flowview.py
+++ b/mitmproxy/console/flowview.py
@@ -3,14 +3,12 @@ from __future__ import absolute_import, print_function, division
 import math
 import os
 import sys
-import traceback
 
 import urwid
 from typing import Optional, Union  # noqa
 
 from mitmproxy import contentviews
 from mitmproxy import controller
-from mitmproxy import exceptions
 from mitmproxy import models
 from mitmproxy import utils
 from mitmproxy.console import common

--- a/mitmproxy/console/flowview.py
+++ b/mitmproxy/console/flowview.py
@@ -206,36 +206,11 @@ class FlowView(tabs.Tabs):
             )
 
     def _get_content_view(self, message, viewmode, max_lines, _):
-
-        try:
-            content = message.content
-            if content != message.raw_content:
-                enc = "[decoded {}]".format(
-                    message.headers.get("content-encoding")
-                )
-            else:
-                enc = None
-        except ValueError:
-            content = message.raw_content
-            enc = "[cannot decode]"
-        try:
-            query = None
-            if isinstance(message, models.HTTPRequest):
-                query = message.query
-            description, lines = contentviews.get_content_view(
-                viewmode, content, headers=message.headers, query=query
-            )
-        except exceptions.ContentViewException:
-            s = "Content viewer failed: \n" + traceback.format_exc()
-            signals.add_log(s, "error")
-            description, lines = contentviews.get_content_view(
-                contentviews.get("Raw"), content, headers=message.headers
-            )
-            description = description.replace("Raw", "Couldn't parse: falling back to Raw")
-
-        if enc:
-            description = " ".join([enc, description])
-
+        description, lines, error = contentviews.get_message_content_view(
+            viewmode, message
+        )
+        if error:
+            signals.add_log(error, "error")
         # Give hint that you have to tab for the response.
         if description == "No content" and isinstance(message, models.HTTPRequest):
             description = "No request content (press tab to view response)"

--- a/mitmproxy/flow/master.py
+++ b/mitmproxy/flow/master.py
@@ -233,6 +233,7 @@ class FlowMaster(controller.Master):
         if self.server_playback:
             pb = self.do_server_playback(f)
             if not pb and self.kill_nonreplay:
+                self.add_log("Killed {}".format(f.request.url), "info")
                 f.kill(self)
 
     def replay_request(self, f, block=False):

--- a/netlib/http/__init__.py
+++ b/netlib/http/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, print_function, division
 from netlib.http.request import Request
 from netlib.http.response import Response
+from netlib.http.message import Message
 from netlib.http.headers import Headers, parse_content_type
 from netlib.http.message import decoded
 from netlib.http import http1, http2, status_codes, multipart

--- a/netlib/http/__init__.py
+++ b/netlib/http/__init__.py
@@ -9,6 +9,7 @@ from netlib.http import http1, http2, status_codes, multipart
 __all__ = [
     "Request",
     "Response",
+    "Message",
     "Headers", "parse_content_type",
     "decoded",
     "http1", "http2", "status_codes", "multipart",

--- a/test/mitmproxy/builtins/test_dumper.py
+++ b/test/mitmproxy/builtins/test_dumper.py
@@ -15,7 +15,7 @@ class TestDumper(mastertest.MasterTest):
         d = dumper.Dumper()
         sio = StringIO()
 
-        updated = set(["tfile", "flow_detail"])
+        updated = {"tfile", "flow_detail"}
         d.configure(dump.Options(tfile = sio, flow_detail = 0), updated)
         d.response(tutils.tflow())
         assert not sio.getvalue()
@@ -66,10 +66,9 @@ class TestDumper(mastertest.MasterTest):
 
 
 class TestContentView(mastertest.MasterTest):
-    @mock.patch("mitmproxy.contentviews.get_content_view")
-    def test_contentview(self, get_content_view):
-        se = exceptions.ContentViewException(""), ("x", iter([]))
-        get_content_view.side_effect = se
+    @mock.patch("mitmproxy.contentviews.ViewAuto.__call__")
+    def test_contentview(self, view_auto):
+        view_auto.side_effect = exceptions.ContentViewException("")
 
         s = state.State()
         sio = StringIO()

--- a/test/mitmproxy/test_contentview.py
+++ b/test/mitmproxy/test_contentview.py
@@ -1,3 +1,4 @@
+import mock
 from mitmproxy.exceptions import ContentViewException
 from netlib.http import Headers
 from netlib.http import url
@@ -5,6 +6,7 @@ from netlib import multidict
 
 import mitmproxy.contentviews as cv
 from . import tutils
+import netlib.tutils
 
 try:
     import pyamf
@@ -180,43 +182,6 @@ Larry
         assert f[0] == "Query"
         assert [x for x in f[1]] == [[("header", "foo: "), ("text", "bar")]]
 
-    def test_get_content_view(self):
-        r = cv.get_content_view(
-            cv.get("Raw"),
-            b"[1, 2, 3]",
-            headers=Headers(content_type="application/json")
-        )
-        assert "Raw" in r[0]
-
-        r = cv.get_content_view(
-            cv.get("Auto"),
-            b"[1, 2, 3]",
-            headers=Headers(content_type="application/json")
-        )
-        assert r[0] == "JSON"
-
-        r = cv.get_content_view(
-            cv.get("Auto"),
-            b"[1, 2",
-            headers=Headers(content_type="application/json")
-        )
-        assert "Raw" in r[0]
-
-        r = cv.get_content_view(
-            cv.get("Auto"),
-            b"[1, 2, 3]",
-            headers=Headers(content_type="application/vnd.api+json")
-        )
-        assert r[0] == "JSON"
-
-        tutils.raises(
-            ContentViewException,
-            cv.get_content_view,
-            cv.get("AMF"),
-            b"[1, 2",
-            headers=Headers()
-        )
-
     def test_add_cv(self):
         class TestContentView(cv.View):
             name = "test"
@@ -231,6 +196,57 @@ Larry
             cv.add,
             tcv
         )
+
+
+def test_get_content_view():
+    desc, lines, err = cv.get_content_view(
+        cv.get("Raw"),
+        b"[1, 2, 3]",
+    )
+    assert "Raw" in desc
+    assert list(lines)
+    assert not err
+
+    desc, lines, err = cv.get_content_view(
+        cv.get("Auto"),
+        b"[1, 2, 3]",
+        headers=Headers(content_type="application/json")
+    )
+    assert desc == "JSON"
+
+    desc, lines, err = cv.get_content_view(
+        cv.get("JSON"),
+        b"[1, 2",
+    )
+    assert "Couldn't parse" in desc
+
+    with mock.patch("mitmproxy.contentviews.ViewAuto.__call__") as view_auto:
+        view_auto.side_effect = ValueError
+
+        desc, lines, err = cv.get_content_view(
+            cv.get("JSON"),
+            b"[1, 2",
+        )
+        assert err
+        assert "Couldn't parse" in desc
+
+
+def test_get_message_content_view():
+    r = netlib.tutils.treq()
+    desc, lines, err = cv.get_message_content_view(cv.get("Raw"), r)
+    assert desc == "Raw"
+
+    r.encode("gzip")
+    desc, lines, err = cv.get_message_content_view(cv.get("Raw"), r)
+    assert desc == "[decoded gzip] Raw"
+
+    r.headers["content-encoding"] = "deflate"
+    desc, lines, err = cv.get_message_content_view(cv.get("Raw"), r)
+    assert desc == "[cannot decode] Raw"
+
+    r.content = None
+    desc, lines, err = cv.get_message_content_view(cv.get("Raw"), r)
+    assert list(lines) == [[("error", "content missing")]]
 
 
 if pyamf:

--- a/test/mitmproxy/test_contentview.py
+++ b/test/mitmproxy/test_contentview.py
@@ -224,7 +224,7 @@ def test_get_content_view():
         view_auto.side_effect = ValueError
 
         desc, lines, err = cv.get_content_view(
-            cv.get("JSON"),
+            cv.get("Auto"),
             b"[1, 2",
         )
         assert err


### PR DESCRIPTION
This PR unifies the (1) "oh the contentview failed let's log an exception and just do raw mode" and (2) "let's remove the content decoding" logic we have for mitmproxy, mitmdump and (soon) mitmweb.