### PR TITLE
Fix method call in flowfilter example

### DIFF
--- a/examples/flowfilter.py
+++ b/examples/flowfilter.py
@@ -10,7 +10,7 @@ class Filter:
         self.filter = flowfilter.parse(spec)
 
     def response(self, flow):
-        if flowfilter.match(flow, self.filter):
+        if flowfilter.match(self.filter, flow):
             print("Flow matches filter:")
             print(flow)
 


### PR DESCRIPTION
**Issue**
The flowfilter example does not work.

**Root cause**
The `flowfilter.match()` positional arguments are in the wrong order. See method definition here.
https://github.com/mitmproxy/mitmproxy/blob/master/mitmproxy/flowfilter.py#L502

**Fix**
The first argument should be the `filter`, then the `flow`.

Follow up to https://github.com/mitmproxy/mitmproxy/pull/1587/commits/36c04f1631c79ca79712873e151c7f5267cafd46