### PR TITLE
Fix mitmdump error logging, fix #1549

### DIFF
--- a/mitmproxy/exceptions.py
+++ b/mitmproxy/exceptions.py
@@ -27,6 +27,10 @@ class Kill(ProxyException):
 
 
 class ProtocolException(ProxyException):
+    """
+    ProtocolExceptions are caused by invalid user input, unavailable network resources,
+    or other events that are outside of our influence.
+    """
     pass
 
 

--- a/mitmproxy/protocol/http.py
+++ b/mitmproxy/protocol/http.py
@@ -153,12 +153,13 @@ class HttpLayer(base.Layer):
                 # We optimistically guess there might be an HTTP client on the
                 # other end
                 self.send_error_response(400, repr(e))
-                self.log(
-                    "request",
-                    "warn",
-                    "HTTP protocol error in client request: %s" % e
+                six.reraise(
+                    exceptions.ProtocolException,
+                    exceptions.ProtocolException(
+                        "HTTP protocol error in client request: {}".format(e)
+                    ),
+                    sys.exc_info()[2]
                 )
-                return
 
             self.log("request", "debug", [repr(request)])
 

--- a/mitmproxy/proxy/server.py
+++ b/mitmproxy/proxy/server.py
@@ -132,7 +132,7 @@ class ConnectionHandler(object):
                 self.log(str(e), "warn")
                 self.log("Invalid certificate, closing connection. Pass --insecure to disable validation.", "warn")
             else:
-                self.log(repr(e), "warn")
+                self.log(str(e), "warn")
 
                 self.log(traceback.format_exc(), "debug")
             # If an error propagates to the topmost level,


### PR DESCRIPTION
This commit replaces the logging statement introduced in afe34e8b28988bdff91123862194606152c03c33 with the previous implementation where an exception is raised. ProtocolExceptions are normally logged as regular warnings, achieving the same effect for the end user. However, this retains the full stack trace for debug-level logging, which makes the analysis of client errors considerably easier.