### PR TITLE
Stream "requests" (upload) in the same way as "responses" (download)

### DIFF
--- a/mitmproxy/controller.py
+++ b/mitmproxy/controller.py
@@ -25,6 +25,7 @@ Events = frozenset([
     "tcp_close",
 
     "request",
+    "requestheaders",
     "response",
     "responseheaders",
 

--- a/mitmproxy/flow/master.py
+++ b/mitmproxy/flow/master.py
@@ -318,6 +318,16 @@ class FlowMaster(controller.Master):
         return f
 
     @controller.handler
+    def requestheaders(self, f):
+        try:
+            if self.stream_large_bodies:
+                self.stream_large_bodies.run(f, False)
+        except netlib.exceptions.HttpException:
+            f.reply.kill()
+            return
+        return f
+
+    @controller.handler
     def responseheaders(self, f):
         try:
             if self.stream_large_bodies:

--- a/mitmproxy/models/http.py
+++ b/mitmproxy/models/http.py
@@ -70,6 +70,7 @@ class HTTPRequest(MessageMixin, Request):
 
         # Is this request replayed?
         self.is_replay = is_replay
+        self.stream = False
 
     def get_state(self):
         state = super(HTTPRequest, self).get_state()

--- a/mitmproxy/protocol/http.py
+++ b/mitmproxy/protocol/http.py
@@ -219,12 +219,11 @@ class HttpLayer(base.Layer):
                     flow.live = False
 
     def get_request_from_client(self):
-        request = self.read_request()
+        request = self.read_request_headers()
         if request.headers.get("expect", "").lower() == "100-continue":
             # TODO: We may have to use send_response_headers for HTTP2 here.
             self.send_response(models.expect_continue_response)
             request.headers.pop("expect")
-            request.body = b"".join(self.read_request_body(request))
         return request
 
     def send_error_response(self, code, message):
@@ -272,7 +271,24 @@ class HttpLayer(base.Layer):
 
     def get_response_from_server(self, flow):
         def get_response():
-            self.send_request(flow.request)
+            if not flow.request.stream:
+                # no streaming:
+                # we already received the full request from the client and can
+                # send it to the server straight away.
+                self.send_request(flow.request)
+            else:
+                # streaming:
+                # First send the headers and then transfer the request incrementally
+                self.send_request_headers(flow.request)
+                chunks = self.read_request_body(
+                    flow.request
+                )
+                if callable(flow.request.stream):
+                    chunks = flow.request.stream(chunks)
+                self.send_request_body(flow.request, chunks)
+                flow.request.timestamp_end = time.time()
+
+            # Then, start read the response
             flow.response = self.read_response_headers()
 
         try:
@@ -325,6 +341,21 @@ class HttpLayer(base.Layer):
         # For authority-form requests, we only need to determine the request scheme.
         # For relative-form requests, we need to determine host and port as
         # well.
+
+        # Process request headers and read body if not in a stream case
+        # call the appropriate script hook - this is an opportunity for an
+        # inline script to set flow.stream = True
+        flow = self.channel.ask("requestheaders", flow)
+
+        if flow.request.stream:
+            flow.request.data.content = None
+        else:
+            flow.request.data.content = b"".join(self.read_request_body(
+                flow.request
+            ))
+        flow.request.timestamp_end = time.time()
+        # End of process request headers
+
         if self.mode == "regular":
             pass  # only absolute-form at this point, nothing to do here.
         elif self.mode == "upstream":


### PR DESCRIPTION
...when stream mode is enabled.

When using `--stream` option with mitmdump, only "download" (downlink/responses) were "streamed" in chunks. The goal was to have a constant memory usage irrespective of the size of the response.

"upload" (uplink/requests) were not streamed, and so, let's say that you are "uploading" a 1GB file, mitmproxy/dump would temporarily use 1GB RAM.

This patch adds the stream option for "upload" in the same way that it is done for "download".

Note: I first created the patch against the last release and tested it. Then i rebased it. I was not able to test it after the rebase on master as I have some issues running the git master version on my setup.

The "http2" part of the code is completely untested, and just based on code logic.
