### PR TITLE
console/options: kill -> replay_kill_extra

### DIFF
--- a/mitmproxy/console/options.py
+++ b/mitmproxy/console/options.py
@@ -115,7 +115,7 @@ class Options(urwid.WidgetWrap):
                     "Kill Extra",
                     "x",
                     lambda: master.options.replay_kill_extra,
-                    master.options.toggler("kill")
+                    master.options.toggler("replay_kill_extra")
                 ),
                 select.Option(
                     "No Refresh",


### PR DESCRIPTION
@cortesi renamed the kill option to replay_kill_extra in b0213a2, but
missed a usage here because it was in a string. This fixes opening the
options menu in console.