### PR TITLE
[web] Add context menu for flow row

### DIFF
--- a/web/src/css/app.less
+++ b/web/src/css/app.less
@@ -19,3 +19,4 @@ html {
 @import (less) "footer.less";
 @import (less) "codemirror.less";
 @import (less) "contentview.less";
+@import (less) "contextmenu.less";

--- a/web/src/css/contextmenu.less
+++ b/web/src/css/contextmenu.less
@@ -1,0 +1,26 @@
+.react-context-menu {
+    outline: none;
+    background: white;
+    border: 1px solid #a0a0a0;
+    min-width: 120px;
+
+    .react-context-menu-link {
+        padding: 5px 8px;
+        border-bottom: 1px solid lightgray;
+        display: inline-block;
+        width: 100%;
+
+        &.disabled {
+            color: #bbb;
+            cursor: default;
+        }
+
+        &:hover {
+            text-decoration: none;
+
+            &:not(.disabled) {
+                background: #efefef;
+            }
+        }
+    }
+}

--- a/web/src/css/flowtable.less
+++ b/web/src/css/flowtable.less
@@ -10,8 +10,14 @@
 
 .flow-table {
     width: 100%;
-    overflow-y: scroll;
-    overflow-x: hidden;
+    height: 100%;
+    overflow: hidden;
+
+    .flow-table-content {
+        height: 100%;
+        overflow-x: hidden;
+        overflow-y: auto;
+    }
 
     table {
         width: 100%;

--- a/web/src/js/components/FlowContextMenu.jsx
+++ b/web/src/js/components/FlowContextMenu.jsx
@@ -1,0 +1,22 @@
+import { connect } from 'react-redux'
+import { ContextMenu, MenuItem } from 'react-contextmenu'
+import * as flowsActions from '../ducks/flows'
+import { MessageUtils } from '../flow/utils.js'
+
+function FlowContextMenu({ flow, accept, replay, duplicate, remove, revert }) {
+    return (
+        <ContextMenu identifier="flow-table-context-menu">
+            <MenuItem disabled={!flow.intercepted} onClick={() => accept(flow)}>Accept</MenuItem>
+            <MenuItem onClick={() => replay(flow)}>Replay</MenuItem>
+            <MenuItem onClick={() => duplicate(flow)}>Duplicate</MenuItem>
+            <MenuItem onClick={() => remove(flow)}>Delete</MenuItem>
+            <MenuItem onClick={() => revert(flow)}>Revert</MenuItem>
+            <MenuItem disabled={!flow.modified} onClick={() => window.location = MessageUtils.getContentURL(flow, flow.response)}>Download</MenuItem>
+        </ContextMenu>
+    )
+}
+
+export default connect(
+    state => ({}),
+    flowsActions
+)(FlowContextMenu)

--- a/web/src/js/components/FlowTable.jsx
+++ b/web/src/js/components/FlowTable.jsx
@@ -1,11 +1,12 @@
 import React, { PropTypes } from 'react'
 import ReactDOM from 'react-dom'
 import shallowEqual from 'shallowequal'
+import { ContextMenuLayer } from 'react-contextmenu'
 import AutoScroll from './helpers/AutoScroll'
 import { calcVScroll } from './helpers/VirtualScroll'
 import FlowTableHead from './FlowTable/FlowTableHead'
 import FlowRow from './FlowTable/FlowRow'
-import Filt from "../filt/filt"
+import Filt from '../filt/filt'
 
 class FlowTable extends React.Component {
 
@@ -93,7 +94,7 @@ class FlowTable extends React.Component {
         const isHighlighted = highlight ? Filt.parse(highlight) : () => false
 
         return (
-            <div className="flow-table" onScroll={this.onViewportUpdate}>
+            <div className="flow-table-content" onScroll={this.onViewportUpdate}>
                 <table>
                     <thead ref="head" style={{ transform: `translateY(${viewportTop}px)` }}>
                         <FlowTableHead />
@@ -106,7 +107,8 @@ class FlowTable extends React.Component {
                                 flow={flow}
                                 selected={flow === selected}
                                 highlighted={isHighlighted(flow)}
-                                onSelect={this.props.onSelect}
+                                onSelect={() => this.props.onSelect(flow.id)}
+                                onContextMenu={() => this.props.onSelect(flow.id)}
                             />
                         ))}
                         <tr style={{ height: vScroll.paddingBottom }}></tr>
@@ -117,4 +119,4 @@ class FlowTable extends React.Component {
     }
 }
 
-export default AutoScroll(FlowTable)
+export default ContextMenuLayer('flow-table-context-menu')(AutoScroll(FlowTable))

--- a/web/src/js/components/FlowTable/FlowColumns.jsx
+++ b/web/src/js/components/FlowTable/FlowColumns.jsx
@@ -14,9 +14,7 @@ TLSColumn.headerName = ''
 
 export function IconColumn({ flow }) {
     return (
-        <td className="col-icon">
-            <div className={classnames('resource-icon', IconColumn.getIcon(flow))}></div>
-        </td>
+        <td className={classnames('col-icon resource-icon', IconColumn.getIcon(flow))}></td>
     )
 }
 
@@ -72,7 +70,9 @@ PathColumn.headerName = 'Path'
 
 export function MethodColumn({ flow }) {
     return (
-        <td className="col-method">{flow.request.method}</td>
+        <td className="col-method">
+            {flow.request.method}
+        </td>
     )
 }
 
@@ -81,7 +81,9 @@ MethodColumn.headerName = 'Method'
 
 export function StatusColumn({ flow }) {
     return (
-        <td className="col-status">{flow.response && flow.response.status_code}</td>
+        <td className="col-status">
+            {flow.response && flow.response.status_code}
+        </td>
     )
 }
 
@@ -90,7 +92,9 @@ StatusColumn.headerName = 'Status'
 
 export function SizeColumn({ flow }) {
     return (
-        <td className="col-size">{formatSize(SizeColumn.getTotalSize(flow))}</td>
+        <td className="col-size">
+            {formatSize(SizeColumn.getTotalSize(flow))}
+        </td>
     )
 }
 

--- a/web/src/js/components/FlowTable/FlowRow.jsx
+++ b/web/src/js/components/FlowTable/FlowRow.jsx
@@ -5,12 +5,13 @@ import { pure } from '../../utils'
 
 FlowRow.propTypes = {
     onSelect: PropTypes.func.isRequired,
+    onContextMenu: PropTypes.func.isRequired,
     flow: PropTypes.object.isRequired,
     highlighted: PropTypes.bool,
     selected: PropTypes.bool,
 }
 
-function FlowRow({ flow, selected, highlighted, onSelect }) {
+function FlowRow({ flow, selected, highlighted, onSelect, onContextMenu }) {
     const className = classnames({
         'selected': selected,
         'highlighted': highlighted,
@@ -20,7 +21,7 @@ function FlowRow({ flow, selected, highlighted, onSelect }) {
     })
 
     return (
-        <tr className={className} onClick={() => onSelect(flow.id)}>
+        <tr className={className} onClick={onSelect} onContextMenu={onContextMenu}>
             {columns.map(Column => (
                 <Column key={Column.name} flow={flow}/>
             ))}

--- a/web/src/js/components/MainView.jsx
+++ b/web/src/js/components/MainView.jsx
@@ -3,6 +3,7 @@ import { connect } from 'react-redux'
 import Splitter from './common/Splitter'
 import FlowTable from './FlowTable'
 import FlowView from './FlowView'
+import FlowContextMenu from './FlowContextMenu'
 import * as flowsActions from '../ducks/flows'
 import { updateFilter, updateHighlight } from '../ducks/flowView'
 
@@ -19,11 +20,13 @@ class MainView extends Component {
             <div className="main-view">
                 <FlowTable
                     ref="flowTable"
+                    attributes={{ className: 'flow-table' }}
                     flows={flows}
                     selected={selectedFlow}
                     highlight={highlight}
                     onSelect={this.props.selectFlow}
                 />
+                <FlowContextMenu flow={selectedFlow} />
                 {selectedFlow && [
                     <Splitter key="splitter"/>,
                     <FlowView
@@ -49,8 +52,8 @@ export default connect(
     }),
     {
         selectFlow: flowsActions.select,
+        updateFlow: flowsActions.update,
         updateFilter,
         updateHighlight,
-        updateFlow: flowsActions.update,
     }
 )(MainView)

--- a/web/src/js/ducks/flows.js
+++ b/web/src/js/ducks/flows.js
@@ -145,14 +145,15 @@ export function upload(file) {
     return dispatch => fetchApi('/flows/dump', { method: 'post', body })
 }
 
-
+/**
+ * @public
+ */
 export function select(id) {
     return {
         type: SELECT,
         flowIds: id ? [id] : []
     }
 }
-
 
 /**
  * This action creater takes all WebSocket events


### PR DESCRIPTION
ContextMenuLayer always creates an extra layer when rendering [react-contextmenu/contextmenu-layer.js#L94](https://github.com/vkbansal/react-contextmenu/blob/master/src/contextmenu-layer.js#L94), so we need to put it into FlowColumn instead of FlowRow.
