### PR TITLE
Catch ValueErrors from url.parse()

### DIFF
--- a/mitmproxy/tools/console/flowlist.py
+++ b/mitmproxy/tools/console/flowlist.py
@@ -338,9 +338,10 @@ class FlowListBox(urwid.ListBox):
         )
 
     def new_request(self, url, method):
-        parts = mitmproxy.net.http.url.parse(str(url))
-        if not parts:
-            signals.status_message.send(message="Invalid Url")
+        try:
+            parts = mitmproxy.net.http.url.parse(str(url))
+        except ValueError as e:
+            signals.status_message.send(message = "Invalid URL: " + str(e))
             return
         scheme, host, port, path = parts
         f = self.master.create_request(method, scheme, host, port, path)

--- a/test/mitmproxy/console/test_flowlist.py
+++ b/test/mitmproxy/console/test_flowlist.py
@@ -2,7 +2,7 @@ import mitmproxy.tools.console.flowlist as flowlist
 from mitmproxy.tools import console
 from mitmproxy import proxy
 from mitmproxy import options
-from .. import mastertest
+from .. import tservers
 import pytest
 from unittest import mock
 
@@ -15,7 +15,7 @@ def mock_add_log(message):
     raise ScriptError(message)
 
 
-class TestFlowlist(mastertest.MasterTest):
+class TestFlowlist(tservers.MasterTest):
     def mkmaster(self, **opts):
         if "verbosity" not in opts:
             opts["verbosity"] = 1

--- a/test/mitmproxy/console/test_flowlist.py
+++ b/test/mitmproxy/console/test_flowlist.py
@@ -1,19 +1,19 @@
 import mitmproxy.tools.console.flowlist as flowlist
-from mitmproxy.test import tutils
-from mitmproxy.test import tflow
 from mitmproxy.tools import console
 from mitmproxy import proxy
 from mitmproxy import options
-from mitmproxy.tools.console import common
 from .. import mastertest
 import pytest
 from unittest import mock
 
+
 class ScriptError(Exception):
     pass
 
+
 def mock_add_log(message):
     raise ScriptError(message)
+
 
 class TestFlowlist(mastertest.MasterTest):
     def mkmaster(self, **opts):
@@ -21,13 +21,11 @@ class TestFlowlist(mastertest.MasterTest):
             opts["verbosity"] = 1
         o = options.Options(**opts)
         return console.master.ConsoleMaster(o, proxy.DummyServer())
-    
+
     @mock.patch('mitmproxy.tools.console.signals.status_message.send', side_effect = mock_add_log)
-    def test_new_request(self,test_func):
+    def test_new_request(self, test_func):
         m = self.mkmaster()
         x = flowlist.FlowListBox(m)
         with pytest.raises(ScriptError) as e:
             x.new_request("nonexistent url", "GET")
         assert "Invalid URL" in str(e)
-        
-        

--- a/test/mitmproxy/console/test_flowlist.py
+++ b/test/mitmproxy/console/test_flowlist.py
@@ -4,16 +4,7 @@ from mitmproxy import proxy
 from mitmproxy import options
 from .. import tservers
 import pytest
-from unittest import mock
-
-
-class UrlError(Exception):
-    pass
-
-
-def mock_log(message):
-    if "Invalid URL" in message:
-        raise UrlError(message)
+from unittest import mock as Mock
 
 
 class TestFlowlist(tservers.MasterTest):
@@ -23,9 +14,9 @@ class TestFlowlist(tservers.MasterTest):
         o = options.Options(**opts)
         return console.master.ConsoleMaster(o, proxy.DummyServer())
 
-    @mock.patch('mitmproxy.tools.console.signals.status_message.send', side_effect = mock_log)
-    def test_new_request(self, test_func):
+    def test_new_request(self):
         m = self.mkmaster()
         x = flowlist.FlowListBox(m)
-        with pytest.raises(UrlError):
+        with Mock.patch('mitmproxy.tools.console.signals.status_message.send') as mock:
             x.new_request("nonexistent url", "GET")
+        mock.assert_called_once_with(message = "Invalid URL: No hostname given")

--- a/test/mitmproxy/console/test_flowlist.py
+++ b/test/mitmproxy/console/test_flowlist.py
@@ -11,8 +11,9 @@ class UrlError(Exception):
     pass
 
 
-def mock_add_log(message):
-    raise UrlError(message)
+def mock_log(message):
+    if "Invalid URL" in message:
+        raise UrlError(message)
 
 
 class TestFlowlist(tservers.MasterTest):
@@ -22,9 +23,9 @@ class TestFlowlist(tservers.MasterTest):
         o = options.Options(**opts)
         return console.master.ConsoleMaster(o, proxy.DummyServer())
 
-    @mock.patch('mitmproxy.tools.console.signals.status_message.send', side_effect = mock_add_log)
+    @mock.patch('mitmproxy.tools.console.signals.status_message.send', side_effect = mock_log)
     def test_new_request(self, test_func):
         m = self.mkmaster()
         x = flowlist.FlowListBox(m)
-        with pytest.raises(UrlError) as e:
+        with pytest.raises(UrlError):
             x.new_request("nonexistent url", "GET")

--- a/test/mitmproxy/console/test_flowlist.py
+++ b/test/mitmproxy/console/test_flowlist.py
@@ -3,8 +3,7 @@ from mitmproxy.tools import console
 from mitmproxy import proxy
 from mitmproxy import options
 from .. import tservers
-import pytest
-from unittest import mock as Mock
+from unittest import mock
 
 
 class TestFlowlist(tservers.MasterTest):
@@ -17,6 +16,6 @@ class TestFlowlist(tservers.MasterTest):
     def test_new_request(self):
         m = self.mkmaster()
         x = flowlist.FlowListBox(m)
-        with Mock.patch('mitmproxy.tools.console.signals.status_message.send') as mock:
+        with mock.patch('mitmproxy.tools.console.signals.status_message.send') as mock_thing:
             x.new_request("nonexistent url", "GET")
-        mock.assert_called_once_with(message = "Invalid URL: No hostname given")
+        mock_thing.assert_called_once_with(message="Invalid URL: No hostname given")

--- a/test/mitmproxy/console/test_flowlist.py
+++ b/test/mitmproxy/console/test_flowlist.py
@@ -28,4 +28,3 @@ class TestFlowlist(tservers.MasterTest):
         x = flowlist.FlowListBox(m)
         with pytest.raises(UrlError) as e:
             x.new_request("nonexistent url", "GET")
-        assert "Invalid URL" in str(e)

--- a/test/mitmproxy/console/test_flowlist.py
+++ b/test/mitmproxy/console/test_flowlist.py
@@ -7,12 +7,12 @@ import pytest
 from unittest import mock
 
 
-class ScriptError(Exception):
+class UrlError(Exception):
     pass
 
 
 def mock_add_log(message):
-    raise ScriptError(message)
+    raise UrlError(message)
 
 
 class TestFlowlist(tservers.MasterTest):
@@ -26,6 +26,6 @@ class TestFlowlist(tservers.MasterTest):
     def test_new_request(self, test_func):
         m = self.mkmaster()
         x = flowlist.FlowListBox(m)
-        with pytest.raises(ScriptError) as e:
+        with pytest.raises(UrlError) as e:
             x.new_request("nonexistent url", "GET")
         assert "Invalid URL" in str(e)

--- a/test/mitmproxy/console/test_flowlist.py
+++ b/test/mitmproxy/console/test_flowlist.py
@@ -1,0 +1,33 @@
+import mitmproxy.tools.console.flowlist as flowlist
+from mitmproxy.test import tutils
+from mitmproxy.test import tflow
+from mitmproxy.tools import console
+from mitmproxy import proxy
+from mitmproxy import options
+from mitmproxy.tools.console import common
+from .. import mastertest
+import pytest
+from unittest import mock
+
+class ScriptError(Exception):
+    pass
+
+def mock_add_log(message):
+    raise ScriptError(message)
+
+class TestFlowlist(mastertest.MasterTest):
+    def mkmaster(self, **opts):
+        if "verbosity" not in opts:
+            opts["verbosity"] = 1
+        o = options.Options(**opts)
+        return console.master.ConsoleMaster(o, proxy.DummyServer())
+    
+    @mock.patch('mitmproxy.tools.console.signals.status_message.send', side_effect = mock_add_log)
+    def test_new_request(self,test_func):
+        m = self.mkmaster()
+        x = flowlist.FlowListBox(m)
+        with pytest.raises(ScriptError) as e:
+            x.new_request("nonexistent url", "GET")
+        assert "Invalid URL" in str(e)
+        
+        


### PR DESCRIPTION
#1975 had to delete the previous branch

Catch ValueErrors from calls to mitmproxy.net.http.url.parse(). Otherwise mitmproxy crashes due to uncaught exception.
