### PR TITLE
Add Javascript tests to Travis CI. (#2093)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,17 @@ env:
   global:
     - CI_DEPS=codecov>=2.0.5
     - CI_COMMANDS=codecov
+    - MITMWEB_DIR=web
 git:
   depth: 10000
 
 matrix:
   fast_finish: true
+  allow_failures:
+    - language: node_js
+      node_js:
+          - "6"
+          - "iojs"
   include:
     - python: 3.5
       env: TOXENV=lint
@@ -47,6 +53,15 @@ matrix:
       env: TOXENV=individual_coverage
     - python: 3.5
       env: TOXENV=docs
+    - language: node_js
+      node_js:
+          - "6"
+          - "iojs"
+      install: cd $MITMWEB_DIR && npm install
+      script: npm test
+      cache:
+          directories:
+              - $MITMWEB_DIR/node_modules
 
 install:
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ env:
   global:
     - CI_DEPS=codecov>=2.0.5
     - CI_COMMANDS=codecov
-    - MITMWEB_DIR=web
 git:
   depth: 10000
 
@@ -13,9 +12,7 @@ matrix:
   fast_finish: true
   allow_failures:
     - language: node_js
-      node_js:
-          - "6"
-          - "iojs"
+      node_js: "node"
   include:
     - python: 3.5
       env: TOXENV=lint
@@ -54,14 +51,14 @@ matrix:
     - python: 3.5
       env: TOXENV=docs
     - language: node_js
-      node_js:
-          - "6"
-          - "iojs"
-      install: cd $MITMWEB_DIR && npm install
+      node_js: "node"
+      before_install: npm install -g yarn
+      install: cd web && yarn
       script: npm test
       cache:
+          yarn: true
           directories:
-              - $MITMWEB_DIR/node_modules
+              - web/node_modules
 
 install:
   - |


### PR DESCRIPTION
Adding our Javascript tests as a seperated matrix item to Travis CI, set `allow_failures` for now. 
The test result is look like this: [https://travis-ci.org/MatthewShao/mitmproxy/jobs/208819088](https://travis-ci.org/MatthewShao/mitmproxy/jobs/208819088)