### PR TITLE
Support socket manipulation through the server_conn hook.

### DIFF
--- a/netlib/tcp.py
+++ b/netlib/tcp.py
@@ -484,12 +484,14 @@ class _Connection(object):
         if not isinstance(self.connection, SSL.Connection):
             if not getattr(self.wfile, "closed", False):
                 try:
-                    self.wfile.flush()
-                    self.wfile.close()
+                    if self.wfile:
+                        self.wfile.flush()
+                        self.wfile.close()
                 except exceptions.TcpDisconnect:
                     pass
 
-            self.rfile.close()
+            if self.rfile:
+                self.rfile.close()
         else:
             try:
                 self.connection.shutdown()
@@ -729,7 +731,10 @@ class TCPClient(_Connection):
 
     def connect(self):
         try:
-            connection = socket.socket(self.address.family, socket.SOCK_STREAM)
+            if not self.connection:
+                connection = socket.socket(self.address.family, socket.SOCK_STREAM)
+            else:
+                connection = self.connection
 
             if self.spoof_source_address:
                 try:


### PR DESCRIPTION
The checks for self.[rfile|wfile] have been introduced to avoid the following exceptions:
```
Traceback (most recent call last):
  File "/tmp/mitmproxy/mitmproxy/proxy/server.py", line 119, in handle
    root_layer()
  File "/tmp/mitmproxy/mitmproxy/proxy/modes/transparent_proxy.py", line 25, in __call__
    self.disconnect()
  File "/tmp/mitmproxy/mitmproxy/protocol/base.py", line 162, in disconnect
    self.server_conn.finish()
  File "/tmp/mitmproxy/mitmproxy/models/connections.py", line 226, in finish
    tcp.TCPClient.finish(self)
  File "/tmp/mitmproxy/netlib/tcp.py", line 488, in finish
    self.wfile.flush()
AttributeError: 'NoneType' object has no attribute 'flush'

Traceback (most recent call last):
  File "/tmp/mitmproxy/mitmproxy/proxy/server.py", line 119, in handle
    root_layer()
  File "/tmp/mitmproxy/mitmproxy/proxy/modes/transparent_proxy.py", line 25, in __call__
    self.disconnect()
  File "/tmp/mitmproxy/mitmproxy/protocol/base.py", line 162, in disconnect
    self.server_conn.finish()
  File "/tmp/mitmproxy/mitmproxy/models/connections.py", line 226, in finish
    tcp.TCPClient.finish(self)
  File "/tmp/mitmproxy/netlib/tcp.py", line 494, in finish
    self.rfile.close()
AttributeError: 'NoneType' object has no attribute 'close'
```
These exceptions occur if the box, on which mitmproxy is running on, is unable to set up a connection to an external resource, and thereby violates disconnect's precondition.

https://github.com/mitmproxy/mitmproxy/blob/0dbb7033ee1a6e238752381ce99439ef7d38b208/mitmproxy/protocol/base.py#L148-L151
