### PR TITLE
addons.view: clarify modification events

### DIFF
--- a/mitmproxy/tools/console/flowlist.py
+++ b/mitmproxy/tools/console/flowlist.py
@@ -263,10 +263,10 @@ class FlowListWalker(urwid.ListWalker):
 
     def __init__(self, master):
         self.master = master
-        self.master.view.sig_refresh.connect(self.sig_mod)
-        self.master.view.sig_add.connect(self.sig_mod)
-        self.master.view.sig_remove.connect(self.sig_mod)
-        self.master.view.sig_update.connect(self.sig_mod)
+        self.master.view.sig_view_refresh.connect(self.sig_mod)
+        self.master.view.sig_view_add.connect(self.sig_mod)
+        self.master.view.sig_view_remove.connect(self.sig_mod)
+        self.master.view.sig_view_update.connect(self.sig_mod)
         self.master.view.focus.sig_change.connect(self.sig_mod)
         signals.flowlist_change.connect(self.sig_mod)
 

--- a/mitmproxy/tools/web/master.py
+++ b/mitmproxy/tools/web/master.py
@@ -90,10 +90,10 @@ class WebMaster(master.Master):
     def __init__(self, options, server):
         super().__init__(options, server)
         self.view = view.View()
-        self.view.sig_add.connect(self._sig_add)
-        self.view.sig_remove.connect(self._sig_remove)
-        self.view.sig_update.connect(self._sig_update)
-        self.view.sig_refresh.connect(self._sig_refresh)
+        self.view.sig_view_add.connect(self._sig_add)
+        self.view.sig_view_remove.connect(self._sig_remove)
+        self.view.sig_view_update.connect(self._sig_update)
+        self.view.sig_view_refresh.connect(self._sig_refresh)
 
         self.addons.add(*addons.default_addons())
         self.addons.add(self.view, intercept.Intercept())

--- a/test/mitmproxy/addons/test_view.py
+++ b/test/mitmproxy/addons/test_view.py
@@ -38,7 +38,7 @@ def test_order_refresh():
     def save(*args, **kwargs):
         sargs.extend([args, kwargs])
 
-    v.sig_refresh.connect(save)
+    v.sig_view_refresh.connect(save)
 
     tf = tflow.tflow(resp=True)
     with taddons.context(options=Options()) as tctx:
@@ -217,10 +217,10 @@ def test_signals():
         rec_remove.calls = []
         rec_refresh.calls = []
 
-    v.sig_add.connect(rec_add)
-    v.sig_update.connect(rec_update)
-    v.sig_remove.connect(rec_remove)
-    v.sig_refresh.connect(rec_refresh)
+    v.sig_view_add.connect(rec_add)
+    v.sig_view_update.connect(rec_update)
+    v.sig_view_remove.connect(rec_remove)
+    v.sig_view_refresh.connect(rec_refresh)
 
     assert not any([rec_add, rec_update, rec_remove, rec_refresh])
 
@@ -361,6 +361,12 @@ def test_settings():
     assert len(list(v.settings)) == 1
     v.remove(f)
     tutils.raises(KeyError, v.settings.__getitem__, f)
+    assert not v.settings.keys()
+
+    v.add(f)
+    v.settings[f]["foo"] = "bar"
+    assert v.settings.keys()
+    v.clear()
     assert not v.settings.keys()
 
 


### PR DESCRIPTION
This adds a set of store modification events, and uses them for flow settings.
This addresses a bug where settings could persist even after flows were deleted.