### PR TITLE
Add basic auth support for reverse proxy mode

### DIFF
--- a/mitmproxy/proxy/config.py
+++ b/mitmproxy/proxy/config.py
@@ -179,7 +179,13 @@ class ProxyConfig:
                     )
                 except ValueError as v:
                     raise exceptions.OptionsError(str(v))
-            self.authenticator = authentication.BasicProxyAuth(
-                password_manager,
-                "mitmproxy"
-            )
+            if options.mode == "reverse":
+                self.authenticator = authentication.BasicWebsiteAuth(
+                    password_manager,
+                    self.upstream_server.address
+                )
+            else:
+                self.authenticator = authentication.BasicProxyAuth(
+                    password_manager,
+                    "mitmproxy"
+                )

--- a/netlib/http/authentication.py
+++ b/netlib/http/authentication.py
@@ -50,9 +50,9 @@ class NullProxyAuth(object):
         return {}
 
 
-class BasicProxyAuth(NullProxyAuth):
-    CHALLENGE_HEADER = 'Proxy-Authenticate'
-    AUTH_HEADER = 'Proxy-Authorization'
+class BasicAuth(NullProxyAuth):
+    CHALLENGE_HEADER = None
+    AUTH_HEADER = None
 
     def __init__(self, password_manager, realm):
         NullProxyAuth.__init__(self, password_manager)
@@ -78,6 +78,16 @@ class BasicProxyAuth(NullProxyAuth):
 
     def auth_challenge_headers(self):
         return {self.CHALLENGE_HEADER: 'Basic realm="%s"' % self.realm}
+
+
+class BasicWebsiteAuth(BasicAuth):
+    CHALLENGE_HEADER = 'WWW-Authenticate'
+    AUTH_HEADER = 'Authorization'
+
+
+class BasicProxyAuth(BasicAuth):
+    CHALLENGE_HEADER = 'Proxy-Authenticate'
+    AUTH_HEADER = 'Proxy-Authorization'
 
 
 class PassMan(object):

--- a/test/mitmproxy/test_server.py
+++ b/test/mitmproxy/test_server.py
@@ -313,6 +313,22 @@ class TestHTTPAuth(tservers.HTTPProxyTest):
         assert ret.status_code == 202
 
 
+class TestHTTPReverseAuth(tservers.ReverseProxyTest):
+    def test_auth(self):
+        self.master.options.auth_singleuser = "test:test"
+        assert self.pathod("202").status_code == 401
+        p = self.pathoc()
+        ret = p.request("""
+            get
+            '/p/202'
+            h'%s'='%s'
+        """ % (
+            http.authentication.BasicWebsiteAuth.AUTH_HEADER,
+            authentication.assemble_http_basic_auth("basic", "test", "test")
+        ))
+        assert ret.status_code == 202
+
+
 class TestHTTPS(tservers.HTTPProxyTest, CommonMixin, TcpMixin):
     ssl = True
     ssloptions = pathod.SSLOptions(request_client_cert=True)


### PR DESCRIPTION
This PR makes it possible to have basic auth in reverse proxy mode:
```
mitmdump -R http://example.com --singleuser foo:bar
```