### PR TITLE
Adds PyInstaller build indicator to --version argument

### DIFF
--- a/mitmproxy/utils/debug.py
+++ b/mitmproxy/utils/debug.py
@@ -37,8 +37,12 @@ def dump_system_info():
         except:
             pass
 
+    bin_indicator = ""  # PyInstaller builds indicator, if using precompiled binary
+    if getattr(sys, 'frozen', False):
+        bin_indicator = "Precompiled Binary"
+
     data = [
-        "Mitmproxy version: {} ({})".format(version.VERSION, git_describe),
+        "Mitmproxy version: {} ({}) {}".format(version.VERSION, git_describe, bin_indicator),
         "Python version: {}".format(platform.python_version()),
         "Platform: {}".format(platform.platform()),
         "SSL version: {}".format(SSL.SSLeay_version(SSL.SSLEAY_VERSION).decode()),

--- a/test/mitmproxy/utils/test_debug.py
+++ b/test/mitmproxy/utils/test_debug.py
@@ -1,11 +1,13 @@
 import io
 import subprocess
+import sys
 from unittest import mock
 
 from mitmproxy.utils import debug
 
 
 def test_dump_system_info():
+    setattr(sys, 'frozen', True)
     assert debug.dump_system_info()
 
     with mock.patch('subprocess.check_output') as m:


### PR DESCRIPTION
I added "Precompiled Binary" along with the Mitmproxy version line, so the new output for binary uses will be:
```
$ mitmproxy --version
Mitmproxy version: 2.0.0 (1.0.1dev0199-0x4cec88fc) Precompiled Binary
Python version: 3.6.0
Platform: Linux-4.8.13-1-ARCH-x86_64-with-arch
SSL version: OpenSSL 1.0.2j  26 Sep 2016
Linux distro: arch
```
This closes #2033. Please let me know if any changes are required.