### PR TITLE
Fix Travis cipher-suite related breakage

### DIFF
--- a/test/mitmproxy/net/test_tcp.py
+++ b/test/mitmproxy/net/test_tcp.py
@@ -380,14 +380,14 @@ class TestSNI(tservers.ServerTestBase):
 class TestServerCipherList(tservers.ServerTestBase):
     handler = ClientCipherListHandler
     ssl = dict(
-        cipher_list='RC4-SHA'
+        cipher_list='AES256-GCM-SHA384'
     )
 
     def test_echo(self):
         c = tcp.TCPClient(("127.0.0.1", self.port))
         with c.connect():
             c.convert_to_ssl(sni="foo.com")
-            assert c.rfile.readline() == b"['RC4-SHA']"
+            assert c.rfile.readline() == b"['AES256-GCM-SHA384']"
 
 
 class TestServerCurrentCipher(tservers.ServerTestBase):
@@ -400,14 +400,14 @@ class TestServerCurrentCipher(tservers.ServerTestBase):
             self.wfile.flush()
 
     ssl = dict(
-        cipher_list='RC4-SHA'
+        cipher_list='AES256-GCM-SHA384'
     )
 
     def test_echo(self):
         c = tcp.TCPClient(("127.0.0.1", self.port))
         with c.connect():
             c.convert_to_ssl(sni="foo.com")
-            assert b"RC4-SHA" in c.rfile.readline()
+            assert b'AES256-GCM-SHA384' in c.rfile.readline()
 
 
 class TestServerCipherListError(tservers.ServerTestBase):

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ deps =
 passenv = CODECOV_TOKEN CI CI_* TRAVIS TRAVIS_* APPVEYOR APPVEYOR_*
 setenv = HOME = {envtmpdir}
 commands =
+  mitmdump --sysinfo
   py.test --timeout 60 {posargs}
   {env:CI_COMMANDS:python -c ""}
 
@@ -19,6 +20,7 @@ commands = sphinx-build -W -b html -d {envtmpdir}/doctrees . {envtmpdir}/html
 
 [testenv:lint]
 commands =
+  mitmdump --sysinfo
   flake8 --jobs 8 --count mitmproxy pathod examples test
   rstcheck README.rst
   mypy --silent-imports mitmproxy/addons mitmproxy/addonmanager.py mitmproxy/proxy/protocol/


### PR DESCRIPTION
Add a bit of contextual info to our test runs to try to troubleshoot the SSL-related failures. 