### PR TITLE
Include `boudary=...` in mutipart postData

### DIFF
--- a/examples/har_dump.py
+++ b/examples/har_dump.py
@@ -140,7 +140,7 @@ def response(flow):
             for a, b in flow.request.urlencoded_form.items(multi=True)
         ]
         entry["request"]["postData"] = {
-            "mimeType": flow.request.headers.get("Content-Type", "").split(";")[0],
+            "mimeType": flow.request.headers.get("Content-Type", ""),
             "text": flow.request.get_text(strict=False),
             "params": params
         }


### PR DESCRIPTION
Currently, full mimeType is included only in `content-type` request header. While the HAR spec is not very explicit and their example shows just this one example: 
```js
"postData": {
    "mimeType": "multipart/form-data"
    //...
}
```

Would it not make sense to include all the information necessary to parse out the post data `text`. Eg.
```json
"postData": {
    "mimeType": "multipart/form-data; boundary=xYzZY",
    "text": "--xYzZY\r\nContent-Disposition: form-data; name=\"sort1\"\r\n\r\noldest date first\r\n--xYzZY--\r\n"
},
```

Note that elsewhere in HAR spec they include the extra parameters, eg:
```js
"content": {
    "mimeType": "text/html; charset=utf-8",
    // ...
}
``` 
So one could argue that `postData.mimeType` should also include all information necessary to interpret the `text`. In case of `multipart/form-data`, as per RFC2046 http://www.ietf.org/rfc/rfc2046.txt
```
 The Content-Type field for multipart entities requires one parameter, "boundary".
```
WFIW, I believe that earlier incarnations, eg `har_exporter.py` included it in the mimeType.
