### PR TITLE
link to stackoverflow for chrome certificate management

### DIFF
--- a/docs/certinstall.rst
+++ b/docs/certinstall.rst
@@ -89,7 +89,7 @@ See https://wiki.mozilla.org/MozillaRootCertificate#Mozilla_Firefox
 Chrome on Linux
 ^^^^^^^^^^^^^^^
 
-See https://code.google.com/p/chromium/wiki/LinuxCertManagement
+See http://stackoverflow.com/a/15076602/198996
 
 
 The mitmproxy certificate authority


### PR DESCRIPTION
the old link doesnt lead anywhere. i replaced it with a link to an answer on stackoverflow which helped me import the mitmproxy-certificate to chrome

ps: i'm not sure if the new link also applies to chrome on other operating systems? i guess it's the same for all...?