### PR TITLE
Adds --keep-host-header option (#2039)

### DIFF
--- a/docs/features/reverseproxy.rst
+++ b/docs/features/reverseproxy.rst
@@ -31,8 +31,8 @@ Host Header
 
 In reverse proxy mode, mitmproxy automatically rewrites the Host header to match the
 upstream server. This allows mitmproxy to easily connect to existing endpoints on the
-open web (e.g. ``mitmproxy -R https://example.com``). But this behaviour can be
-be disabled by passing ``--keep-host-header`` on the console.
+open web (e.g. ``mitmproxy -R https://example.com``). You can disable this behaviour
+by passing ``--keep-host-header`` on the console.
 
 However, keep in mind that absolute URLs within the returned document or HTTP redirects will
 NOT be rewritten by mitmproxy. This means that if you click on a link for "http://example.com"

--- a/docs/features/reverseproxy.rst
+++ b/docs/features/reverseproxy.rst
@@ -31,7 +31,8 @@ Host Header
 
 In reverse proxy mode, mitmproxy automatically rewrites the Host header to match the
 upstream server. This allows mitmproxy to easily connect to existing endpoints on the
-open web (e.g. ``mitmproxy -R https://example.com``).
+open web (e.g. ``mitmproxy -R https://example.com``). But this behaviour can be
+be disabled by passing ``--keep-host-header`` on the console.
 
 However, keep in mind that absolute URLs within the returned document or HTTP redirects will
 NOT be rewritten by mitmproxy. This means that if you click on a link for "http://example.com"

--- a/mitmproxy/options.py
+++ b/mitmproxy/options.py
@@ -72,6 +72,7 @@ class Options(optmanager.OptManager):
         upstream_bind_address: str = "",
         mode: str = "regular",
         no_upstream_cert: bool = False,
+        keep_host_header: bool = False,
 
         http2: bool = True,
         http2_priority: bool = False,
@@ -162,6 +163,7 @@ class Options(optmanager.OptManager):
         self.upstream_bind_address = upstream_bind_address
         self.mode = mode
         self.no_upstream_cert = no_upstream_cert
+        self.keep_host_header = keep_host_header
 
         self.http2 = http2
         self.http2_priority = http2_priority

--- a/mitmproxy/proxy/protocol/http.py
+++ b/mitmproxy/proxy/protocol/http.py
@@ -290,7 +290,7 @@ class HttpLayer(base.Layer):
             request.first_line_format = "relative"
 
         # update host header in reverse proxy mode
-        if self.config.options.mode == "reverse":
+        if self.config.options.mode == "reverse" and not self.config.options.keep_host_header:
             f.request.host_header = self.config.upstream_server.address.host
 
         # Determine .scheme, .host and .port attributes for inline scripts. For

--- a/mitmproxy/tools/cmdline.py
+++ b/mitmproxy/tools/cmdline.py
@@ -112,6 +112,7 @@ def get_common_options(args):
         replacements=args.replacements,
         replacement_files=args.replacement_files,
         setheaders=args.setheaders,
+        keep_host_header=args.keep_host_header,
         server_replay=args.server_replay,
         scripts=args.scripts,
         stickycookie=stickycookie,
@@ -386,6 +387,11 @@ def proxy_options(parser):
         "--upstream-bind-address",
         action="store", type=str, dest="upstream_bind_address",
         help="Address to bind upstream requests to (defaults to none)"
+    )
+    group.add_argument(
+        "--keep-host-header",
+        action="store_true", dest="keep_host_header",
+        help="Keep the host header as proxy addres"
     )
 
 

--- a/mitmproxy/tools/cmdline.py
+++ b/mitmproxy/tools/cmdline.py
@@ -391,7 +391,7 @@ def proxy_options(parser):
     group.add_argument(
         "--keep-host-header",
         action="store_true", dest="keep_host_header",
-        help="Keep the host header as proxy addres"
+        help="Reverse Proxy: Keep the original host header instead of rewriting it to the reverse proxy target."
     )
 
 

--- a/test/mitmproxy/proxy/test_server.py
+++ b/test/mitmproxy/proxy/test_server.py
@@ -482,6 +482,26 @@ class TestHTTPSNoCommonName(tservers.HTTPProxyTest):
 class TestReverse(tservers.ReverseProxyTest, CommonMixin, TcpMixin):
     reverse = True
 
+    def test_host_header(self):
+        self.config.options.keep_host_header = True
+        p = self.pathoc()
+        with p.connect():
+            resp = p.request("get:/p/200:h'Host'='example.com'")
+        assert resp.status_code == 200
+
+        req = self.master.state.flows[0].request
+        assert req.host_header == "example.com"
+
+    def test_overridden_host_header(self):
+        self.config.options.keep_host_header = False  # default value
+        p = self.pathoc()
+        with p.connect():
+            resp = p.request("get:/p/200:h'Host'='example.com'")
+        assert resp.status_code == 200
+
+        req = self.master.state.flows[0].request
+        assert req.host_header == "127.0.0.1"
+
 
 class TestReverseSSL(tservers.ReverseProxyTest, CommonMixin, TcpMixin):
     reverse = True

--- a/test/mitmproxy/test_examples.py
+++ b/test/mitmproxy/test_examples.py
@@ -114,13 +114,11 @@ class TestScripts(tservers.MasterTest):
 
         # Rewrite by reverse proxy mode
         f.request.scheme = "https"
-        f.request.host = "mitmproxy.org"
         f.request.port = 443
 
         m.request(f)
 
         assert f.request.scheme == "http"
-        assert f.request.host == original_host
         assert f.request.port == 80
 
         assert f.request.headers["Host"] == original_host


### PR DESCRIPTION
As per the discussion in [#2034](https://github.com/mitmproxy/mitmproxy/pull/2034#issuecomment-280770573) (closed) and #2039 issue, this adds a `--keep-host-header` option to avoid auto header rewrite. 

fixes #2039