### PR TITLE
Add "Request.host_header"

### DIFF
--- a/examples/complex/dns_spoofing.py
+++ b/examples/complex/dns_spoofing.py
@@ -34,7 +34,7 @@ class Rerouter:
         The original host header is retrieved early
         before flow.request is replaced by mitmproxy new outgoing request
         """
-        flow.metadata["original_host"] = flow.request.headers["Host"]
+        flow.metadata["original_host"] = flow.request.host_header
 
     def request(self, flow):
         if flow.client_conn.ssl_established:
@@ -53,7 +53,7 @@ class Rerouter:
             if m.group("port"):
                 port = int(m.group("port"))
 
-        flow.request.headers["Host"] = host_header
+        flow.request.host_header = host_header
         flow.request.host = sni or host_header
         flow.request.port = port
 

--- a/mitmproxy/export.py
+++ b/mitmproxy/export.py
@@ -73,7 +73,7 @@ def python_code(flow: http.HTTPFlow):
 
     headers = flow.request.headers.copy()
     # requests adds those by default.
-    for x in ("host", "content-length"):
+    for x in (":authority", "host", "content-length"):
         headers.pop(x, None)
     writearg("headers", dict(headers))
     try:
@@ -130,7 +130,7 @@ def locust_code(flow):
     if flow.request.headers:
         lines = [
             (_native(k), _native(v)) for k, v in flow.request.headers.fields
-            if _native(k).lower() not in ["host", "cookie"]
+            if _native(k).lower() not in [":authority", "host", "cookie"]
         ]
         lines = ["            '%s': '%s',\n" % (k, v) for k, v in lines]
         headers += "\n        headers = {\n%s        }\n" % "".join(lines)

--- a/mitmproxy/net/http/http1/assemble.py
+++ b/mitmproxy/net/http/http1/assemble.py
@@ -78,8 +78,9 @@ def _assemble_request_headers(request_data):
     Args:
         request_data (mitmproxy.net.http.request.RequestData)
     """
-    headers = request_data.headers.copy()
+    headers = request_data.headers
     if "host" not in headers and request_data.scheme and request_data.host and request_data.port:
+        headers = headers.copy()
         headers["host"] = mitmproxy.net.http.url.hostport(
             request_data.scheme,
             request_data.host,

--- a/mitmproxy/net/http/request.py
+++ b/mitmproxy/net/http/request.py
@@ -165,11 +165,8 @@ class Request(message.Message):
         self.data.host = host
 
         # Update host header
-        if "host" in self.headers:
-            if host:
-                self.headers["host"] = host
-            else:
-                self.headers.pop("host")
+        if self.host_header is not None:
+            self.host_header = host
 
     @property
     def host_header(self) -> Optional[str]:
@@ -248,9 +245,10 @@ class Request(message.Message):
 
     def _parse_host_header(self):
         """Extract the host and port from Host header"""
-        if "host" not in self.headers:
+        host = self.host_header
+        if not host:
             return None, None
-        host, port = self.headers["host"], None
+        port = None
         m = host_header_re.match(host)
         if m:
             host = m.group("host").strip("[]")

--- a/mitmproxy/proxy/protocol/http.py
+++ b/mitmproxy/proxy/protocol/http.py
@@ -291,7 +291,7 @@ class HttpLayer(base.Layer):
 
         # update host header in reverse proxy mode
         if self.config.options.mode == "reverse":
-            f.request.headers["Host"] = self.config.upstream_server.address.host
+            f.request.host_header = self.config.upstream_server.address.host
 
         # Determine .scheme, .host and .port attributes for inline scripts. For
         # absolute-form requests, they are directly given in the request. For
@@ -301,11 +301,10 @@ class HttpLayer(base.Layer):
         if self.mode is HTTPMode.transparent:
             # Setting request.host also updates the host header, which we want
             # to preserve
-            host_header = f.request.headers.get("host", None)
+            host_header = f.request.host_header
             f.request.host = self.__initial_server_conn.address.host
             f.request.port = self.__initial_server_conn.address.port
-            if host_header:
-                f.request.headers["host"] = host_header
+            f.request.host_header = host_header  # set again as .host overwrites this.
             f.request.scheme = "https" if self.__initial_server_tls else "http"
         self.channel.ask("request", f)
 


### PR DESCRIPTION
This PR introduces `request.host_header`, which transparently maps between "Host" and ":authority" headers.

fixes #2034
fixes #2036
closes #1791