### PR TITLE
http2: add an indicator for pushed streams

### DIFF
--- a/mitmproxy/addons/dumper.py
+++ b/mitmproxy/addons/dumper.py
@@ -116,7 +116,8 @@ class Dumper:
         else:
             client = ""
 
-        method = flow.request.method
+        pushed = ' PUSH_PROMISE' if 'h2-pushed-stream' in flow.metadata else ''
+        method = flow.request.method + pushed
         method_color = dict(
             GET="green",
             DELETE="red"

--- a/mitmproxy/flow.py
+++ b/mitmproxy/flow.py
@@ -7,7 +7,7 @@ from mitmproxy import stateobject
 from mitmproxy import connections
 from mitmproxy import version
 
-from typing import Optional  # noqa
+from typing import Optional, Dict  # noqa
 
 
 class Error(stateobject.StateObject):
@@ -83,6 +83,7 @@ class Flow(stateobject.StateObject):
         self._backup = None  # type: Optional[Flow]
         self.reply = None  # type: Optional[controller.Reply]
         self.marked = False  # type: bool
+        self.metadata = dict()  # type: Dict[str, str]
 
     _stateobject_attributes = dict(
         id=str,
@@ -92,6 +93,7 @@ class Flow(stateobject.StateObject):
         type=str,
         intercepted=bool,
         marked=bool,
+        metadata=dict,
     )
 
     def get_state(self):
@@ -120,6 +122,7 @@ class Flow(stateobject.StateObject):
         f.live = False
         f.client_conn = self.client_conn.copy()
         f.server_conn = self.server_conn.copy()
+        f.metadata = self.metadata.copy()
 
         if self.error:
             f.error = self.error.copy()

--- a/mitmproxy/io_compat.py
+++ b/mitmproxy/io_compat.py
@@ -69,6 +69,7 @@ def convert_018_019(data):
     data["client_conn"]["sni"] = None
     data["client_conn"]["cipher_name"] = None
     data["client_conn"]["tls_version"] = None
+    data["metadata"] = dict()
     return data
 
 

--- a/mitmproxy/proxy/protocol/http1.py
+++ b/mitmproxy/proxy/protocol/http1.py
@@ -9,7 +9,7 @@ class Http1Layer(httpbase._HttpTransmissionLayer):
         super().__init__(ctx)
         self.mode = mode
 
-    def read_request_headers(self):
+    def read_request_headers(self, flow):
         return http.HTTPRequest.wrap(
             http1.read_request_head(self.client_conn.rfile)
         )

--- a/mitmproxy/tools/console/common.py
+++ b/mitmproxy/tools/console/common.py
@@ -327,7 +327,7 @@ def export_to_clip_or_file(key, scope, flow, writer):
 
 
 @lru_cache(maxsize=800)
-def raw_format_flow(f):
+def raw_format_flow(f, flow):
     f = dict(f)
     pile = []
     req = []
@@ -346,7 +346,9 @@ def raw_format_flow(f):
 
     if f["req_is_replay"]:
         req.append(fcol(SYMBOL_REPLAY, "replay"))
-    req.append(fcol(f["req_method"], "method"))
+
+    pushed = ' PUSH_PROMISE' if 'h2-pushed-stream' in flow.metadata else ''
+    req.append(fcol(f["req_method"] + pushed, "method"))
 
     preamble = sum(i[1] for i in req) + len(req) - 1
 
@@ -451,10 +453,11 @@ def format_flow(f, focus, extended=False, hostheader=False, max_url_len=False):
             resp_clen = contentdesc,
             roundtrip = roundtrip,
         ))
+
         t = f.response.headers.get("content-type")
         if t:
             d["resp_ctype"] = t.split(";")[0]
         else:
             d["resp_ctype"] = ""
 
-    return raw_format_flow(tuple(sorted(d.items())))
+    return raw_format_flow(tuple(sorted(d.items())), f)


### PR DESCRIPTION
This PR adds an indicator to mitmproxy and mitmdump to indicate pushed streams.

<img width="557" alt="screen shot 2016-10-27 at 19 44 27" src="https://cloud.githubusercontent.com/assets/114300/19792962/f3573356-9c7e-11e6-934f-a925024a42db.png">

<img width="660" alt="screen shot 2016-10-27 at 19 42 50" src="https://cloud.githubusercontent.com/assets/114300/19792963/f357ac50-9c7e-11e6-8287-4506a3823484.png">

To keep track of this information, the `HTTPLayer` now gets to keep track of its own `flow` as attribute.

Furthermore, this PR introduces a `flow.metadata` dict, which can be used to store additional information about flows.
This might be useful for scripts/addons to store external data:
  * correlating SQL query times from an external DB system
  * computed statistics
  * a GUID to keep track of each flow
  * etc.