### PR TITLE
Fix #1877

### DIFF
--- a/mitmproxy/net/http/message.py
+++ b/mitmproxy/net/http/message.py
@@ -103,7 +103,11 @@ class Message(serializable.Serializable):
         ce = self.headers.get("content-encoding")
         if ce:
             try:
-                return encoding.decode(self.raw_content, ce)
+                content = encoding.decode(self.raw_content, ce)
+                # A client may illegally specify a byte -> str encoding here (e.g. utf8)
+                if isinstance(content, str):
+                    raise ValueError("Invalid Content-Encoding: {}".format(ce))
+                return content
             except ValueError:
                 if strict:
                     raise

--- a/test/mitmproxy/net/http/test_message.py
+++ b/test/mitmproxy/net/http/test_message.py
@@ -141,6 +141,15 @@ class TestMessageContentEncoding:
         assert r.headers["content-encoding"]
         assert r.get_content(strict=False) == b"foo"
 
+    def test_utf8_as_ce(self):
+        r = tutils.tresp()
+        r.headers["content-encoding"] = "utf8"
+        r.raw_content = b"foo"
+        with tutils.raises(ValueError):
+            assert r.content
+        assert r.headers["content-encoding"]
+        assert r.get_content(strict=False) == b"foo"
+
     def test_cannot_decode(self):
         r = tutils.tresp()
         r.encode("gzip")


### PR DESCRIPTION
Some clients illegally send UTF-8 as content-type, which would previously succeed, but return a str as `message.content`. We need to catch this and throw an exception.