### PR TITLE
Added servercachereplay addon

### DIFF
--- a/mitmproxy/addons/__init__.py
+++ b/mitmproxy/addons/__init__.py
@@ -8,6 +8,7 @@ from mitmproxy.addons import replace
 from mitmproxy.addons import script
 from mitmproxy.addons import setheaders
 from mitmproxy.addons import serverplayback
+from mitmproxy.addons import servercacheplayback
 from mitmproxy.addons import stickyauth
 from mitmproxy.addons import stickycookie
 from mitmproxy.addons import streambodies
@@ -29,6 +30,7 @@ def default_addons():
         replace.Replace(),
         setheaders.SetHeaders(),
         serverplayback.ServerPlayback(),
+        servercacheplayback.ServerCachePlayBack(),
         clientplayback.ClientPlayback(),
         upstream_auth.UpstreamAuth(),
         disable_h2c_upgrade.DisableH2CleartextUpgrade(),

--- a/mitmproxy/addons/servercacheplayback.py
+++ b/mitmproxy/addons/servercacheplayback.py
@@ -1,0 +1,59 @@
+from mitmproxy import exceptions
+from mitmproxy import io
+
+from mitmproxy.addons import serverplayback
+
+
+class ServerCachePlayBack(serverplayback.ServerPlayback):
+    def __init__(self):
+        super().__init__()
+        self._enabled = False
+
+    def load(self, flows):
+        for i in flows:
+            if i.response:
+                self.flowmap[self._hash(i)] = i
+
+    def enable(self, flows=None):
+        self._enabled = True
+        if flows:
+            self.load(flows)
+
+    def disable(self):
+        self._enabled = False
+        self.clear()
+
+    @property
+    def enabled(self):
+        return self._enabled
+
+    def configure(self, options, updated):
+        self.options = options
+        if "server_cache_replay" in updated:
+            if options.server_cache_replay:
+                flows = []
+                if options.server_cache_replay_load:
+                    try:
+                        flows = io.read_flows_from_paths(options.server_cache_replay_load)
+                    except exceptions.FlowReadException as e:
+                        raise exceptions.OptionsError(str(e))
+                self.enable(flows=flows)
+            else:
+                self.disable()
+
+    def request(self, f):
+        if not self._enabled:
+            return
+
+        flow_hash = self._hash(f)
+        # First check if the flow exists in our known flow_hash, if it doesn't, let's add it
+        # and proceed without replaying it.
+        known_flow = self.flowmap.get(flow_hash)
+        if not known_flow:
+            self.flowmap[flow_hash] = f
+            return
+
+        # Otherwise, let's turn the current flow response into our known response
+        response = known_flow.response.copy()
+        response.is_replay = True
+        f.response = response

--- a/mitmproxy/options.py
+++ b/mitmproxy/options.py
@@ -43,6 +43,8 @@ class Options(optmanager.OptManager):
             server_replay_use_headers: Sequence[str] = [],
             setheaders: Sequence[Tuple[str, str, str]] = [],
             server_replay: Sequence[str] = [],
+            server_cache_replay: bool = False,
+            server_cache_replay_load: Sequence[str] = [],
             stickycookie: Optional[str] = None,
             stickyauth: Optional[str] = None,
             stream_large_bodies: Optional[int] = None,
@@ -127,6 +129,8 @@ class Options(optmanager.OptManager):
         self.server_replay_use_headers = server_replay_use_headers
         self.setheaders = setheaders
         self.server_replay = server_replay
+        self.server_cache_replay = server_cache_replay
+        self.server_cache_replay_load = server_cache_replay_load
         self.stickycookie = stickycookie
         self.stickyauth = stickyauth
         self.stream_large_bodies = stream_large_bodies

--- a/mitmproxy/tools/cmdline.py
+++ b/mitmproxy/tools/cmdline.py
@@ -227,6 +227,8 @@ def get_common_options(args):
         replacements=reps,
         setheaders=setheaders,
         server_replay=args.server_replay,
+        server_cache_replay=args.server_cache_replay,
+        server_cache_replay_load=args.server_cache_replay_load,
         scripts=args.scripts,
         stickycookie=stickycookie,
         stickyauth=stickyauth,
@@ -607,10 +609,21 @@ def client_replay(parser):
 
 def server_replay(parser):
     group = parser.add_argument_group("Server Replay")
-    group.add_argument(
+    replay_or_cache = group.add_mutually_exclusive_group()
+    replay_or_cache.add_argument(
         "-S", "--server-replay",
         action="append", dest="server_replay", metavar="PATH",
         help="Replay server responses from a saved file."
+    )
+    replay_or_cache.add_argument(
+        "-C", "--server-cache-replay",
+        action="store_true", dest="server_cache_replay",
+        help="Replay known server responses."
+    )
+    group.add_argument(
+        "--server-cache-replay-load",
+        action="append", dest="server_cache_replay_load", metavar="PATH",
+        help="Load server responses from a saved file for server cache replay functionality."
     )
     group.add_argument(
         "-k", "--replay-kill-extra",

--- a/mitmproxy/utils/flows.py
+++ b/mitmproxy/utils/flows.py
@@ -1,0 +1,83 @@
+"""
+This utility module provides additional utility methods that are directly
+related to an HTTPFlow object.
+"""
+import hashlib
+import typing
+import urllib.parse
+
+import mitmproxy.http
+
+
+def hash_flow(flow: mitmproxy.http.HTTPFlow,
+              include_headers_list: typing.Optional[list]=None,
+              ignore_host: bool=False,
+              ignore_content: bool=False,
+              ignore_payload_params_list: typing.Optional[list]=None,
+              ignore_query_params_list: typing.Optional[list]=None) -> str:
+    """
+    Calculates a loose hash of the flow request.
+
+    The hash is based on the the port, scheme, method, host, path, parameters, and headers.
+    Note that it is possible to filter certain parameters to be included in the hash with the
+    `ignore_payload_params_list` and `ignore_query_params_list`.  The `include_headers_list` is a
+    whitelist of headers.
+
+    Args:
+        flow: The flow object to generate a hash from
+        include_headers_list: List of headers we want to include in the hash.
+        ignore_host: Ignore the host when calculating the hash.
+        ignore_content: Ignore the entirety of the payload content.
+            Note: When this parameter is set to true, the `ignore_payload_params` and
+            `ignore_query_params_list` parameters are ignored since they are mutually exclusive.
+        ignore_payload_params_list: List of payload params that we want to ignore.
+        ignore_query_params_list: List of query params that we want to ignore.
+
+    Returns:
+        Returns a hash string of the flow.
+    """
+    r = flow.request
+    url_parsed = urllib.parse.urlparse(r.url)
+    queries_array = urllib.parse.parse_qsl(url_parsed.query, keep_blank_values=True)
+
+    key = [
+        str(i)
+        for i in {r.port, r.scheme, r.method, url_parsed.path}
+    ]  # type: typing.List[typing.Any]
+    if not ignore_host:
+        key.append(r.host)
+
+    # Is there payload any params we want to ignore?
+    if not ignore_content:
+        if ignore_payload_params_list and r.multipart_form:
+            key.extend(
+                (k, v)
+                for k, v in r.multipart_form.items(multi=True)
+                if k.decode(errors="replace") not in ignore_payload_params_list
+            )
+        elif ignore_payload_params_list and r.urlencoded_form:
+            key.extend(
+                (k, v)
+                for k, v in r.urlencoded_form.items(multi=True)
+                if k not in ignore_payload_params_list
+            )
+        # We don't care about the specifics of which content to include, include everything
+        else:
+            key.append(str(r.raw_content))
+
+    # Is there any query params we want to ignore?
+    for k, v in queries_array:
+        if k not in ignore_query_params_list:
+            key.append((k, v))
+
+    # By default, we ignore headers, these params specify which headers to include
+    if include_headers_list:
+        headers = []
+        for header_name in include_headers_list:
+            header_value = r.headers.get(header_name)
+            headers.append((header_name, header_value))
+        key.append(headers)
+
+    # Note: this was exactly how the key list was hashed before, not entirely sure as to why
+    # exactly it was done this way, that is, the repr typecasting and encoding.
+    return hashlib.sha256(repr(key).encode("utf8", "surrogateescape")).digest()

--- a/test/mitmproxy/addons/test_servercacheplayback.py
+++ b/test/mitmproxy/addons/test_servercacheplayback.py
@@ -1,0 +1,83 @@
+import os
+from mitmproxy.test import tutils
+from mitmproxy.test import tflow
+from mitmproxy.test import taddons
+
+from mitmproxy.addons import servercacheplayback
+from mitmproxy import options
+from mitmproxy import exceptions
+from mitmproxy import io
+
+
+def tdump(path, flows):
+    w = io.FlowWriter(open(path, "wb"))
+    for i in flows:
+        w.add(i)
+
+
+def test_config():
+    s = servercacheplayback.ServerCachePlayBack()
+    with tutils.tmpdir() as p:
+        with taddons.context() as tctx:
+            fpath = os.path.join(p, "flows")
+            flow = tflow.tflow(resp=True)
+
+            assert not flow.response.is_replay
+
+            tdump(fpath, [tflow.tflow(resp=True)])
+            tctx.configure(s, server_cache_replay=True, server_cache_replay_load=[fpath])
+
+            # Make sure the response is now a replay
+            s.request(flow)
+
+            assert flow.response.is_replay
+
+
+def test_config_invalid_file():
+    s = servercacheplayback.ServerCachePlayBack()
+    with tutils.tmpdir() as p:
+        with taddons.context() as tctx:
+            fpath = os.path.join(p, "flows")
+            tdump(fpath, [tflow.tflow(resp=True)])
+            tutils.raises(exceptions.OptionsError, tctx.configure, s,
+                          server_cache_replay=True,
+                          server_cache_replay_load=[p])
+
+
+def test_tick():
+    s = servercacheplayback.ServerCachePlayBack()
+    with taddons.context() as tctx:
+        s.stop = True
+        s.final_flow = tflow.tflow()
+        s.final_flow.live = False
+        s.tick()
+        assert tctx.master.should_exit.is_set()
+
+
+def test_server_cache_playback():
+    scp = servercacheplayback.ServerCachePlayBack()
+    scp.configure(options.Options(), [])
+    f = tflow.tflow(resp=True)
+
+    assert not scp.enabled
+    assert not scp.flowmap
+
+    scp.enable(flows=[f])
+
+    assert scp.enabled
+    assert scp.flowmap
+
+    scp.request(f)
+    assert f.response.is_replay
+
+
+def test_server_cache_playback_disabled_no_response():
+    scp = servercacheplayback.ServerCachePlayBack()
+    scp.configure(options.Options(), [])
+    f = tflow.tflow(resp=True)
+
+    assert not scp.enabled
+    assert not scp.flowmap
+
+    scp.request(f)
+    assert not f.response.is_replay


### PR DESCRIPTION
This addon will automatically replay known server responses
without having to save/load flows.  It uses the same
whitelisting/blacklisting options of serverplayback addon,
i.e, filtering out payload params, including headers, etc...

This addon can be used either through the URWID GUI or
through CLI arguments.  The argument to enable
the addon is "--server-cache-replay" and the argument
to load saved files is "--server-cache-replay-load".
Note that --server-cache-replay and --server-replay are
mutually exclusive options.

For the GUI, an additional menu is presented when the
user presses the "S" key where he/she will decide
whether they want to use the server replay addon or the
new servercachereplay addon.