### PR TITLE
add test coverage protection

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -28,7 +28,7 @@ install:
   - "pip install -U tox"
 
 test_script:
-  - ps: "tox -- --cov mitmproxy --cov pathod -v"
+  - ps: "tox -- --verbose --cov-report=term"
   - ps: |
       $Env:VERSION = $(python mitmproxy/version.py)
       $Env:SKIP_MITMPROXY = "python -c `"print('skip mitmproxy')`""

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ bower_components
 sslkeylogfile.log
 .tox/
 .python-version
+coverage.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ install:
   - pip install tox
 
 script:
-  - tox -- --cov mitmproxy --cov pathod -v
+  - tox -- --verbose --cov-report=term
   - |
     if [[ $BDIST == "1" ]]
     then

--- a/mitmproxy/net/http/http2/framereader.py
+++ b/mitmproxy/net/http/http2/framereader.py
@@ -1,6 +1,6 @@
 import codecs
 
-import hyperframe
+import hyperframe.frame
 from mitmproxy import exceptions
 
 
@@ -20,6 +20,6 @@ def parse_frame(header, body=None):
         body = header[9:]
         header = header[:9]
 
-    frame, length = hyperframe.frame.Frame.parse_frame_header(header)
+    frame, _ = hyperframe.frame.Frame.parse_frame_header(header)
     frame.parse_body(memoryview(body))
     return frame

--- a/mitmproxy/net/http/http2/utils.py
+++ b/mitmproxy/net/http/http2/utils.py
@@ -14,11 +14,12 @@ def parse_headers(headers):
     host = None
     port = None
 
+    if method == b'CONNECT':
+        raise NotImplementedError("CONNECT over HTTP/2 is not implemented.")
+
     if path == b'*' or path.startswith(b"/"):
         first_line_format = "relative"
-    elif method == b'CONNECT':  # pragma: no cover
-        raise NotImplementedError("CONNECT over HTTP/2 is not implemented.")
-    else:  # pragma: no cover
+    else:
         first_line_format = "absolute"
         # FIXME: verify if path or :host contains what we need
         scheme, host, port, _ = url.parse(path)

--- a/mitmproxy/utils/debug.py
+++ b/mitmproxy/utils/debug.py
@@ -45,17 +45,17 @@ def dump_system_info():
     ]
     d = platform.linux_distribution()
     t = "Linux distro: %s %s %s" % d
-    if d[0]:  # pragma: no-cover
+    if d[0]:  # pragma: no cover
         data.append(t)
 
     d = platform.mac_ver()
     t = "Mac version: %s %s %s" % d
-    if d[0]:  # pragma: no-cover
+    if d[0]:  # pragma: no cover
         data.append(t)
 
     d = platform.win32_ver()
     t = "Windows version: %s %s %s %s" % d
-    if d[0]:  # pragma: no-cover
+    if d[0]:  # pragma: no cover
         data.append(t)
 
     return "\n".join(data)
@@ -135,11 +135,11 @@ def dump_stacks(signal=None, frame=None, file=sys.stdout, testing=False):
             if line:
                 code.append("  %s" % (line.strip()))
     print("\n".join(code), file=file)
-    if not testing:
+    if not testing:  # pragma: no cover
         sys.exit(1)
 
 
 def register_info_dumpers():
-    if os.name != "nt":
+    if os.name != "nt":  # pragma: windows no cover
         signal.signal(signal.SIGUSR1, dump_info)
         signal.signal(signal.SIGUSR2, dump_stacks)

--- a/mitmproxy/utils/typecheck.py
+++ b/mitmproxy/utils/typecheck.py
@@ -58,6 +58,7 @@ def check_type(attr_name: str, value: typing.Any, typeinfo: type) -> None:
         except AttributeError:
             # Python 3.5.0
             T = typeinfo.__parameters__[0]
+
         if not isinstance(value, (tuple, list)):
             raise e
         for v in value:

--- a/pathod/protocols/websockets.py
+++ b/pathod/protocols/websockets.py
@@ -53,4 +53,3 @@ class WebsocketsProtocol:
                         )
                         lg("crafting websocket spec: %s" % frame_log["spec"])
                         self.pathod_handler.addlog(frame_log)
-        return self.handle_websocket, None

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,5 +1,7 @@
+import os
 import pytest
 import OpenSSL
+
 import mitmproxy.net.tcp
 
 
@@ -12,3 +14,104 @@ requires_alpn = pytest.mark.skipif(
 def disable_alpn(monkeypatch):
     monkeypatch.setattr(mitmproxy.net.tcp, 'HAS_ALPN', False)
     monkeypatch.setattr(OpenSSL.SSL._lib, 'Cryptography_HAS_ALPN', False)
+
+
+enable_coverage = False
+coverage_values = []
+coverage_passed = False
+
+
+def pytest_addoption(parser):
+    parser.addoption('--full-cov',
+                     action='append',
+                     dest='full_cov',
+                     default=[],
+                     help="Require full test coverage of 100%% for this module/path/filename (multi-allowed). Default: none")
+
+    parser.addoption('--no-full-cov',
+                     action='append',
+                     dest='no_full_cov',
+                     default=[],
+                     help="Exclude file from a parent 100%% coverage requirement (multi-allowed). Default: none")
+
+
+def pytest_configure(config):
+    global enable_coverage
+    enable_coverage = (
+        len(config.getoption('file_or_dir')) == 0 and
+        len(config.getoption('full_cov')) > 0 and
+        config.pluginmanager.getplugin("_cov") is not None and
+        config.pluginmanager.getplugin("_cov").cov_controller is not None and
+        config.pluginmanager.getplugin("_cov").cov_controller.cov is not None
+    )
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtestloop(session):
+    global enable_coverage
+    global coverage_values
+    global coverage_passed
+
+    if not enable_coverage:
+        yield
+        return
+
+    cov = pytest.config.pluginmanager.getplugin("_cov").cov_controller.cov
+
+    if os.name == 'nt':
+        cov.exclude('pragma: windows no cover')
+
+    yield
+
+    coverage_values = dict([(name, 0) for name in pytest.config.option.full_cov])
+
+    prefix = os.getcwd()
+    excluded_files = [os.path.normpath(f) for f in pytest.config.option.no_full_cov]
+    measured_files = [os.path.normpath(os.path.relpath(f, prefix)) for f in cov.get_data().measured_files()]
+    measured_files = [f for f in measured_files if f not in excluded_files]
+
+    for name in pytest.config.option.full_cov:
+        files = [f for f in measured_files if f.startswith(os.path.normpath(name))]
+        try:
+            with open(os.devnull, 'w') as null:
+                coverage_values[name] = cov.report(files, ignore_errors=True, file=null)
+        except:
+            pass
+
+    if any(v < 100 for v in coverage_values.values()):
+        # make sure we get the EXIT_TESTSFAILED exit code
+        session.testsfailed += 1
+    else:
+        coverage_passed = True
+
+
+def pytest_terminal_summary(terminalreporter, exitstatus):
+    global enable_coverage
+    global coverage_values
+    global coverage_passed
+
+    if not enable_coverage:
+        return
+
+    terminalreporter.write('\n')
+    if not coverage_passed:
+        markup = {'red': True, 'bold': True}
+        msg = "FAIL: Full test coverage not reached!\n"
+        terminalreporter.write(msg, **markup)
+
+        for name, value in coverage_values.items():
+            if value < 100:
+                markup = {'red': True, 'bold': True}
+            else:
+                markup = {'green': True}
+            msg = 'Coverage for {}: {:.2f}%\n'.format(name, value)
+            terminalreporter.write(msg, **markup)
+    else:
+        markup = {'green': True}
+        msg = 'SUCCESS: Full test coverage reached in modules and files:\n'
+        msg += '{}\n\n'.format('\n'.join(pytest.config.option.full_cov))
+        terminalreporter.write(msg, **markup)
+
+    msg = 'Excluded files:\n'
+    msg += '{}\n'.format('\n'.join(pytest.config.option.no_full_cov))
+    terminalreporter.write(msg)

--- a/test/mitmproxy/addons/test_view.py
+++ b/test/mitmproxy/addons/test_view.py
@@ -76,7 +76,7 @@ def test_simple():
     assert v.get_by_id(f.id)
     assert not v.get_by_id("nonexistent")
 
-    # These all just call udpate
+    # These all just call update
     v.error(f)
     v.response(f)
     v.intercept(f)

--- a/test/mitmproxy/net/http/http2/test_framereader.py
+++ b/test/mitmproxy/net/http/http2/test_framereader.py
@@ -1,1 +1,41 @@
-# foobar
+import pytest
+import codecs
+from io import BytesIO
+import hyperframe.frame
+
+from mitmproxy import exceptions
+from mitmproxy.net.http.http2 import read_raw_frame, parse_frame
+
+
+def test_read_raw_frame():
+    raw = codecs.decode('000006000101234567666f6f626172', 'hex_codec')
+    bio = BytesIO(raw)
+    bio.safe_read = bio.read
+
+    header, body = read_raw_frame(bio)
+    assert header
+    assert body
+
+
+def test_read_raw_frame_failed():
+    raw = codecs.decode('485454000000000000', 'hex_codec')
+    bio = BytesIO(raw)
+    bio.safe_read = bio.read
+
+    with pytest.raises(exceptions.HttpException):
+        read_raw_frame(bio)
+
+
+def test_parse_frame():
+    f = parse_frame(
+        codecs.decode('000006000101234567', 'hex_codec'),
+        codecs.decode('666f6f626172', 'hex_codec')
+    )
+    assert isinstance(f, hyperframe.frame.Frame)
+
+
+def test_parse_frame_combined():
+    f = parse_frame(
+        codecs.decode('000006000101234567666f6f626172', 'hex_codec'),
+    )
+    assert isinstance(f, hyperframe.frame.Frame)

--- a/test/mitmproxy/net/http/http2/test_utils.py
+++ b/test/mitmproxy/net/http/http2/test_utils.py
@@ -1,0 +1,70 @@
+import pytest
+
+from mitmproxy.net.http.http2 import parse_headers
+
+
+class TestHttp2ParseHeaders:
+
+    def test_relative(self):
+        h = dict([
+            (':authority', "127.0.0.1:1234"),
+            (':method', 'GET'),
+            (':scheme', 'https'),
+            (':path', '/'),
+        ])
+        first_line_format, method, scheme, host, port, path = parse_headers(h)
+        assert first_line_format == 'relative'
+        assert method == b'GET'
+        assert scheme == b'https'
+        assert host == b'127.0.0.1'
+        assert port == 1234
+        assert path == b'/'
+
+    def test_absolute(self):
+        h = dict([
+            (':authority', "127.0.0.1:1234"),
+            (':method', 'GET'),
+            (':scheme', 'https'),
+            (':path', 'https://127.0.0.1:4321'),
+        ])
+        first_line_format, method, scheme, host, port, path = parse_headers(h)
+        assert first_line_format == 'absolute'
+        assert method == b'GET'
+        assert scheme == b'https'
+        assert host == b'127.0.0.1'
+        assert port == 1234
+        assert path == b'https://127.0.0.1:4321'
+
+    @pytest.mark.parametrize("scheme, expected_port", [
+        ('http', 80),
+        ('https', 443),
+    ])
+    def test_without_port(self, scheme, expected_port):
+        h = dict([
+            (':authority', "127.0.0.1"),
+            (':method', 'GET'),
+            (':scheme', scheme),
+            (':path', '/'),
+        ])
+        _, _, _, _, port, _ = parse_headers(h)
+        assert port == expected_port
+
+    def test_without_authority(self):
+        h = dict([
+            (':method', 'GET'),
+            (':scheme', 'https'),
+            (':path', '/'),
+        ])
+        _, _, _, host, _, _ = parse_headers(h)
+        assert host == b'localhost'
+
+    def test_connect(self):
+        h = dict([
+            (':authority', "127.0.0.1"),
+            (':method', 'CONNECT'),
+            (':scheme', 'https'),
+            (':path', '/'),
+        ])
+
+        with pytest.raises(NotImplementedError):
+            parse_headers(h)

--- a/test/mitmproxy/script/test_concurrent.py
+++ b/test/mitmproxy/script/test_concurrent.py
@@ -8,7 +8,6 @@ from mitmproxy.addons import script
 import time
 
 from test.mitmproxy import mastertest
-from test.mitmproxy import tutils as ttutils
 
 
 class Thing:
@@ -18,7 +17,6 @@ class Thing:
 
 
 class TestConcurrent(mastertest.MasterTest):
-    @ttutils.skip_appveyor
     def test_concurrent(self):
         with taddons.context() as tctx:
             sc = script.Script(

--- a/test/mitmproxy/utils/test_debug.py
+++ b/test/mitmproxy/utils/test_debug.py
@@ -1,10 +1,16 @@
 import io
+import subprocess
+from unittest import mock
 
 from mitmproxy.utils import debug
 
 
 def test_dump_system_info():
     assert debug.dump_system_info()
+
+    with mock.patch('subprocess.check_output') as m:
+        m.side_effect = subprocess.CalledProcessError(-1, 'git describe --tags --long')
+        assert 'release version' in debug.dump_system_info()
 
 
 def test_dump_info():

--- a/test/mitmproxy/utils/test_typecheck.py
+++ b/test/mitmproxy/utils/test_typecheck.py
@@ -38,8 +38,15 @@ def test_check_union():
     with pytest.raises(TypeError):
         typecheck.check_type("foo", [], typing.Union[int, str])
 
+    # Python 3.5 only defines __union_params__
+    m = mock.Mock()
+    m.__str__ = lambda self: "typing.Union"
+    m.__union_params__ = (int,)
+    typecheck.check_type("foo", 42, m)
+
 
 def test_check_tuple():
+    typecheck.check_type("foo", (42, "42"), typing.Tuple[int, str])
     with pytest.raises(TypeError):
         typecheck.check_type("foo", None, typing.Tuple[int, str])
     with pytest.raises(TypeError):
@@ -48,7 +55,12 @@ def test_check_tuple():
         typecheck.check_type("foo", (42, 42), typing.Tuple[int, str])
     with pytest.raises(TypeError):
         typecheck.check_type("foo", ("42", 42), typing.Tuple[int, str])
-    typecheck.check_type("foo", (42, "42"), typing.Tuple[int, str])
+
+    # Python 3.5 only defines __tuple_params__
+    m = mock.Mock()
+    m.__str__ = lambda self: "typing.Tuple"
+    m.__tuple_params__ = (int, str)
+    typecheck.check_type("foo", (42, "42"), m)
 
 
 def test_check_sequence():
@@ -62,7 +74,7 @@ def test_check_sequence():
     with pytest.raises(TypeError):
         typecheck.check_type("foo", "foo", typing.Sequence[str])
 
-    # Python 3.5.0 only defines __parameters__
+    # Python 3.5 only defines __parameters__
     m = mock.Mock()
     m.__str__ = lambda self: "typing.Sequence"
     m.__parameters__ = (int,)

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,27 @@ passenv = CODECOV_TOKEN CI CI_* TRAVIS TRAVIS_* APPVEYOR APPVEYOR_* SNAPSHOT_* O
 setenv = HOME = {envtmpdir}
 commands =
   mitmdump --version
-  py.test --timeout 60 {posargs}
+  pytest --timeout 60 --cov-report='' --cov=mitmproxy --cov=pathod \
+    --full-cov=mitmproxy/addons/ \
+    --full-cov=mitmproxy/contentviews/ --no-full-cov=mitmproxy/contentviews/__init__.py --no-full-cov=mitmproxy/contentviews/protobuf.py --no-full-cov=mitmproxy/contentviews/wbxml.py --no-full-cov=mitmproxy/contentviews/xml_html.py \
+    --full-cov=mitmproxy/net/http/ --no-full-cov=mitmproxy/net/http/cookies.py --no-full-cov=mitmproxy/net/http/encoding.py --no-full-cov=mitmproxy/net/http/message.py --no-full-cov=mitmproxy/net/http/request.py --no-full-cov=mitmproxy/net/http/response.py --no-full-cov=mitmproxy/net/http/url.py \
+    --full-cov=mitmproxy/net/websockets/ \
+    --full-cov=mitmproxy/net/wsgi.py \
+    --full-cov=mitmproxy/proxy/__init__.py \
+    --full-cov=mitmproxy/proxy/modes/ --no-full-cov=mitmproxy/proxy/modes/socks_proxy.py \
+    --full-cov=mitmproxy/proxy/protocol/__init__.py \
+    --full-cov=mitmproxy/script/ \
+    --full-cov=mitmproxy/test/ --no-full-cov=mitmproxy/test/tutils.py \
+    --full-cov=mitmproxy/types/ --no-full-cov=mitmproxy/types/basethread.py \
+    --full-cov=mitmproxy/utils/ \
+    --full-cov=mitmproxy/__init__.py \
+    --full-cov=mitmproxy/addonmanager.py \
+    --full-cov=mitmproxy/ctx.py \
+    --full-cov=mitmproxy/exceptions.py \
+    --full-cov=mitmproxy/log.py \
+    --full-cov=mitmproxy/options.py \
+    --full-cov=pathod/ --no-full-cov=pathod/pathoc.py --no-full-cov=pathod/pathod.py --no-full-cov=pathod/test.py --no-full-cov=pathod/protocols/http2.py \
+    {posargs}
   {env:CI_COMMANDS:python -c ""}
 
 [testenv:docs]
@@ -24,12 +44,13 @@ commands =
   flake8 --jobs 8 --count mitmproxy pathod examples test release
   rstcheck README.rst
   mypy --silent-imports \
-    mitmproxy/addons \
+    mitmproxy/addons/ \
     mitmproxy/addonmanager.py \
     mitmproxy/proxy/protocol/ \
     mitmproxy/log.py \
-    mitmproxy/tools/dump.py mitmproxy/tools/web \
-    mitmproxy/contentviews
+    mitmproxy/tools/dump.py \
+    mitmproxy/tools/web/ \
+    mitmproxy/contentviews/
 
 [testenv:wheel]
 recreate = True


### PR DESCRIPTION
This PR adds a custom pytest plugin using the hooks API.
New CLI parameter are available: `--full-cov=[path]` and `--no-full-cov=[file]`.
This makes pytest fail with an exitcode if the coverage for one or more file paths is less than 100%.

The plan is to slowly increase coverage for the mitmproxy core and add more and more paths until we can just say: `--full-cov=mitmproxy` which protects everything against dropping coverage metrics.