### PR TITLE
Fix compat with Python 3.5.0

### DIFF
--- a/mitmproxy/utils/typecheck.py
+++ b/mitmproxy/utils/typecheck.py
@@ -1,5 +1,4 @@
 import typing
-import sys
 
 
 def check_type(attr_name: str, value: typing.Any, typeinfo: type) -> None:
@@ -25,10 +24,11 @@ def check_type(attr_name: str, value: typing.Any, typeinfo: type) -> None:
     typename = str(typeinfo)
 
     if typename.startswith("typing.Union"):
-        if sys.version_info < (3, 6):
-            types = typeinfo.__union_params__
-        else:
+        try:
             types = typeinfo.__args__
+        except AttributeError:
+            # Python 3.5.x
+            types = typeinfo.__union_params__
 
         for T in types:
             try:
@@ -39,10 +39,11 @@ def check_type(attr_name: str, value: typing.Any, typeinfo: type) -> None:
                 return
         raise e
     elif typename.startswith("typing.Tuple"):
-        if sys.version_info < (3, 6):
-            types = typeinfo.__tuple_params__
-        else:
+        try:
             types = typeinfo.__args__
+        except AttributeError:
+            # Python 3.5.x
+            types = typeinfo.__tuple_params__
 
         if not isinstance(value, (tuple, list)):
             raise e
@@ -52,7 +53,11 @@ def check_type(attr_name: str, value: typing.Any, typeinfo: type) -> None:
             check_type("{}[{}]".format(attr_name, i), x, T)
         return
     elif typename.startswith("typing.Sequence"):
-        T = typeinfo.__args__[0]
+        try:
+            T = typeinfo.__args__[0]
+        except AttributeError:
+            # Python 3.5.0
+            T = typeinfo.__parameters__[0]
         if not isinstance(value, (tuple, list)):
             raise e
         for v in value:

--- a/mitmproxy/utils/typecheck.py
+++ b/mitmproxy/utils/typecheck.py
@@ -65,6 +65,8 @@ def check_type(attr_name: str, value: typing.Any, typeinfo: type) -> None:
     elif typename.startswith("typing.IO"):
         if hasattr(value, "read"):
             return
+        else:
+            raise e
     elif not isinstance(value, typeinfo):
         raise e
 

--- a/test/mitmproxy/utils/test_typecheck.py
+++ b/test/mitmproxy/utils/test_typecheck.py
@@ -1,7 +1,9 @@
+import io
 import typing
 
 import mock
 import pytest
+
 from mitmproxy.utils import typecheck
 
 
@@ -66,3 +68,9 @@ def test_check_sequence():
     m.__str__ = lambda self: "typing.Sequence"
     m.__parameters__ = (int,)
     typecheck.check_type("foo", [10], m)
+
+
+def test_check_io():
+    typecheck.check_type("foo", io.StringIO(), typing.IO[str])
+    with pytest.raises(TypeError):
+        typecheck.check_type("foo", "foo", typing.IO[str])

--- a/test/mitmproxy/utils/test_typecheck.py
+++ b/test/mitmproxy/utils/test_typecheck.py
@@ -1,5 +1,6 @@
 import typing
 
+import mock
 import pytest
 from mitmproxy.utils import typecheck
 
@@ -57,3 +58,11 @@ def test_check_sequence():
         typecheck.check_type("foo", [10, "foo"], typing.Sequence[int])
     with pytest.raises(TypeError):
         typecheck.check_type("foo", [b"foo"], typing.Sequence[str])
+    with pytest.raises(TypeError):
+        typecheck.check_type("foo", "foo", typing.Sequence[str])
+
+    # Python 3.5.0 only defines __parameters__
+    m = mock.Mock()
+    m.__str__ = lambda self: "typing.Sequence"
+    m.__parameters__ = (int,)
+    typecheck.check_type("foo", [10], m)


### PR DESCRIPTION
This should fix #1894. Checking `sys.version_info` is a bit flaky as (if I interpret the reports correctly) one can still install the typing module from pypi on older versions.