### PR TITLE
http2: normalize headers before sending

### DIFF
--- a/mitmproxy/proxy/protocol/http2.py
+++ b/mitmproxy/proxy/protocol/http2.py
@@ -97,7 +97,6 @@ class Http2Layer(base.Layer):
             client_side=False,
             header_encoding=False,
             validate_outbound_headers=False,
-            normalize_outbound_headers=False,
             validate_inbound_headers=False)
         self.connections[self.client_conn] = SafeH2Connection(self.client_conn, config=config)
 
@@ -107,7 +106,6 @@ class Http2Layer(base.Layer):
                 client_side=True,
                 header_encoding=False,
                 validate_outbound_headers=False,
-                normalize_outbound_headers=False,
                 validate_inbound_headers=False)
             self.connections[self.server_conn] = SafeH2Connection(self.server_conn, config=config)
         self.connections[self.server_conn].initiate_connection()


### PR DESCRIPTION
This might have prevented https://github.com/mitmproxy/mitmproxy/pull/2034.