### PR TITLE
Exempt localhost from upstream binding introduced in #879

### DIFF
--- a/mitmproxy/cmdline.py
+++ b/mitmproxy/cmdline.py
@@ -208,6 +208,11 @@ def get_common_options(args):
     if args.quiet:
         args.verbose = 0
 
+    if args.addr in ("localhost", "127.0.0.1", "::1"):
+        upstream_bind_address = ""
+    else:
+        upstream_bind_address = args.addr
+
     return dict(
         app=args.app,
         app_host=args.app_host,
@@ -251,6 +256,7 @@ def get_common_options(args):
         ignore_hosts = args.ignore_hosts,
         listen_host = args.addr,
         listen_port = args.port,
+        upstream_bind_address = upstream_bind_address,
         mode = mode,
         no_upstream_cert = args.no_upstream_cert,
         spoof_source_address = args.spoof_source_address,

--- a/mitmproxy/options.py
+++ b/mitmproxy/options.py
@@ -67,6 +67,7 @@ class Options(optmanager.OptManager):
             ignore_hosts = (),  # type: Sequence[str]
             listen_host = "",  # type: str
             listen_port = LISTEN_PORT,  # type: int
+            upstream_bind_address = "",  # type: str
             mode = "regular",  # type: str
             no_upstream_cert = False,  # type: bool
             rawtcp = False,  # type: bool
@@ -127,6 +128,7 @@ class Options(optmanager.OptManager):
         self.ignore_hosts = ignore_hosts
         self.listen_host = listen_host
         self.listen_port = listen_port
+        self.upstream_bind_address = upstream_bind_address
         self.mode = mode
         self.no_upstream_cert = no_upstream_cert
         self.rawtcp = rawtcp

--- a/mitmproxy/protocol/base.py
+++ b/mitmproxy/protocol/base.py
@@ -121,7 +121,7 @@ class ServerConnectionMixin(object):
                 server_address, (self.ctx.client_conn.address.host, 0), True)
         else:
             self.server_conn = models.ServerConnection(
-                server_address, (self.config.options.listen_host, 0))
+                server_address, (self.config.options.upstream_bind_address, 0))
 
         self.__check_self_connect()
 


### PR DESCRIPTION
Fixes #1718.