### PR TITLE
Added proxy_username to HTTPFlow object (Backport to 0.18.2)

### DIFF
--- a/mitmproxy/models/http.py
+++ b/mitmproxy/models/http.py
@@ -173,6 +173,8 @@ class HTTPFlow(flow.Flow):
         """:py:class:`ClientConnection` object """
         self.intercepted = False
         """ Is this flow currently being intercepted? """
+        self.proxy_username = None  # type: string
+        """ :py:class:`string` object """
 
     _stateobject_attributes = flow.Flow._stateobject_attributes.copy()
     _stateobject_attributes.update(
@@ -182,7 +184,7 @@ class HTTPFlow(flow.Flow):
 
     def __repr__(self):
         s = "<HTTPFlow"
-        for a in ("request", "response", "error", "client_conn", "server_conn"):
+        for a in ("request", "response", "error", "client_conn", "server_conn", "proxy_username"):
             if getattr(self, a, False):
                 s += "\r\n  %s = {flow.%s}" % (a, a)
         s += ">"
@@ -194,6 +196,8 @@ class HTTPFlow(flow.Flow):
             f.request = self.request.copy()
         if self.response:
             f.response = self.response.copy()
+        if self.proxy_username:
+            f.proxy_username = ''.join(self.proxy_username)
         return f
 
     def replace(self, pattern, repl, *args, **kwargs):

--- a/test/mitmproxy/protocol/test_http1.py
+++ b/test/mitmproxy/protocol/test_http1.py
@@ -12,6 +12,10 @@ class TestHTTPFlow(object):
         f = tutils.tflow(resp=True, err=True)
         assert repr(f)
 
+    def test_proxy_username(self):
+        f = tutils.tflow(resp=True, proxy_username="some_proxy_username")
+        assert f.proxy_username == "some_proxy_username"
+
 
 class TestInvalidRequests(tservers.HTTPProxyTest):
     ssl = True

--- a/test/mitmproxy/test_flow.py
+++ b/test/mitmproxy/test_flow.py
@@ -40,7 +40,7 @@ def test_app_registry():
 class TestHTTPFlow(object):
 
     def test_copy(self):
-        f = tutils.tflow(resp=True)
+        f = tutils.tflow(resp=True, proxy_username=True)
         f.get_state()
         f2 = f.copy()
         a = f.get_state()
@@ -56,6 +56,8 @@ class TestHTTPFlow(object):
         assert f.request.headers is not f2.request.headers
         assert f.response.get_state() == f2.response.get_state()
         assert f.response is not f2.response
+        assert f.proxy_username == f2.proxy_username
+        assert f.proxy_username is not f2.proxy_username
 
         f = tutils.tflow(err=True)
         f2 = f.copy()

--- a/test/mitmproxy/tutils.py
+++ b/test/mitmproxy/tutils.py
@@ -89,13 +89,14 @@ def ttcpflow(client_conn=True, server_conn=True, messages=True, err=None):
     return f
 
 
-def tflow(client_conn=True, server_conn=True, req=True, resp=None, err=None):
+def tflow(client_conn=True, server_conn=True, req=True, resp=None, err=None, proxy_username=None):
     """
     @type client_conn: bool | None | mitmproxy.proxy.connection.ClientConnection
     @type server_conn: bool | None | mitmproxy.proxy.connection.ServerConnection
     @type req:         bool | None | mitmproxy.protocol.http.HTTPRequest
     @type resp:        bool | None | mitmproxy.protocol.http.HTTPResponse
     @type err:         bool | None | mitmproxy.protocol.primitives.Error
+    @type proxy_username:  bool | None | string
     @return:           mitmproxy.protocol.http.HTTPFlow
     """
     if client_conn is True:
@@ -108,6 +109,8 @@ def tflow(client_conn=True, server_conn=True, req=True, resp=None, err=None):
         resp = netlib.tutils.tresp()
     if err is True:
         err = terr()
+    if proxy_username is True:
+        proxy_username = "myusername"
 
     if req:
         req = HTTPRequest.wrap(req)
@@ -116,6 +119,7 @@ def tflow(client_conn=True, server_conn=True, req=True, resp=None, err=None):
 
     f = HTTPFlow(client_conn, server_conn)
     f.request = req
+    f.proxy_username = proxy_username
     f.response = resp
     f.error = err
     f.reply = controller.DummyReply()


### PR DESCRIPTION
Hi,

This is a backport of PR #1732 for MITMProxy 0.18.2. It adds a variable `proxy_username` to the HTTPFlow class, which is used to store the username authenticating with MITMProxy.

I'm quite new to the codebase (and also to Python) so this may not be structured in the best way possible - please could you review the code and feel free to suggest improvements or additional tests?

Thanks,

Martyn.