### PR TITLE
Added proxy_username to HTTPFlow object

### DIFF
--- a/mitmproxy/http.py
+++ b/mitmproxy/http.py
@@ -163,6 +163,8 @@ class HTTPFlow(flow.Flow):
         """:py:class:`ClientConnection` object """
         self.intercepted = False  # type: bool
         """ Is this flow currently being intercepted? """
+        self.proxy_username = None # type: string
+        """ :py:class:`String` object """
 
     _stateobject_attributes = flow.Flow._stateobject_attributes.copy()
     _stateobject_attributes.update(
@@ -172,7 +174,7 @@ class HTTPFlow(flow.Flow):
 
     def __repr__(self):
         s = "<HTTPFlow"
-        for a in ("request", "response", "error", "client_conn", "server_conn"):
+        for a in ("request", "response", "error", "client_conn", "server_conn", "proxy_username"):
             if getattr(self, a, False):
                 s += "\r\n  %s = {flow.%s}" % (a, a)
         s += ">"
@@ -184,6 +186,8 @@ class HTTPFlow(flow.Flow):
             f.request = self.request.copy()
         if self.response:
             f.response = self.response.copy()
+        if self.proxy_username:
+            f.proxy_username = ''.join(self.proxy_username)
         return f
 
     def replace(self, pattern, repl, *args, **kwargs):

--- a/mitmproxy/test/tflow.py
+++ b/mitmproxy/test/tflow.py
@@ -26,13 +26,14 @@ def ttcpflow(client_conn=True, server_conn=True, messages=True, err=None):
     return f
 
 
-def tflow(client_conn=True, server_conn=True, req=True, resp=None, err=None):
+def tflow(client_conn=True, server_conn=True, req=True, resp=None, err=None, proxy_username=None):
     """
     @type client_conn: bool | None | mitmproxy.proxy.connection.ClientConnection
     @type server_conn: bool | None | mitmproxy.proxy.connection.ServerConnection
     @type req:         bool | None | mitmproxy.proxy.protocol.http.HTTPRequest
     @type resp:        bool | None | mitmproxy.proxy.protocol.http.HTTPResponse
     @type err:         bool | None | mitmproxy.proxy.protocol.primitives.Error
+    @type proxy_username:  bool | None | string
     @return:           mitmproxy.proxy.protocol.http.HTTPFlow
     """
     if client_conn is True:
@@ -45,6 +46,9 @@ def tflow(client_conn=True, server_conn=True, req=True, resp=None, err=None):
         resp = tutils.tresp()
     if err is True:
         err = terr()
+    if proxy_username is True:
+        proxy_username = "myusername"
+
 
     if req:
         req = http.HTTPRequest.wrap(req)
@@ -53,6 +57,7 @@ def tflow(client_conn=True, server_conn=True, req=True, resp=None, err=None):
 
     f = http.HTTPFlow(client_conn, server_conn)
     f.request = req
+    f.proxy_username = proxy_username
     f.response = resp
     f.error = err
     f.reply = controller.DummyReply()

--- a/test/mitmproxy/protocol/test_http1.py
+++ b/test/mitmproxy/protocol/test_http1.py
@@ -11,6 +11,9 @@ class TestHTTPFlow:
         f = tflow.tflow(resp=True, err=True)
         assert repr(f)
 
+    def test_proxyusername(self):
+        f = tflow.tflow(resp=True, proxy_username="some_proxy_username")
+        assert f.proxy_username == "some_proxy_username"
 
 class TestInvalidRequests(tservers.HTTPProxyTest):
     ssl = True

--- a/test/mitmproxy/test_flow.py
+++ b/test/mitmproxy/test_flow.py
@@ -20,7 +20,7 @@ from . import tservers
 class TestHTTPFlow:
 
     def test_copy(self):
-        f = tflow.tflow(resp=True)
+        f = tflow.tflow(resp=True, proxy_username=True)
         f.get_state()
         f2 = f.copy()
         a = f.get_state()
@@ -36,6 +36,8 @@ class TestHTTPFlow:
         assert f.request.headers is not f2.request.headers
         assert f.response.get_state() == f2.response.get_state()
         assert f.response is not f2.response
+        assert f.proxy_username == f2.proxy_username
+        assert f.proxy_username is not f2.proxy_username
 
         f = tflow.tflow(err=True)
         f2 = f.copy()


### PR DESCRIPTION
Hi,

This PR adds a variable `proxy_username` to the HTTPFlow class, which is used to store the username authenticating with MITMProxy.

I'm quite new to the codebase (and also to Python) so this may not be structured in the best way possible - please could you review the code and feel free to suggest improvements or additional tests?

Thanks,

Martyn.