### PR TITLE
Remove pytz in hardump

### DIFF
--- a/examples/complex/har_dump.py
+++ b/examples/complex/har_dump.py
@@ -10,7 +10,7 @@ import zlib
 import os
 
 from datetime import datetime
-import pytz
+from datetime import timezone
 
 import mitmproxy
 
@@ -89,7 +89,7 @@ def response(flow):
     # Timings set to -1 will be ignored as per spec.
     full_time = sum(v for v in timings.values() if v > -1)
 
-    started_date_time = format_datetime(datetime.utcfromtimestamp(flow.request.timestamp_start))
+    started_date_time = datetime.fromtimestamp(flow.request.timestamp_start, timezone.utc).isoformat()
 
     # Response body size and encoding
     response_body_size = len(flow.response.raw_content)
@@ -173,10 +173,6 @@ def done():
         mitmproxy.ctx.log("HAR dump finished (wrote %s bytes to file)" % len(json_dump))
 
 
-def format_datetime(dt):
-    return dt.replace(tzinfo=pytz.timezone("UTC")).isoformat()
-
-
 def format_cookies(cookie_list):
     rv = []
 
@@ -198,7 +194,7 @@ def format_cookies(cookie_list):
         # Expiration time needs to be formatted
         expire_ts = cookies.get_expiration_ts(attrs)
         if expire_ts is not None:
-            cookie_har["expires"] = format_datetime(datetime.fromtimestamp(expire_ts))
+            cookie_har["expires"] = datetime.fromtimestamp(expire_ts, timezone.utc).isoformat()
 
         rv.append(cookie_har)
 

--- a/setup.py
+++ b/setup.py
@@ -113,7 +113,6 @@ setup(
         ],
         'examples': [
             "beautifulsoup4>=4.4.1, <4.6",
-            "pytz>=2015.07.0, <=2016.10",
             "Pillow>=3.2, <4.1",
         ]
     }


### PR DESCRIPTION
Removes pytz from har_dump script.
Also, this uses utcfromtimestamp 
https://github.com/mitmproxy/mitmproxy/blob/master/examples/complex/har_dump.py#L92
whereas this uses fromtimestamp
https://github.com/mitmproxy/mitmproxy/blob/master/examples/complex/har_dump.py#L201

both of these were being passed to the same function which then set the tzinfo to UTC. I think both should have been utcfromtimestamp. 
In the fix both the times give UTC date time