### PR TITLE
fix websocket message display crash in console.

### DIFF
--- a/mitmproxy/tools/console/master.py
+++ b/mitmproxy/tools/console/master.py
@@ -412,7 +412,7 @@ class ConsoleMaster(master.Master):
     def websocket_message(self, f):
         super().websocket_message(f)
         message = f.messages[-1]
-        signals.add_log(message.info, "info")
+        signals.add_log(f.message_info(message), "info")
         signals.add_log(strutils.bytes_to_escaped_str(message.content), "debug")
 
     @controller.handler


### PR DESCRIPTION
I caught a crash when I was viewing the issue list on github with mitmproxy on.
```python
Traceback (most recent call last):
  File "/home/matthew/Hack/mitmproxy/mitmproxy/tools/console/master.py", line 281, in run
    self.loop.run()
  File "/home/matthew/Hack/mitmproxy/venv3.5/lib/python3.5/site-packages/urwid/main_loop.py", line 278, in run
    self._run()
  File "/home/matthew/Hack/mitmproxy/venv3.5/lib/python3.5/site-packages/urwid/main_loop.py", line 376, in _run
    self.event_loop.run()
  File "/home/matthew/Hack/mitmproxy/venv3.5/lib/python3.5/site-packages/urwid/main_loop.py", line 682, in run
    self._loop()
  File "/home/matthew/Hack/mitmproxy/venv3.5/lib/python3.5/site-packages/urwid/main_loop.py", line 715, in _loop
    alarm_callback()
  File "/home/matthew/Hack/mitmproxy/venv3.5/lib/python3.5/site-packages/urwid/main_loop.py", line 164, in cb
    callback(self, user_data)
  File "/home/matthew/Hack/mitmproxy/mitmproxy/tools/console/master.py", line 239, in ticker
    changed = self.tick(timeout=0)
  File "/home/matthew/Hack/mitmproxy/mitmproxy/master.py", line 109, in tick
    handle_func(obj)
  File "/home/matthew/Hack/mitmproxy/mitmproxy/controller.py", line 68, in wrapper
    ret = f(master, message)
  File "/home/matthew/Hack/mitmproxy/mitmproxy/tools/console/master.py", line 415, in websocket_message
    signals.add_log(message.info, "info")
AttributeError: 'WebSocketMessage' object has no attribute 'info'

mitmproxy has crashed!
Please lodge a bug report at:
	https://github.com/mitmproxy/mitmproxy
Shutting down...
```
I looked into it and it seems that the message information should be obtain by `WebSocketFlow.message_info()`, I referred to `mitmproxy.addons.dumper` and found it should be `f.message_info(message)`.