### PR TITLE
Improve the way we handle upstream errors

### DIFF
--- a/examples/flowbasic
+++ b/examples/flowbasic
@@ -32,8 +32,8 @@ class MyMaster(flow.FlowMaster):
         print("error", f)
 
     @controller.handler
-    def log(self, f):
-        print("log", f)
+    def log(self, l):
+        print("log", l.msg)
 
 opts = options.Options(cadir="~/.mitmproxy/")
 config = ProxyConfig(opts)


### PR DESCRIPTION
- Don't log a traceback for either HTTP or HTTPS DNS resolution or TCP
connection errors. These are "ordinary" errors, not mitmproxy issues.
- Ensure that the error handler is correctly called for SSL-related protocol
errors.