### PR TITLE
Truncate URLs in console

### DIFF
--- a/mitmproxy/console/common.py
+++ b/mitmproxy/console/common.py
@@ -32,8 +32,6 @@ METHOD_OPTIONS = [
     ("edit raw", "e"),
 ]
 
-MAX_URL_LEN = 200
-
 
 def is_keypress(k):
     """
@@ -330,7 +328,7 @@ def export_to_clip_or_file(key, scope, flow, writer):
 flowcache = utils.LRUCache(800)
 
 
-def raw_format_flow(f, focus, extended, short_urls):
+def raw_format_flow(f, focus, extended, truncate_urls):
     f = dict(f)
     pile = []
     req = []
@@ -363,8 +361,8 @@ def raw_format_flow(f, focus, extended, short_urls):
     url = f["req_url"]
 
     # TODO: Add a configuration setting that disables this behaviour?
-    if short_urls and len(url) > MAX_URL_LEN:
-        url = url[:MAX_URL_LEN] + "..."
+    if truncate_urls and len(url) > truncate_urls:
+        url = url[:truncate_urls] + "..."
 
     if f["req_http_version"] not in ("HTTP/1.0", "HTTP/1.1"):
         url += " " + f["req_http_version"]
@@ -417,7 +415,7 @@ def raw_format_flow(f, focus, extended, short_urls):
     return urwid.Pile(pile)
 
 
-def format_flow(f, focus, extended=False, hostheader=False, short_urls=True):
+def format_flow(f, focus, extended=False, hostheader=False, truncate_urls=False):
     d = dict(
         intercepted = f.intercepted,
         acked = f.reply.state == "committed",
@@ -461,5 +459,5 @@ def format_flow(f, focus, extended=False, hostheader=False, short_urls=True):
         tuple(sorted(d.items())),
         focus,
         extended,
-        short_urls,
+        truncate_urls,
     )

--- a/mitmproxy/console/common.py
+++ b/mitmproxy/console/common.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 from __future__ import absolute_import, print_function, division
 
 import os
@@ -328,11 +330,11 @@ def export_to_clip_or_file(key, scope, flow, writer):
 flowcache = utils.LRUCache(800)
 
 
-def raw_format_flow(f, focus, extended, truncate_urls):
+def raw_format_flow(f):
     f = dict(f)
     pile = []
     req = []
-    if extended:
+    if f["extended"]:
         req.append(
             fcol(
                 human.format_timestamp(f["req_timestamp"]),
@@ -340,7 +342,7 @@ def raw_format_flow(f, focus, extended, truncate_urls):
             )
         )
     else:
-        req.append(fcol(">>" if focus else "  ", "focus"))
+        req.append(fcol(">>" if f["focus"] else "  ", "focus"))
 
     if f["marked"]:
         req.append(fcol(SYMBOL_MARK, "mark"))
@@ -360,9 +362,8 @@ def raw_format_flow(f, focus, extended, truncate_urls):
 
     url = f["req_url"]
 
-    # TODO: Add a configuration setting that disables this behaviour?
-    if truncate_urls and len(url) > truncate_urls:
-        url = url[:truncate_urls] + "..."
+    if f["max_url_len"] and len(url) > f["max_url_len"]:
+        url = url[:f["max_url_len"]] + "…"
 
     if f["req_http_version"] not in ("HTTP/1.0", "HTTP/1.1"):
         url += " " + f["req_http_version"]
@@ -389,7 +390,7 @@ def raw_format_flow(f, focus, extended, truncate_urls):
         if f["resp_is_replay"]:
             resp.append(fcol(SYMBOL_REPLAY, "replay"))
         resp.append(fcol(f["resp_code"], ccol))
-        if extended:
+        if f["extended"]:
             resp.append(fcol(f["resp_reason"], ccol))
         if f["intercepted"] and f["resp_code"] and not f["acked"]:
             rc = "intercept"
@@ -415,8 +416,12 @@ def raw_format_flow(f, focus, extended, truncate_urls):
     return urwid.Pile(pile)
 
 
-def format_flow(f, focus, extended=False, hostheader=False, truncate_urls=False):
+def format_flow(f, focus, extended=False, hostheader=False, max_url_len=False):
     d = dict(
+        focus=focus,
+        extended=extended,
+        max_url_len=max_url_len,
+
         intercepted = f.intercepted,
         acked = f.reply.state == "committed",
 
@@ -454,10 +459,5 @@ def format_flow(f, focus, extended=False, hostheader=False, truncate_urls=False)
             d["resp_ctype"] = t.split(";")[0]
         else:
             d["resp_ctype"] = ""
-    return flowcache.get(
-        raw_format_flow,
-        tuple(sorted(d.items())),
-        focus,
-        extended,
-        truncate_urls,
-    )
+
+    return flowcache.get(raw_format_flow, tuple(sorted(d.items())))

--- a/mitmproxy/console/flowlist.py
+++ b/mitmproxy/console/flowlist.py
@@ -116,10 +116,12 @@ class ConnectionItem(urwid.WidgetWrap):
         urwid.WidgetWrap.__init__(self, w)
 
     def get_text(self):
+        cols, _ = self.master.ui.get_cols_rows()
         return common.format_flow(
             self.flow,
             self.f,
-            hostheader = self.master.options.showhost,
+            hostheader=self.master.options.showhost,
+            truncate_urls=cols,
         )
 
     def selectable(self):

--- a/mitmproxy/console/flowlist.py
+++ b/mitmproxy/console/flowlist.py
@@ -121,7 +121,7 @@ class ConnectionItem(urwid.WidgetWrap):
             self.flow,
             self.f,
             hostheader=self.master.options.showhost,
-            truncate_urls=cols,
+            max_url_len=cols,
         )
 
     def selectable(self):

--- a/mitmproxy/console/flowview.py
+++ b/mitmproxy/console/flowview.py
@@ -104,22 +104,24 @@ class FlowViewHeader(urwid.WidgetWrap):
     def __init__(self, master, f):
         self.master = master  # type: "mitmproxy.console.master.ConsoleMaster"
         self.flow = f  # type: models.HTTPFlow
+        cols, _ = self.master.ui.get_cols_rows()
         self._w = common.format_flow(
             f,
             False,
             extended=True,
-            short_urls=False,
+            truncate_urls=cols,
             hostheader=self.master.options.showhost
         )
         signals.flow_change.connect(self.sig_flow_change)
 
     def sig_flow_change(self, sender, flow):
+        cols, _ = self.master.ui.get_cols_rows()
         if flow == self.flow:
             self._w = common.format_flow(
                 flow,
                 False,
                 extended=True,
-                short_urls=False,
+                truncate_urls=cols,
                 hostheader=self.master.options.showhost
             )
 

--- a/mitmproxy/console/flowview.py
+++ b/mitmproxy/console/flowview.py
@@ -104,24 +104,20 @@ class FlowViewHeader(urwid.WidgetWrap):
     def __init__(self, master, f):
         self.master = master  # type: "mitmproxy.console.master.ConsoleMaster"
         self.flow = f  # type: models.HTTPFlow
-        cols, _ = self.master.ui.get_cols_rows()
         self._w = common.format_flow(
             f,
             False,
             extended=True,
-            truncate_urls=cols,
             hostheader=self.master.options.showhost
         )
         signals.flow_change.connect(self.sig_flow_change)
 
     def sig_flow_change(self, sender, flow):
-        cols, _ = self.master.ui.get_cols_rows()
         if flow == self.flow:
             self._w = common.format_flow(
                 flow,
                 False,
                 extended=True,
-                truncate_urls=cols,
                 hostheader=self.master.options.showhost
             )
 

--- a/mitmproxy/console/flowview.py
+++ b/mitmproxy/console/flowview.py
@@ -108,6 +108,7 @@ class FlowViewHeader(urwid.WidgetWrap):
             f,
             False,
             extended=True,
+            short_urls=False,
             hostheader=self.master.options.showhost
         )
         signals.flow_change.connect(self.sig_flow_change)
@@ -118,6 +119,7 @@ class FlowViewHeader(urwid.WidgetWrap):
                 flow,
                 False,
                 extended=True,
+                short_urls=False,
                 hostheader=self.master.options.showhost
             )
 


### PR DESCRIPTION
An attempt to fix #1485

Currently, URLs are shortened in the `flowlist`, but are displayed as-is in the `flowview`. 

I'd actually prefer to shorten them in both the views, but then we need to come up with a way to view the full URL.

It could be via an option in the UI like we have `Show Host` or a hotkey that toggles the behaviour in both the views.