### PR TITLE
Roll out synchronisation for mitmproxy tests

### DIFF
--- a/mitmproxy/addons.py
+++ b/mitmproxy/addons.py
@@ -4,7 +4,7 @@ import pprint
 
 
 def _get_name(itm):
-    return getattr(itm, "name", itm.__class__.__name__)
+    return getattr(itm, "name", itm.__class__.__name__.lower())
 
 
 class Addons(object):
@@ -12,6 +12,16 @@ class Addons(object):
         self.chain = []
         self.master = master
         master.options.changed.connect(self.options_update)
+
+    def get(self, name):
+        """
+            Retrieve an addon by name. Addon names are equal to the .name
+            attribute on the instance, or the lower case class name if that
+            does not exist.
+        """
+        for i in self.chain:
+            if name == _get_name(i):
+                return i
 
     def options_update(self, options, updated):
         for i in self.chain:
@@ -38,14 +48,6 @@ class Addons(object):
     def done(self):
         for i in self.chain:
             self.invoke_with_context(i, "done")
-
-    def has_addon(self, name):
-        """
-            Is an addon with this name registered?
-        """
-        for i in self.chain:
-            if _get_name(i) == name:
-                return True
 
     def __len__(self):
         return len(self.chain)

--- a/mitmproxy/builtins/serverplayback.py
+++ b/mitmproxy/builtins/serverplayback.py
@@ -88,13 +88,14 @@ class ServerPlayback(object):
 
     def configure(self, options, updated):
         self.options = options
-        if options.server_replay and "server_replay" in updated:
-            try:
-                flows = flow.read_flows_from_paths(options.server_replay)
-            except exceptions.FlowReadException as e:
-                raise exceptions.OptionsError(str(e))
+        if "server_replay" in updated:
             self.clear()
-            self.load(flows)
+            if options.server_replay:
+                try:
+                    flows = flow.read_flows_from_paths(options.server_replay)
+                except exceptions.FlowReadException as e:
+                    raise exceptions.OptionsError(str(e))
+                self.load(flows)
 
         # FIXME: These options have to be renamed to something more sensible -
         # prefixed with serverplayback_ where appropriate, and playback_ where

--- a/mitmproxy/console/master.py
+++ b/mitmproxy/console/master.py
@@ -248,9 +248,6 @@ class ConsoleMaster(flow.FlowMaster):
         if options.client_replay:
             self.client_playback_path(options.client_replay)
 
-        if options.server_replay:
-            self.server_playback_path(options.server_replay)
-
         self.view_stack = []
 
         if options.app:
@@ -390,21 +387,6 @@ class ConsoleMaster(flow.FlowMaster):
         flows = self._readflows(path)
         if flows:
             self.start_client_playback(flows, False)
-
-    def server_playback_path(self, path):
-        if not isinstance(path, list):
-            path = [path]
-        flows = self._readflows(path)
-        if flows:
-            self.start_server_playback(
-                flows,
-                self.options.kill, self.options.rheaders,
-                False, self.options.nopop,
-                self.options.replay_ignore_params,
-                self.options.replay_ignore_content,
-                self.options.replay_ignore_payload_params,
-                self.options.replay_ignore_host
-            )
 
     def spawn_editor(self, data):
         text = not isinstance(data, bytes)

--- a/mitmproxy/console/statusbar.py
+++ b/mitmproxy/console/statusbar.py
@@ -147,14 +147,12 @@ class StatusBar(urwid.WidgetWrap):
         if self.master.client_playback:
             r.append("[")
             r.append(("heading_key", "cplayback"))
-            r.append(":%s to go]" % self.master.client_playback.count())
-        if self.master.server_playback:
+            r.append(":%s]" % self.master.client_playback.count())
+        if self.master.options.server_replay:
             r.append("[")
             r.append(("heading_key", "splayback"))
-            if self.master.options.nopop:
-                r.append(":%s in file]" % self.master.server_playback.count())
-            else:
-                r.append(":%s to go]" % self.master.server_playback.count())
+            a = self.master.addons.get("serverplayback")
+            r.append(":%s]" % a.count())
         if self.master.options.ignore_hosts:
             r.append("[")
             r.append(("heading_key", "I"))

--- a/mitmproxy/console/window.py
+++ b/mitmproxy/console/window.py
@@ -57,13 +57,11 @@ class Window(urwid.Frame):
                     callback = self.master.stop_client_playback_prompt,
                 )
         elif k == "s":
-            if not self.master.server_playback:
-                signals.status_prompt_path.send(
-                    self,
-                    prompt = "Server replay path",
-                    callback = self.master.server_playback_path
-                )
-            else:
+            a = self.master.addons.get("serverplayback")
+            if a.count():
+                def stop_server_playback(response):
+                    if response == "y":
+                        self.master.options.server_replay = []
                 signals.status_prompt_onekey.send(
                     self,
                     prompt = "Stop current server replay?",
@@ -71,7 +69,13 @@ class Window(urwid.Frame):
                         ("yes", "y"),
                         ("no", "n"),
                     ),
-                    callback = self.master.stop_server_playback_prompt,
+                    callback = stop_server_playback
+                )
+            else:
+                signals.status_prompt_path.send(
+                    self,
+                    prompt = "Server playback path",
+                    callback = lambda x: self.master.options.setter("server_replay")([x])
                 )
 
     def keypress(self, size, k):

--- a/mitmproxy/protocol/http_replay.py
+++ b/mitmproxy/protocol/http_replay.py
@@ -33,6 +33,7 @@ class RequestReplayThread(basethread.BaseThread):
     def run(self):
         r = self.flow.request
         first_line_format_backup = r.first_line_format
+        server = None
         try:
             self.flow.response = None
 
@@ -103,3 +104,5 @@ class RequestReplayThread(basethread.BaseThread):
             self.channel.tell("log", Log(traceback.format_exc(), "error"))
         finally:
             r.first_line_format = first_line_format_backup
+            if server:
+                server.finish()

--- a/test/mitmproxy/protocol/test_http1.py
+++ b/test/mitmproxy/protocol/test_http1.py
@@ -18,14 +18,15 @@ class TestInvalidRequests(tservers.HTTPProxyTest):
 
     def test_double_connect(self):
         p = self.pathoc()
-        r = p.request("connect:'%s:%s'" % ("127.0.0.1", self.server2.port))
+        with p.connect():
+            r = p.request("connect:'%s:%s'" % ("127.0.0.1", self.server2.port))
         assert r.status_code == 400
         assert b"Invalid HTTP request form" in r.content
 
     def test_relative_request(self):
         p = self.pathoc_raw()
-        p.connect()
-        r = p.request("get:/p/200")
+        with p.connect():
+            r = p.request("get:/p/200")
         assert r.status_code == 400
         assert b"Invalid HTTP request form" in r.content
 
@@ -61,5 +62,8 @@ class TestHeadContentLength(tservers.HTTPProxyTest):
 
     def test_head_content_length(self):
         p = self.pathoc()
-        resp = p.request("""head:'%s/p/200:h"Content-Length"="42"'""" % self.server.urlbase)
+        with p.connect():
+            resp = p.request(
+                """head:'%s/p/200:h"Content-Length"="42"'""" % self.server.urlbase
+            )
         assert resp.headers["Content-Length"] == "42"

--- a/test/mitmproxy/test_addons.py
+++ b/test/mitmproxy/test_addons.py
@@ -17,5 +17,5 @@ def test_simple():
     m = controller.Master(o)
     a = addons.Addons(m)
     a.add(o, TAddon("one"))
-    assert a.has_addon("one")
-    assert not a.has_addon("two")
+    assert a.get("one")
+    assert not a.get("two")

--- a/test/mitmproxy/test_fuzzing.py
+++ b/test/mitmproxy/test_fuzzing.py
@@ -11,17 +11,20 @@ class TestFuzzy(tservers.HTTPProxyTest):
     def test_idna_err(self):
         req = r'get:"http://localhost:%s":i10,"\xc6"'
         p = self.pathoc()
-        assert p.request(req % self.server.port).status_code == 400
+        with p.connect():
+            assert p.request(req % self.server.port).status_code == 400
 
     def test_nullbytes(self):
         req = r'get:"http://localhost:%s":i19,"\x00"'
         p = self.pathoc()
-        assert p.request(req % self.server.port).status_code == 400
+        with p.connect():
+            assert p.request(req % self.server.port).status_code == 400
 
     def test_invalid_ipv6_url(self):
         req = 'get:"http://localhost:%s":i13,"["'
         p = self.pathoc()
-        resp = p.request(req % self.server.port)
+        with p.connect():
+            resp = p.request(req % self.server.port)
         assert resp.status_code == 400
 
     # def test_invalid_upstream(self):


### PR DESCRIPTION
This extends some of the work I did for pathod and netlib to the mitmproxy test
suite. It also fixes what may be a leak in replays.

Failing on connection leak is disabled on Windows for the moment.

Fixes #1535