### PR TITLE
Added console_ prefix to options in palettepicker to resolve issue #2068

### DIFF
--- a/mitmproxy/tools/console/palettepicker.py
+++ b/mitmproxy/tools/console/palettepicker.py
@@ -43,7 +43,7 @@ class PalettePicker(urwid.WidgetWrap):
                 i,
                 None,
                 lambda: self.master.options.console_palette == name,
-                lambda: setattr(self.master.options, "palette", name)
+                lambda: setattr(self.master.options, "console_palette", name)
             )
 
         for i in high:
@@ -59,7 +59,7 @@ class PalettePicker(urwid.WidgetWrap):
                     "Transparent",
                     "T",
                     lambda: master.options.console_palette_transparent,
-                    master.options.toggler("palette_transparent")
+                    master.options.toggler("console_palette_transparent")
                 )
             ]
         )


### PR DESCRIPTION
Added 'console_' prefix to mitmproxy/tools/console/palettepicker.py to fix #2068. 
