### PR TITLE
rename mitmproxy.filt -> mitmproxy.flowfilter

### DIFF
--- a/docs/features/filters.rst
+++ b/docs/features/filters.rst
@@ -8,7 +8,7 @@ Filter expressions consist of the following operators:
 
 .. documentedlist::
     :header: "Expression" "Description"
-    :listobject: mitmproxy.filt.help
+    :listobject: mitmproxy.flowfilter.help
 
 - Regexes are Python-style
 - Regexes can be specified as quoted strings
@@ -36,4 +36,3 @@ Anything but requests with a text/html content type:
 .. code-block:: none
 
     !(~q & ~t "text/html")
-

--- a/examples/flowfilter.py
+++ b/examples/flowfilter.py
@@ -1,15 +1,16 @@
 # This scripts demonstrates how to use mitmproxy's filter pattern in scripts.
-# Usage: mitmdump -s "filter.py FILTER"
+# Usage: mitmdump -s "flowfilter.py FILTER"
+
 import sys
-from mitmproxy import filter
+from mitmproxy import flowfilter
 
 
 class Filter:
     def __init__(self, spec):
-        self.filter = filter.parse(spec)
+        self.filter = flowfilter.parse(spec)
 
     def response(self, flow):
-        if flow.match(self.filter):
+        if flowfilter.match(flow, self.filter):
             print("Flow matches filter:")
             print(flow)
 

--- a/examples/flowfilter.py
+++ b/examples/flowfilter.py
@@ -1,12 +1,12 @@
 # This scripts demonstrates how to use mitmproxy's filter pattern in scripts.
-# Usage: mitmdump -s "filt.py FILTER"
+# Usage: mitmdump -s "filter.py FILTER"
 import sys
-from mitmproxy import filt
+from mitmproxy import filter
 
 
 class Filter:
     def __init__(self, spec):
-        self.filter = filt.parse(spec)
+        self.filter = filter.parse(spec)
 
     def response(self, flow):
         if flow.match(self.filter):

--- a/mitmproxy/builtins/dumper.py
+++ b/mitmproxy/builtins/dumper.py
@@ -220,7 +220,7 @@ class Dumper(object):
             return False
         if not self.filter:
             return True
-        elif flowfilter.match(f, self.filter):
+        elif flowfilter.match(self.filter, f):
             return True
         return False
 

--- a/mitmproxy/builtins/dumper.py
+++ b/mitmproxy/builtins/dumper.py
@@ -220,7 +220,7 @@ class Dumper(object):
             return False
         if not self.filter:
             return True
-        elif f.match(self.filter):
+        elif flowfilter.match(f, self.filter):
             return True
         return False
 

--- a/mitmproxy/builtins/dumper.py
+++ b/mitmproxy/builtins/dumper.py
@@ -9,7 +9,7 @@ import typing  # noqa
 from mitmproxy import contentviews
 from mitmproxy import ctx
 from mitmproxy import exceptions
-from mitmproxy import filt
+from mitmproxy import flowfilter
 from netlib import human
 from netlib import strutils
 
@@ -22,14 +22,14 @@ def indent(n, text):
 
 class Dumper(object):
     def __init__(self):
-        self.filter = None  # type: filt.TFilter
+        self.filter = None  # type: flowfilter.TFilter
         self.flow_detail = None  # type: int
         self.outfp = None  # type: typing.io.TextIO
         self.showhost = None  # type: bool
 
     def configure(self, options, updated):
         if options.filtstr:
-            self.filter = filt.parse(options.filtstr)
+            self.filter = flowfilter.parse(options.filtstr)
             if not self.filter:
                 raise exceptions.OptionsError(
                     "Invalid filter expression: %s" % options.filtstr

--- a/mitmproxy/builtins/filestreamer.py
+++ b/mitmproxy/builtins/filestreamer.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, print_function, division
 import os.path
 
 from mitmproxy import exceptions
+from mitmproxy import flowfilter
 from mitmproxy.flow import io
 
 
@@ -25,17 +26,17 @@ class FileStreamer:
             self.done()
 
         if options.outfile:
-            filt = None
+            flt = None
             if options.get("filtstr"):
-                filt = filt.parse(options.filtstr)
-                if not filt:
+                flt = flowfilter.parse(options.filtstr)
+                if not flt:
                     raise exceptions.OptionsError(
                         "Invalid filter specification: %s" % options.filtstr
                     )
             path, mode = options.outfile
             if mode not in ("wb", "ab"):
                 raise exceptions.OptionsError("Invalid mode.")
-            err = self.start_stream_to_path(path, mode, filt)
+            err = self.start_stream_to_path(path, mode, flt)
             if err:
                 raise exceptions.OptionsError(err)
 

--- a/mitmproxy/builtins/replace.py
+++ b/mitmproxy/builtins/replace.py
@@ -1,7 +1,7 @@
 import re
 
 from mitmproxy import exceptions
-from mitmproxy import filt
+from mitmproxy import flowfilter
 
 
 class Replace:
@@ -18,8 +18,8 @@ class Replace:
         """
         lst = []
         for fpatt, rex, s in options.replacements:
-            cpatt = filt.parse(fpatt)
-            if not cpatt:
+            flt = flowfilter.parse(fpatt)
+            if not flt:
                 raise exceptions.OptionsError(
                     "Invalid filter pattern: %s" % fpatt
                 )
@@ -29,12 +29,12 @@ class Replace:
                 raise exceptions.OptionsError(
                     "Invalid regular expression: %s - %s" % (rex, str(e))
                 )
-            lst.append((rex, s, cpatt))
+            lst.append((rex, s, flt))
         self.lst = lst
 
     def execute(self, f):
-        for rex, s, cpatt in self.lst:
-            if cpatt(f):
+        for rex, s, flt in self.lst:
+            if flt(f):
                 if f.response:
                     f.response.replace(rex, s, flags=re.DOTALL)
                 else:

--- a/mitmproxy/builtins/setheaders.py
+++ b/mitmproxy/builtins/setheaders.py
@@ -1,5 +1,5 @@
 from mitmproxy import exceptions
-from mitmproxy import filt
+from mitmproxy import flowfilter
 
 
 class SetHeaders:
@@ -15,19 +15,19 @@ class SetHeaders:
             value: Header value string
         """
         for fpatt, header, value in options.setheaders:
-            cpatt = filt.parse(fpatt)
-            if not cpatt:
+            flt = flowfilter.parse(fpatt)
+            if not flt:
                 raise exceptions.OptionsError(
                     "Invalid setheader filter pattern %s" % fpatt
                 )
-            self.lst.append((fpatt, header, value, cpatt))
+            self.lst.append((fpatt, header, value, flt))
 
     def run(self, f, hdrs):
-        for _, header, value, cpatt in self.lst:
-            if cpatt(f):
+        for _, header, value, flt in self.lst:
+            if flt(f):
                 hdrs.pop(header, None)
-        for _, header, value, cpatt in self.lst:
-            if cpatt(f):
+        for _, header, value, flt in self.lst:
+            if flt(f):
                 hdrs.add(header, value)
 
     def request(self, flow):

--- a/mitmproxy/builtins/stickyauth.py
+++ b/mitmproxy/builtins/stickyauth.py
@@ -22,6 +22,6 @@ class StickyAuth:
         host = flow.request.host
         if "authorization" in flow.request.headers:
             self.hosts[host] = flow.request.headers["authorization"]
-        elif flowfilter.match(flow, self.flt):
+        elif flowfilter.match(self.flt, flow):
             if host in self.hosts:
                 flow.request.headers["authorization"] = self.hosts[host]

--- a/mitmproxy/builtins/stickyauth.py
+++ b/mitmproxy/builtins/stickyauth.py
@@ -1,18 +1,17 @@
 from __future__ import absolute_import, print_function, division
 
-from mitmproxy import filt
 from mitmproxy import exceptions
+from mitmproxy import flowfilter
 
 
 class StickyAuth:
     def __init__(self):
-        # Compiled filter
         self.flt = None
         self.hosts = {}
 
     def configure(self, options, updated):
         if options.stickyauth:
-            flt = filt.parse(options.stickyauth)
+            flt = flowfilter.parse(options.stickyauth)
             if not flt:
                 raise exceptions.OptionsError(
                     "stickyauth: invalid filter expression: %s" % options.stickyauth

--- a/mitmproxy/builtins/stickyauth.py
+++ b/mitmproxy/builtins/stickyauth.py
@@ -22,6 +22,6 @@ class StickyAuth:
         host = flow.request.host
         if "authorization" in flow.request.headers:
             self.hosts[host] = flow.request.headers["authorization"]
-        elif flow.match(self.flt):
+        elif flowfilter.match(flow, self.flt):
             if host in self.hosts:
                 flow.request.headers["authorization"] = self.hosts[host]

--- a/mitmproxy/builtins/stickycookie.py
+++ b/mitmproxy/builtins/stickycookie.py
@@ -3,7 +3,7 @@ from six.moves import http_cookiejar
 from netlib.http import cookies
 
 from mitmproxy import exceptions
-from mitmproxy import filt
+from mitmproxy import flowfilter
 
 
 def ckey(attrs, f):
@@ -34,7 +34,7 @@ class StickyCookie:
 
     def configure(self, options, updated):
         if options.stickycookie:
-            flt = filt.parse(options.stickycookie)
+            flt = flowfilter.parse(options.stickycookie)
             if not flt:
                 raise exceptions.OptionsError(
                     "stickycookie: invalid filter expression: %s" % options.stickycookie

--- a/mitmproxy/builtins/stickycookie.py
+++ b/mitmproxy/builtins/stickycookie.py
@@ -64,7 +64,7 @@ class StickyCookie:
     def request(self, flow):
         if self.flt:
             l = []
-            if flowfilter.match(flow, self.flt):
+            if flowfilter.match(self.flt, flow):
                 for domain, port, path in self.jar.keys():
                     match = [
                         domain_match(flow.request.host, domain),

--- a/mitmproxy/builtins/stickycookie.py
+++ b/mitmproxy/builtins/stickycookie.py
@@ -64,7 +64,7 @@ class StickyCookie:
     def request(self, flow):
         if self.flt:
             l = []
-            if flow.match(self.flt):
+            if flowfilter.match(flow, self.flt):
                 for domain, port, path in self.jar.keys():
                     match = [
                         domain_match(flow.request.host, domain),

--- a/mitmproxy/cmdline.py
+++ b/mitmproxy/cmdline.py
@@ -4,7 +4,7 @@ import configargparse
 import os
 import re
 from mitmproxy import exceptions
-from mitmproxy import filt
+from mitmproxy import flowfilter
 from mitmproxy import options
 from mitmproxy import platform
 from netlib import human
@@ -32,7 +32,7 @@ def _parse_hook(s):
     if not a:
         raise ParseException("Empty clause: %s" % str(patt))
 
-    if not filt.parse(patt):
+    if not flowfilter.parse(patt):
         raise ParseException("Malformed filter pattern: %s" % patt)
 
     return patt, a, b

--- a/mitmproxy/console/grideditor/editors.py
+++ b/mitmproxy/console/grideditor/editors.py
@@ -1,9 +1,9 @@
 from __future__ import absolute_import, print_function, division
 import re
 import urwid
-from mitmproxy import filt
-from mitmproxy.builtins import script
 from mitmproxy import exceptions
+from mitmproxy import flowfilter
+from mitmproxy.builtins import script
 from mitmproxy.console import common
 from mitmproxy.console.grideditor import base
 from mitmproxy.console.grideditor import col_bytes
@@ -81,7 +81,7 @@ class ReplaceEditor(base.GridEditor):
 
     def is_error(self, col, val):
         if col == 0:
-            if not filt.parse(val):
+            if not flowfilter.parse(val):
                 return "Invalid filter specification."
         elif col == 1:
             try:
@@ -101,7 +101,7 @@ class SetHeadersEditor(base.GridEditor):
 
     def is_error(self, col, val):
         if col == 0:
-            if not filt.parse(val):
+            if not flowfilter.parse(val):
                 return "Invalid filter specification"
         return False
 

--- a/mitmproxy/console/help.py
+++ b/mitmproxy/console/help.py
@@ -4,7 +4,7 @@ import platform
 
 import urwid
 
-from mitmproxy import filt
+from mitmproxy import flowfilter
 from mitmproxy.console import common
 from mitmproxy.console import signals
 
@@ -60,29 +60,7 @@ class HelpView(urwid.ListBox):
         )
 
         text.append(urwid.Text([("head", "\n\nFilter expressions:\n")]))
-        f = []
-        for i in filt.filt_unary:
-            f.append(
-                ("~%s" % i.code, i.help)
-            )
-        for i in filt.filt_rex:
-            f.append(
-                ("~%s regex" % i.code, i.help)
-            )
-        for i in filt.filt_int:
-            f.append(
-                ("~%s int" % i.code, i.help)
-            )
-        f.sort()
-        f.extend(
-            [
-                ("!", "unary not"),
-                ("&", "and"),
-                ("|", "or"),
-                ("(...)", "grouping"),
-            ]
-        )
-        text.extend(common.format_keyvals(f, key="key", val="text", indent=4))
+        text.extend(common.format_keyvals(flowfilter.help, key="key", val="text", indent=4))
 
         text.append(
             urwid.Text(

--- a/mitmproxy/console/master.py
+++ b/mitmproxy/console/master.py
@@ -34,7 +34,7 @@ from mitmproxy.console import palettes
 from mitmproxy.console import signals
 from mitmproxy.console import statusbar
 from mitmproxy.console import window
-from mitmproxy.filt import FMarked
+from mitmproxy.flowfilter import FMarked
 from netlib import tcp, strutils
 
 EVENTLOG_SIZE = 500

--- a/mitmproxy/console/master.py
+++ b/mitmproxy/console/master.py
@@ -126,7 +126,7 @@ class ConsoleState(flow.State):
         self.set_focus(self.focus)
         return ret
 
-    def get_nearest_matching_flow(self, flow, filt):
+    def get_nearest_matching_flow(self, flow, flt):
         fidx = self.view.index(flow)
         dist = 1
 
@@ -135,9 +135,9 @@ class ConsoleState(flow.State):
             fprev, _ = self.get_from_pos(fidx - dist)
             fnext, _ = self.get_from_pos(fidx + dist)
 
-            if fprev and flowfilter.match(fprev, filt):
+            if fprev and flowfilter.match(flt, fprev):
                 return fprev
-            elif fnext and flowfilter.match(fnext, filt):
+            elif fnext and flowfilter.match(flt, fnext):
                 return fnext
 
             dist += 1
@@ -670,14 +670,14 @@ class ConsoleMaster(flow.FlowMaster):
     def process_flow(self, f):
         should_intercept = any(
             [
-                self.state.intercept and flowfilter.match(f, self.state.intercept) and not f.request.is_replay,
+                self.state.intercept and flowfilter.match(self.state.intercept, f) and not f.request.is_replay,
                 f.intercepted,
             ]
         )
         if should_intercept:
             f.intercept(self)
         signals.flowlist_change.send(self)
-        signals.flow_change.send(self, flow = f)
+        signals.flow_change.send(self, flow=f)
 
     def clear_events(self):
         self.logbuffer[:] = []

--- a/mitmproxy/console/master.py
+++ b/mitmproxy/console/master.py
@@ -22,6 +22,7 @@ from mitmproxy import contentviews
 from mitmproxy import controller
 from mitmproxy import exceptions
 from mitmproxy import flow
+from mitmproxy import flowfilter
 from mitmproxy import utils
 import mitmproxy.options
 from mitmproxy.console import flowlist
@@ -134,9 +135,9 @@ class ConsoleState(flow.State):
             fprev, _ = self.get_from_pos(fidx - dist)
             fnext, _ = self.get_from_pos(fidx + dist)
 
-            if fprev and fprev.match(filt):
+            if fprev and flowfilter.match(fprev, filt):
                 return fprev
-            elif fnext and fnext.match(filt):
+            elif fnext and flowfilter.match(fnext, filt):
                 return fnext
 
             dist += 1
@@ -669,7 +670,7 @@ class ConsoleMaster(flow.FlowMaster):
     def process_flow(self, f):
         should_intercept = any(
             [
-                self.state.intercept and f.match(self.state.intercept) and not f.request.is_replay,
+                self.state.intercept and flowfilter.match(f, self.state.intercept) and not f.request.is_replay,
                 f.intercepted,
             ]
         )

--- a/mitmproxy/flow/io.py
+++ b/mitmproxy/flow/io.py
@@ -56,14 +56,14 @@ class FlowReader:
 
 
 class FilteredFlowWriter:
-    def __init__(self, fo, filt):
+    def __init__(self, fo, flt):
         self.fo = fo
-        self.filt = filt
+        self.flt = flt
 
-    def add(self, f):
-        if self.filt and not flowfilter.match(f, self.filt):
+    def add(self, flow):
+        if self.flt and not flowfilter.match(self.flt, flow):
             return
-        d = f.get_state()
+        d = flow.get_state()
         tnetstring.dump(d, self.fo)
 
 

--- a/mitmproxy/flow/io.py
+++ b/mitmproxy/flow/io.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, print_function, division
 import os
 
 from mitmproxy import exceptions
+from mitmproxy import flowfilter
 from mitmproxy import models
 from mitmproxy.contrib import tnetstring
 from mitmproxy.flow import io_compat
@@ -60,7 +61,7 @@ class FilteredFlowWriter:
         self.filt = filt
 
     def add(self, f):
-        if self.filt and not f.match(self.filt):
+        if self.filt and not flowfilter.match(f, self.filt):
             return
         d = f.get_state()
         tnetstring.dump(d, self.fo)

--- a/mitmproxy/flow/state.py
+++ b/mitmproxy/flow/state.py
@@ -5,7 +5,7 @@ from abc import abstractmethod, ABCMeta
 import six
 from typing import List  # noqa
 
-from mitmproxy import filt
+from mitmproxy import flowfilter
 from mitmproxy import models  # noqa
 
 
@@ -53,11 +53,11 @@ def _pos(*args):
 
 
 class FlowView(FlowList):
-    def __init__(self, store, filt=None):
+    def __init__(self, store, flt=None):
         super(FlowView, self).__init__()
-        if not filt:
-            filt = _pos
-        self._build(store, filt)
+        if not flt:
+            flt = _pos
+        self._build(store, flt)
 
         self.store = store
         self.store.views.append(self)
@@ -65,9 +65,9 @@ class FlowView(FlowList):
     def _close(self):
         self.store.views.remove(self)
 
-    def _build(self, flows, filt=None):
-        if filt:
-            self.filt = filt
+    def _build(self, flows, flt=None):
+        if flt:
+            self.filt = flt
         self._list = list(filter(self.filt, flows))
 
     def _add(self, f):
@@ -229,21 +229,21 @@ class State(object):
         if txt == self.filter_txt:
             return
         if txt:
-            f = filt.parse(txt)
-            if not f:
+            flt = flowfilter.parse(txt)
+            if not flt:
                 return "Invalid filter expression."
             self.view._close()
-            self.view = FlowView(self.flows, f)
+            self.view = FlowView(self.flows, flt)
         else:
             self.view._close()
             self.view = FlowView(self.flows, None)
 
     def set_intercept(self, txt):
         if txt:
-            f = filt.parse(txt)
-            if not f:
+            flt = flowfilter.parse(txt)
+            if not flt:
                 return "Invalid filter expression."
-            self.intercept = f
+            self.intercept = flt
         else:
             self.intercept = None
 

--- a/mitmproxy/flowfilter.py
+++ b/mitmproxy/flowfilter.py
@@ -36,6 +36,7 @@ from __future__ import absolute_import, print_function, division
 import re
 import sys
 import functools
+import six
 
 from mitmproxy.models.http import HTTPFlow
 from mitmproxy.models.tcp import TCPFlow
@@ -501,16 +502,15 @@ def parse(s):
         return None
 
 
-def match(self, flow, flt):
+def match(flow, flt):
     """
-        Match a flow against a compiled filter expression.
+        Matches a flow against a compiled filter expression.
         Returns True if matched, False if not.
 
         If flt is a string, it will be compiled as a filter expression.
         If the expression is invalid, ValueError is raised.
     """
     if isinstance(flt, six.string_types):
-
         flt = parse(flt)
         if not flt:
             raise ValueError("Invalid filter expression.")

--- a/mitmproxy/flowfilter.py
+++ b/mitmproxy/flowfilter.py
@@ -502,7 +502,7 @@ def parse(s):
         return None
 
 
-def match(flow, flt):
+def match(flt, flow):
     """
         Matches a flow against a compiled filter expression.
         Returns True if matched, False if not.

--- a/mitmproxy/models/flow.py
+++ b/mitmproxy/models/flow.py
@@ -189,20 +189,20 @@ class Flow(stateobject.StateObject):
         self.reply.commit()
         master.handle_accept_intercept(self)
 
-    def match(self, f):
+    def match(self, flt):
         """
-            Match this flow against a compiled filter expression. Returns True
-            if matched, False if not.
+            Matches a flow against a compiled filter expression.
+            Returns True if matched, False if not.
 
-            If f is a string, it will be compiled as a filter expression. If
-            the expression is invalid, ValueError is raised.
+            If flt is a string, it will be compiled as a filter expression.
+            If the expression is invalid, ValueError is raised.
         """
-        if isinstance(f, six.string_types):
-            from .. import filt
+        if isinstance(flt, six.string_types):
+            from ..flowfilter import parse
 
-            f = filt.parse(f)
-            if not f:
+            flt = parse(flt)
+            if not flt:
                 raise ValueError("Invalid filter expression.")
-        if f:
-            return f(self)
+        if flt:
+            return flt(self)
         return True

--- a/mitmproxy/models/flow.py
+++ b/mitmproxy/models/flow.py
@@ -189,20 +189,9 @@ class Flow(stateobject.StateObject):
         self.reply.commit()
         master.handle_accept_intercept(self)
 
-    def match(self, flt):
-        """
-            Matches a flow against a compiled filter expression.
-            Returns True if matched, False if not.
+    def match(self, f):
+        import warnings
+        warnings.warn(".match() is deprecated, please use flowfilter.match(some_flow, some_filter) instead.", DeprecationWarning)
 
-            If flt is a string, it will be compiled as a filter expression.
-            If the expression is invalid, ValueError is raised.
-        """
-        if isinstance(flt, six.string_types):
-            from ..flowfilter import parse
-
-            flt = parse(flt)
-            if not flt:
-                raise ValueError("Invalid filter expression.")
-        if flt:
-            return flt(self)
-        return True
+        from mitmproxy import flowfilter
+        return flowfilter.match(self, f)

--- a/mitmproxy/models/flow.py
+++ b/mitmproxy/models/flow.py
@@ -8,8 +8,6 @@ from mitmproxy import stateobject
 from mitmproxy.models.connections import ClientConnection
 from mitmproxy.models.connections import ServerConnection
 
-import six
-
 from netlib import version
 from typing import Optional  # noqa
 
@@ -188,10 +186,3 @@ class Flow(stateobject.StateObject):
         self.reply.ack()
         self.reply.commit()
         master.handle_accept_intercept(self)
-
-    def match(self, f):
-        import warnings
-        warnings.warn(".match() is deprecated, please use flowfilter.match(some_flow, some_filter) instead.", DeprecationWarning)
-
-        from mitmproxy import flowfilter
-        return flowfilter.match(self, f)

--- a/mitmproxy/web/app.py
+++ b/mitmproxy/web/app.py
@@ -14,7 +14,7 @@ import tornado.web
 from io import BytesIO
 from mitmproxy.flow import FlowWriter, FlowReader
 
-from mitmproxy import filt
+from mitmproxy import flowfilter
 from mitmproxy import models
 from mitmproxy import contentviews
 from netlib import version
@@ -151,11 +151,11 @@ class IndexHandler(RequestHandler):
         self.render("index.html")
 
 
-class FiltHelp(RequestHandler):
+class FilterHelp(RequestHandler):
 
     def get(self):
         self.write(dict(
-            commands=filt.help
+            commands=flowfilter.help
         ))
 
 
@@ -434,7 +434,7 @@ class Application(tornado.web.Application):
         self.master = master
         handlers = [
             (r"/", IndexHandler),
-            (r"/filter-help", FiltHelp),
+            (r"/filter-help", FilterHelp),
             (r"/updates", ClientConnection),
             (r"/events", Events),
             (r"/flows", Flows),

--- a/test/mitmproxy/test_flow.py
+++ b/test/mitmproxy/test_flow.py
@@ -68,14 +68,14 @@ class TestHTTPFlow(object):
 
     def test_match(self):
         f = tutils.tflow(resp=True)
-        assert not flowfilter.match(f, "~b test")
-        assert flowfilter.match(f, None)
-        assert not flowfilter.match(f, "~b test")
+        assert not flowfilter.match("~b test", f)
+        assert flowfilter.match(None, f)
+        assert not flowfilter.match("~b test", f)
 
         f = tutils.tflow(err=True)
-        assert flowfilter.match(f, "~e")
+        assert flowfilter.match("~e", f)
 
-        tutils.raises(ValueError, flowfilter.match, f, "~")
+        tutils.raises(ValueError, flowfilter.match, "~", f)
 
     def test_backup(self):
         f = tutils.tflow()
@@ -195,14 +195,14 @@ class TestTCPFlow:
 
     def test_match(self):
         f = tutils.ttcpflow()
-        assert not flowfilter.match(f, "~b nonexistent")
-        assert flowfilter.match(f, None)
-        assert not flowfilter.match(f, "~b nonexistent")
+        assert not flowfilter.match("~b nonexistent", f)
+        assert flowfilter.match(None, f)
+        assert not flowfilter.match("~b nonexistent", f)
 
         f = tutils.ttcpflow(err=True)
-        assert flowfilter.match(f, "~e")
+        assert flowfilter.match("~e", f)
 
-        tutils.raises(ValueError, flowfilter.match, f, "~")
+        tutils.raises(ValueError, flowfilter.match, "~", f)
 
 
 class TestState:

--- a/test/mitmproxy/test_flow.py
+++ b/test/mitmproxy/test_flow.py
@@ -3,7 +3,7 @@ import io
 
 import netlib.utils
 from netlib.http import Headers
-from mitmproxy import filt, flow, options
+from mitmproxy import flowfilter, flow, options
 from mitmproxy.contrib import tnetstring
 from mitmproxy.exceptions import FlowReadException, Kill
 from mitmproxy.models import Error
@@ -400,8 +400,8 @@ class TestSerialize:
 
     def test_filter(self):
         sio = io.BytesIO()
-        fl = filt.parse("~c 200")
-        w = flow.FilteredFlowWriter(sio, fl)
+        flt = flowfilter.parse("~c 200")
+        w = flow.FilteredFlowWriter(sio, flt)
 
         f = tutils.tflow(resp=True)
         f.response.status_code = 200

--- a/test/mitmproxy/test_flow.py
+++ b/test/mitmproxy/test_flow.py
@@ -68,14 +68,14 @@ class TestHTTPFlow(object):
 
     def test_match(self):
         f = tutils.tflow(resp=True)
-        assert not f.match("~b test")
-        assert f.match(None)
-        assert not f.match("~b test")
+        assert not flowfilter.match(f, "~b test")
+        assert flowfilter.match(f, None)
+        assert not flowfilter.match(f, "~b test")
 
         f = tutils.tflow(err=True)
-        assert f.match("~e")
+        assert flowfilter.match(f, "~e")
 
-        tutils.raises(ValueError, f.match, "~")
+        tutils.raises(ValueError, flowfilter.match, f, "~")
 
     def test_backup(self):
         f = tutils.tflow()
@@ -195,14 +195,14 @@ class TestTCPFlow:
 
     def test_match(self):
         f = tutils.ttcpflow()
-        assert not f.match("~b nonexistent")
-        assert f.match(None)
-        assert not f.match("~b nonexistent")
+        assert not flowfilter.match(f, "~b nonexistent")
+        assert flowfilter.match(f, None)
+        assert not flowfilter.match(f, "~b nonexistent")
 
         f = tutils.ttcpflow(err=True)
-        assert f.match("~e")
+        assert flowfilter.match(f, "~e")
 
-        tutils.raises(ValueError, f.match, "~")
+        tutils.raises(ValueError, flowfilter.match, f, "~")
 
 
 class TestState:


### PR DESCRIPTION
There seems to be a bug here, which is now fixed:
https://github.com/mitmproxy/mitmproxy/blob/d068000f16cb44b7277de04ba20bd1fc62e4a956/mitmproxy/builtins/filestreamer.py#L30

Also I removed a bit of code duplication here:
https://github.com/mitmproxy/mitmproxy/pull/1587/files#diff-6aaebdf9a233f01096f39e9db9f3d091L63

Since `flow.match` will be removed, I added a `DeprecationWarning` and moved the actual function to `flowfilter.match`.