### PR TITLE
Fixes #1473 API to create new requests

### DIFF
--- a/examples/simple/request_all_methods.py
+++ b/examples/simple/request_all_methods.py
@@ -1,0 +1,13 @@
+from mitmproxy import ctx
+
+
+def request(flow):
+    methods = ["GET", "POST", "PUT", "DELETE"]
+    methods.remove(flow.request.method)
+    f1 = flow.copy()
+    f2 = flow.copy()
+    f3 = flow.copy()
+    if not flow.request.is_replay:
+        ctx.master.new_request(methods[0], f1)
+        ctx.master.new_request(methods[1], f2)
+        ctx.master.new_request(methods[2], f3)

--- a/mitmproxy/master.py
+++ b/mitmproxy/master.py
@@ -238,6 +238,26 @@ class Master:
             rt.join()
         return rt
 
+    def new_request(
+            self,
+            method,
+            f: http.HTTPFlow,
+            block: bool = False
+    ) -> http_replay.RequestReplayThread:
+        """
+        Replay a HTTP request with a different method to receive a new response from the server.
+        Args:
+            method: Request method
+            f: The flow to replay.
+            block: If True, this function will wait for the replay to finish.
+                This causes a deadlock if activated in the main thread.
+
+        Returns:
+            The thread object doing the replay.
+        """
+        f.request.method = method
+        return self.replay_request(f, block)
+
     @controller.handler
     def log(self, l):
         pass

--- a/test/mitmproxy/test_flow.py
+++ b/test/mitmproxy/test_flow.py
@@ -295,13 +295,16 @@ class TestFlowMaster:
         fm = master.Master(None, DummyServer())
         f = tflow.tflow(resp=True)
         f.request.content = None
-        tutils.raises("missing", fm.new_request, f.request.method, f)
+        with pytest.raises("missing"):
+            fm.new_request(f.request.method, f)
 
         f.intercepted = True
-        tutils.raises("intercepted", fm.new_request, f.request.method, f)
+        with pytest.raises("intercepted"):
+            fm.new_request(f.request.method, f)
 
         f.live = True
-        tutils.raises("live", fm.new_request, f.request.method, f)
+        with pytest.raises("live"):
+            fm.new_request(f.request.method, f)
 
     def test_all(self):
         s = tservers.TestState()

--- a/test/mitmproxy/test_flow.py
+++ b/test/mitmproxy/test_flow.py
@@ -291,6 +291,18 @@ class TestFlowMaster:
         fm = master.Master(None, DummyServer())
         assert fm.create_request("GET", "http", "example.com", 80, "/")
 
+    def test_new_request(self):
+        fm = master.Master(None, DummyServer())
+        f = tflow.tflow(resp=True)
+        f.request.content = None
+        tutils.raises("missing", fm.new_request, f.request.method, f)
+
+        f.intercepted = True
+        tutils.raises("intercepted", fm.new_request, f.request.method, f)
+
+        f.live = True
+        tutils.raises("live", fm.new_request, f.request.method, f)
+
     def test_all(self):
         s = tservers.TestState()
         fm = master.Master(None, DummyServer())


### PR DESCRIPTION
Created a function to send requests with different methods from current request. Also included an example script.
Link to discussion:
https://discourse.mitmproxy.org/t/are-there-any-script-examples-for-creating-a-get-post-put/134