### PR TITLE
proxy/protocol/base: Allow spoofing fixed source

### DIFF
--- a/mitmproxy/proxy/protocol/base.py
+++ b/mitmproxy/proxy/protocol/base.py
@@ -109,12 +109,14 @@ class ServerConnectionMixin:
         super().__init__()
 
         self.server_conn = None
-        if self.config.options.spoof_source_address:
+        if self.config.options.spoof_source_address and self.config.options.upstream_bind_address == '':
             self.server_conn = connections.ServerConnection(
                 server_address, (self.ctx.client_conn.address.host, 0), True)
         else:
             self.server_conn = connections.ServerConnection(
-                server_address, (self.config.options.upstream_bind_address, 0))
+                server_address, (self.config.options.upstream_bind_address, 0),
+                self.config.options.spoof_source_address
+            )
 
         self.__check_self_connect()
 

--- a/mitmproxy/tools/cmdline.py
+++ b/mitmproxy/tools/cmdline.py
@@ -485,7 +485,8 @@ def proxy_options(parser):
     group.add_argument(
         "--spoof-source-address",
         action="store_true", dest="spoof_source_address",
-        help="Use the client's IP for server-side connections"
+        help="Use the client's IP for server-side connections. "
+             "Combine with --upstream-bind-address to spoof a fixed source address."
     )
     group.add_argument(
         "--upstream-bind-address",


### PR DESCRIPTION
Allow combining --spoof-source-address and --upstream-bind-address to
spoof a fixed source address.  Also update the help text for
--spoof-source-address to indicate this new possibility.