### PR TITLE
certutils: cap the cert store size at 100 by default

### DIFF
--- a/netlib/debug.py
+++ b/netlib/debug.py
@@ -91,7 +91,7 @@ def dump_info(signal=None, frame=None, file=sys.stdout, testing=False):  # pragm
     itms = list(d.items())
     itms.sort(key=lambda x: x[1])
     for i in itms[-20:]:
-        print(i[1], i[0])
+        print(i[1], i[0], file=file)
     print("****************************************************", file=file)
 
     if not testing:

--- a/test/netlib/test_certutils.py
+++ b/test/netlib/test_certutils.py
@@ -74,6 +74,31 @@ class TestCertStore:
             cert, key, chain_file = ca.get_cert(b"foo.bar.com", [b"*.baz.com"])
             assert b"*.baz.com" in cert.altnames
 
+    def test_expire(self):
+        with tutils.tmpdir() as d:
+            ca = certutils.CertStore.from_store(d, "test")
+            ca.STORE_CAP = 3
+            ca.get_cert(b"one.com", [])
+            ca.get_cert(b"two.com", [])
+            ca.get_cert(b"three.com", [])
+
+            assert (b"one.com", ()) in ca.certs
+            assert (b"two.com", ()) in ca.certs
+            assert (b"three.com", ()) in ca.certs
+
+            ca.get_cert(b"one.com", [])
+
+            assert (b"one.com", ()) in ca.certs
+            assert (b"two.com", ()) in ca.certs
+            assert (b"three.com", ()) in ca.certs
+
+            ca.get_cert(b"four.com", [])
+
+            assert (b"one.com", ()) not in ca.certs
+            assert (b"two.com", ()) in ca.certs
+            assert (b"three.com", ()) in ca.certs
+            assert (b"four.com", ()) in ca.certs
+
     def test_overrides(self):
         with tutils.tmpdir() as d:
             ca1 = certutils.CertStore.from_store(os.path.join(d, "ca1"), "test")


### PR DESCRIPTION
This should be enough to give us reuse without growing infinitely. This is part of fixing the memory situation in mitmdump.

TODO: There's an opportunity here for a better algorithm, that expires certs based on least-recently-accessed time, rather than oldest generated time.