### PR TITLE
[web] fix scroll bug in flow detail. (#2083)

### DIFF
--- a/web/src/css/flowdetail.less
+++ b/web/src/css/flowdetail.less
@@ -14,8 +14,7 @@
     }
 
     section {
-        display: flex;
-        flex-direction: column;
+        overflow-y: scroll;
         >article{
             overflow: auto;
             padding: 5px 12px 0;


### PR DESCRIPTION
This fix the scroll bus when viewing flow details in Firefox. Works for me in both Firefox and Chrome.