### PR TITLE
remove backport.ssl_match_hostname

### DIFF
--- a/mitmproxy/net/tcp.py
+++ b/mitmproxy/net/tcp.py
@@ -5,15 +5,15 @@ import sys
 import threading
 import time
 import traceback
-
 import binascii
+from ssl import match_hostname
+from ssl import CertificateError
 
 from typing import Optional  # noqa
 
 from mitmproxy.utils import strutils
 
 import certifi
-from backports import ssl_match_hostname
 import OpenSSL
 from OpenSSL import SSL
 
@@ -726,8 +726,8 @@ class TCPClient(_Connection):
                 hostname = sni
             else:
                 hostname = "no-hostname"
-            ssl_match_hostname.match_hostname(crt, hostname)
-        except (ValueError, ssl_match_hostname.CertificateError) as e:
+            match_hostname(crt, hostname)
+        except (ValueError, CertificateError) as e:
             self.ssl_verification_error = exceptions.InvalidCertificateException(
                 "Certificate Verification Error for {}: {}".format(
                     sni or repr(self.address),

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,6 @@ setup(
     # https://packaging.python.org/en/latest/requirements/#install-requires
     # It is not considered best practice to use install_requires to pin dependencies to specific versions.
     install_requires=[
-        "backports.ssl_match_hostname>=3.5.0.1, <3.6",
         "blinker>=1.4, <1.5",
         "click>=6.2, <7.0",
         "certifi>=2015.11.20.1",  # no semver here - this should always be on the last release!


### PR DESCRIPTION
This is already included in Python 3.5+