### PR TITLE
fix bug when parse multipart

### DIFF
--- a/mitmproxy/net/http/multipart.py
+++ b/mitmproxy/net/http/multipart.py
@@ -21,12 +21,12 @@ def decode(hdrs, content):
         r = []
 
         for i in content.split(b"--" + boundary):
-            parts = i.splitlines()
+            parts = i.split(b'\r\n\r\n', 2)
             if len(parts) > 1 and parts[0][0:2] != b"--":
-                match = rx.search(parts[1])
+                match = rx.search(parts[0])
                 if match:
                     key = match.group(1)
-                    value = b"".join(parts[3 + parts[2:].index(b""):])
+                    value = parts[1][0:len(parts[1] - 2)]
                     r.append((key, value))
         return r
     return []


### PR DESCRIPTION
When using mitmproxy, I found a bug which may occur when parsing multipart data. Here is my solutioin, as shown below, I changed 3 lines.

In the first line, which leads to the bug, the origin code use `splitlines` method. However, if the data contains data like `\n` or `\r\n`, it will also be discarded. Unfortunately, many protobuf message begins with `\n`.

According to the RFC file, there must be a `\r\n\r\n` between boundary and data body, so I use this to split the string. Then seconde parameter `2` makes sure that data body won't be splitted.

Since this will change the structure of `parts`, now we need to search first element of `parts` to get the key.

Since there is another `\r\n` at the end of `parts[1]`, I just ignore them.