### PR TITLE
add websocket on/off switch, improve logging (fix #1546, fix #1547)

### DIFF
--- a/mitmproxy/cmdline.py
+++ b/mitmproxy/cmdline.py
@@ -1,14 +1,12 @@
 from __future__ import absolute_import, print_function, division
 
+import configargparse
 import os
 import re
-
-import configargparse
-
 from mitmproxy import exceptions
 from mitmproxy import filt
-from mitmproxy import platform
 from mitmproxy import options
+from mitmproxy import platform
 from netlib import human
 from netlib import tcp
 from netlib import version
@@ -257,6 +255,7 @@ def get_common_options(args):
         no_upstream_cert = args.no_upstream_cert,
         spoof_source_address = args.spoof_source_address,
         rawtcp = args.rawtcp,
+        websockets = args.websockets,
         upstream_server = upstream_server,
         upstream_auth = args.upstream_auth,
         ssl_version_client = args.ssl_version_client,
@@ -475,6 +474,13 @@ def proxy_options(parser):
                         "Disabled by default. "
                         "Default value will change in a future version."
                         )
+    websockets = group.add_mutually_exclusive_group()
+    websockets.add_argument("--websockets", action="store_true", dest="websockets")
+    websockets.add_argument("--no-websockets", action="store_false", dest="websockets",
+                            help="Explicitly enable/disable experimental WebSocket support. "
+                                 "Disabled by default as messages are only printed to the event log and not retained. "
+                                 "Default value will change in a future version."
+                            )
     group.add_argument(
         "--spoof-source-address",
         action="store_true", dest="spoof_source_address",

--- a/mitmproxy/options.py
+++ b/mitmproxy/options.py
@@ -70,6 +70,7 @@ class Options(optmanager.OptManager):
             mode = "regular",  # type: str
             no_upstream_cert = False,  # type: bool
             rawtcp = False,  # type: bool
+            websockets = False,  # type: bool
             spoof_source_address = False,  # type: bool
             upstream_server = "",  # type: str
             upstream_auth = "",  # type: str
@@ -129,6 +130,7 @@ class Options(optmanager.OptManager):
         self.mode = mode
         self.no_upstream_cert = no_upstream_cert
         self.rawtcp = rawtcp
+        self.websockets = websockets
         self.spoof_source_address = spoof_source_address
         self.upstream_server = upstream_server
         self.upstream_auth = upstream_auth

--- a/mitmproxy/protocol/http.py
+++ b/mitmproxy/protocol/http.py
@@ -1,23 +1,20 @@
 from __future__ import absolute_import, print_function, division
 
-import time
-import sys
-import traceback
-
 import h2.exceptions
+import netlib.exceptions
 import six
-
+import sys
+import time
+import traceback
 from mitmproxy import exceptions
 from mitmproxy import models
-from mitmproxy.protocol import base
-
-import netlib.exceptions
+from mitmproxy import protocol
 from netlib import http
 from netlib import tcp
 from netlib import websockets
 
 
-class _HttpTransmissionLayer(base.Layer):
+class _HttpTransmissionLayer(protocol.base.Layer):
 
     def read_request(self):
         raise NotImplementedError()
@@ -82,7 +79,7 @@ class ConnectServerConnection(object):
         __nonzero__ = __bool__
 
 
-class UpstreamConnectLayer(base.Layer):
+class UpstreamConnectLayer(protocol.base.Layer):
 
     def __init__(self, ctx, connect_request):
         super(UpstreamConnectLayer, self).__init__(ctx)
@@ -122,7 +119,7 @@ class UpstreamConnectLayer(base.Layer):
         self.server_conn.address = address
 
 
-class HttpLayer(base.Layer):
+class HttpLayer(protocol.base.Layer):
 
     def __init__(self, ctx, mode):
         super(HttpLayer, self).__init__(ctx)
@@ -193,8 +190,8 @@ class HttpLayer(base.Layer):
 
             try:
                 if websockets.check_handshake(request.headers) and websockets.check_client_version(request.headers):
-                    # we only support RFC6455 with WebSockets version 13
-                    # allow inline scripts to manupulate the client handshake
+                    # We only support RFC6455 with WebSockets version 13
+                    # allow inline scripts to manipulate the client handshake
                     self.channel.ask("websockets_handshake", flow)
 
                 if not flow.response:
@@ -217,12 +214,8 @@ class HttpLayer(base.Layer):
                     return
 
                 # Handle 101 Switching Protocols
-                # It may be useful to pass additional args (such as the upgrade header)
-                # to next_layer in the future
                 if flow.response.status_code == 101:
-                    layer = self.ctx.next_layer(self, flow)
-                    layer()
-                    return
+                    return self.handle_101_switching_protocols(flow)
 
                 # Upstream Proxy Mode: Handle CONNECT
                 if flow.request.first_line_format == "authority" and flow.response.status_code == 200:
@@ -438,3 +431,26 @@ class HttpLayer(base.Layer):
                     ))
                 return False
         return True
+
+    def handle_101_switching_protocols(self, flow):
+        """
+        Handle a successful HTTP 101 Switching Protocols Response, received after e.g. a WebSocket upgrade request.
+        """
+        # Check for WebSockets handshake
+        is_websockets = (
+            flow and
+            websockets.check_handshake(flow.request.headers) and
+            websockets.check_handshake(flow.response.headers)
+        )
+        if is_websockets and not self.config.options.websockets:
+            self.log(
+                "Client requested WebSocket connection, but the protocol is currently disabled in mitmproxy.",
+                "info"
+            )
+
+        if is_websockets and self.config.options.websockets:
+            layer = protocol.WebSocketsLayer(self, flow)
+        else:
+            layer = self.ctx.next_layer(self)
+
+        layer()

--- a/mitmproxy/protocol/http.py
+++ b/mitmproxy/protocol/http.py
@@ -8,13 +8,14 @@ import time
 import traceback
 from mitmproxy import exceptions
 from mitmproxy import models
-from mitmproxy import protocol
+from mitmproxy.protocol import base
+from mitmproxy.protocol import websockets as pwebsockets
 from netlib import http
 from netlib import tcp
 from netlib import websockets
 
 
-class _HttpTransmissionLayer(protocol.base.Layer):
+class _HttpTransmissionLayer(base.Layer):
 
     def read_request(self):
         raise NotImplementedError()
@@ -79,7 +80,7 @@ class ConnectServerConnection(object):
         __nonzero__ = __bool__
 
 
-class UpstreamConnectLayer(protocol.base.Layer):
+class UpstreamConnectLayer(base.Layer):
 
     def __init__(self, ctx, connect_request):
         super(UpstreamConnectLayer, self).__init__(ctx)
@@ -119,7 +120,7 @@ class UpstreamConnectLayer(protocol.base.Layer):
         self.server_conn.address = address
 
 
-class HttpLayer(protocol.base.Layer):
+class HttpLayer(base.Layer):
 
     def __init__(self, ctx, mode):
         super(HttpLayer, self).__init__(ctx)
@@ -449,7 +450,7 @@ class HttpLayer(protocol.base.Layer):
             )
 
         if is_websockets and self.config.options.websockets:
-            layer = protocol.WebSocketsLayer(self, flow)
+            layer = pwebsockets.WebSocketsLayer(self, flow)
         else:
             layer = self.ctx.next_layer(self)
 

--- a/mitmproxy/proxy/config.py
+++ b/mitmproxy/proxy/config.py
@@ -10,6 +10,7 @@ import six
 from OpenSSL import SSL, crypto
 
 from mitmproxy import exceptions
+from mitmproxy import options as moptions  # noqa
 from netlib import certutils
 from netlib import tcp
 from netlib.http import authentication
@@ -71,7 +72,7 @@ def parse_upstream_auth(auth):
 class ProxyConfig:
 
     def __init__(self, options):
-        self.options = options
+        self.options = options  # type: moptions.Options
 
         self.authenticator = None
         self.check_ignore = None
@@ -83,7 +84,7 @@ class ProxyConfig:
         options.changed.connect(self.configure)
 
     def configure(self, options, updated):
-        # type: (mitmproxy.options.Options, Any) -> None
+        # type: (moptions.Options, Any) -> None
         if options.add_upstream_certs_to_client_chain and not options.ssl_insecure:
             raise exceptions.OptionsError(
                 "The verify-upstream-cert requires certificate verification to be disabled. "

--- a/mitmproxy/proxy/root_context.py
+++ b/mitmproxy/proxy/root_context.py
@@ -4,7 +4,6 @@ import sys
 
 import six
 
-from netlib import websockets
 import netlib.exceptions
 from mitmproxy import exceptions
 from mitmproxy import protocol
@@ -33,7 +32,7 @@ class RootContext(object):
         self.channel = channel
         self.config = config
 
-    def next_layer(self, top_layer, flow=None):
+    def next_layer(self, top_layer):
         """
         This function determines the next layer in the protocol stack.
 
@@ -43,22 +42,10 @@ class RootContext(object):
         Returns:
             The next layer
         """
-        layer = self._next_layer(top_layer, flow)
+        layer = self._next_layer(top_layer)
         return self.channel.ask("next_layer", layer)
 
-    def _next_layer(self, top_layer, flow):
-        if flow is not None:
-            # We already have a flow, try to derive the next information from it
-
-            # Check for WebSockets handshake
-            is_websockets = (
-                flow and
-                websockets.check_handshake(flow.request.headers) and
-                websockets.check_handshake(flow.response.headers)
-            )
-            if isinstance(top_layer, protocol.HttpLayer) and is_websockets:
-                return protocol.WebSocketsLayer(top_layer, flow)
-
+    def _next_layer(self, top_layer):
         try:
             d = top_layer.client_conn.rfile.peek(3)
         except netlib.exceptions.TcpException as e:

--- a/test/mitmproxy/protocol/test_websockets.py
+++ b/test/mitmproxy/protocol/test_websockets.py
@@ -65,7 +65,8 @@ class _WebSocketsTestBase(object):
         opts = options.Options(
             listen_port=0,
             no_upstream_cert=False,
-            ssl_insecure=True
+            ssl_insecure=True,
+            websockets=True,
         )
         opts.cadir = os.path.join(tempfile.gettempdir(), "mitmproxy")
         return opts


### PR DESCRIPTION
@Kriechi: Can I get a quick review from you for this one?

- We now have a `--websockets/--no-websockets` switch. Off by default (like `--raw-tcp`), but there's an info log message if a client attempts a websocket connection.
- Move the websocket upgrade code into protocol/http as it is entirely HTTP specific. Before that it would have broken on non-HTTP Flows.
- Set logging verbosity of websocket data frames from debug to info (this is what #1547 was referring to, where I did not have the time to log into the code)
- Move websocket logging before calling `.send()` so that we still log if sending fails.