### PR TITLE
Fix WBXML parsing to work with Python3 and the MITMProxy 2.0 codebase

### DIFF
--- a/mitmproxy/contrib/wbxml/ASCommandResponse.py
+++ b/mitmproxy/contrib/wbxml/ASCommandResponse.py
@@ -41,7 +41,7 @@ class ASCommandResponse:
 				raise ValueError("Empty WBXML body passed")
 		except Exception as e:
 			self.xmlString = None
-			raise ValueError("Error: {0}".format(e.message))
+			raise ValueError("Error: {0}".format(e))
 
 	def getWBXMLBytes(self):
 		return self.wbxmlBytes

--- a/mitmproxy/contrib/wbxml/ASWBXMLByteQueue.py
+++ b/mitmproxy/contrib/wbxml/ASWBXMLByteQueue.py
@@ -40,7 +40,7 @@ class ASWBXMLByteQueue(Queue):
         Queue.__init__(self)
 
         for byte in wbxmlBytes:
-            self.put(ord(byte))
+            self.put(byte)
             self.bytesEnqueued += 1
 
 

--- a/mitmproxy/contrib/wbxml/ASWBXMLCodePage.py
+++ b/mitmproxy/contrib/wbxml/ASWBXMLCodePage.py
@@ -39,12 +39,12 @@ class ASWBXMLCodePage:
 		self.tagLookup[tag] = token
 	
 	def getToken(self, tag):
-		if self.tagLookup.has_key(tag):
+		if tag in self.tagLookup:
 			return self.tagLookup[tag]
 		return 0xFF
 	
 	def getTag(self, token):
-		if self.tokenLookup.has_key(token):
+		if token in self.tokenLookup:
 			return self.tokenLookup[token]
 		return None
 	


### PR DESCRIPTION
Fixes for the WBXML parser to work correctly with MITM Proxy 2.0, which uses python 3