### PR TITLE
Closes #1580 Gives warning when explicit proxy configured in transparent mode

### DIFF
--- a/mitmproxy/proxy/protocol/http.py
+++ b/mitmproxy/proxy/protocol/http.py
@@ -145,7 +145,7 @@ def validate_request_form(mode, request):
     if request.first_line_format not in allowed_request_forms:
         if mode == HTTPMode.transparent:
             err_message = (
-                "Mitmproxy received an {} request even though it is not running in regular mode. 
+                "Mitmproxy received an {} request even though it is not running in regular mode. "
                 "This usually indicates a misconfiguration, please see "
                 "http://docs.mitmproxy.org/en/stable/modes.html for details."
             ).format("HTTP CONNECT" if request.first_line_format == "authority" else "absolute-form")

--- a/mitmproxy/proxy/protocol/http.py
+++ b/mitmproxy/proxy/protocol/http.py
@@ -131,7 +131,7 @@ class HTTPMode(enum.Enum):
 # At this point, we see only a subset of the proxy modes
 MODE_REQUEST_FORMS = {
     HTTPMode.regular: ("authority", "absolute"),
-    HTTPMode.transparent: ("relative"),
+    HTTPMode.transparent: ("relative",),
     HTTPMode.upstream: ("authority", "absolute"),
 }
 
@@ -143,9 +143,14 @@ def validate_request_form(mode, request):
         )
     allowed_request_forms = MODE_REQUEST_FORMS[mode]
     if request.first_line_format not in allowed_request_forms:
-        err_message = "Invalid HTTP request form (expected: %s, got: %s)" % (
-            " or ".join(allowed_request_forms), request.first_line_format
-        )
+        if mode == HTTPMode.transparent:
+            err_message = "Mitmproxy received an (absolute-form|HTTP CONNECT) request even though" \
+                          " it is not running in regular mode. This usually indicates a misconfiguration, " \
+                          "please see http://docs.mitmproxy.org/en/stable/modes.html for details."
+        else:
+            err_message = "Invalid HTTP request form (expected: %s, got: %s)" % (
+                " or ".join(allowed_request_forms), request.first_line_format
+            )
         raise exceptions.HttpException(err_message)
 
 

--- a/mitmproxy/proxy/protocol/http.py
+++ b/mitmproxy/proxy/protocol/http.py
@@ -144,9 +144,11 @@ def validate_request_form(mode, request):
     allowed_request_forms = MODE_REQUEST_FORMS[mode]
     if request.first_line_format not in allowed_request_forms:
         if mode == HTTPMode.transparent:
-            err_message = "Mitmproxy received an (absolute-form|HTTP CONNECT) request even though" \
-                          " it is not running in regular mode. This usually indicates a misconfiguration, " \
-                          "please see http://docs.mitmproxy.org/en/stable/modes.html for details."
+            err_message = (
+                "Mitmproxy received an {} request even though it is not running in regular mode. 
+                "This usually indicates a misconfiguration, please see "
+                "http://docs.mitmproxy.org/en/stable/modes.html for details."
+            ).format("HTTP CONNECT" if request.first_line_format == "authority" else "absolute-form")
         else:
             err_message = "Invalid HTTP request form (expected: %s, got: %s)" % (
                 " or ".join(allowed_request_forms), request.first_line_format

--- a/test/mitmproxy/protocol/test_http1.py
+++ b/test/mitmproxy/protocol/test_http1.py
@@ -30,6 +30,16 @@ class TestInvalidRequests(tservers.HTTPProxyTest):
         assert b"Invalid HTTP request form" in r.content
 
 
+class TestProxyMisconfiguration(tservers.TransparentProxyTest):
+
+    def test_absolute_request(self):
+        p = self.pathoc()
+        with p.connect():
+            r = p.request("get:'http://localhost:%d/p/200'" % self.server.port)
+        assert r.status_code == 400
+        assert b"misconfiguration" in r.content
+
+
 class TestExpectHeader(tservers.HTTPProxyTest):
 
     def test_simple(self):


### PR DESCRIPTION
Checks if mode is transparent and request is of authority or absolute form and gives the message accordingly. I tried to find out the best way to check if an explicit proxy is actually set or not but couldn't find anything.  
One thing which I noticed though was, when I did 
`curl -i -v -x localhost:8080 example.com`
`Proxy-Connection: Keep-Alive` header was being sent 
If you want I can check for that instead of just checking whether mode is transparent or not or check for both
Change in line 129 because:
http://stackoverflow.com/a/3511300