### PR TITLE
Allow underscore in hostname

### DIFF
--- a/mitmproxy/net/check.py
+++ b/mitmproxy/net/check.py
@@ -1,6 +1,7 @@
 import re
 
-_label_valid = re.compile(b"(?!-)[A-Z\d-]{1,63}(?<!-)$", re.IGNORECASE)
+# Allow underscore in host name
+_label_valid = re.compile(b"(?!-)[A-Z\d\-_]{1,63}(?<!-)$", re.IGNORECASE)
 
 
 def is_valid_host(host: bytes) -> bool:

--- a/test/mitmproxy/net/test_check.py
+++ b/test/mitmproxy/net/test_check.py
@@ -8,3 +8,5 @@ def test_is_valid_host():
     assert check.is_valid_host(b"one.two")
     assert not check.is_valid_host(b"one" * 255)
     assert check.is_valid_host(b"one.two.")
+    # Allow underscore
+    assert check.is_valid_host(b"one_two")


### PR DESCRIPTION
Resolved #1529 

Update the regular expression to allow underscore in hostname.
The user-visible traceback mentioned at the issue seems to be fixed.

Though underscore is not recommended be part of hostname,
not sure that to display some warning message about it will help or make it better?