### PR TITLE
[web] Add mouse support for FilterInput popover.

### DIFF
--- a/web/src/css/header.less
+++ b/web/src/css/header.less
@@ -113,5 +113,12 @@ header {
     .popover-content {
         max-height: 500px;
         overflow-y: auto;
+
+        tr {
+            cursor: pointer;
+            &:hover {
+                background-color: hsla(209, 52%, 84%, 0.5) !important;
+            }
+        }
     }
 }

--- a/web/src/js/components/Header/FilterDocs.jsx
+++ b/web/src/js/components/Header/FilterDocs.jsx
@@ -11,7 +11,7 @@ export default class FilterDocs extends Component {
 
     constructor(props, context) {
         super(props, context)
-        this.state = { doc: FilterDocs.doc }
+        this.state = { doc: FilterDocs.doc, selectHandler: props.selectHandler}
     }
 
     componentWillMount() {
@@ -29,6 +29,10 @@ export default class FilterDocs extends Component {
         }
     }
 
+    handleClick(e, value){
+        this.state.selectHandler(value.split(" ")[0] + " ")
+    }
+
     render() {
         const { doc } = this.state
         return !doc ? (
@@ -37,7 +41,7 @@ export default class FilterDocs extends Component {
             <table className="table table-condensed">
                 <tbody>
                     {doc.commands.map(cmd => (
-                        <tr key={cmd[1]}>
+                        <tr key={cmd[1]} onClick={e => this.handleClick(e, cmd[0])}>
                             <td>{cmd[0].replace(' ', '\u00a0')}</td>
                             <td>{cmd[1]}</td>
                         </tr>

--- a/web/src/js/components/Header/FilterDocs.jsx
+++ b/web/src/js/components/Header/FilterDocs.jsx
@@ -11,7 +11,7 @@ export default class FilterDocs extends Component {
 
     constructor(props, context) {
         super(props, context)
-        this.state = { doc: FilterDocs.doc, selectHandler: props.selectHandler}
+        this.state = { doc: FilterDocs.doc }
     }
 
     componentWillMount() {
@@ -29,10 +29,6 @@ export default class FilterDocs extends Component {
         }
     }
 
-    handleClick(e, value){
-        this.state.selectHandler(value.split(" ")[0] + " ")
-    }
-
     render() {
         const { doc } = this.state
         return !doc ? (
@@ -41,7 +37,7 @@ export default class FilterDocs extends Component {
             <table className="table table-condensed">
                 <tbody>
                     {doc.commands.map(cmd => (
-                        <tr key={cmd[1]} onClick={e => this.handleClick(e, cmd[0])}>
+                        <tr key={cmd[1]} onClick={e => this.props.selectHandler(cmd[0].split(" ")[0] + " ")}>
                             <td>{cmd[0].replace(' ', '\u00a0')}</td>
                             <td>{cmd[1]}</td>
                         </tr>

--- a/web/src/js/components/Header/FilterInput.jsx
+++ b/web/src/js/components/Header/FilterInput.jsx
@@ -21,6 +21,7 @@ export default class FilterInput extends Component {
         this.onKeyDown = this.onKeyDown.bind(this)
         this.onMouseEnter = this.onMouseEnter.bind(this)
         this.onMouseLeave = this.onMouseLeave.bind(this)
+        this.selectFilter = this.selectFilter.bind(this)
     }
 
     componentWillReceiveProps(nextProps) {
@@ -41,7 +42,7 @@ export default class FilterInput extends Component {
 
     getDesc() {
         if (!this.state.value) {
-            return <FilterDocs/>
+            return <FilterDocs selectHandler={this.selectFilter}/>
         }
         try {
             return Filt.parse(this.state.value).desc
@@ -83,6 +84,10 @@ export default class FilterInput extends Component {
             this.setState({mousefocus: false})
         }
         e.stopPropagation()
+    }
+
+    selectFilter(cmd) {
+        this.setState({value: cmd})
     }
 
     blur() {

--- a/web/src/js/components/Header/FilterInput.jsx
+++ b/web/src/js/components/Header/FilterInput.jsx
@@ -88,6 +88,7 @@ export default class FilterInput extends Component {
 
     selectFilter(cmd) {
         this.setState({value: cmd})
+        ReactDOM.findDOMNode(this.refs.input).focus()
     }
 
     blur() {


### PR DESCRIPTION
This PR makes the FilterInput box more user-friendly. Originally, the popover will appear when you click the FilterInput box, but you could not select the filter item by mouse, you have to type into the box. 
I make the item in the popover click-able, and the selected filter will appear in the input box.
![img](http://matshao.qiniudn.com/2017-03-02%2011-15-56)