### PR TITLE
mitmdump: use a dummy state object

### DIFF
--- a/mitmproxy/dump.py
+++ b/mitmproxy/dump.py
@@ -35,7 +35,7 @@ class Options(options.Options):
 class DumpMaster(flow.FlowMaster):
 
     def __init__(self, server, options):
-        flow.FlowMaster.__init__(self, options, server, flow.State())
+        flow.FlowMaster.__init__(self, options, server, flow.DummyState())
         self.has_errored = False
         self.addons.add(*builtins.default_addons())
         self.addons.add(dumper.Dumper())
@@ -81,13 +81,6 @@ class DumpMaster(flow.FlowMaster):
     def log(self, e):
         if e.level == "error":
             self.has_errored = True
-
-    @controller.handler
-    def request(self, f):
-        f = super(DumpMaster, self).request(f)
-        if f:
-            self.state.delete_flow(f)
-        return f
 
     def run(self):  # pragma: no cover
         if self.options.rfile and not self.options.keepserving:

--- a/mitmproxy/flow/__init__.py
+++ b/mitmproxy/flow/__init__.py
@@ -6,10 +6,10 @@ from mitmproxy.flow.master import FlowMaster
 from mitmproxy.flow.modules import (
     AppRegistry, StreamLargeBodies
 )
-from mitmproxy.flow.state import State, FlowView
+from mitmproxy.flow.state import State, DummyState, FlowView
 
 __all__ = [
     "export", "modules",
     "FlowWriter", "FilteredFlowWriter", "FlowReader", "read_flows_from_paths",
-    "FlowMaster", "AppRegistry", "StreamLargeBodies", "State", "FlowView",
+    "FlowMaster", "AppRegistry", "StreamLargeBodies", "DummyState", "State", "FlowView",
 ]

--- a/mitmproxy/flow/state.py
+++ b/mitmproxy/flow/state.py
@@ -267,3 +267,13 @@ class State(object):
 
     def killall(self, master):
         self.flows.kill_all(master)
+
+
+class DummyState:
+    flows = ()
+
+    def add_flow(self, *args, **kwargs):
+        pass
+
+    def update_flow(self, *args, **kwargs):
+        pass


### PR DESCRIPTION
Most of the mitmdump memory leak turns out to be due to our leaky handling of
the state object. Since mitmdump doesn't actually use the state object, we can
replace it with a shell.