### PR TITLE
Added note about server-side replay for sessions recorded in reverse-proxy mode

### DIFF
--- a/docs/features/serverreplay.rst
+++ b/docs/features/serverreplay.rst
@@ -33,6 +33,19 @@ updated in a similar way.
 You can turn off response refreshing using the ``--norefresh`` argument, or using
 the :kbd:`o` options shortcut within :program:`mitmproxy`.
 
+
+Replaying a session recorded in Reverse-proxy Mode
+--------------------------------------------------
+
+If you have captured the session in reverse proxy mode, in order to replay it you 
+still have to specify the server URL, otherwise you may get the error: 
+'HTTP protocol error in client request: Invalid HTTP request form (expected authority or absolute...)'.
+
+During replay, when the client's requests match previously recorded requests, then the
+respective recorded responses are simply replayed  by mitmproxy. 
+Otherwise, the unmatched requests is forwarded to the upstream server.
+If forwarding is not desired, you can use the --kill (-k) switch to prevent that.
+
 ================== ===========
 command-line       ``-S path``
 mitmproxy shortcut :kbd:`R` then :kbd:`s`


### PR DESCRIPTION
I have added some notes to serverreplay.rst as discussed in the forum topic https://discourse.mitmproxy.org/t/how-to-replay-requests-that-were-recorded-in-reverse-proxy-mode/292/2. Please revise and feel free to correct any style or imprecision in the explanation.