### PR TITLE
Controls the length of URL displayed using the -d option

### DIFF
--- a/mitmproxy/addons/dumper.py
+++ b/mitmproxy/addons/dumper.py
@@ -125,7 +125,7 @@ class Dumper:
             url = flow.request.pretty_url
         else:
             url = flow.request.url
-        terminalWidthLimit = shutil.get_terminal_size()[0] - 25
+        terminalWidthLimit = max(shutil.get_terminal_size()[0] - 25 , 50)
         if self.flow_detail < 1 and len(url) > terminalWidthLimit:
             url = url[:terminalWidthLimit] + "…"
         url = click.style(strutils.escape_control_characters(url), bold=True)

--- a/mitmproxy/addons/dumper.py
+++ b/mitmproxy/addons/dumper.py
@@ -2,6 +2,7 @@ import itertools
 import sys
 
 import click
+import shutil
 
 import typing  # noqa
 
@@ -124,7 +125,7 @@ class Dumper:
             url = flow.request.pretty_url
         else:
             url = flow.request.url
-        terminalWidthLimit = click.get_terminal_size()[0] - 25
+        terminalWidthLimit = shutil.get_terminal_size()[0] - 25
         if self.flow_detail < 1 and len(url) > terminalWidthLimit:
             url = url[:terminalWidthLimit] + "…"
         url = click.style(strutils.escape_control_characters(url), bold=True)

--- a/mitmproxy/addons/dumper.py
+++ b/mitmproxy/addons/dumper.py
@@ -125,7 +125,7 @@ class Dumper:
             url = flow.request.pretty_url
         else:
             url = flow.request.url
-        terminalWidthLimit = max(shutil.get_terminal_size()[0] - 25 , 50)
+        terminalWidthLimit = max(shutil.get_terminal_size()[0] - 25, 50)
         if self.flow_detail < 1 and len(url) > terminalWidthLimit:
             url = url[:terminalWidthLimit] + "…"
         url = click.style(strutils.escape_control_characters(url), bold=True)

--- a/mitmproxy/addons/dumper.py
+++ b/mitmproxy/addons/dumper.py
@@ -124,6 +124,8 @@ class Dumper:
             url = flow.request.pretty_url
         else:
             url = flow.request.url
+        if self.flow_detail < 1 and len(url) > 200:
+            url = url[:199] + "…"
         url = click.style(strutils.escape_control_characters(url), bold=True)
 
         http_version = ""

--- a/mitmproxy/addons/dumper.py
+++ b/mitmproxy/addons/dumper.py
@@ -124,8 +124,8 @@ class Dumper:
             url = flow.request.pretty_url
         else:
             url = flow.request.url
-        if self.flow_detail < 1 and len(url) > 200:
-            url = url[:199] + "…"
+        if self.flow_detail < 1 and len(url) > click.get_terminal_size()[0] - 10:
+            url = url[:(click.get_terminal_size()[0] - 10)] + "…"
         url = click.style(strutils.escape_control_characters(url), bold=True)
 
         http_version = ""

--- a/mitmproxy/addons/dumper.py
+++ b/mitmproxy/addons/dumper.py
@@ -124,8 +124,9 @@ class Dumper:
             url = flow.request.pretty_url
         else:
             url = flow.request.url
-        if self.flow_detail < 1 and len(url) > click.get_terminal_size()[0] - 10:
-            url = url[:(click.get_terminal_size()[0] - 10)] + "…"
+        terminalWidthLimit = click.get_terminal_size()[0] - 25
+        if self.flow_detail < 1 and len(url) > terminalWidthLimit:
+            url = url[:terminalWidthLimit] + "…"
         url = click.style(strutils.escape_control_characters(url), bold=True)
 
         http_version = ""

--- a/test/mitmproxy/addons/test_dumper.py
+++ b/test/mitmproxy/addons/test_dumper.py
@@ -132,7 +132,7 @@ def test_echo_request_line():
 
         ctx.configure(d, flow_detail=0, showhost=True)
         f = tflow.tflow(client_conn=None, server_conn=True, resp=True)
-        terminalWidth = max(shutil.get_terminal_size()[0] - 25, 50)
+        terminalWidth = max(shutil.get_terminal_size()[0] - 25 , 50)
         f.request.url = "http://address:22/" + ("x" * terminalWidth) + "textToBeTruncated"
         d._echo_request_line(f)
         assert "textToBeTruncated" not in sio.getvalue()

--- a/test/mitmproxy/addons/test_dumper.py
+++ b/test/mitmproxy/addons/test_dumper.py
@@ -133,7 +133,7 @@ def test_echo_request_line():
         ctx.configure(d, flow_detail=0, showhost=True)
         f = tflow.tflow(client_conn=None, server_conn=True, resp=True)
         terminalWidth = shutil.get_terminal_size()[0]
-        f.request.pretty_url = "http://address:22/"+"x"*terminalWidth+"textToBeTruncated"
+        f.request.url = "http://address:22/"+"x"*terminalWidth+"textToBeTruncated"
         d._echo_request_line(f)
         assert "textToBeTruncated" not in sio.getvalue()
         sio.truncate(0)

--- a/test/mitmproxy/addons/test_dumper.py
+++ b/test/mitmproxy/addons/test_dumper.py
@@ -7,6 +7,7 @@ from mitmproxy.addons import dumper
 from mitmproxy import exceptions
 from mitmproxy.tools import dump
 from mitmproxy import http
+import shutil
 import mock
 
 

--- a/test/mitmproxy/addons/test_dumper.py
+++ b/test/mitmproxy/addons/test_dumper.py
@@ -133,7 +133,7 @@ def test_echo_request_line():
         ctx.configure(d, flow_detail=0, showhost=True)
         f = tflow.tflow(client_conn=None, server_conn=True, resp=True)
         terminalWidth = shutil.get_terminal_size()[0]
-        f.request.url = "http://address:22/"+"x"*terminalWidth+"textToBeTruncated"
+        f.request.url = "http://address:22/" + ("x" * terminalWidth) + "textToBeTruncated"
         d._echo_request_line(f)
         assert "textToBeTruncated" not in sio.getvalue()
         sio.truncate(0)

--- a/test/mitmproxy/addons/test_dumper.py
+++ b/test/mitmproxy/addons/test_dumper.py
@@ -82,7 +82,7 @@ def test_simple():
         d.response(flow)
         assert sio.getvalue()
         sio.truncate(0)
-        
+
         ctx.configure(d, flow_detail=4)
         flow = tflow.tflow()
         flow.request.content = None
@@ -129,7 +129,7 @@ def test_echo_request_line():
         d._echo_request_line(f)
         assert "nonstandard" in sio.getvalue()
         sio.truncate(0)
-        
+
         ctx.configure(d, flow_detail=0, showhost=True)
         f = tflow.tflow(client_conn=None, server_conn=True, resp=True)
         terminalWidth = shutil.get_terminal_size()[0]

--- a/test/mitmproxy/addons/test_dumper.py
+++ b/test/mitmproxy/addons/test_dumper.py
@@ -132,7 +132,7 @@ def test_echo_request_line():
 
         ctx.configure(d, flow_detail=0, showhost=True)
         f = tflow.tflow(client_conn=None, server_conn=True, resp=True)
-        terminalWidth = max(shutil.get_terminal_size()[0] - 25 , 50)
+        terminalWidth = max(shutil.get_terminal_size()[0] - 25, 50)
         f.request.url = "http://address:22/" + ("x" * terminalWidth) + "textToBeTruncated"
         d._echo_request_line(f)
         assert "textToBeTruncated" not in sio.getvalue()

--- a/test/mitmproxy/addons/test_dumper.py
+++ b/test/mitmproxy/addons/test_dumper.py
@@ -82,7 +82,7 @@ def test_simple():
         d.response(flow)
         assert sio.getvalue()
         sio.truncate(0)
-
+        
         ctx.configure(d, flow_detail=4)
         flow = tflow.tflow()
         flow.request.content = None

--- a/test/mitmproxy/addons/test_dumper.py
+++ b/test/mitmproxy/addons/test_dumper.py
@@ -132,7 +132,7 @@ def test_echo_request_line():
 
         ctx.configure(d, flow_detail=0, showhost=True)
         f = tflow.tflow(client_conn=None, server_conn=True, resp=True)
-        terminalWidth = shutil.get_terminal_size()[0]
+        terminalWidth = max(shutil.get_terminal_size()[0] - 25, 50)
         f.request.url = "http://address:22/" + ("x" * terminalWidth) + "textToBeTruncated"
         d._echo_request_line(f)
         assert "textToBeTruncated" not in sio.getvalue()

--- a/test/mitmproxy/addons/test_dumper.py
+++ b/test/mitmproxy/addons/test_dumper.py
@@ -128,6 +128,14 @@ def test_echo_request_line():
         d._echo_request_line(f)
         assert "nonstandard" in sio.getvalue()
         sio.truncate(0)
+        
+        ctx.configure(d, flow_detail=0, showhost=True)
+        f = tflow.tflow(client_conn=None, server_conn=True, resp=True)
+        terminalWidth = shutil.get_terminal_size()[0]
+        f.request.pretty_url = "http://address:22/"+"x"*terminalWidth+"textToBeTruncated"
+        d._echo_request_line(f)
+        assert "textToBeTruncated" not in sio.getvalue()
+        sio.truncate(0)
 
 
 class TestContentView:


### PR DESCRIPTION
Done with reference to #1623. Controls the length of URL displayed using the `-d` or `flow_detail` option. The full length URL is displayed if `flow_detail > 0`, else it is shortened.
Also uses the terminal width obtained from `click.get_terminal_size()` to determine the cutoff length.