### PR TITLE
Add version check for Python 3.4-

### DIFF
--- a/mitmproxy/tools/main.py
+++ b/mitmproxy/tools/main.py
@@ -1,6 +1,12 @@
+from __future__ import print_function  # this is here for the version check to work on Python 2.
 import os
 import signal
 import sys
+
+if sys.version_info < (3, 5):
+    print("#" * 49, file=sys.stderr)
+    print("# mitmproxy only supports Python 3.5 and above! #", file=sys.stderr)
+    print("#" * 49, file=sys.stderr)
 
 from mitmproxy.tools import cmdline
 from mitmproxy import exceptions


### PR DESCRIPTION
This adresses https://github.com/mitmproxy/mitmproxy/issues/1646#issuecomment-255503746. There are a couple of subtle issues:

1. We need to do the check before the mitmproxy/mitmdump/mitmweb functions, because some Python files are now invalid syntax for Python 2.
1. We ideally don't want a mere module import cause side effects. However, mitmproxy is downright incompatible with 3.4-, so we surely want to do _something_. Instead of `sys.exit()`ing, we just print to stderr. The current behaviour is as follows:

Python 3.4:
```
C:\Users\user>C:\Python34\Scripts\mitmdump.exe
#################################################
# mitmproxy only supports Python 3.5 and above! #
#################################################
Traceback (most recent call last):
  File "C:\Python34\Scripts\mitmdump-script.py", line 9, in <module>
    load_entry_point('mitmproxy==0.19', 'console_scripts', 'mitmdump')()
  File "c:\python34\lib\site-packages\pkg_resources\__init__.py", line 519, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "c:\python34\lib\site-packages\pkg_resources\__init__.py", line 2630, in load_entry_point
    return ep.load()
  File "c:\python34\lib\site-packages\pkg_resources\__init__.py", line 2310, in load
    return self.resolve()
  File "c:\python34\lib\site-packages\pkg_resources\__init__.py", line 2316, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "c:\users\user\git\mitmproxy\mitmproxy\tools\main.py", line 11, in <module>
    from mitmproxy.tools import cmdline
  File "c:\users\user\git\mitmproxy\mitmproxy\tools\cmdline.py", line 5, in <module>
    from mitmproxy import flowfilter
  File "c:\users\user\git\mitmproxy\mitmproxy\flowfilter.py", line 39, in <module>
    from mitmproxy import http
  File "c:\users\user\git\mitmproxy\mitmproxy\http.py", line 3, in <module>
    from mitmproxy import flow
  File "c:\users\user\git\mitmproxy\mitmproxy\flow.py", line 5, in <module>
    from mitmproxy import stateobject
  File "c:\users\user\git\mitmproxy\mitmproxy\stateobject.py", line 1, in <module>
    from typing import Any
ImportError: No module named 'typing'
```

Python 2.7:
```
C:\Users\user>C:\Python27\Scripts\mitmdump.exe
#################################################
# mitmproxy only supports Python 3.5 and above! #
#################################################
Traceback (most recent call last):
  File "C:\Python27\Scripts\mitmdump-script.py", line 11, in <module>
    load_entry_point('mitmproxy', 'console_scripts', 'mitmdump')()
  File "c:\python27\lib\site-packages\pkg_resources\__init__.py", line 567, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "c:\python27\lib\site-packages\pkg_resources\__init__.py", line 2604, in load_entry_point
    return ep.load()
  File "c:\python27\lib\site-packages\pkg_resources\__init__.py", line 2264, in load
    return self.resolve()
  File "c:\python27\lib\site-packages\pkg_resources\__init__.py", line 2270, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "c:\users\user\git\mitmproxy\mitmproxy\tools\main.py", line 11, in <module>
    from mitmproxy.tools import cmdline
  File "c:\users\user\git\mitmproxy\mitmproxy\tools\cmdline.py", line 5, in <module>
    from mitmproxy import flowfilter
  File "c:\users\user\git\mitmproxy\mitmproxy\flowfilter.py", line 67
    ), file=fp)
           ^
SyntaxError: invalid syntax
```