### PR TITLE
Fix SNI invert ignore

### DIFF
--- a/mitmproxy/proxy/root_context.py
+++ b/mitmproxy/proxy/root_context.py
@@ -50,7 +50,7 @@ class RootContext:
         # 1. check for --ignore
         if self.config.check_ignore:
             ignore = self.config.check_ignore(top_layer.server_conn.address)
-            if not ignore and client_tls:
+            if client_tls:
                 try:
                     client_hello = protocol.TlsClientHello.from_client_conn(self.client_conn)
                 except exceptions.TlsProtocolException as e:


### PR DESCRIPTION
When using an invert ignore expression on a hostname (e.g.
'?!(example\.com)'), all TLS connections will be ignored as the SNI
hostname is not yet parsed. With this fix, we will always try to match
against the SNI hostname.