### PR TITLE
First-order conversion to Python3-only

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -7,8 +7,6 @@ environment:
   matrix:
     - PYTHON: "C:\\Python35"
       TOXENV: "py35"
-    - PYTHON: "C:\\Python27"
-      TOXENV: "py27"
 
   SNAPSHOT_HOST:
     secure: NeTo57s2rJhCd/mjKHetXVxCFd3uhr8txnjnAXD1tUI=

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,10 +28,6 @@ matrix:
       env: TOXENV=py35 BDIST=1
     - python: 3.5
       env: TOXENV=py35 NO_ALPN=1
-    - python: 2.7
-      env: TOXENV=py27
-    - python: 2.7
-      env: TOXENV=py27 NO_ALPN=1
     - python: 3.5
       env: TOXENV=docs
   allow_failures:

--- a/README.rst
+++ b/README.rst
@@ -110,7 +110,6 @@ The following tox environments are relevant for local testing:
 
 .. code-block:: text
 
-    tox -e py27  # runs all tests with Python 2.7
     tox -e py35  # runs all tests with Python 3.5
     tox -e docs  # runs a does-it-compile check on the documentation
     tox -e lint  # runs the linter for coding style checks

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -101,9 +101,9 @@ Installation On Windows
     **There is no interactive user interface on Windows.**
 
 
-First, install the latest version of Python 2.7 from the `Python website`_.
-If you already have an older version of Python 2.7 installed, make sure to install pip_
-(pip is included in Python 2.7.9+ by default). If pip aborts with an error, make sure you are using the current version of pip.
+First, install the latest version of Python 3.5 from the `Python website`_.
+If you already have an older version of Python 3.5 installed, make sure to install pip_
+(pip is included in Python by default). If pip aborts with an error, make sure you are using the current version of pip.
 
 >>> python -m pip install --upgrade pip
 

--- a/mitmproxy/console/common.py
+++ b/mitmproxy/console/common.py
@@ -6,7 +6,6 @@ import os
 
 import urwid
 import urwid.util
-import six
 
 import netlib
 from mitmproxy import utils
@@ -39,7 +38,7 @@ def is_keypress(k):
     """
         Is this input event a keypress?
     """
-    if isinstance(k, six.string_types):
+    if isinstance(k, str):
         return True
 
 
@@ -110,7 +109,7 @@ def shortcuts(k):
 
 
 def fcol(s, attr):
-    s = six.text_type(s)
+    s = str(s)
     return (
         "fixed",
         len(s),

--- a/mitmproxy/contentviews.py
+++ b/mitmproxy/contentviews.py
@@ -22,7 +22,6 @@ import json
 import logging
 import lxml.etree
 import lxml.html
-import six
 import subprocess
 import traceback
 from PIL import ExifTags
@@ -56,7 +55,7 @@ def pretty_json(s):
     except ValueError:
         return None
     pretty = json.dumps(p, sort_keys=True, indent=4, ensure_ascii=False)
-    if isinstance(pretty, six.text_type):
+    if isinstance(pretty, str):
         # json.dumps _may_ decide to return unicode, if the JSON object is not ascii.
         # From limited testing this is always valid utf8 (otherwise json.loads will fail earlier),
         # so we can just re-encode it here.

--- a/mitmproxy/contrib/tnetstring.py
+++ b/mitmproxy/contrib/tnetstring.py
@@ -121,7 +121,7 @@ def _rdumpq(q, size, value):
         write(b':')
         write(span)
         return size + 2 + len(span) + ldata
-    elif isinstance(value, six.text_type):
+    elif isinstance(value, str):
         data = value.encode("utf8")
         ldata = len(data)
         span = str(ldata).encode()

--- a/mitmproxy/flow/export.py
+++ b/mitmproxy/flow/export.py
@@ -12,10 +12,10 @@ import netlib.http
 
 def _native(s):
     if six.PY2:
-        if isinstance(s, six.text_type):
+        if isinstance(s, str):
             return s.encode()
     else:
-        if isinstance(s, six.binary_type):
+        if isinstance(s, bytes):
             return s.decode()
     return s
 

--- a/mitmproxy/flowfilter.py
+++ b/mitmproxy/flowfilter.py
@@ -36,7 +36,6 @@ from __future__ import absolute_import, print_function, division
 import re
 import sys
 import functools
-import six
 
 from mitmproxy.models.http import HTTPFlow
 from mitmproxy.models.tcp import TCPFlow
@@ -510,7 +509,7 @@ def match(flt, flow):
         If flt is a string, it will be compiled as a filter expression.
         If the expression is invalid, ValueError is raised.
     """
-    if isinstance(flt, six.string_types):
+    if isinstance(flt, str):
         flt = parse(flt)
         if not flt:
             raise ValueError("Invalid filter expression.")

--- a/mitmproxy/models/connections.py
+++ b/mitmproxy/models/connections.py
@@ -205,7 +205,7 @@ class ServerConnection(tcp.TCPClient, stateobject.StateObject):
         self.wfile.flush()
 
     def establish_ssl(self, clientcerts, sni, **kwargs):
-        if sni and not isinstance(sni, six.string_types):
+        if sni and not isinstance(sni, str):
             raise ValueError("sni must be str, not " + type(sni).__name__)
         clientcert = None
         if clientcerts:

--- a/mitmproxy/protocol/tls.py
+++ b/mitmproxy/protocol/tls.py
@@ -407,7 +407,7 @@ class TlsLayer(base.Layer):
             self._establish_tls_with_server()
 
     def set_server_tls(self, server_tls, sni=None):
-        # type: (bool, Union[six.text_type, None, False]) -> None
+        # type: (bool, Union[str, None, False]) -> None
         """
         Set the TLS settings for the next server connection that will be established.
         This function will not alter an existing connection.

--- a/netlib/basetypes.py
+++ b/netlib/basetypes.py
@@ -1,9 +1,7 @@
-import six
 import abc
 
 
-@six.add_metaclass(abc.ABCMeta)
-class Serializable(object):
+class Serializable(metaclass=abc.ABCMeta):
     """
     Abstract Base Class that defines an API to save an object's state and restore it later on.
     """

--- a/netlib/certutils.py
+++ b/netlib/certutils.py
@@ -3,7 +3,6 @@ import os
 import ssl
 import time
 import datetime
-from six.moves import filter
 import ipaddress
 
 import sys

--- a/netlib/encoding.py
+++ b/netlib/encoding.py
@@ -5,7 +5,6 @@ from __future__ import absolute_import
 
 import codecs
 import collections
-import six
 from io import BytesIO
 
 import gzip
@@ -91,7 +90,7 @@ def encode(decoded, encoding, errors='strict'):
     try:
         try:
             value = decoded
-            if not six.PY2 and isinstance(value, six.string_types):
+            if isinstance(value, str):
                 value = decoded.encode()
             encoded = custom_encode[encoding](value)
         except KeyError:

--- a/netlib/http/headers.py
+++ b/netlib/http/headers.py
@@ -3,26 +3,19 @@ from __future__ import absolute_import, print_function, division
 import re
 
 import collections
-import six
 from netlib import multidict
 from netlib import strutils
 
 # See also: http://lucumr.pocoo.org/2013/7/2/the-updated-guide-to-unicode/
 
-if six.PY2:  # pragma: no cover
-    def _native(x):
-        return x
 
-    def _always_bytes(x):
-        strutils.always_bytes(x, "utf-8", "replace")  # raises a TypeError if x != str/bytes/None.
-        return x
-else:
-    # While headers _should_ be ASCII, it's not uncommon for certain headers to be utf-8 encoded.
-    def _native(x):
-        return x.decode("utf-8", "surrogateescape")
+# While headers _should_ be ASCII, it's not uncommon for certain headers to be utf-8 encoded.
+def _native(x):
+    return x.decode("utf-8", "surrogateescape")
 
-    def _always_bytes(x):
-        return strutils.always_bytes(x, "utf-8", "surrogateescape")
+
+def _always_bytes(x):
+    return strutils.always_bytes(x, "utf-8", "surrogateescape")
 
 
 class Headers(multidict.MultiDict):
@@ -93,7 +86,7 @@ class Headers(multidict.MultiDict):
         # content_type -> content-type
         headers = {
             _always_bytes(name).replace(b"_", b"-"): _always_bytes(value)
-            for name, value in six.iteritems(headers)
+            for name, value in headers.items()
         }
         self.update(headers)
 
@@ -112,9 +105,6 @@ class Headers(multidict.MultiDict):
             return b"\r\n".join(b": ".join(field) for field in self.fields) + b"\r\n"
         else:
             return b""
-
-    if six.PY2:  # pragma: no cover
-        __str__ = __bytes__
 
     def __delitem__(self, key):
         key = _always_bytes(key)
@@ -167,9 +157,9 @@ class Headers(multidict.MultiDict):
         Returns:
             The number of replacements made.
         """
-        if isinstance(pattern, six.text_type):
+        if isinstance(pattern, str):
             pattern = strutils.escaped_str_to_bytes(pattern)
-        if isinstance(repl, six.text_type):
+        if isinstance(repl, str):
             repl = strutils.escaped_str_to_bytes(repl)
         pattern = re.compile(pattern, flags)
         replacements = 0

--- a/netlib/http/message.py
+++ b/netlib/http/message.py
@@ -3,24 +3,17 @@ from __future__ import absolute_import, print_function, division
 import re
 import warnings
 
-import six
-
 from netlib import encoding, strutils, basetypes
 from netlib.http import headers
 
-if six.PY2:  # pragma: no cover
-    def _native(x):
-        return x
 
-    def _always_bytes(x):
-        return x
-else:
-    # While headers _should_ be ASCII, it's not uncommon for certain headers to be utf-8 encoded.
-    def _native(x):
-        return x.decode("utf-8", "surrogateescape")
+# While headers _should_ be ASCII, it's not uncommon for certain headers to be utf-8 encoded.
+def _native(x):
+    return x.decode("utf-8", "surrogateescape")
 
-    def _always_bytes(x):
-        return strutils.always_bytes(x, "utf-8", "surrogateescape")
+
+def _always_bytes(x):
+    return strutils.always_bytes(x, "utf-8", "surrogateescape")
 
 
 class MessageData(basetypes.Serializable):
@@ -194,7 +187,7 @@ class Message(basetypes.Serializable):
             return "latin-1"
 
     def get_text(self, strict=True):
-        # type: (bool) -> six.text_type
+        # type: (bool) -> str
         """
         The HTTP message body decoded with both content-encoding header (e.g. gzip)
         and content-type header charset.
@@ -214,7 +207,7 @@ class Message(basetypes.Serializable):
         except ValueError:
             if strict:
                 raise
-            return content.decode("utf8", "replace" if six.PY2 else "surrogateescape")
+            return content.decode("utf8", "surrogateescape")
 
     def set_text(self, text):
         if text is None:
@@ -230,7 +223,7 @@ class Message(basetypes.Serializable):
             ct[2]["charset"] = "utf-8"
             self.headers["content-type"] = headers.assemble_content_type(*ct)
             enc = "utf8"
-            self.content = text.encode(enc, "replace" if six.PY2 else "surrogateescape")
+            self.content = text.encode(enc, "surrogateescape")
 
     text = property(get_text, set_text)
 
@@ -269,9 +262,9 @@ class Message(basetypes.Serializable):
         Returns:
             The number of replacements made.
         """
-        if isinstance(pattern, six.text_type):
+        if isinstance(pattern, str):
             pattern = strutils.escaped_str_to_bytes(pattern)
-        if isinstance(repl, six.text_type):
+        if isinstance(repl, str):
             repl = strutils.escaped_str_to_bytes(repl)
         replacements = 0
         if self.content:

--- a/netlib/http/request.py
+++ b/netlib/http/request.py
@@ -1,9 +1,7 @@
 from __future__ import absolute_import, print_function, division
 
 import re
-
-import six
-from six.moves import urllib
+import urllib
 
 from netlib import multidict
 from netlib import strutils
@@ -34,19 +32,19 @@ class RequestData(message.MessageData):
         timestamp_start=None,
         timestamp_end=None
     ):
-        if isinstance(method, six.text_type):
+        if isinstance(method, str):
             method = method.encode("ascii", "strict")
-        if isinstance(scheme, six.text_type):
+        if isinstance(scheme, str):
             scheme = scheme.encode("ascii", "strict")
-        if isinstance(host, six.text_type):
+        if isinstance(host, str):
             host = host.encode("idna", "strict")
-        if isinstance(path, six.text_type):
+        if isinstance(path, str):
             path = path.encode("ascii", "strict")
-        if isinstance(http_version, six.text_type):
+        if isinstance(http_version, str):
             http_version = http_version.encode("ascii", "strict")
         if not isinstance(headers, nheaders.Headers):
             headers = nheaders.Headers(headers)
-        if isinstance(content, six.text_type):
+        if isinstance(content, str):
             raise ValueError("Content must be bytes, not {}".format(type(content).__name__))
 
         self.first_line_format = first_line_format
@@ -89,9 +87,9 @@ class Request(message.Message):
             Returns:
                 The number of replacements made.
         """
-        if isinstance(pattern, six.text_type):
+        if isinstance(pattern, str):
             pattern = strutils.escaped_str_to_bytes(pattern)
-        if isinstance(repl, six.text_type):
+        if isinstance(repl, str):
             repl = strutils.escaped_str_to_bytes(repl)
 
         c = super(Request, self).replace(pattern, repl, flags, count)
@@ -147,10 +145,6 @@ class Request(message.Message):
 
         Setting the host attribute also updates the host header, if present.
         """
-
-        if six.PY2:  # pragma: no cover
-            return self.data.host
-
         if not self.data.host:
             return self.data.host
         try:
@@ -160,7 +154,7 @@ class Request(message.Message):
 
     @host.setter
     def host(self, host):
-        if isinstance(host, six.text_type):
+        if isinstance(host, str):
             try:
                 # There's no non-strict mode for IDNA encoding.
                 # We don't want this operation to fail though, so we try

--- a/netlib/http/response.py
+++ b/netlib/http/response.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import, print_function, division
 
-import six
 import time
 from email.utils import parsedate_tz, formatdate, mktime_tz
 from netlib import human
@@ -27,13 +26,13 @@ class ResponseData(message.MessageData):
         timestamp_start=None,
         timestamp_end=None
     ):
-        if isinstance(http_version, six.text_type):
+        if isinstance(http_version, str):
             http_version = http_version.encode("ascii", "strict")
-        if isinstance(reason, six.text_type):
+        if isinstance(reason, str):
             reason = reason.encode("ascii", "strict")
         if not isinstance(headers, nheaders.Headers):
             headers = nheaders.Headers(headers)
-        if isinstance(content, six.text_type):
+        if isinstance(content, str):
             raise ValueError("Content must be bytes, not {}".format(type(content).__name__))
 
         self.http_version = http_version

--- a/netlib/http/url.py
+++ b/netlib/http/url.py
@@ -1,5 +1,4 @@
-import six
-from six.moves import urllib
+import urllib
 
 from netlib import utils
 
@@ -41,7 +40,7 @@ def parse(url):
     if not parsed.hostname:
         raise ValueError("No hostname given")
 
-    if isinstance(url, six.binary_type):
+    if isinstance(url, bytes):
         host = parsed.hostname
 
         # this should not raise a ValueError,
@@ -86,20 +85,14 @@ def encode(s):
     """
         Takes a list of (key, value) tuples and returns a urlencoded string.
     """
-    if six.PY2:
-        return urllib.parse.urlencode(s, False)
-    else:
-        return urllib.parse.urlencode(s, False, errors="surrogateescape")
+    return urllib.parse.urlencode(s, False, errors="surrogateescape")
 
 
 def decode(s):
     """
         Takes a urlencoded string and returns a list of surrogate-escaped (key, value) tuples.
     """
-    if six.PY2:
-        return urllib.parse.parse_qsl(s, keep_blank_values=True)
-    else:
-        return urllib.parse.parse_qsl(s, keep_blank_values=True, errors='surrogateescape')
+    return urllib.parse.parse_qsl(s, keep_blank_values=True, errors='surrogateescape')
 
 
 def quote(b, safe="/"):
@@ -108,10 +101,7 @@ def quote(b, safe="/"):
         An ascii-encodable str.
     """
     # type: (str) -> str
-    if six.PY2:
-        return urllib.parse.quote(b, safe=safe)
-    else:
-        return urllib.parse.quote(b, safe=safe, errors="surrogateescape")
+    return urllib.parse.quote(b, safe=safe, errors="surrogateescape")
 
 
 def unquote(s):
@@ -122,11 +112,7 @@ def unquote(s):
         A surrogate-escaped str
     """
     # type: (str) -> str
-
-    if six.PY2:
-        return urllib.parse.unquote(s)
-    else:
-        return urllib.parse.unquote(s, errors="surrogateescape")
+    return urllib.parse.unquote(s, errors="surrogateescape")
 
 
 def hostport(scheme, host, port):
@@ -136,7 +122,7 @@ def hostport(scheme, host, port):
     if (port, scheme) in [(80, "http"), (443, "https"), (80, b"http"), (443, b"https")]:
         return host
     else:
-        if isinstance(host, six.binary_type):
+        if isinstance(host, bytes):
             return b"%s:%d" % (host, port)
         else:
             return "%s:%d" % (host, port)

--- a/netlib/multidict.py
+++ b/netlib/multidict.py
@@ -8,12 +8,10 @@ try:
 except ImportError:  # pragma: no cover
     from collections import MutableMapping  # Workaround for Python < 3.3
 
-import six
 from netlib import basetypes
 
 
-@six.add_metaclass(ABCMeta)
-class _MultiDict(MutableMapping, basetypes.Serializable):
+class _MultiDict(MutableMapping, basetypes.Serializable, metaclass=ABCMeta):
     def __repr__(self):
         fields = (
             repr(field)
@@ -231,8 +229,7 @@ class MultiDict(_MultiDict):
         return key
 
 
-@six.add_metaclass(ABCMeta)
-class ImmutableMultiDict(MultiDict):
+class ImmutableMultiDict(MultiDict, metaclass=ABCMeta):
     def _immutable(self, *_):
         raise TypeError('{} objects are immutable'.format(self.__class__.__name__))
 

--- a/netlib/tutils.py
+++ b/netlib/tutils.py
@@ -4,7 +4,6 @@ import os
 import time
 import shutil
 from contextlib import contextmanager
-import six
 import sys
 
 from netlib import utils, tcp, http
@@ -31,20 +30,20 @@ def tmpdir(*args, **kwargs):
 
 
 def _check_exception(expected, actual, exc_tb):
-    if isinstance(expected, six.string_types):
+    if isinstance(expected, str):
         if expected.lower() not in str(actual).lower():
-            six.reraise(AssertionError, AssertionError(
+            raise AssertionError(
                 "Expected %s, but caught %s" % (
                     repr(expected), repr(actual)
                 )
-            ), exc_tb)
+            )
     else:
         if not isinstance(actual, expected):
-            six.reraise(AssertionError, AssertionError(
+            raise AssertionError(
                 "Expected %s, but caught %s %s" % (
                     expected.__name__, actual.__class__.__name__, repr(actual)
                 )
-            ), exc_tb)
+            )
 
 
 def raises(expected_exception, obj=None, *args, **kwargs):

--- a/netlib/version_check.py
+++ b/netlib/version_check.py
@@ -7,7 +7,6 @@ from __future__ import division, absolute_import, print_function
 import sys
 import inspect
 import os.path
-import six
 
 import OpenSSL
 
@@ -15,7 +14,7 @@ PYOPENSSL_MIN_VERSION = (0, 15)
 
 
 def check_pyopenssl_version(min_version=PYOPENSSL_MIN_VERSION, fp=sys.stderr):
-    min_version_str = u".".join(six.text_type(x) for x in min_version)
+    min_version_str = u".".join(str(x) for x in min_version)
     try:
         v = tuple(int(x) for x in OpenSSL.__version__.split(".")[:2])
     except ValueError:

--- a/netlib/websockets/frame.py
+++ b/netlib/websockets/frame.py
@@ -3,8 +3,6 @@ import os
 import struct
 import io
 
-import six
-
 from netlib import tcp
 from netlib import strutils
 from netlib import utils
@@ -129,7 +127,7 @@ class FrameHeader(object):
 
         second_byte = utils.setbit(self.length_code, 7, self.mask)
 
-        b = six.int2byte(first_byte) + six.int2byte(second_byte)
+        b = bytes([first_byte, second_byte])
 
         if self.payload_length < 126:
             pass
@@ -148,17 +146,12 @@ class FrameHeader(object):
             b += self.masking_key
         return b
 
-    if six.PY2:
-        __str__ = __bytes__
-
     @classmethod
     def from_file(cls, fp):
         """
           read a websockets frame header
         """
-        first_byte = six.byte2int(fp.safe_read(1))
-        second_byte = six.byte2int(fp.safe_read(1))
-
+        first_byte, second_byte = fp.safe_read(2)
         fin = utils.getbit(first_byte, 7)
         rsv1 = utils.getbit(first_byte, 6)
         rsv2 = utils.getbit(first_byte, 5)
@@ -256,9 +249,6 @@ class Frame(object):
         else:
             b += self.payload
         return b
-
-    if six.PY2:
-        __str__ = __bytes__
 
     @classmethod
     def from_file(cls, fp):

--- a/netlib/websockets/masker.py
+++ b/netlib/websockets/masker.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import
 
-import six
-
 
 class Masker(object):
     """
@@ -19,10 +17,7 @@ class Masker(object):
     def mask(self, offset, data):
         result = bytearray(data)
         for i in range(len(data)):
-            if six.PY2:
-                result[i] ^= ord(self.key[offset % 4])
-            else:
-                result[i] ^= self.key[offset % 4]
+            result[i] ^= self.key[offset % 4]
             offset += 1
         result = bytes(result)
         return result

--- a/netlib/wsgi.py
+++ b/netlib/wsgi.py
@@ -2,9 +2,8 @@ from __future__ import (absolute_import, print_function, division)
 
 import time
 import traceback
-import six
-from io import BytesIO
-from six.moves import urllib
+import urllib
+import io
 
 from netlib import http, tcp, strutils
 
@@ -67,7 +66,7 @@ class WSGIAdaptor(object):
         environ = {
             'wsgi.version': (1, 0),
             'wsgi.url_scheme': strutils.native(flow.request.scheme, "latin-1"),
-            'wsgi.input': BytesIO(flow.request.content or b""),
+            'wsgi.input': io.BytesIO(flow.request.content or b""),
             'wsgi.errors': errsoc,
             'wsgi.multithread': True,
             'wsgi.multiprocess': False,
@@ -139,7 +138,7 @@ class WSGIAdaptor(object):
         def start_response(status, headers, exc_info=None):
             if exc_info:
                 if state["headers_sent"]:
-                    six.reraise(*exc_info)
+                    raise exc_info[1]
             elif state["status"]:
                 raise AssertionError('Response already started')
             state["status"] = status
@@ -148,7 +147,7 @@ class WSGIAdaptor(object):
                 self.error_page(soc, state["headers_sent"], traceback.format_tb(exc_info[2]))
                 state["headers_sent"] = True
 
-        errs = six.BytesIO()
+        errs = io.BytesIO()
         try:
             dataiter = self.app(
                 self.make_environ(request, errs, **env), start_response

--- a/pathod/language/base.py
+++ b/pathod/language/base.py
@@ -3,7 +3,6 @@ import os
 import abc
 import pyparsing as pp
 
-import six
 from six.moves import reduce
 from netlib import strutils
 from netlib import human
@@ -342,7 +341,7 @@ class OptionsOrValue(_Component):
         # it to be canonical. The user can specify a different case by using a
         # string value literal.
         self.option_used = False
-        if isinstance(value, six.string_types):
+        if isinstance(value, str):
             for i in self.options:
                 # Find the exact option value in a case-insensitive way
                 if i.lower() == value.lower():

--- a/pathod/pathoc.py
+++ b/pathod/pathoc.py
@@ -461,7 +461,7 @@ class Pathoc(tcp.TCPClient):
 
             May raise a exceptions.NetlibException
         """
-        if isinstance(r, six.string_types):
+        if isinstance(r, str):
             r = next(language.parse_pathoc(r, self.use_http2))
 
         if isinstance(r, language.http.Request):

--- a/setup.py
+++ b/setup.py
@@ -30,8 +30,6 @@ setup(
         "Operating System :: POSIX",
         "Operating System :: Microsoft :: Windows",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: Implementation :: CPython",
@@ -92,13 +90,6 @@ setup(
             "pydivert>=0.0.7, <0.1",
         ],
         ':sys_platform != "win32"': [
-        ],
-        # Do not use a range operator here: https://bitbucket.org/pypa/setuptools/issues/380
-        # Ubuntu Trusty and other still ship with setuptools < 17.1
-        ':python_version == "2.7"': [
-            "enum34>=1.0.4, <2",
-            "ipaddress>=1.0.15, <1.1",
-            "typing==3.5.2.2",
         ],
         'dev': [
             "tox>=2.3, <3",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py35, docs, lint
+envlist = py35, docs, lint
 skipsdist = True
 toxworkdir={env:TOX_WORK_DIR:.tox}
 


### PR DESCRIPTION
- Zap various occurrences of Python2 in docs and scripts
- Remove six from netlib, and some other places where obvious project-wide
search and replace works.