### PR TITLE
Force not verify server certificate if client doesn't send SNI

### DIFF
--- a/mitmproxy/proxy/protocol/tls.py
+++ b/mitmproxy/proxy/protocol/tls.py
@@ -2,6 +2,8 @@ import struct
 from typing import Optional  # noqa
 from typing import Union
 
+from OpenSSL import SSL
+
 import construct
 from mitmproxy import exceptions
 from mitmproxy.contrib.tls import _constructs
@@ -522,12 +524,13 @@ class TlsLayer(base.Layer):
                         ciphers_server.append(CIPHER_ID_NAME_MAP[id])
                 ciphers_server = ':'.join(ciphers_server)
 
+            verify_options = self.config.openssl_verification_mode_server if self.server_sni else SSL.VERIFY_NONE
             self.server_conn.establish_ssl(
                 self.config.clientcerts,
                 self.server_sni,
                 method=self.config.openssl_method_server,
                 options=self.config.openssl_options_server,
-                verify_options=self.config.openssl_verification_mode_server,
+                verify_options=verify_options,
                 ca_path=self.config.options.ssl_verify_upstream_trusted_cadir,
                 ca_pemfile=self.config.options.ssl_verify_upstream_trusted_ca,
                 cipher_list=ciphers_server,


### PR DESCRIPTION
If _client_hello.sni is None, mitmproxy need get certificate subject from upstream server. But _establish_tls_with_server will be failed if server_sni (whose value gets from _client_hello.sni) is None and config.openssl_verification_mode_server is SSL.VERIFY_PEER.
That causes client who doesn't sent SNI can't connect to server through mitmproxy.