### PR TITLE
Added Content-Length header to examples/redirect_requests.py

### DIFF
--- a/examples/redirect_requests.py
+++ b/examples/redirect_requests.py
@@ -12,6 +12,7 @@ def request(flow):
     # Method 1: Answer with a locally generated response
     if flow.request.pretty_host.endswith("example.com"):
         resp = HTTPResponse.make(200, b"Hello World", {"Content-Type": "text/html"})
+        resp.headers["Content-Length"] = str(len(resp.body))
         flow.reply.send(resp)
 
     # Method 2: Redirect the request to a different server


### PR DESCRIPTION
Current example returns no *Content-Length* header, which causes some warnings. For example:

<pre>
$ curl -x http://localhost:8080  -v example.com
* Rebuilt URL to: example.com/
*   Trying 127.0.0.1...
* Connected to localhost (127.0.0.1) port 8080 (#0)
> GET HTTP://example.com/ HTTP/1.1
> Host: example.com
> User-Agent: curl/7.43.0
> Accept: */*
> Proxy-Connection: Keep-Alive
> 
< HTTP/1.1 200 OK
< Content-Type: text/html
<b>* no chunk, no close, no size. Assume close to signal end</b>
< 
* Closing connection 0
Hello World
</pre>

This patch adds missing header.