### PR TITLE
mitmdump: fix reading from stdin

### DIFF
--- a/mitmproxy/master.py
+++ b/mitmproxy/master.py
@@ -170,8 +170,11 @@ class Master:
         path = os.path.expanduser(path)
         try:
             if path == "-":
-                # This is incompatible with Python 3 - maybe we can use click?
-                freader = io.FlowReader(sys.stdin)
+                try:
+                    sys.stdin.buffer.read(0)
+                except Exception as e:
+                    raise IOError("Cannot read from stdin: {}".format(e))
+                freader = io.FlowReader(sys.stdin.buffer)
                 return self.load_flows(freader)
             else:
                 with open(path, "rb") as f:


### PR DESCRIPTION
See https://docs.python.org/3/library/sys.html#sys.stdin:

> To write or read binary data from/to the standard streams, use the underlying binary buffer object. For example, to write bytes to stdout, use sys.stdout.buffer.write(b'abc').
However, if you are writing a library (and do not control in which context its code will be executed), be aware that the standard streams may be replaced with file-like objects like io.StringIO which do not support the buffer attribute.