### PR TITLE
How can I get the MITM certificate from a flow in a script hook?

### DIFF
--- a/mitmproxy/connections.py
+++ b/mitmproxy/connections.py
@@ -136,6 +136,7 @@ class ServerConnection(tcp.TCPClient, stateobject.StateObject):
         source_address: Local IP address or client's source IP address.
         ssl_established: True if TLS is established, False otherwise
         cert: The certificate presented by the remote during the TLS handshake
+        mimtcert: The certificate presented by mitmproxy to the client
         sni: Server Name Indication sent by the proxy during the TLS handshake
         alpn_proto_negotiated: The negotiated application protocol
         via: The underlying server connection (e.g. the connection to the upstream proxy in upstream proxy mode)
@@ -187,6 +188,7 @@ class ServerConnection(tcp.TCPClient, stateobject.StateObject):
         source_address=tcp.Address,
         ssl_established=bool,
         cert=certs.SSLCert,
+        mitmcert=certs.SSLCert,
         sni=str,
         alpn_proto_negotiated=bytes,
         timestamp_start=float,
@@ -207,6 +209,7 @@ class ServerConnection(tcp.TCPClient, stateobject.StateObject):
             address=dict(address=address, use_ipv6=False),
             ip_address=dict(address=address, use_ipv6=False),
             cert=None,
+            mitmcert=None,
             sni=None,
             alpn_proto_negotiated=None,
             source_address=dict(address=('', 0), use_ipv6=False),

--- a/mitmproxy/proxy/protocol/tls.py
+++ b/mitmproxy/proxy/protocol/tls.py
@@ -465,6 +465,8 @@ class TlsLayer(base.Layer):
         self.log("Establish TLS with client", "debug")
         cert, key, chain_file = self._find_cert()
 
+        self.server_conn.mitmcert = cert
+
         if self.config.options.add_upstream_certs_to_client_chain:
             extra_certs = self.server_conn.server_certs
         else:


### PR DESCRIPTION
I'm using mitmdump 1.0.2 to intercept a TLS connection and log and modify it with TCP hooks (`--tcp foo.host.com -s script.py`).

I need to find and replace the hex/ASCII digest of the *upstream* server certificate with the digest of mitmproxy's *generated* certificate—because the client expects to receive and check the certificate hash at the application level.

I can easily get the real/upstream server certificate from `flow.server_conn.cert`. But how can I get the generated/MITM cert sent to the client in the TCP hooks?

```python
def tcp_message(flow):
    d = flow.dumpfile
    m = flow.messages[-1]
    c = m.content

    real_server_hash = flow.server_conn.cert.digest('sha1').replace(b':',b'').lower()

    #####
    # FIXME: how can I figure out the hash of the certificate that mitmproxy is sending to the client?
    mitm_server_hash = b'hardcodedvaluehere'
    #####

    nc = m.content
    nc = nc.replace(real_server_hash, mitm_server_hash)
    if nc!=m.content:
        print("%s message: replaced real cert hash (%r) with mitmproxy cert hash (%r)" % ('outgoing' if m.from_client else 'incoming', real_server_hash, mitm_server_hash), file=stderr)
        m.content = nc
```