### PR TITLE
Dumper: limit url length

### DIFF
--- a/mitmproxy/builtins/dumper.py
+++ b/mitmproxy/builtins/dumper.py
@@ -130,6 +130,8 @@ class Dumper:
             url = flow.request.pretty_url
         else:
             url = flow.request.url
+        if len(url) > 200:
+            url = url[:199] + "…"
         url = click.style(strutils.escape_control_characters(url), bold=True)
 
         http_version = ""


### PR DESCRIPTION
This PR limits the URL length echoed by the dumper addon. We already do the same in the console ui, and I find it kind of useful when facing screen-filling ad tracker URLs.

Ok for everyone?