### PR TITLE
Fix SSL error on OS X

### DIFF
--- a/netlib/tcp.py
+++ b/netlib/tcp.py
@@ -817,7 +817,7 @@ class BaseHandler(_Connection):
             until then we're conservative.
         """
 
-        context = self._create_ssl_context(**sslctx_kwargs)
+        context = self._create_ssl_context(ca_pemfile=chain_file, **sslctx_kwargs)
 
         context.use_privatekey(key)
         if isinstance(cert, certutils.SSLCert):
@@ -839,10 +839,6 @@ class BaseHandler(_Connection):
                 # Return true to prevent cert verification error
                 return True
             context.set_verify(SSL.VERIFY_PEER, save_cert)
-
-        # Cert Verify
-        if chain_file:
-            context.load_verify_locations(chain_file)
 
         if dhparams:
             SSL._lib.SSL_CTX_set_tmp_dh(context._context, dhparams)


### PR DESCRIPTION
I've found a fix for #1585, but I'm not sure it's complete yet, or if it might break something that I'm unaware of. I'd love some feedback as to whether this seems like a proper solution.

This fixes an issue that occurs when a user supplies a custom SSL cert w/ intermediate certs that *contradict* the default certifi set of root certificates. In particular, this addresses an issue where the "COMODO RSA Certification Authority" cert in certifi is NOT trusted on OS X by default as of OS X 10.11.6. Even when the user manually supplied a different valid "COMODO RSA Certification Authority" cert in their custom SSL cert .pem file, that cert would be overridden by certifi's default cert.

Now, when the user specifies a custom certificate, mitmproxy will load ONLY that custom certificate when creating an SSL context for the client. That way, we guarantee that the manually specified intermediate certs will be returned to the client. This means the client will definitely receive the set of certs specified in the manually specified .pem file.