### PR TITLE
Improve Flow Export

### DIFF
--- a/mitmproxy/http.py
+++ b/mitmproxy/http.py
@@ -1,9 +1,11 @@
 import cgi
 
 from mitmproxy import flow
+
 from mitmproxy.net import http
 from mitmproxy import version
 from mitmproxy.net import tcp
+from mitmproxy import connections  # noqa
 
 
 class HTTPRequest(http.Request):
@@ -155,22 +157,22 @@ class HTTPFlow(flow.Flow):
     def __init__(self, client_conn, server_conn, live=None):
         super().__init__("http", client_conn, server_conn, live)
 
-        self.request = None
+        self.request = None  # type: HTTPRequest
         """ :py:class:`HTTPRequest` object """
-        self.response = None
+        self.response = None  # type: HTTPResponse
         """ :py:class:`HTTPResponse` object """
-        self.error = None
+        self.error = None  # type: flow.Error
         """ :py:class:`Error` object
 
         Note that it's possible for a Flow to have both a response and an error
         object. This might happen, for instance, when a response was received
         from the server, but there was an error sending it back to the client.
         """
-        self.server_conn = server_conn
+        self.server_conn = server_conn  # type: connections.ServerConnection
         """ :py:class:`ServerConnection` object """
-        self.client_conn = client_conn
+        self.client_conn = client_conn  # type: connections.ClientConnection
         """:py:class:`ClientConnection` object """
-        self.intercepted = False
+        self.intercepted = False  # type: bool
         """ Is this flow currently being intercepted? """
 
     _stateobject_attributes = flow.Flow._stateobject_attributes.copy()

--- a/test/mitmproxy/data/test_flow_export/python_get.py
+++ b/test/mitmproxy/data/test_flow_export/python_get.py
@@ -1,22 +1,9 @@
 import requests
 
-url = 'http://address/path'
-
-headers = {
-    'header': 'qvalue',
-    'content-length': '7',
-}
-
-params = {
-    'a': ['foo', 'bar'],
-    'b': 'baz',
-}
-
-response = requests.request(
-    method='GET',
-    url=url,
-    headers=headers,
-    params=params,
+response = requests.get(
+    'http://address:22/path',
+    params=[('a', 'foo'), ('a', 'bar'), ('b', 'baz')],
+    headers={'header': 'qvalue'}
 )
 
 print(response.text)

--- a/test/mitmproxy/data/test_flow_export/python_patch.py
+++ b/test/mitmproxy/data/test_flow_export/python_patch.py
@@ -1,24 +1,10 @@
 import requests
 
-url = 'http://address/path'
-
-headers = {
-    'header': 'qvalue',
-    'content-length': '7',
-}
-
-params = {
-    'query': 'param',
-}
-
-data = '''content'''
-
-response = requests.request(
-    method='PATCH',
-    url=url,
-    headers=headers,
-    params=params,
-    data=data,
+response = requests.patch(
+    'http://address:22/path',
+    params=[('query', 'param')],
+    headers={'header': 'qvalue'},
+    data=b'content'
 )
 
 print(response.text)

--- a/test/mitmproxy/data/test_flow_export/python_post.py
+++ b/test/mitmproxy/data/test_flow_export/python_post.py
@@ -1,13 +1,8 @@
 import requests
 
-url = 'http://address/path'
-
-data = '''content'''
-
-response = requests.request(
-    method='POST',
-    url=url,
-    data=data,
+response = requests.post(
+    'http://address:22/path',
+    data=b'content'
 )
 
 print(response.text)

--- a/test/mitmproxy/data/test_flow_export/python_post_json.py
+++ b/test/mitmproxy/data/test_flow_export/python_post_json.py
@@ -1,23 +1,9 @@
 import requests
 
-url = 'http://address/path'
-
-headers = {
-    'content-type': 'application/json',
-}
-
-
-json = {
-    'email': 'example@example.com',
-    'name': 'example',
-}
-
-
-response = requests.request(
-    method='POST',
-    url=url,
-    headers=headers,
-    json=json,
+response = requests.post(
+    'http://address:22/path',
+    headers={'content-type': 'application/json'},
+    json={'email': 'example@example.com', 'name': 'example'}
 )
 
 print(response.text)

--- a/test/mitmproxy/test_flow_export.py
+++ b/test/mitmproxy/test_flow_export.py
@@ -34,17 +34,17 @@ def req_patch():
 class TestExportCurlCommand:
     def test_get(self):
         flow = tutils.tflow(req=req_get())
-        result = """curl -H 'header:qvalue' -H 'content-length:7' 'http://address/path?a=foo&a=bar&b=baz'"""
+        result = """curl -H 'header:qvalue' -H 'content-length:7' 'http://address:22/path?a=foo&a=bar&b=baz'"""
         assert export.curl_command(flow) == result
 
     def test_post(self):
         flow = tutils.tflow(req=req_post())
-        result = """curl -X POST 'http://address/path' --data-binary 'content'"""
+        result = """curl -X POST 'http://address:22/path' --data-binary 'content'"""
         assert export.curl_command(flow) == result
 
     def test_patch(self):
         flow = tutils.tflow(req=req_patch())
-        result = """curl -H 'header:qvalue' -H 'content-length:7' -X PATCH 'http://address/path?query=param' --data-binary 'content'"""
+        result = """curl -H 'header:qvalue' -H 'content-length:7' -X PATCH 'http://address:22/path?query=param' --data-binary 'content'"""
         assert export.curl_command(flow) == result
 
 
@@ -98,25 +98,6 @@ class TestExportLocustTask:
     def test_patch(self):
         flow = tutils.tflow(req=req_patch())
         python_equals("data/test_flow_export/locust_task_patch.py", export.locust_task(flow))
-
-
-class TestIsJson:
-    def test_empty(self):
-        assert export.is_json(None, None) is False
-
-    def test_json_type(self):
-        headers = Headers(content_type="application/json")
-        assert export.is_json(headers, b"foobar") is False
-
-    def test_valid(self):
-        headers = Headers(content_type="application/foobar")
-        j = export.is_json(headers, b'{"name": "example", "email": "example@example.com"}')
-        assert j is False
-
-    def test_valid2(self):
-        headers = Headers(content_type="application/json")
-        j = export.is_json(headers, b'{"name": "example", "email": "example@example.com"}')
-        assert isinstance(j, dict)
 
 
 class TestURL:


### PR DESCRIPTION
This PR reduces the Python code verbosity in particular, e.g. by using requests' `requests.post` shorthand instead of `requests.request(method="POST", ...`.

This also fixes #1573.