### PR TITLE
Call error handler and mark flow on HTTPException

### DIFF
--- a/mitmproxy/proxy/protocol/http.py
+++ b/mitmproxy/proxy/protocol/http.py
@@ -276,6 +276,8 @@ class HttpLayer(base.Layer):
             # We optimistically guess there might be an HTTP client on the
             # other end
             self.send_error_response(400, repr(e))
+            f.error = flow.Error(str(e))
+            self.channel.ask("error", f)
             raise exceptions.ProtocolException(
                 "HTTP protocol error in client request: {}".format(e)
             )


### PR DESCRIPTION
Hi,

This allows scripts to handle HTTPException exceptions such as "HTTP Body too large" raised in [mitmproxy/net/http/http1/read.py:131](https://github.com/mitmproxy/mitmproxy/blob/master/mitmproxy/net/http/http1/read.py#L131).

This simply follows how ProtocolException exceptions are [handled](https://github.com/mitmproxy/mitmproxy/blob/master/mitmproxy/proxy/protocol/http.py#L212).

It also marks the flow with the error [as is done elsewhere](https://github.com/mitmproxy/mitmproxy/blob/master/mitmproxy/proxy/protocol/http.py#L211).

I would like to handle errors like this and I couldn't see any other way. If this commit makes sense to you and doesn't break anything I would like to get it merged in. 

I'd be happy to add a test if someone could help suggest where it should go and maybe point to an existing test that might help me get started.

Cheers