### PR TITLE
Use existing urlencoding conventions when re-encoding edited form #1946

### DIFF
--- a/mitmproxy/net/http/request.py
+++ b/mitmproxy/net/http/request.py
@@ -426,8 +426,6 @@ class Request(message.Message):
         self.headers["content-type"] = "application/x-www-form-urlencoded"
         #self.content = mitmproxy.net.http.url.encode(form_data).encode()
         self._sanitized_form_data_replacement(form_data)
-        # only raw_content should be URL encoded, content should be decoded
-
         
     @urlencoded_form.setter
     def urlencoded_form(self, value):

--- a/mitmproxy/net/http/request.py
+++ b/mitmproxy/net/http/request.py
@@ -366,33 +366,33 @@ class Request(message.Message):
             except ValueError:
                 pass
         return ()
-    
+
     def _sanitized_form_data_replacement(self, form_data):
-        # create backup of unmodified content
-        backup = self.content
         # check if unmodified content changes with URL encoding
-        url_decoded_content = urllib.parse.parse_qsl(self.content,keep_blank_values=True)
+        url_decoded_content = urllib.parse.parse_qsl(self.content, keep_blank_values=True)
         url_reencoded_content = urllib.parse.urlencode(url_decoded_content, doseq=True).encode()
         if self.content == url_reencoded_content:
             # encoding the unmodified content doesn't change anything, so we should be good to go on as usual
             self.content = mitmproxy.net.http.url.encode(form_data).encode()
         else:
             # if we are here, we have to alter encoding behavior to mimic the one used in unmodified POST request
-            
-            #check if content isn't encoded at all
+
+            # check if content isn't encoded at all
             if self.content == urllib.parse.unquote(url_reencoded_content.decode()).encode():
                 # if we land here, the new content mustn't be URL encoded thus we decode the result before setting new content
-                # this is the case for "https://www.facebook.com/ajax/updatestatus.php" but additionally the "=" sign is omitted on SOME empty keys
+                # this is the case for "https://www.facebook.com/ajax/updatestatus.php" but additionally the "=" sign is
+                # omitted on SOME empty keys
                 self.content = urllib.parse.unquote(mitmproxy.net.http.url.encode(form_data)).encode()
             # check if content isn't encoded at all and equal signs are omitted
-            elif self.content == urllib.parse.unquote(url_reencoded_content.decode()).replace("=&","&").encode():
+            elif self.content == urllib.parse.unquote(url_reencoded_content.decode()).replace("=&", "&").encode():
                 # remove equal sign for keys without value
-                self.content = urllib.parse.unquote(mitmproxy.net.http.url.encode(form_data)).replace("=&","&").encode()
+                self.content = urllib.parse.unquote(mitmproxy.net.http.url.encode(form_data)).replace("=&", "&").encode()
             # the next check should address the facebook issue, which is an absolute weird corner case:
             # here's a real, but trimmed down data section of a POST request to "https://www.facebook.com/ajax/updatestatus.php"
             # with content-type 'application/x-www-form-urlencoded'
             #
-            # self.content: b'attachment&backdated_date[year]&composer_source_surface=newsfeed&multilingual_specified_lang=&__pc=PHASED%3ADEFAULT'
+            # self.content:
+            # b'attachment&backdated_date[year]&composer_source_surface=newsfeed&multilingual_specified_lang=&__pc=PHASED%3ADEFAULT'
             #    * the first two keys have no value, but no equal sign appended
             #    * the second key shows that no URL encoding ist used ("[" and "]")
             #    * the third key shows a key=value pair
@@ -402,21 +402,20 @@ class Request(message.Message):
             # To cope with that, a somehow hacky approach is used
             #    If unmodified and unquoted POST data contains ONE SINGLE key without a value, which hasn't an equal sign appended
             #    we remove all equal signs on empty keys in modified data
-            elif any ("=" not in param for param in urllib.parse.unquote(self.content.decode()).split("&")):
+            elif any("=" not in param for param in urllib.parse.unquote(self.content.decode()).split("&")):
                 # if we are here, there was at least one key without value but no equal sign appended in unquoted POST form data
                 # thus we remove "=" for all keys without value
-                
+
                 # unquote
-                modified_content=mitmproxy.net.http.url.encode(form_data)
+                modified_content = mitmproxy.net.http.url.encode(form_data)
                 # remove equal sign
-                modified_content=modified_content.replace("=&","&").encode()
+                modified_content = modified_content.replace("=&", "&").encode()
                 self.content = modified_content
-                
-            # additional corner cases could be added to with new "elif" statements    
+
+            # additional corner cases could be added to with new "elif" statements
             else:
                 # if we are here we trigger default behavior again
                 self.content = mitmproxy.net.http.url.encode(form_data).encode()
-                
 
     def _set_urlencoded_form(self, form_data):
         """
@@ -424,9 +423,9 @@ class Request(message.Message):
         This will overwrite the existing content if there is one.
         """
         self.headers["content-type"] = "application/x-www-form-urlencoded"
-        #self.content = mitmproxy.net.http.url.encode(form_data).encode()
+        # self.content = mitmproxy.net.http.url.encode(form_data).encode()
         self._sanitized_form_data_replacement(form_data)
-        
+
     @urlencoded_form.setter
     def urlencoded_form(self, value):
         self._set_urlencoded_form(value)

--- a/mitmproxy/net/http/request.py
+++ b/mitmproxy/net/http/request.py
@@ -366,6 +366,57 @@ class Request(message.Message):
             except ValueError:
                 pass
         return ()
+    
+    def _sanitized_form_data_replacement(self, form_data):
+        # create backup of unmodified content
+        backup = self.content
+        # check if unmodified content changes with URL encoding
+        url_decoded_content = urllib.parse.parse_qsl(self.content,keep_blank_values=True)
+        url_reencoded_content = urllib.parse.urlencode(url_decoded_content, doseq=True).encode()
+        if self.content == url_reencoded_content:
+            # encoding the unmodified content doesn't change anything, so we should be good to go on as usual
+            self.content = mitmproxy.net.http.url.encode(form_data).encode()
+        else:
+            # if we are here, we have to alter encoding behavior to mimic the one used in unmodified POST request
+            
+            #check if content isn't encoded at all
+            if self.content == urllib.parse.unquote(url_reencoded_content.decode()).encode():
+                # if we land here, the new content mustn't be URL encoded thus we decode the result before setting new content
+                # this is the case for "https://www.facebook.com/ajax/updatestatus.php" but additionally the "=" sign is omitted on SOME empty keys
+                self.content = urllib.parse.unquote(mitmproxy.net.http.url.encode(form_data)).encode()
+            # check if content isn't encoded at all and equal signs are omitted
+            elif self.content == urllib.parse.unquote(url_reencoded_content.decode()).replace("=&","&").encode():
+                # remove equal sign for keys without value
+                self.content = urllib.parse.unquote(mitmproxy.net.http.url.encode(form_data)).replace("=&","&").encode()
+            # the next check should address the facebook issue, which is an absolute weird corner case:
+            # here's a real, but trimmed down data section of a POST request to "https://www.facebook.com/ajax/updatestatus.php"
+            # with content-type 'application/x-www-form-urlencoded'
+            #
+            # self.content: b'attachment&backdated_date[year]&composer_source_surface=newsfeed&multilingual_specified_lang=&__pc=PHASED%3ADEFAULT'
+            #    * the first two keys have no value, but no equal sign appended
+            #    * the second key shows that no URL encoding ist used ("[" and "]")
+            #    * the third key shows a key=value pair
+            #    * the next key "multilingual_specified_lang" again has no value, but this time an equal sign is appended
+            #    * the last key has assigned a value, which is URL encoded ("%3A" == ":")
+            #
+            # To cope with that, a somehow hacky approach is used
+            #    If unmodified and unquoted POST data contains ONE SINGLE key without a value, which hasn't an equal sign appended
+            #    we remove all equal signs on empty keys in modified data
+            elif any ("=" not in param for param in urllib.parse.unquote(self.content.decode()).split("&")):
+                # if we are here, there was at least one key without value but no equal sign appended in unquoted POST form data
+                # thus we remove "=" for all keys without value
+                
+                # unquote
+                modified_content=mitmproxy.net.http.url.encode(form_data)
+                # remove equal sign
+                modified_content=modified_content.replace("=&","&").encode()
+                self.content = modified_content
+                
+            # additional corner cases could be added to with new "elif" statements    
+            else:
+                # if we are here we trigger default behavior again
+                self.content = mitmproxy.net.http.url.encode(form_data).encode()
+                
 
     def _set_urlencoded_form(self, form_data):
         """
@@ -373,8 +424,11 @@ class Request(message.Message):
         This will overwrite the existing content if there is one.
         """
         self.headers["content-type"] = "application/x-www-form-urlencoded"
-        self.content = mitmproxy.net.http.url.encode(form_data).encode()
+        #self.content = mitmproxy.net.http.url.encode(form_data).encode()
+        self._sanitized_form_data_replacement(form_data)
+        # only raw_content should be URL encoded, content should be decoded
 
+        
     @urlencoded_form.setter
     def urlencoded_form(self, value):
         self._set_urlencoded_form(value)

--- a/mitmproxy/net/http/url.py
+++ b/mitmproxy/net/http/url.py
@@ -82,11 +82,24 @@ def unparse(scheme, host, port, path=""):
     return "%s://%s%s" % (scheme, hostport(scheme, host, port), path)
 
 
-def encode(s: Sequence[Tuple[str, str]]) -> str:
+def encode(s: Sequence[Tuple[str, str]], similar_to: str=None) -> str:
     """
         Takes a list of (key, value) tuples and returns a urlencoded string.
+        If similar_to is passed, the output is formatted similar to the provided urlencoded string.
     """
-    return urllib.parse.urlencode(s, False, errors="surrogateescape")
+
+    remove_trailing_equal = False
+    if similar_to:
+        remove_trailing_equal = any("=" not in param for param in similar_to.split("&"))
+
+    encoded = urllib.parse.urlencode(s, False, errors="surrogateescape")
+
+    if remove_trailing_equal:
+        encoded = encoded.replace("=&", "&")
+        if encoded[-1] == '=':
+            encoded = encoded[:-1]
+
+    return encoded
 
 
 def decode(s):

--- a/test/mitmproxy/net/http/test_url.py
+++ b/test/mitmproxy/net/http/test_url.py
@@ -85,6 +85,26 @@ surrogates_quoted = (
 )
 
 
+def test_empty_key_trailing_equal_sign():
+    """
+    Some HTTP clients don't send trailing equal signs for parameters without assigned value, e.g. they send
+        foo=bar&baz&qux=quux
+    instead of
+        foo=bar&baz=&qux=quux
+    The respective behavior of encode() should be driven by a reference string given in similar_to parameter
+    """
+    reference_without_equal = "key1=val1&key2&key3=val3"
+    reference_with_equal = "key1=val1&key2=&key3=val3"
+
+    post_data_empty_key_middle = [('one', 'two'), ('emptykey', ''), ('three', 'four')]
+    post_data_empty_key_end = [('one', 'two'), ('three', 'four'), ('emptykey', '')]
+
+    assert url.encode(post_data_empty_key_middle, similar_to = reference_with_equal) == "one=two&emptykey=&three=four"
+    assert url.encode(post_data_empty_key_end, similar_to = reference_with_equal) == "one=two&three=four&emptykey="
+    assert url.encode(post_data_empty_key_middle, similar_to = reference_without_equal) == "one=two&emptykey&three=four"
+    assert url.encode(post_data_empty_key_end, similar_to = reference_without_equal) == "one=two&three=four&emptykey"
+
+
 def test_encode():
     assert url.encode([('foo', 'bar')])
     assert url.encode([('foo', surrogates)])


### PR DESCRIPTION
Handles corner case discussed in issue [#1946](https://github.com/mitmproxy/mitmproxy/issues/1946)

Only considers requests (no responses)

Works for "https://www.facebook.com/ajax/updatestatus.php"