### PR TITLE
Avoid adding Host header in reverse mode for HTTP2 streams

### DIFF
--- a/mitmproxy/proxy/protocol/http.py
+++ b/mitmproxy/proxy/protocol/http.py
@@ -290,7 +290,7 @@ class HttpLayer(base.Layer):
             request.first_line_format = "relative"
 
         # update host header in reverse proxy mode
-        if self.config.options.mode == "reverse":
+        if self.config.options.mode == "reverse" and not f.request.headers[":authority"]:
             f.request.headers["Host"] = self.config.upstream_server.address.host
 
         # Determine .scheme, .host and .port attributes for inline scripts. For


### PR DESCRIPTION
In "Reverse Proxy" mode, the proxy was adding "Host" headers to all requests sent out, even for ones on HTTP/2 connections.

The spec says this is something senders should not do:
> Clients that generate HTTP/2 requests directly SHOULD use the ":authority" pseudo-header field instead of the Host header field.  An intermediary that converts an HTTP/2 request to HTTP/1.1 MUST create a Host header field if one is not present in a request by copying the value of the ":authority" pseudo-header field.

Apparently, various HTTP/2 servers were not taking it well, and responded to such requests with RST_STREAMs indicating PROTOCOL_ERROR.

This PR changes that behavior.