### PR TITLE
Revamp replacement hooks

### DIFF
--- a/mitmproxy/addons/__init__.py
+++ b/mitmproxy/addons/__init__.py
@@ -28,6 +28,7 @@ def default_addons():
         onboarding.Onboarding(),
         proxyauth.ProxyAuth(),
         replace.Replace(),
+        replace.ReplaceFile(),
         script.ScriptLoader(),
         serverplayback.ServerPlayback(),
         setheaders.SetHeaders(),

--- a/mitmproxy/options.py
+++ b/mitmproxy/options.py
@@ -1,4 +1,4 @@
-from typing import Tuple, Optional, Sequence
+from typing import Tuple, Optional, Sequence, Union
 
 from mitmproxy import optmanager
 
@@ -38,7 +38,8 @@ class Options(optmanager.OptManager):
         rfile: Optional[str] = None,
         scripts: Sequence[str] = [],
         showhost: bool = False,
-        replacements: Sequence[Tuple[str, str, str]] = [],
+        replacements: Sequence[Union[Tuple[str, str, str], str]] = [],
+        replacement_files: Sequence[Union[Tuple[str, str, str], str]] = [],
         server_replay_use_headers: Sequence[str] = [],
         setheaders: Sequence[Tuple[str, str, str]] = [],
         server_replay: Sequence[str] = [],
@@ -124,6 +125,7 @@ class Options(optmanager.OptManager):
         self.scripts = scripts
         self.showhost = showhost
         self.replacements = replacements
+        self.replacement_files = replacement_files
         self.server_replay_use_headers = server_replay_use_headers
         self.setheaders = setheaders
         self.server_replay = server_replay

--- a/mitmproxy/tools/console/options.py
+++ b/mitmproxy/tools/console/options.py
@@ -6,6 +6,8 @@ from mitmproxy.tools.console import grideditor
 from mitmproxy.tools.console import select
 from mitmproxy.tools.console import signals
 
+from mitmproxy.addons import replace
+
 footer = [
     ('heading_key', "enter/space"), ":toggle ",
     ('heading_key', "C"), ":clear all ",
@@ -215,10 +217,16 @@ class Options(urwid.WidgetWrap):
         )
 
     def replacepatterns(self):
+        data = []
+        for d in self.master.options.replacements:
+            if isinstance(d, str):
+                data.append(replace.parse_hook(d))
+            else:
+                data.append(d)
         self.master.view_grideditor(
             grideditor.ReplaceEditor(
                 self.master,
-                self.master.options.replacements,
+                data,
                 self.master.options.setter("replacements")
             )
         )

--- a/test/mitmproxy/test_cmdline.py
+++ b/test/mitmproxy/test_cmdline.py
@@ -3,38 +3,6 @@ from mitmproxy.tools import cmdline
 from mitmproxy.test import tutils
 
 
-def test_parse_replace_hook():
-    x = cmdline.parse_replace_hook("/foo/bar/voing")
-    assert x == ("foo", "bar", "voing")
-
-    x = cmdline.parse_replace_hook("/foo/bar/vo/ing/")
-    assert x == ("foo", "bar", "vo/ing/")
-
-    x = cmdline.parse_replace_hook("/bar/voing")
-    assert x == (".*", "bar", "voing")
-
-    tutils.raises(
-        cmdline.ParseException,
-        cmdline.parse_replace_hook,
-        "/foo"
-    )
-    tutils.raises(
-        "replacement regex",
-        cmdline.parse_replace_hook,
-        "patt/[/rep"
-    )
-    tutils.raises(
-        "filter pattern",
-        cmdline.parse_replace_hook,
-        "/~/foo/rep"
-    )
-    tutils.raises(
-        "empty clause",
-        cmdline.parse_replace_hook,
-        "//"
-    )
-
-
 def test_parse_setheaders():
     x = cmdline.parse_setheader("/foo/bar/voing")
     assert x == ("foo", "bar", "voing")
@@ -64,38 +32,6 @@ def test_common():
         opts
     )
     opts.setheader = []
-
-    opts.replace = ["/foo/bar/voing"]
-    v = cmdline.get_common_options(opts)
-    assert v["replacements"] == [("foo", "bar", "voing")]
-
-    opts.replace = ["//"]
-    tutils.raises(
-        "empty clause",
-        cmdline.get_common_options,
-        opts
-    )
-
-    opts.replace = []
-    opts.replace_file = [("/foo/bar/nonexistent")]
-    tutils.raises(
-        "could not read replace file",
-        cmdline.get_common_options,
-        opts
-    )
-
-    opts.replace_file = [("/~/bar/nonexistent")]
-    tutils.raises(
-        "filter pattern",
-        cmdline.get_common_options,
-        opts
-    )
-
-    p = tutils.test_data.path("mitmproxy/data/replace")
-    opts.replace_file = [("/foo/bar/%s" % p)]
-    v = cmdline.get_common_options(opts)["replacements"]
-    assert len(v) == 1
-    assert v[0][2].strip() == b"replacecontents"
 
 
 def test_mitmproxy():


### PR DESCRIPTION
- Replacement specifiers can be either strings or tuples. This lets us cope
gracefully with command-line parsing (and posible quick interactive
specification) without having to special-case replacement hooks, or have
knowledge of hook specification leak outside the addon. We can also now use the
same command-line spec format in config files.
- Split replacement and replacement from file into separate addons and options.
Files are now read on each replacement, so you can edit replacement files in
place without restart.
- Modernise the test suite to use addon test helpers.

TODO: editing and displaying replace-from-file in console app