### PR TITLE
IPv6 binding support

### DIFF
--- a/mitmproxy/net/tcp.py
+++ b/mitmproxy/net/tcp.py
@@ -333,11 +333,11 @@ class Address(serializable.Serializable):
         return Address(**state)
 
     @classmethod
-    def wrap(cls, t):
+    def wrap(cls, t, **kw):
         if isinstance(t, cls):
             return t
         else:
-            return cls(t)
+            return cls(t, **kw)
 
     def __call__(self):
         return self.address
@@ -923,7 +923,7 @@ class TCPServer:
     request_queue_size = 20
 
     def __init__(self, address, use_ipv6=None):
-        self.address = Address(address, use_ipv6)
+        self.address = Address.wrap(address, use_ipv6=use_ipv6)
         self.__is_shut_down = threading.Event()
         self.__shutdown_request = False
         self.socket = socket.socket(self.address.family, socket.SOCK_STREAM)

--- a/mitmproxy/options.py
+++ b/mitmproxy/options.py
@@ -69,6 +69,7 @@ class Options(optmanager.OptManager):
         ignore_hosts: Sequence[str] = [],
         listen_host: str = "",
         listen_port: int = LISTEN_PORT,
+        listen_ipv6: Optional[bool] = None,
         upstream_bind_address: str = "",
         mode: str = "regular",
         no_upstream_cert: bool = False,
@@ -156,6 +157,7 @@ class Options(optmanager.OptManager):
         self.ignore_hosts = ignore_hosts
         self.listen_host = listen_host
         self.listen_port = listen_port
+        self.listen_ipv6 = listen_ipv6
         self.upstream_bind_address = upstream_bind_address
         self.mode = mode
         self.no_upstream_cert = no_upstream_cert

--- a/mitmproxy/proxy/server.py
+++ b/mitmproxy/proxy/server.py
@@ -42,7 +42,8 @@ class ProxyServer(tcp.TCPServer):
         self.config = config
         try:
             super().__init__(
-                (config.options.listen_host, config.options.listen_port)
+                (config.options.listen_host, config.options.listen_port),
+                config.options.listen_ipv6
             )
             if config.options.mode == "transparent":
                 platform.init_transparent_mode()

--- a/mitmproxy/tools/cmdline.py
+++ b/mitmproxy/tools/cmdline.py
@@ -141,6 +141,7 @@ def get_common_options(args):
         ignore_hosts = args.ignore_hosts,
         listen_host = args.addr,
         listen_port = args.port,
+        listen_ipv6 = args.listen_ipv6,
         upstream_bind_address = args.upstream_bind_address,
         mode = mode,
         no_upstream_cert = args.no_upstream_cert,
@@ -298,6 +299,16 @@ def proxy_options(parser):
         "-b", "--bind-address",
         action="store", type=str, dest="addr",
         help="Address to bind proxy to (defaults to all interfaces)"
+    )
+    group.add_argument(
+        "-6", "--bind-ipv6",
+        action="store_true", dest="listen_ipv6",
+        help="Listen on IPv6 interface only"
+    )
+    group.add_argument(
+        "-4", "--bind-ipv4",
+        action="store_false", dest="listen_ipv6",
+        help="Listen on IPv4 interface only"
     )
     group.add_argument(
         "-I", "--ignore",


### PR DESCRIPTION
Added support for binding to IPv6 interfaces. Now mitmproxy can automatically detect & bind to IPv6 addresses, for example, using `-b ::1` or `-b localhost -6`.
Introduces 2 new options: `-4` (`--bind-ipv4`) and `-6` (`--bind-ipv6`).

Based on my request from https://discourse.mitmproxy.org/t/serving-on-ipv6/331/4.