### PR TITLE
Fix #1928, @concurrent decorator in class

### DIFF
--- a/mitmproxy/script/concurrent.py
+++ b/mitmproxy/script/concurrent.py
@@ -29,4 +29,7 @@ def concurrent(fn):
             "script.concurrent (%s)" % fn.__name__,
             target=run
         ).start()
-    return _concurrent
+    if "." in fn.__qualname__:
+        return staticmethod(_concurrent)
+    else:
+        return _concurrent

--- a/mitmproxy/script/concurrent.py
+++ b/mitmproxy/script/concurrent.py
@@ -29,6 +29,7 @@ def concurrent(fn):
             "script.concurrent (%s)" % fn.__name__,
             target=run
         ).start()
+    # Support @concurrent for class-based addons
     if "." in fn.__qualname__:
         return staticmethod(_concurrent)
     else:

--- a/test/mitmproxy/data/addonscripts/concurrent_decorator_class.py
+++ b/test/mitmproxy/data/addonscripts/concurrent_decorator_class.py
@@ -1,0 +1,13 @@
+import time
+from mitmproxy.script import concurrent
+
+
+class ConcurrentClass:
+
+    @concurrent
+    def request(flow):
+        time.sleep(0.1)
+
+
+def start():
+    return ConcurrentClass()


### PR DESCRIPTION
Fixes #1928, I wrote a simple script to test how should we fix this:
```python
import time

from mitmproxy.script import concurrent


class ConcurrentClass:

    @concurrent  # Remove this and see what happens
    def request(flow):
        # You don't want to use mitmproxy.ctx from a different thread
        print("handle request: %s%s" % (flow.request.host, flow.request.path))
        time.sleep(5)
        print("start  request: %s%s" % (flow.request.host, flow.request.path))


def start():
    return ConcurrentClass()

```
If we load this script and request a web page, it will throw something like "take one positional argument but two were given", it seems that the method in the class accept a hidden parameter `self`. The first things came out of my head is adding a decorator `@staticmethod` for the methods, but that's not neat enough and also increase the burden of script developers.

Then I call the `staticmethod()` before returning the `_concurrent`, however, we should determine if the function is in a class or not. I tried to use the metadata `__self__` or `__class__`, but unfortunately, the decorator does not preserve such metadata for us, so I look up all the thing we could use in `dir(fn)`.

I found the `__qualname__` could be used, for example, for the script above, `request.__qualname__` would be `ConcurrentClass.request`, but for a function out of class, the value would be simply `request`. A dot `.` is enough to judge these two situations.

I know this is kind of strange, but it works fine. If you have any other idea, please do let me know.
