### PR TITLE
[web] Fix #2071, remove client_connect.mitmcert when dumping flow into json.

### DIFF
--- a/mitmproxy/tools/web/app.py
+++ b/mitmproxy/tools/web/app.py
@@ -85,6 +85,7 @@ def flow_to_json(flow: mitmproxy.flow.Flow) -> dict:
                 "is_replay": flow.response.is_replay,
             }
     f.get("server_conn", {}).pop("cert", None)
+    f.get("client_conn", {}).pop("mitmcert", None)
 
     return f
 


### PR DESCRIPTION
Fix #2071 which cause a crush when visiting any website in https with mitmweb.