### PR TITLE
Notify when proxy server started

### DIFF
--- a/mitmproxy/dump.py
+++ b/mitmproxy/dump.py
@@ -48,6 +48,10 @@ class DumpMaster(flow.FlowMaster):
         self.options = self.options  # type: Options
         self.set_stream_large_bodies(options.stream_large_bodies)
 
+        print("Proxy server listening at http://%s:%d" % (
+            (options.listen_host or "0.0.0.0"),
+            options.listen_port))
+
         if self.server and self.options.http2 and not tcp.HAS_ALPN:  # pragma: no cover
             print("ALPN support missing (OpenSSL 1.0.2+ required)!\n"
                   "HTTP/2 is disabled. Use --no-http2 to silence this warning.",


### PR DESCRIPTION
Resolved #1505 

I think use the channel for communication between server and master is a good practice.
But I need your advise for
1. Is the notification message is OK?
2. Is override the serve_forever from TCPServer ok? Or we have some better way to do this.

Thanks!