### PR TITLE
Content views edit

### DIFF
--- a/web/src/js/components/ContentView/ContentViewOptions.jsx
+++ b/web/src/js/components/ContentView/ContentViewOptions.jsx
@@ -12,13 +12,13 @@ ContentViewOptions.propTypes = {
 function ContentViewOptions({ flow, message, uploadContent, readonly, contentViewDescription }) {
     return (
         <div className="view-options">
-            <ViewSelector message={message}/>
+            {readonly ? <ViewSelector message={message}/> : <span><b>View:</b> edit</span>}
             &nbsp;
             <DownloadContentButton flow={flow} message={message}/>
             &nbsp;
             {!readonly && <UploadContentButton uploadContent={uploadContent}/> }
             &nbsp;
-            <span>{contentViewDescription}</span>
+            {readonly && <span>{contentViewDescription}</span>}
         </div>
     )
 }

--- a/web/src/js/components/ContentView/ViewSelector.jsx
+++ b/web/src/js/components/ContentView/ViewSelector.jsx
@@ -1,6 +1,5 @@
 import React, { PropTypes, Component } from 'react'
 import { connect } from 'react-redux'
-import * as ContentViews from './ContentViews'
 import { setContentView } from '../../ducks/ui/flow';
 import Dropdown from '../common/Dropdown'
 
@@ -8,26 +7,19 @@ import Dropdown from '../common/Dropdown'
 ViewSelector.propTypes = {
     contentViews: PropTypes.array.isRequired,
     activeView: PropTypes.string.isRequired,
-    isEdit: PropTypes.bool.isRequired,
     setContentView: PropTypes.func.isRequired
 }
 
-function ViewSelector ({contentViews, activeView, isEdit, setContentView}){
-    let edit = ContentViews.Edit.displayName
-    let inner = <span> <b>View:</b> {activeView} <span className="caret"></span> </span>
+function ViewSelector ({contentViews, activeView, setContentView}){
+    let inner = <span> <b>View:</b> {activeView.toLowerCase()} <span className="caret"></span> </span>
 
     return (
         <Dropdown dropup className="pull-left" btnClass="btn btn-default btn-xs" text={inner}>
             {contentViews.map(name =>
-                <a href="#" key={name} onClick={e => {e.preventDefault(); setContentView(name)}}>
+                <a href="#" key={name}  onClick={e => {e.preventDefault(); setContentView(name)}}>
                     {name.toLowerCase().replace('_', ' ')}
                 </a>
                 )
-            }
-            {isEdit &&
-                <a href="#" onClick={e => {e.preventDefault(); setContentView(edit)}}>
-                    {edit.toLowerCase()}
-                </a>
             }
         </Dropdown>
     )
@@ -37,7 +29,6 @@ export default connect (
     state => ({
         contentViews: state.settings.contentViews,
         activeView: state.ui.flow.contentView,
-        isEdit: !!state.ui.flow.modifiedFlow,
     }), {
         setContentView,
     }

--- a/web/src/js/ducks/ui/flow.js
+++ b/web/src/js/ducks/ui/flow.js
@@ -89,7 +89,7 @@ export default function reducer(state = defaultState, action) {
                 ...state,
                 tab: action.tab ? action.tab : 'request',
                 displayLarge: false,
-                showFullContent: false
+                showFullContent: state.contentView == 'Edit'
             }
 
         case SET_CONTENT_VIEW:


### PR DESCRIPTION
there is a bug with the "show full content" button. if you activate the edit mode, the whole content is visible in the code editor, but if you switch between the tab (response, request,...) then the redux state will change to showFullContent=false.

the second commit removes the content  view selector, because if you modify a content without saving it you cannot use the server side content views correctly. 