### PR TITLE
Fix for dns_spoofing.py example

### DIFF
--- a/examples/complex/dns_spoofing.py
+++ b/examples/complex/dns_spoofing.py
@@ -27,7 +27,7 @@ import re
 # https://bugzilla.mozilla.org/show_bug.cgi?id=45891
 parse_host_header = re.compile(r"^(?P<host>[^:]+|\[.+\])(?::(?P<port>\d+))?$")
 
-class DnsSpoofing:
+class Rerouter:
     def __init__(self):
         self.hostHeader = None
 
@@ -55,4 +55,4 @@ class DnsSpoofing:
         flow.request.port = port
 
 def start():
-    return DnsSpoofing()
+    return Rerouter()

--- a/examples/complex/dns_spoofing.py
+++ b/examples/complex/dns_spoofing.py
@@ -51,7 +51,7 @@ class Rerouter:
 
         m = parse_host_header.match(self.host_header)
         if m:
-            host_header = m.group("host").strip("[]")
+            self.host_header = m.group("host").strip("[]")
             if m.group("port"):
                 port = int(m.group("port"))
 

--- a/examples/complex/dns_spoofing.py
+++ b/examples/complex/dns_spoofing.py
@@ -53,6 +53,7 @@ class Rerouter:
             if m.group("port"):
                 port = int(m.group("port"))
 
+        flow.request.headers["Host"] = host_header
         flow.request.host = sni or host_header
         flow.request.port = port
 

--- a/examples/complex/dns_spoofing.py
+++ b/examples/complex/dns_spoofing.py
@@ -27,6 +27,7 @@ import re
 # https://bugzilla.mozilla.org/show_bug.cgi?id=45891
 parse_host_header = re.compile(r"^(?P<host>[^:]+|\[.+\])(?::(?P<port>\d+))?$")
 
+
 class Rerouter:
     def __init__(self):
         self.hostHeader = None
@@ -53,6 +54,7 @@ class Rerouter:
 
         flow.request.host = sni or host_header
         flow.request.port = port
+
 
 def start():
     return Rerouter()

--- a/test/mitmproxy/test_examples.py
+++ b/test/mitmproxy/test_examples.py
@@ -108,15 +108,21 @@ class TestScripts(mastertest.MasterTest):
         original_host = "example.com"
 
         host_header = Headers(host=original_host)
-        f = tflow.tflow(req=tutils.treq(headers=host_header))
+        f = tflow.tflow(req=tutils.treq(headers=host_header, port=80))
 
         m.requestheaders(f)
 
         # Rewrite by reverse proxy mode
+        f.request.scheme = "https"
         f.request.host = "mitmproxy.org"
+        f.request.port = 443
 
         m.request(f)
+
+        assert f.request.scheme == "http"
         assert f.request.host == original_host
+        assert f.request.port == 80
+
         assert f.request.headers["Host"] == original_host
 
 

--- a/test/mitmproxy/test_examples.py
+++ b/test/mitmproxy/test_examples.py
@@ -103,6 +103,22 @@ class TestScripts(mastertest.MasterTest):
         m.request(f)
         assert f.response.content == b"Hello World"
 
+    def test_dns_spoofing(self):
+        m, sc = tscript("complex/dns_spoofing.py")
+        original_host = "example.com"
+
+        host_header = Headers(host=original_host)
+        f = tflow.tflow(req=tutils.treq(headers=host_header))
+
+        m.requestheaders(f)
+
+        # Rewrite by reverse proxy mode
+        f.request.host = "mitmproxy.org"
+
+        m.request(f)
+        assert f.request.host == original_host
+        assert f.request.headers["Host"] == original_host
+
 
 class TestHARDump:
 


### PR DESCRIPTION
Hi,
The `dns_spoofing.py` example works for HTTPS connections but not for HTTP. The original Host header can not be retrieved from `flow.request.pretty_host` in the `request` event.
Here is a new version of the example based on the solution suggested by @mhils in [this forum thread](https://discourse.mitmproxy.org/t/could-mitmproxy-be-used-for-reverse-proxy-for-multi-sites/253/6).
