### PR TITLE
Add command line arg to force specific SNI

### DIFF
--- a/mitmproxy/protocol/tls.py
+++ b/mitmproxy/protocol/tls.py
@@ -326,12 +326,12 @@ class TlsLayer(base.Layer):
           the server connection.
     """
 
-    def __init__(self, ctx, client_tls, server_tls):
+    def __init__(self, ctx, client_tls, server_tls, custom_server_sni = None):
         super(TlsLayer, self).__init__(ctx)
         self._client_tls = client_tls
         self._server_tls = server_tls
 
-        self._custom_server_sni = None
+        self._custom_server_sni = custom_server_sni
         self._client_hello = None  # type: TlsClientHello
 
     def __call__(self):

--- a/mitmproxy/proxy/root_context.py
+++ b/mitmproxy/proxy/root_context.py
@@ -69,7 +69,7 @@ class RootContext(object):
         # An inline script may upgrade from http to https,
         # in which case we need some form of TLS layer.
         if isinstance(top_layer, modes.ReverseProxy):
-            return protocol.TlsLayer(top_layer, client_tls, top_layer.server_tls)
+            return protocol.TlsLayer(top_layer, client_tls, top_layer.server_tls, top_layer.server_conn.address.host)
         if isinstance(top_layer, protocol.ServerConnectionMixin) or isinstance(top_layer, protocol.UpstreamConnectLayer):
             return protocol.TlsLayer(top_layer, client_tls, client_tls)
 

--- a/test/mitmproxy/test_server.py
+++ b/test/mitmproxy/test_server.py
@@ -101,10 +101,16 @@ class CommonMixin:
         if not self.ssl:
             return
 
+        if getattr(self, 'reverse', False):
+            # In reverse proxy mode, we expect to use the upstream host as our SNI value
+            expected_sni = "127.0.0.1"
+        else:
+            expected_sni = "testserver.com"
+
         f = self.pathod("304", sni="testserver.com")
         assert f.status_code == 304
         log = self.server.last_log()
-        assert log["request"]["sni"] == "testserver.com"
+        assert log["request"]["sni"] == expected_sni
 
 
 class TcpMixin:


### PR DESCRIPTION
This fixes an SNI issue in reverse proxy mode.

##### Steps to reproduce the problem:

1. Start a reverse proxy instance that connects to an HTTPS endpoint using SNI:
`mitmproxy -R https://www.example.com --setheader :~q:Host:www.example.com`
3. Open `https://localhost:8080/` in a web browser

##### What is the expected behavior?

mitmproxy should use the domain `www.example.com` to negotiate SNI with the server.

##### What went wrong?

mitmproxy instead sends no SNI value to the server, and the request fails with the following error: `Cannot establish TLS with www.example.com:443 (sni: None): TlsException('Cannot validate certificate hostname without SNI',)`

##### How does this PR fix the issue?

This PR adds a `--server-sni` flag that allows you to specify an SNI value that should always be used. Thus, you can fix the original problem above by adding the new flag: `mitmproxy -R https://www.example.com --setheader :~q:Host:www.example.com --server-sni www.example.com`.

---

Hope this is helpful! Happy to make adjustments if you think there's a better way to address this problem :)