### PR TITLE
Wsgiapp: Only raise exception if an error occurred.

### DIFF
--- a/mitmproxy/addons/wsgiapp.py
+++ b/mitmproxy/addons/wsgiapp.py
@@ -30,8 +30,8 @@ class WSGIApp:
         )
         if err:
             ctx.log.error("Error in wsgi app. %s" % err)
+            raise exceptions.AddonHalt()
         flow.reply.kill()
-        raise exceptions.AddonHalt()
 
     def request(self, f):
         if (f.request.pretty_host, f.request.port) == (self.host, self.port):


### PR DESCRIPTION
Currently, mitmproxy always raises an exception when serving a wsgiapp even if everything worked as expected. This patch causes mitmproxy to only raise an exception if an error actually occurred.