### PR TITLE
add macOS/OSX installation instructions to onboarding page

### DIFF
--- a/mitmproxy/addons/onboardingapp/templates/index.html
+++ b/mitmproxy/addons/onboardingapp/templates/index.html
@@ -24,6 +24,26 @@
 </div>
 
 <hr/>
+
+<div class="text-left">
+  <h3>Apple: How to install on macOS / OSX</h3>
+  <ul>
+    <li>Download PEM file (from above link)</li>
+    <li>Double-click the PEM file</li>
+    <li>The "Keychain Access" applications opens</li>
+    <li>Find the new certificate "mitmproxy" in the list</li>
+    <li>Double-click the "mitmproxy" entry</li>
+    <li>A dialog window openes up</li>
+    <li>Change "Secure Socket Layer (SSL)" to "Always Trust"</li>
+    <li>Close the dialog window (and enter your password if prompted)</li>
+    <li>Done!</li>
+  </ul>
+</div>
+
+
+
+<hr/>
+
 <div class="text-center">
     Other mitmproxy users cannot intercept your connection.
 </div>
@@ -32,4 +52,4 @@
     between mitmproxy installations.
 </div>
 
-{% end %}  
+{% end %}


### PR DESCRIPTION
Ideally somebody would contribute installation instructions for other systems as well.
Maybe even make it fancy by only showing the correct block after clicking the icon...