### PR TITLE
Make Options keyword-only

### DIFF
--- a/mitmproxy/options.py
+++ b/mitmproxy/options.py
@@ -23,6 +23,7 @@ DEFAULT_CLIENT_CIPHERS = "ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA
 class Options(optmanager.OptManager):
     def __init__(
             self,
+            *,  # all args are keyword-only.
             # TODO: rename to onboarding_app_*
             app: bool = True,
             app_host: str = APP_HOST,

--- a/mitmproxy/tools/console/master.py
+++ b/mitmproxy/tools/console/master.py
@@ -203,6 +203,7 @@ class ConsoleState(state.State):
 class Options(mitmproxy.options.Options):
     def __init__(
             self,
+            *,  # all args are keyword-only.
             eventlog: bool = False,
             follow: bool = False,
             intercept: bool = False,

--- a/mitmproxy/tools/dump.py
+++ b/mitmproxy/tools/dump.py
@@ -18,6 +18,7 @@ class DumpError(Exception):
 class Options(options.Options):
     def __init__(
             self,
+            *, # all args are keyword-only.
             keepserving: bool = False,
             filtstr: Optional[str] = None,
             flow_detail: int = 1,

--- a/mitmproxy/tools/web/master.py
+++ b/mitmproxy/tools/web/master.py
@@ -94,6 +94,7 @@ class WebState(state.State):
 class Options(options.Options):
     def __init__(
             self,
+            *,  # all args are keyword-only.
             intercept: Optional[str] = None,
             wdebug: bool = bool,
             wport: int = 8081,


### PR DESCRIPTION
If noone objects, I would like to make our option classes keyword-only as proposed in [PEP 3102](https://www.python.org/dev/peps/pep-3102/):  Arguments can only be supplied by keyword and not as a positional argument.