### PR TITLE
Update app.py

### DIFF
--- a/mitmproxy/web/app.py
+++ b/mitmproxy/web/app.py
@@ -116,7 +116,7 @@ class RequestHandler(BasicAuth, tornado.web.RequestHandler):
     def json(self):
         if not self.request.headers.get("Content-Type").startswith("application/json"):
             return None
-        return json.loads(self.request.body)
+        return json.loads(self.request.body.decode())
 
     @property
     def state(self):


### PR DESCRIPTION
 (Mac os X yosemite)

Fixes error:
Traceback (most recent call last):
  File "/usr/local/lib/python3.5/site-packages/tornado-4.4.1-py3.5-macosx-10.11-x86_64.egg/tornado/web.py", line 1467, in _execute
    result = method(*self.path_args, **self.path_kwargs)
  File "/Users/<user>/Desktop/mitmproxy/mitmproxy/web/app.py", line 390, in put
    for k, v in six.iteritems(self.json):
  File "/Users/<user>/Desktop/mitmproxy/mitmproxy/web/app.py", line 119, in json
    return json.loads(self.request.body)
  File "/usr/local/Cellar/python3/3.5.2_1/Frameworks/Python.framework/Versions/3.5/lib/python3.5/json/__init__.py", line 312, in loads
    s.__class__.__name__))
TypeError: the JSON object must be str, not 'bytes'
ERROR:tornado.access:500 PUT /settings ...