### PR TITLE
handle SIGINT with a quit prompt

### DIFF
--- a/mitmproxy/tools/console/master.py
+++ b/mitmproxy/tools/console/master.py
@@ -109,13 +109,13 @@ class ConsoleMaster(master.Master):
 
     def prompt_for_exit(self):
         signals.status_prompt_onekey.send(
-                self,
-                prompt = "Quit",
-                keys = (
-                    ("yes", "y"),
-                    ("no", "n"),
-                ),
-                callback = self.quit,
+            self,
+            prompt = "Quit",
+            keys = (
+                ("yes", "y"),
+                ("no", "n"),
+            ),
+            callback = self.quit,
         )
 
     def sig_add_log(self, sender, e, level):


### PR DESCRIPTION
Added a SIGINT handler to mitmproxy to catch CTRL-C key combinations and prompt the user to confirm that he indeed wants to quit. It will prevent accidentally closing down mitmproxy when using CTRL-C.

**Motivation**
 
For example, if you are viewing a flow and click on  `e` to edit it, but then actually reconsider and don't want to edit it after all, instinctively I would hit CTRL-C to cancel the current command. But this kills the whole process and I lose all the work I have done, which is quite frustrating.