### PR TITLE
Make the upstream bind address a separate option

### DIFF
--- a/mitmproxy/options.py
+++ b/mitmproxy/options.py
@@ -69,6 +69,7 @@ class Options(optmanager.OptManager):
             ignore_hosts: Sequence[str] = (),
             listen_host: str = "",
             listen_port: int = LISTEN_PORT,
+            upstream_bind_address: str = "",
             mode: str = "regular",
             no_upstream_cert: bool = False,
             rawtcp: bool = False,
@@ -131,6 +132,7 @@ class Options(optmanager.OptManager):
         self.ignore_hosts = ignore_hosts
         self.listen_host = listen_host
         self.listen_port = listen_port
+        self.upstream_bind_address = upstream_bind_address
         self.mode = mode
         self.no_upstream_cert = no_upstream_cert
         self.rawtcp = rawtcp

--- a/mitmproxy/proxy/protocol/base.py
+++ b/mitmproxy/proxy/protocol/base.py
@@ -114,7 +114,7 @@ class ServerConnectionMixin:
                 server_address, (self.ctx.client_conn.address.host, 0), True)
         else:
             self.server_conn = connections.ServerConnection(
-                server_address, (self.config.options.listen_host, 0))
+                server_address, (self.config.options.upstream_bind_address, 0))
 
         self.__check_self_connect()
 

--- a/mitmproxy/tools/cmdline.py
+++ b/mitmproxy/tools/cmdline.py
@@ -251,6 +251,7 @@ def get_common_options(args):
         ignore_hosts = args.ignore_hosts,
         listen_host = args.addr,
         listen_port = args.port,
+        upstream_bind_address = args.upstream_bind_address,
         mode = mode,
         no_upstream_cert = args.no_upstream_cert,
         spoof_source_address = args.spoof_source_address,
@@ -485,6 +486,11 @@ def proxy_options(parser):
         "--spoof-source-address",
         action="store_true", dest="spoof_source_address",
         help="Use the client's IP for server-side connections"
+    )
+    group.add_argument(
+        "--upstream-bind-address",
+        action="store", type=str, dest="upstream_bind_address", default='',
+        help="Address to bind upstream requests to (defaults to none)"
     )
 
 


### PR DESCRIPTION
This forward ports the changes in #1735 to master, and makes the upstream bind address its own option entirely.  I'm going to build on this to allow combining upstream bind address and spoof source address options to spoof a fixed source address for all clients in another PR.