### PR TITLE
console: display http version in details

### DIFF
--- a/mitmproxy/tools/console/flowdetailview.py
+++ b/mitmproxy/tools/console/flowdetailview.py
@@ -1,5 +1,6 @@
 import urwid
 
+from mitmproxy import http
 from mitmproxy.tools.console import common, searchable
 from mitmproxy.utils import human
 from mitmproxy.utils import strutils
@@ -12,7 +13,7 @@ def maybe_timestamp(base, attr):
         return "active"
 
 
-def flowdetails(state, flow):
+def flowdetails(state, flow: http.HTTPFlow):
     text = []
 
     sc = flow.server_conn
@@ -21,7 +22,7 @@ def flowdetails(state, flow):
     resp = flow.response
     metadata = flow.metadata
 
-    if metadata is not None and len(metadata.items()) > 0:
+    if metadata is not None and len(metadata) > 0:
         parts = [[str(k), repr(v)] for k, v in metadata.items()]
         text.append(urwid.Text([("head", "Metadata:")]))
         text.extend(common.format_keyvals(parts, key="key", val="text", indent=4))
@@ -32,6 +33,8 @@ def flowdetails(state, flow):
             ["Address", repr(sc.address)],
             ["Resolved Address", repr(sc.ip_address)],
         ]
+        if resp:
+            parts.append(["HTTP Version", resp.http_version])
         if sc.alpn_proto_negotiated:
             parts.append(["ALPN", sc.alpn_proto_negotiated])
 
@@ -91,6 +94,8 @@ def flowdetails(state, flow):
         parts = [
             ["Address", repr(cc.address)],
         ]
+        if req:
+            parts.append(["HTTP Version", req.http_version])
         if cc.tls_version:
             parts.append(["TLS Version", cc.tls_version])
         if cc.sni:


### PR DESCRIPTION
We currently don't display the request/response HTTP version in `raw_format_flow` (this is used in the flow list and the flow view header) unless it's HTTP/2.0. We should expose what has been sent by client and server somewhere. This would naturally go in the request or response view, but there's no really good place for that, unless we want to extend `raw_format_flow` to be more verbose in the flow view. This adds it to the Detail view instead... @mitmproxy/devs, what do you think?