### PR TITLE
Update proxyauth.py to add proxyauth metadata

### DIFF
--- a/mitmproxy/addons/proxyauth.py
+++ b/mitmproxy/addons/proxyauth.py
@@ -1,7 +1,7 @@
 import binascii
 import weakref
 from typing import Optional
-from typing import Mapping  # noqa
+from typing import MutableMapping  # noqa
 from typing import Tuple
 
 import passlib.apache
@@ -46,7 +46,7 @@ class ProxyAuth:
         self.htpasswd = None
         self.singleuser = None
         self.mode = None
-        self.authenticated = weakref.WeakKeyDictionary()  # type: Mapping[connections.ClientConnection, Tuple[str, str]]
+        self.authenticated = weakref.WeakKeyDictionary()  # type: MutableMapping[connections.ClientConnection, Tuple[str, str]]
         """Contains all connections that are permanently authenticated after an HTTP CONNECT"""
 
     def enabled(self) -> bool:

--- a/mitmproxy/addons/proxyauth.py
+++ b/mitmproxy/addons/proxyauth.py
@@ -1,7 +1,7 @@
 import binascii
 import weakref
 from typing import Optional
-from typing import Set  # noqa
+from typing import Mapping  # noqa
 from typing import Tuple
 
 import passlib.apache
@@ -46,7 +46,7 @@ class ProxyAuth:
         self.htpasswd = None
         self.singleuser = None
         self.mode = None
-        self.authenticated = weakref.WeakKeyDictionary()
+        self.authenticated = weakref.WeakKeyDictionary()  # type: Mapping[connections.ClientConnection, Tuple[str, str]]
         """Contains all connections that are permanently authenticated after an HTTP CONNECT"""
 
     def enabled(self) -> bool:

--- a/mitmproxy/addons/proxyauth.py
+++ b/mitmproxy/addons/proxyauth.py
@@ -155,7 +155,7 @@ class ProxyAuth:
     def http_connect(self, f: http.HTTPFlow) -> None:
         if self.enabled():
             if self.authenticate(f):
-                self.authenticated[f.client_conn]=f.metadata["proxyauth"]
+                self.authenticated[f.client_conn] = f.metadata["proxyauth"]
 
     def requestheaders(self, f: http.HTTPFlow) -> None:
         if self.enabled():

--- a/test/mitmproxy/addons/test_proxyauth.py
+++ b/test/mitmproxy/addons/test_proxyauth.py
@@ -171,3 +171,4 @@ def test_handlers():
         f2 = tflow.tflow(client_conn=f.client_conn)
         up.requestheaders(f2)
         assert not f2.response
+        assert f2.metadata["proxyauth"] == ('test','test')

--- a/test/mitmproxy/addons/test_proxyauth.py
+++ b/test/mitmproxy/addons/test_proxyauth.py
@@ -171,4 +171,4 @@ def test_handlers():
         f2 = tflow.tflow(client_conn=f.client_conn)
         up.requestheaders(f2)
         assert not f2.response
-        assert f2.metadata["proxyauth"] == ('test','test')
+        assert f2.metadata["proxyauth"] == ('test', 'test')


### PR DESCRIPTION
Fixes #2111 
Add `proxyauth` metadata to previously authenticated connections