### PR TITLE
addons: unit tests to 100%

### DIFF
--- a/test/mitmproxy/addons/test_stickyauth.py
+++ b/test/mitmproxy/addons/test_stickyauth.py
@@ -10,7 +10,15 @@ def test_configure():
     r = stickyauth.StickyAuth()
     with taddons.context() as tctx:
         tctx.configure(r, stickyauth="~s")
-        tutils.raises(exceptions.OptionsError, tctx.configure, r, stickyauth="~~")
+        tutils.raises(
+            exceptions.OptionsError,
+            tctx.configure,
+            r,
+            stickyauth="~~"
+        )
+
+        tctx.configure(r, stickyauth=None)
+        assert not r.flt
 
 
 def test_simple():

--- a/test/mitmproxy/addons/test_stickycookie.py
+++ b/test/mitmproxy/addons/test_stickycookie.py
@@ -3,7 +3,6 @@ from mitmproxy.test import tutils
 from mitmproxy.test import taddons
 
 from mitmproxy.addons import stickycookie
-from mitmproxy import options
 from mitmproxy.test import tutils as ntutils
 
 
@@ -15,11 +14,15 @@ def test_domain_match():
 class TestStickyCookie:
     def test_config(self):
         sc = stickycookie.StickyCookie()
-        o = options.Options(stickycookie = "~b")
-        tutils.raises(
-            "invalid filter",
-            sc.configure, o, o.keys()
-        )
+        with taddons.context() as tctx:
+            tutils.raises(
+                "invalid filter", tctx.configure, sc, stickycookie="~b"
+            )
+
+            tctx.configure(sc, stickycookie="foo")
+            assert sc.flt
+            tctx.configure(sc, stickycookie=None)
+            assert not sc.flt
 
     def test_simple(self):
         sc = stickycookie.StickyCookie()

--- a/test/mitmproxy/addons/test_streamfile.py
+++ b/test/mitmproxy/addons/test_streamfile.py
@@ -22,6 +22,10 @@ def test_configure():
                 "invalid filter",
                 tctx.configure, sa, streamfile=p, filtstr="~~"
             )
+            tctx.configure(sa, filtstr="foo")
+            assert sa.filt
+            tctx.configure(sa, filtstr=None)
+            assert not sa.filt
 
 
 def rd(p):

--- a/test/mitmproxy/addons/test_view.py
+++ b/test/mitmproxy/addons/test_view.py
@@ -73,12 +73,15 @@ def test_simple():
     assert v.store_count() == 0
     v.request(f)
     assert list(v) == [f]
+    assert v.get_by_id(f.id)
+    assert not v.get_by_id("nonexistent")
 
     # These all just call udpate
     v.error(f)
     v.response(f)
     v.intercept(f)
     v.resume(f)
+    v.kill(f)
     assert list(v) == [f]
 
     v.request(f)


### PR DESCRIPTION
This patch pushes the coverage of ./tests/mitproxy/addons to 100% of the addons
module.