### PR TITLE
Remove dead run_scripthooks example reference.

### DIFF
--- a/examples/dup_and_replay.py
+++ b/examples/dup_and_replay.py
@@ -4,4 +4,4 @@ from mitmproxy import ctx
 def request(flow):
     f = ctx.master.state.duplicate_flow(flow)
     f.request.path = "/changed"
-    ctx.master.replay_request(f, block=True, run_scripthooks=False)
+    ctx.master.replay_request(f, block=True)


### PR DESCRIPTION
It seems that `run_scripthooks` is dead, so this should fix this example.