### PR TITLE
Resolved #1639: display sni on ClientConnection

### DIFF
--- a/mitmproxy/connections.py
+++ b/mitmproxy/connections.py
@@ -20,6 +20,7 @@ class ClientConnection(tcp.BaseHandler, stateobject.StateObject):
         timestamp_start: Connection start timestamp
         timestamp_ssl_setup: TLS established timestamp
         timestamp_end: Connection end timestamp
+        sni: Server Name Indication sent by client during the TLS handshake
     """
 
     def __init__(self, client_connection, address, server):
@@ -40,6 +41,7 @@ class ClientConnection(tcp.BaseHandler, stateobject.StateObject):
         self.timestamp_end = None
         self.timestamp_ssl_setup = None
         self.protocol = None
+        self.sni = None
 
     def __bool__(self):
         return bool(self.connection) and not self.finished
@@ -61,6 +63,7 @@ class ClientConnection(tcp.BaseHandler, stateobject.StateObject):
         timestamp_start=float,
         timestamp_ssl_setup=float,
         timestamp_end=float,
+        sni=str,
     )
 
     def copy(self):
@@ -86,12 +89,14 @@ class ClientConnection(tcp.BaseHandler, stateobject.StateObject):
             ssl_established=False,
             timestamp_start=None,
             timestamp_end=None,
-            timestamp_ssl_setup=None
+            timestamp_ssl_setup=None,
+            sni=None
         ))
 
     def convert_to_ssl(self, *args, **kwargs):
         super().convert_to_ssl(*args, **kwargs)
         self.timestamp_ssl_setup = time.time()
+        self.sni = self.connection.get_servername()
 
     def finish(self):
         super().finish()

--- a/mitmproxy/io_compat.py
+++ b/mitmproxy/io_compat.py
@@ -66,6 +66,7 @@ def convert_017_018(data):
 
 def convert_018_019(data):
     data["version"] = (0, 19)
+    data["client_conn"]["sni"] = None
     return data
 
 

--- a/mitmproxy/tools/console/flowdetailview.py
+++ b/mitmproxy/tools/console/flowdetailview.py
@@ -82,6 +82,8 @@ def flowdetails(state, flow):
         parts = [
             ["Address", repr(cc.address)],
         ]
+        if cc.sni:
+            parts.append(["Server Name Indication", cc.sni])
 
         text.extend(
             common.format_keyvals(parts, key="key", val="text", indent=4)

--- a/test/mitmproxy/tutils.py
+++ b/test/mitmproxy/tutils.py
@@ -132,6 +132,7 @@ def tclient_conn():
         timestamp_start=1,
         timestamp_ssl_setup=2,
         timestamp_end=3,
+        sni="address",
     ))
     c.reply = controller.DummyReply()
     return c


### PR DESCRIPTION
There is still one test cannot pass that I need your advise how could I solved that.

The test is ```test/mitmproxy/test_flow_format_compat.py``` that will load a dump file ```data/dumpfile-011```
The dumpfile didn't contains sni info so that when the program try deserialize from dumpfile,
the state of ClientConnection didn't contains the sni field.

Is that I need add sni in the dumpfile manually? Or there is another way?
Thanks!

```
    def test_load():
        with open(tutils.test_data.path("data/dumpfile-011"), "rb") as f:
            flow_reader = io.FlowReader(f)
>           flows = list(flow_reader.stream())

test/mitmproxy/test_flow_format_compat.py:9: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
mitmproxy/io.py:43: in stream
    yield FLOW_TYPES[data["type"]].from_state(data)
mitmproxy/flow.py:112: in from_state
    f.set_state(state)
mitmproxy/flow.py:107: in set_state
    super().set_state(state)
mitmproxy/stateobject.py:60: in set_state
    obj = cls.from_state(val)
mitmproxy/connections.py:81: in from_state
    f.set_state(state)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <ClientConnection: [ssl] None>, state = {'address': {'address': [b'127.0.0.1', 60786], 'use_ipv6': False}, 'timestamp_end': None, 'timestamp_start': 1469208633.936}

    def set_state(self, state):
        """
            Load object state from data returned by a get_state call.
            """
        state = state.copy()
        for attr, cls in self._stateobject_attributes.items():
>           val = state.pop(attr)
E           KeyError: 'sni'

mitmproxy/stateobject.py:52: KeyError
```