### PR TITLE
fix #1430

### DIFF
--- a/mitmproxy/exceptions.py
+++ b/mitmproxy/exceptions.py
@@ -103,6 +103,10 @@ class ControlException(ProxyException):
     pass
 
 
+class SetServerNotAllowedException(ProxyException):
+    pass
+
+
 class OptionsError(Exception):
     pass
 


### PR DESCRIPTION
fixes #1430 by raising a `SetServerNotAllowedException` and writing an entry to the eventlog.