### PR TITLE
Add except clause to catch script parsing errors

### DIFF
--- a/mitmproxy/addons/script.py
+++ b/mitmproxy/addons/script.py
@@ -252,7 +252,7 @@ class ScriptLoader:
                     try:
                         sc = Script(s)
                     except ValueError as e:
-                        raise ValueError(str(e))
+                        raise exceptions.OptionsError(str(e))
                     ordered.append(sc)
                     newscripts.append(sc)
 

--- a/mitmproxy/addons/script.py
+++ b/mitmproxy/addons/script.py
@@ -208,7 +208,7 @@ class ScriptLoader:
         try:
             sc = Script(command)
         except ValueError as e:
-            raise exceptions.OptionsError(str(e))
+            raise ValueError(str(e))
         sc.load_script()
         for f in flows:
             for evt, o in events.event_sequence(f):
@@ -252,7 +252,7 @@ class ScriptLoader:
                     try:
                         sc = Script(s)
                     except ValueError as e:
-                        raise exceptions.OptionsError(str(e))
+                        raise ValueError(str(e))
                     ordered.append(sc)
                     newscripts.append(sc)
 

--- a/mitmproxy/addons/script.py
+++ b/mitmproxy/addons/script.py
@@ -205,7 +205,11 @@ class ScriptLoader:
         An addon that manages loading scripts from options.
     """
     def run_once(self, command, flows):
-        sc = Script(command)
+        try:
+            sc = Script(command)
+        except exceptions.OptionsError as e:
+            ctx.log.error("Script error: %s" % e)
+            return None
         sc.load_script()
         for f in flows:
             for evt, o in events.event_sequence(f):

--- a/mitmproxy/addons/script.py
+++ b/mitmproxy/addons/script.py
@@ -20,7 +20,7 @@ def parse_command(command):
         Returns a (path, args) tuple.
     """
     if not command or not command.strip():
-        raise exceptions.OptionsError("Empty script command.")
+        raise ValueError("Empty script command.")
     # Windows: escape all backslashes in the path.
     if os.name == "nt":  # pragma: no cover
         backslashes = shlex.split(command, posix=False)[0].count("\\")
@@ -28,13 +28,13 @@ def parse_command(command):
     args = shlex.split(command)  # pragma: no cover
     args[0] = os.path.expanduser(args[0])
     if not os.path.exists(args[0]):
-        raise exceptions.OptionsError(
+        raise ValueError(
             ("Script file not found: %s.\r\n"
              "If your script path contains spaces, "
              "make sure to wrap it in additional quotes, e.g. -s \"'./foo bar/baz.py' --args\".") %
             args[0])
     elif os.path.isdir(args[0]):
-        raise exceptions.OptionsError("Not a file: %s" % args[0])
+        raise ValueError("Not a file: %s" % args[0])
     return args[0], args[1:]
 
 
@@ -207,9 +207,8 @@ class ScriptLoader:
     def run_once(self, command, flows):
         try:
             sc = Script(command)
-        except exceptions.OptionsError as e:
-            ctx.log.error("Script error: %s" % e)
-            return None
+        except ValueError as e:
+            raise exceptions.OptionsError(str(e))
         sc.load_script()
         for f in flows:
             for evt, o in events.event_sequence(f):
@@ -250,7 +249,10 @@ class ScriptLoader:
                     ordered.append(current[s])
                 else:
                     ctx.log.info("Loading script: %s" % s)
-                    sc = Script(s)
+                    try:
+                        sc = Script(s)
+                    except ValueError as e:
+                        raise exceptions.OptionsError(str(e))
                     ordered.append(sc)
                     newscripts.append(sc)
 

--- a/mitmproxy/tools/console/master.py
+++ b/mitmproxy/tools/console/master.py
@@ -148,8 +148,8 @@ class ConsoleMaster(master.Master):
         try:
             with self.handlecontext():
                 sc.run_once(command, [f])
-        except mitmproxy.exceptions.AddonError as e:
-            signals.add_log("Script error: %s" % e, "warn")
+        except mitmproxy.exceptions.OptionsError as e:
+            signals.add_log("Input error: %s" % e, "warn")
 
     def toggle_eventlog(self):
         self.options.eventlog = not self.options.eventlog

--- a/mitmproxy/tools/console/master.py
+++ b/mitmproxy/tools/console/master.py
@@ -148,7 +148,7 @@ class ConsoleMaster(master.Master):
         try:
             with self.handlecontext():
                 sc.run_once(command, [f])
-        except mitmproxy.exceptions.OptionsError as e:
+        except ValueError as e:
             signals.add_log("Input error: %s" % e, "warn")
 
     def toggle_eventlog(self):

--- a/test/mitmproxy/addons/test_script.py
+++ b/test/mitmproxy/addons/test_script.py
@@ -202,13 +202,14 @@ class TestScriptLoader:
         evts = [i[1] for i in sc.ns.call_log]
         assert evts == ['start', 'requestheaders', 'request', 'responseheaders', 'response', 'done']
 
-        with taddons.context() as tctx:
-            f = tflow.tflow(resp=True)
-            with m.handlecontext():
-                sc = sl.run_once(
-                    "nonexistent", [f]
-                )
-            assert "Script error" in tctx.master.event_log[0][1]
+        f = tflow.tflow(resp=True)
+        with m.handlecontext():
+            tutils.raises(
+                "file not found",
+                sl.run_once,
+                "nonexistent",
+                [f]
+            )
 
     def test_simple(self):
         o = options.Options(scripts=[])

--- a/test/mitmproxy/addons/test_script.py
+++ b/test/mitmproxy/addons/test_script.py
@@ -205,9 +205,7 @@ class TestScriptLoader:
         f = tflow.tflow(resp=True)
         with m.handlecontext():
             sc = sl.run_once(
-                tutils.test_data.path(
-                    "nonexistent"
-                ), [f]
+                "nonexistent", [f]
             )
         assert "Script error" in tctx.master.event_log[0][1]
 

--- a/test/mitmproxy/addons/test_script.py
+++ b/test/mitmproxy/addons/test_script.py
@@ -57,10 +57,10 @@ def test_reloadhandler():
 
 class TestParseCommand:
     def test_empty_command(self):
-        with tutils.raises(exceptions.OptionsError):
+        with tutils.raises(ValueError):
             script.parse_command("")
 
-        with tutils.raises(exceptions.OptionsError):
+        with tutils.raises(ValueError):
             script.parse_command("  ")
 
     def test_no_script_file(self):

--- a/test/mitmproxy/addons/test_script.py
+++ b/test/mitmproxy/addons/test_script.py
@@ -202,13 +202,14 @@ class TestScriptLoader:
         evts = [i[1] for i in sc.ns.call_log]
         assert evts == ['start', 'requestheaders', 'request', 'responseheaders', 'response', 'done']
 
+        f = tflow.tflow(resp=True)
         with m.handlecontext():
-            tutils.raises(
-                "file not found",
-                sl.run_once,
-                "nonexistent",
-                [f]
+            sc = sl.run_once(
+                tutils.test_data.path(
+                    "nonexistent"
+                ), [f]
             )
+        assert "Script error" in tctx.master.event_log[0][1]
 
     def test_simple(self):
         o = options.Options(scripts=[])

--- a/test/mitmproxy/addons/test_script.py
+++ b/test/mitmproxy/addons/test_script.py
@@ -202,12 +202,13 @@ class TestScriptLoader:
         evts = [i[1] for i in sc.ns.call_log]
         assert evts == ['start', 'requestheaders', 'request', 'responseheaders', 'response', 'done']
 
-        f = tflow.tflow(resp=True)
-        with m.handlecontext():
-            sc = sl.run_once(
-                "nonexistent", [f]
-            )
-        assert "Script error" in tctx.master.event_log[0][1]
+        with taddons.context() as tctx:
+            f = tflow.tflow(resp=True)
+            with m.handlecontext():
+                sc = sl.run_once(
+                    "nonexistent", [f]
+                )
+            assert "Script error" in tctx.master.event_log[0][1]
 
     def test_simple(self):
         o = options.Options(scripts=[])

--- a/test/mitmproxy/console/test_master.py
+++ b/test/mitmproxy/console/test_master.py
@@ -5,7 +5,7 @@ from mitmproxy import proxy
 from mitmproxy import options
 from mitmproxy.tools.console import common
 from .. import mastertest
-import mock
+from unittest import mock
 
 class ScriptError(Exception):
     pass

--- a/test/mitmproxy/console/test_master.py
+++ b/test/mitmproxy/console/test_master.py
@@ -7,12 +7,15 @@ from mitmproxy.tools.console import common
 from .. import mastertest
 from unittest import mock
 
+
 class ScriptError(Exception):
     pass
 
+
 def mock_add_log(e, level):
-    if level in ("warn", "error"):
+    if "Input error" in e:
         raise ScriptError(e)
+
 
 def test_format_keyvals():
     assert common.format_keyvals(
@@ -44,10 +47,10 @@ class TestMaster(mastertest.MasterTest):
             assert len(m.view) == i
 
     @mock.patch('mitmproxy.tools.console.signals.add_log', side_effect=mock_add_log)
-    def test_run_script_once(self,func):
+    def test_run_script_once(self, test_func):
         m = self.mkmaster()
         f = tflow.tflow(resp=True)
-        with mitmproxy.test.tutils.raises(ScriptError) as e:
+        with mitmproxy.test.tutils.raises(ScriptError):
             m.run_script_once("nonexistent", [f])
 
     def test_intercept(self):


### PR DESCRIPTION
Done in reference to #1909 Add an except clause in `run_once` function when calling the `Script` class constructor. Returning an empty `Script` object seems more of a hassle than returning `None`, given that the returned object is never used.