### PR TITLE
Fix decoding when content-encoding: none

### DIFF
--- a/netlib/encoding.py
+++ b/netlib/encoding.py
@@ -76,7 +76,7 @@ def encode(decoded, encoding, errors='strict'):
     Raises:
         ValueError, if encoding fails.
     """
-    if len(decoded) == 0:
+    if len(decoded) == 0 or encoding == "none":
         return decoded
 
     global _cache

--- a/netlib/encoding.py
+++ b/netlib/encoding.py
@@ -34,7 +34,7 @@ def decode(encoded, encoding, errors='strict'):
     Raises:
         ValueError, if decoding fails.
     """
-    if len(encoded) == 0:
+    if len(encoded) == 0 or encoding == "none":
         return encoded
 
     global _cache

--- a/netlib/encoding.py
+++ b/netlib/encoding.py
@@ -34,7 +34,7 @@ def decode(encoded, encoding, errors='strict'):
     Raises:
         ValueError, if decoding fails.
     """
-    if len(encoded) == 0 or encoding == "none":
+    if len(encoded) == 0:
         return encoded
 
     global _cache
@@ -76,7 +76,7 @@ def encode(decoded, encoding, errors='strict'):
     Raises:
         ValueError, if encoding fails.
     """
-    if len(decoded) == 0 or encoding == "none":
+    if len(decoded) == 0:
         return decoded
 
     global _cache
@@ -162,12 +162,14 @@ def encode_deflate(content):
 
 
 custom_decode = {
+    "none": identity,
     "identity": identity,
     "gzip": decode_gzip,
     "deflate": decode_deflate,
     "br": decode_brotli,
 }
 custom_encode = {
+    "none": identity,
     "identity": identity,
     "gzip": encode_gzip,
     "deflate": encode_deflate,

--- a/test/netlib/test_encoding.py
+++ b/test/netlib/test_encoding.py
@@ -11,6 +11,11 @@ def test_identity():
         encoding.encode(b"string", "nonexistent encoding")
 
 
+def test_none():
+    assert b"string" == encoding.decode(b"string", "none")
+    assert b"string" == encoding.encode(b"string", "none")
+
+
 @pytest.mark.parametrize("encoder", [
     'gzip',
     'br',

--- a/test/netlib/test_encoding.py
+++ b/test/netlib/test_encoding.py
@@ -4,16 +4,15 @@ import pytest
 from netlib import encoding, tutils
 
 
-def test_identity():
-    assert b"string" == encoding.decode(b"string", "identity")
-    assert b"string" == encoding.encode(b"string", "identity")
+@pytest.mark.parametrize("encoder", [
+    'identity',
+    'none',
+])
+def test_identity(encoder):
+    assert b"string" == encoding.decode(b"string", encoder)
+    assert b"string" == encoding.encode(b"string", encoder)
     with tutils.raises(ValueError):
         encoding.encode(b"string", "nonexistent encoding")
-
-
-def test_none():
-    assert b"string" == encoding.decode(b"string", "none")
-    assert b"string" == encoding.encode(b"string", "none")
 
 
 @pytest.mark.parametrize("encoder", [


### PR DESCRIPTION
##### Steps to reproduce the problem:

```
In [7]: encoding.decode('', 'none')
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-7-a83dfad39aec> in <module>()
----> 1 encoding.decode('', 'none')

/home/ames/dev/mitmproxy/netlib/encoding.pyc in decode(encoded, encoding, errors)
     54             type(e).__name__,
     55             repr(encoded)[:10],
---> 56             repr(encoding),
     57         ))
     58 

ValueError: LookupError when decoding '' with 'none'
```

##### What is the expected behavior?

Return the same value.

##### What went wrong?

I encountered a website that sent a content-encoding header of 'none', which `netlib.encoding` doesn't seem to be able to handle. I realize that it's an out of spec header value, but I believe it should be handled gracefully.

---

Mitmproxy Version: master (0.18)
