### PR TITLE
Fix crash when duplicating flow

### DIFF
--- a/mitmproxy/flow.py
+++ b/mitmproxy/flow.py
@@ -113,8 +113,8 @@ class Flow(stateobject.StateObject):
     def copy(self):
         f = super().copy()
         f.id = str(uuid.uuid4())
-        f.live = False;
-        if self.reply != None:
+        f.live = False
+        if self.reply is not None:
             f.reply = controller.DummyReply()
         return f
 

--- a/mitmproxy/flow.py
+++ b/mitmproxy/flow.py
@@ -113,7 +113,9 @@ class Flow(stateobject.StateObject):
     def copy(self):
         f = super().copy()
         f.id = str(uuid.uuid4())
-        f.live = False
+        f.live = False;
+        if self.reply != None:
+            f.reply = controller.DummyReply()
         return f
 
     def modified(self):


### PR DESCRIPTION
As discussed with @cortesi about this #2096  over IRC . Now it will set reply to DummyReply whenever we duplicate any flow. #2086 . 