### PR TITLE
Update tcpproxy.rst

### DIFF
--- a/docs/features/anticache.rst
+++ b/docs/features/anticache.rst
@@ -11,5 +11,5 @@ sure you capture an HTTP exchange in its totality. It's also often used during
 
 ================== ======================
 command-line       ``--anticache``
-mitmproxy shortcut :kbd:`o` then :kbd:`a`
+mitmproxy shortcut :kbd:`O` then :kbd:`a`
 ================== ======================

--- a/docs/features/passthrough.rst
+++ b/docs/features/passthrough.rst
@@ -23,7 +23,7 @@ How it works
 
 ================== ======================
 command-line       ``--ignore regex``
-mitmproxy shortcut :kbd:`o` then :kbd:`I`
+mitmproxy shortcut :kbd:`O` then :kbd:`I`
 ================== ======================
 
 

--- a/docs/features/replacements.rst
+++ b/docs/features/replacements.rst
@@ -61,12 +61,12 @@ times.
 Interactively
 -------------
 
-The :kbd:`R` shortcut key in the mitmproxy options menu (:kbd:`o`) lets you add and edit
+The :kbd:`R` shortcut key in the mitmproxy options menu (:kbd:`O`) lets you add and edit
 replacement hooks using a built-in editor. The context-sensitive help (:kbd:`?`) has
 complete usage information.
 
 ================== =======================
 command-line       ``--replace``,
                    ``--replace-from-file``
-mitmproxy shortcut :kbd:`o` then :kbd:`R`
+mitmproxy shortcut :kbd:`O` then :kbd:`R`
 ================== =======================

--- a/docs/features/serverreplay.rst
+++ b/docs/features/serverreplay.rst
@@ -31,7 +31,7 @@ in the past at the time of replay, and vice versa. Cookie expiry times are
 updated in a similar way.
 
 You can turn off response refreshing using the ``--norefresh`` argument, or using
-the :kbd:`o` options shortcut within :program:`mitmproxy`.
+the :kbd:`O` options shortcut within :program:`mitmproxy`.
 
 
 Replaying a session recorded in Reverse-proxy Mode

--- a/docs/features/setheaders.rst
+++ b/docs/features/setheaders.rst
@@ -15,5 +15,5 @@ Example: Set the **Host** header to "example.com" for all requests.
 
 ================== =======================
 command-line       ``--setheader PATTERN``
-mitmproxy shortcut :kbd:`o` then :kbd:`H`
+mitmproxy shortcut :kbd:`O` then :kbd:`H`
 ================== =======================

--- a/docs/features/sticky.rst
+++ b/docs/features/sticky.rst
@@ -22,7 +22,7 @@ to interact with the secured resources.
 
 ================== ======================
 command-line       ``-t FILTER``
-mitmproxy shortcut :kbd:`o` then :kbd:`t`
+mitmproxy shortcut :kbd:`O` then :kbd:`t`
 ================== ======================
 
 
@@ -37,5 +37,5 @@ replay of HTTP Digest authentication.
 
 ================== ======================
 command-line       ``-u FILTER``
-mitmproxy shortcut :kbd:`o` then :kbd:`A`
+mitmproxy shortcut :kbd:`O` then :kbd:`A`
 ================== ======================

--- a/docs/features/tcpproxy.rst
+++ b/docs/features/tcpproxy.rst
@@ -19,7 +19,7 @@ How it works
 
 ================== ======================
 command-line       ``--tcp HOST``
-mitmproxy shortcut :kbd:`o` then :kbd:`T`
+mitmproxy shortcut :kbd:`O` then :kbd:`T`
 ================== ======================
 
 For a detailed description how the hostname pattern works, please look at the :ref:`passthrough`

--- a/docs/features/upstreamcerts.rst
+++ b/docs/features/upstreamcerts.rst
@@ -19,5 +19,5 @@ Upstream cert sniffing is on by default, and can optionally be turned off.
 
 ================== ======================
 command-line       ``--no-upstream-cert``
-mitmproxy shortcut :kbd:`o` then :kbd:`U`
+mitmproxy shortcut :kbd:`O` then :kbd:`U`
 ================== ======================

--- a/docs/mitmproxy.rst
+++ b/docs/mitmproxy.rst
@@ -66,7 +66,7 @@ At the moment, the Grid Editor is used in four parts of mitmproxy:
   - Editing request or response headers (:kbd:`e` for edit, then :kbd:`h` for headers in flow view)
   - Editing a query string (:kbd:`e` for edit, then :kbd:`q` for query in flow view)
   - Editing a URL-encoded form (:kbd:`e` for edit, then :kbd:`f` for form in flow view)
-  - Editing replacement patterns (:kbd:`o` for options, then :kbd:`R` for Replacement Patterns)
+  - Editing replacement patterns (:kbd:`O` for options, then :kbd:`R` for Replacement Patterns)
 
 If there is is no data, an empty editor will be started to let you add some.
 Here is the editor showing the headers from a request:


### PR DESCRIPTION
Correction in key short cut for TCP Proxy

At least my latest version mitmproxy 2.0.0 (Python 3.6.0) on OS X 10.11.6 works as TCP proxy mode by pressing `O` ( **upper case** ) and `T` 