### PR TITLE
Encode urlencoded_form items when editing

### DIFF
--- a/mitmproxy/tools/console/grideditor/editors.py
+++ b/mitmproxy/tools/console/grideditor/editors.py
@@ -65,8 +65,8 @@ class HeaderEditor(base.GridEditor):
 class URLEncodedFormEditor(base.GridEditor):
     title = "Editing URL-encoded form"
     columns = [
-        col_bytes.Column("Key"),
-        col_bytes.Column("Value")
+        col_text.Column("Key"),
+        col_text.Column("Value")
     ]
 
 


### PR DESCRIPTION
Resolved #1901 

Encode the url encoded form before display it.
If there is any problem, please kindly let me know, thanks!