### PR TITLE
Don't call error for flow kill

### DIFF
--- a/mitmproxy/flow.py
+++ b/mitmproxy/flow.py
@@ -165,7 +165,6 @@ class Flow(stateobject.StateObject):
             self.reply.take()
         self.reply.kill(force=True)
         self.reply.commit()
-        master.error(self)
 
     def intercept(self, master):
         """

--- a/mitmproxy/tools/console/flowview.py
+++ b/mitmproxy/tools/console/flowview.py
@@ -480,7 +480,7 @@ class FlowView(tabs.Tabs):
         else:
             new_flow, new_idx = self.state.get_prev(idx)
         if new_flow is None:
-            signals.status_message.send(message="No more flows!")
+            signals.status_message.send(message="No more flows")
         else:
             signals.pop_view_state.send(self)
             self.master.view_flow(new_flow, self.tab_offset)

--- a/test/mitmproxy/test_flow.py
+++ b/test/mitmproxy/test_flow.py
@@ -104,7 +104,6 @@ class TestHTTPFlow:
         assert f.killable
         f.kill(fm)
         assert not f.killable
-        assert fm.error.called
         assert f.reply.value == Kill
 
     def test_killall(self):


### PR DESCRIPTION
This is now the error handler on master, so whatever the intention was it's now
definitely wrong.

This fixes a crash when intercepted flows are deleted from console (among others). 