### PR TITLE
run tests on Python 3.6

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -7,6 +7,9 @@ environment:
   matrix:
     - PYTHON: "C:\\Python35"
       TOXENV: "py35"
+    # TODO: ENABLE WHEN AVAILABLE
+    # - PYTHON: "C:\\Python36"
+    #   TOXENV: "py36"
 
   SNAPSHOT_HOST:
     secure: NeTo57s2rJhCd/mjKHetXVxCFd3uhr8txnjnAXD1tUI=

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,15 @@ matrix:
             # change this with future releases!
             - debian-sid
           packages:
+    - python: 3.6
+      env: TOXENV=py36 OPENSSL_ALPN
+      addons:
+        apt:
+          sources:
+            # Debian sid currently holds OpenSSL 1.1.0
+            # change this with future releases!
+            - debian-sid
+          packages:
             - libssl-dev
     - python: 3.5
       env: TOXENV=docs

--- a/dev.sh
+++ b/dev.sh
@@ -2,7 +2,7 @@
 set -e
 set -x
 
-PYVERSION=3.5
+PYVERSION=${1:-3.5}
 VENV="venv$PYVERSION"
 
 echo "Creating dev environment in $VENV using Python $PYVERSION"

--- a/mitmproxy/net/http/url.py
+++ b/mitmproxy/net/http/url.py
@@ -51,21 +51,23 @@ def parse(url):
     else:
         host = parsed.hostname.encode("idna")
         parsed = encode_parse_result(parsed, "ascii")
+    if not check.is_valid_host(host):
+        raise ValueError("Invalid Host")
 
-    port = parsed.port
+    try:
+        port = parsed.port
+    except:
+        raise ValueError("Invalid Port")
     if not port:
         port = 443 if parsed.scheme == b"https" else 80
+    if not check.is_valid_port(port):
+        raise ValueError("Invalid Port")
 
     full_path = urllib.parse.urlunparse(
         (b"", b"", parsed.path, parsed.params, parsed.query, parsed.fragment)
     )
     if not full_path.startswith(b"/"):
         full_path = b"/" + full_path
-
-    if not check.is_valid_host(host):
-        raise ValueError("Invalid Host")
-    if not check.is_valid_port(port):
-        raise ValueError("Invalid Port")
 
     return parsed.scheme, host, port, full_path
 

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setup(
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3 :: Only",
         "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
         "Topic :: Security",

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,9 @@
 [tox]
-envlist = py35, docs, lint
+envlist = py35, py36, docs, lint
 skipsdist = True
 toxworkdir={env:TOX_WORK_DIR:.tox}
 
 [testenv]
-basepython = python3.5
 deps =
   {env:CI_DEPS:}
   -rrequirements.txt


### PR DESCRIPTION
For the time being, I would recommend to keep 3.5 as default python distribution, and consider 3.6 a feature-upgrade, until it has matured enough, and most major Linux distros ship it.

- ~~Add Python 3.6 tests to AppVeyor~~
- [x] Add marker in setup.py
- [x] Fix 3.6 incompatibilities

fixes #1886