### PR TITLE
Custom options for addons

### DIFF
--- a/examples/complex/dns_spoofing.py
+++ b/examples/complex/dns_spoofing.py
@@ -1,11 +1,12 @@
 """
-This script makes it possible to use mitmproxy in scenarios where IP spoofing has been used to redirect
-connections to mitmproxy. The way this works is that we rely on either the TLS Server Name Indication (SNI) or the
-Host header of the HTTP request.
-Of course, this is not foolproof - if an HTTPS connection comes without SNI, we don't
-know the actual target and cannot construct a certificate that looks valid.
-Similarly, if there's no Host header or a spoofed Host header, we're out of luck as well.
-Using transparent mode is the better option most of the time.
+This script makes it possible to use mitmproxy in scenarios where IP spoofing
+has been used to redirect connections to mitmproxy. The way this works is that
+we rely on either the TLS Server Name Indication (SNI) or the Host header of the
+HTTP request. Of course, this is not foolproof - if an HTTPS connection comes
+without SNI, we don't know the actual target and cannot construct a certificate
+that looks valid. Similarly, if there's no Host header or a spoofed Host header,
+we're out of luck as well. Using transparent mode is the better option most of
+the time.
 
 Usage:
     mitmproxy
@@ -53,5 +54,5 @@ class Rerouter:
         flow.request.port = port
 
 
-def start():
+def start(opts):
     return Rerouter()

--- a/examples/complex/har_dump.py
+++ b/examples/complex/har_dump.py
@@ -25,7 +25,7 @@ HAR = {}
 SERVERS_SEEN = set()
 
 
-def start():
+def start(opts):
     """
         Called once on script startup before any other events.
     """

--- a/examples/complex/remote_debug.py
+++ b/examples/complex/remote_debug.py
@@ -14,6 +14,6 @@ Usage:
 """
 
 
-def start():
+def start(opts):
     import pydevd
     pydevd.settrace("localhost", port=5678, stdoutToServer=True, stderrToServer=True)

--- a/examples/complex/tls_passthrough.py
+++ b/examples/complex/tls_passthrough.py
@@ -112,7 +112,7 @@ class TlsFeedback(TlsLayer):
 tls_strategy = None
 
 
-def start():
+def start(opts):
     global tls_strategy
     if len(sys.argv) == 2:
         tls_strategy = ProbabilisticStrategy(float(sys.argv[1]))

--- a/examples/simple/add_header_class.py
+++ b/examples/simple/add_header_class.py
@@ -3,5 +3,5 @@ class AddHeader:
         flow.response.headers["newheader"] = "foo"
 
 
-def start():
+def start(opts):
     return AddHeader()

--- a/examples/simple/custom_contentview.py
+++ b/examples/simple/custom_contentview.py
@@ -20,7 +20,7 @@ class ViewSwapCase(contentviews.View):
 view = ViewSwapCase()
 
 
-def start():
+def start(opts):
     contentviews.add(view)
 
 

--- a/examples/simple/custom_option.py
+++ b/examples/simple/custom_option.py
@@ -1,0 +1,10 @@
+from mitmproxy import ctx
+
+
+def start(options):
+    ctx.log.info("Registering option 'custom'")
+    options.add_option("custom", str, "default", "A custom option")
+
+
+def configure(options, updated):
+    ctx.log.info("custom option value: %s" % options.custom)

--- a/examples/simple/custom_option.py
+++ b/examples/simple/custom_option.py
@@ -3,7 +3,7 @@ from mitmproxy import ctx
 
 def start(options):
     ctx.log.info("Registering option 'custom'")
-    options.add_option("custom", str, "default", "A custom option")
+    options.add_option("custom", bool, False, "A custom option")
 
 
 def configure(options, updated):

--- a/examples/simple/custom_option.py
+++ b/examples/simple/custom_option.py
@@ -7,4 +7,5 @@ def start(options):
 
 
 def configure(options, updated):
-    ctx.log.info("custom option value: %s" % options.custom)
+    if "custom" in updated:
+        ctx.log.info("custom option value: %s" % options.custom)

--- a/examples/simple/filter_flows.py
+++ b/examples/simple/filter_flows.py
@@ -17,7 +17,7 @@ class Filter:
             print(flow)
 
 
-def start():
+def start(opts):
     if len(sys.argv) != 2:
         raise ValueError("Usage: -s 'filt.py FILTER'")
     return Filter(sys.argv[1])

--- a/examples/simple/io_write_dumpfile.py
+++ b/examples/simple/io_write_dumpfile.py
@@ -23,7 +23,7 @@ class Writer:
             self.w.add(flow)
 
 
-def start():
+def start(opts):
     if len(sys.argv) != 2:
         raise ValueError('Usage: -s "flowriter.py filename"')
     return Writer(sys.argv[1])

--- a/examples/simple/log_events.py
+++ b/examples/simple/log_events.py
@@ -7,6 +7,6 @@ If you want to help us out: https://github.com/mitmproxy/mitmproxy/issues/1530 :
 from mitmproxy import ctx
 
 
-def start():
+def start(opts):
     ctx.log.info("This is some informative text.")
     ctx.log.error("This is an error.")

--- a/examples/simple/modify_body_inject_iframe.py
+++ b/examples/simple/modify_body_inject_iframe.py
@@ -23,7 +23,7 @@ class Injector:
             flow.response.content = str(html).encode("utf8")
 
 
-def start():
+def start(opts):
     if len(sys.argv) != 2:
         raise ValueError('Usage: -s "iframe_injector.py url"')
     return Injector(sys.argv[1])

--- a/examples/simple/script_arguments.py
+++ b/examples/simple/script_arguments.py
@@ -9,7 +9,7 @@ class Replacer:
         flow.response.replace(self.src, self.dst)
 
 
-def start():
+def start(opts):
     parser = argparse.ArgumentParser()
     parser.add_argument("src", type=str)
     parser.add_argument("dst", type=str)

--- a/examples/simple/wsgi_flask_app.py
+++ b/examples/simple/wsgi_flask_app.py
@@ -14,7 +14,7 @@ def hello_world():
     return 'Hello World!'
 
 
-def start():
+def start(opts):
     # Host app at the magic domain "proxapp" on port 80. Requests to this
     # domain and port combination will now be routed to the WSGI app instance.
     return wsgiapp.WSGIApp(app, "proxapp", 80)

--- a/mitmproxy/addons/termstatus.py
+++ b/mitmproxy/addons/termstatus.py
@@ -1,0 +1,23 @@
+from mitmproxy import ctx
+
+"""
+    A tiny addon to print the proxy status to terminal. Eventually this could
+    also print some stats on exit.
+"""
+
+
+class TermStatus:
+    def __init__(self):
+        self.server = False
+
+    def configure(self, options, updated):
+        if "server" in updated:
+            self.server = options.server
+
+    def running(self):
+        if self.server:
+            ctx.log.info(
+                "Proxy server listening at http://{}:{}".format(
+                    *ctx.master.server.address,
+                )
+            )

--- a/mitmproxy/eventsequence.py
+++ b/mitmproxy/eventsequence.py
@@ -33,6 +33,7 @@ Events = frozenset([
     "done",
     "log",
     "start",
+    "running",
     "tick",
 ])
 

--- a/mitmproxy/master.py
+++ b/mitmproxy/master.py
@@ -76,12 +76,16 @@ class Master:
 
     def run(self):
         self.start()
+        running = False
         try:
             while not self.should_exit.is_set():
                 # Don't choose a very small timeout in Python 2:
                 # https://github.com/mitmproxy/mitmproxy/issues/443
                 # TODO: Lower the timeout value if we move to Python 3.
                 self.tick(0.1)
+                if not running:
+                    running = True
+                    self.addons.invoke_all_with_context("running")
         finally:
             self.shutdown()
 

--- a/mitmproxy/optmanager.py
+++ b/mitmproxy/optmanager.py
@@ -338,6 +338,8 @@ class OptManager:
             optname, optval = parts[0], None
         else:
             optname, optval = parts[0], parts[1]
+        if optname not in self._options:
+            raise exceptions.OptionsError("No such option %s" % optname)
         o = self._options[optname]
 
         if o.typespec in (str, typing.Optional[str]):

--- a/mitmproxy/optmanager.py
+++ b/mitmproxy/optmanager.py
@@ -435,7 +435,7 @@ class OptManager:
             raise ValueError("Unsupported option type: %s", o.typespec)
 
 
-def dump(opts):
+def dump_defaults(opts):
     """
         Dumps an annotated file with all options.
     """

--- a/mitmproxy/tools/cmdline.py
+++ b/mitmproxy/tools/cmdline.py
@@ -23,7 +23,7 @@ def common_options(parser, opts):
     parser.add_argument(
         '--options',
         action='store_true',
-        help="Dump all options",
+        help="Show all options and their default values",
     )
     parser.add_argument(
         "--conf",

--- a/mitmproxy/tools/console/options.py
+++ b/mitmproxy/tools/console/options.py
@@ -1,6 +1,7 @@
 import urwid
 
 from mitmproxy import contentviews
+from mitmproxy import optmanager
 from mitmproxy.tools.console import common
 from mitmproxy.tools.console import grideditor
 from mitmproxy.tools.console import select
@@ -173,7 +174,7 @@ class Options(urwid.WidgetWrap):
         return super().keypress(size, key)
 
     def do_save(self, path):
-        self.master.options.save(path)
+        optmanager.save(self.master.options, path)
         return "Saved"
 
     def save(self):

--- a/mitmproxy/tools/dump.py
+++ b/mitmproxy/tools/dump.py
@@ -3,7 +3,7 @@ from mitmproxy import exceptions
 from mitmproxy import addons
 from mitmproxy import options
 from mitmproxy import master
-from mitmproxy.addons import dumper, termlog
+from mitmproxy.addons import dumper, termlog, termstatus
 
 
 class DumpMaster(master.Master):
@@ -18,16 +18,10 @@ class DumpMaster(master.Master):
         master.Master.__init__(self, options, server)
         self.has_errored = False
         if with_termlog:
-            self.addons.add(termlog.TermLog())
+            self.addons.add(termlog.TermLog(), termstatus.TermStatus())
         self.addons.add(*addons.default_addons())
         if with_dumper:
             self.addons.add(dumper.Dumper())
-
-        if self.options.server:
-            self.add_log(
-                "Proxy server listening at http://{}:{}".format(server.address[0], server.address[1]),
-                "info"
-            )
 
         if options.rfile:
             try:

--- a/mitmproxy/tools/main.py
+++ b/mitmproxy/tools/main.py
@@ -45,9 +45,6 @@ def process_options(parser, opts, args):
     if args.quiet:
         args.flow_detail = 0
 
-    for i in args.setoptions:
-        opts.set(i)
-
     adict = {}
     for n in dir(args):
         if n in opts:
@@ -77,6 +74,8 @@ def run(MasterKlass, args):  # pragma: no cover
         opts.load_paths(args.conf)
         server = process_options(parser, opts, args)
         master = MasterKlass(opts, server)
+        master.addons.configure_all(opts, opts.keys())
+        opts.set(*args.setoptions)
 
         def cleankill(*args, **kwargs):
             master.shutdown()

--- a/mitmproxy/tools/main.py
+++ b/mitmproxy/tools/main.py
@@ -69,7 +69,7 @@ def run(MasterKlass, args):  # pragma: no cover
     args = parser.parse_args(args)
     master = None
     try:
-        opts.load_paths(args.conf)
+        optmanager.load_paths(opts, args.conf)
         server = process_options(parser, opts, args)
         master = MasterKlass(opts, server)
         master.addons.configure_all(opts, opts.keys())

--- a/mitmproxy/tools/main.py
+++ b/mitmproxy/tools/main.py
@@ -69,10 +69,13 @@ def run(MasterKlass, args):  # pragma: no cover
     args = parser.parse_args(args)
     master = None
     try:
-        optmanager.load_paths(opts, args.conf)
+        unknown = optmanager.load_paths(opts, args.conf)
         server = process_options(parser, opts, args)
         master = MasterKlass(opts, server)
         master.addons.configure_all(opts, opts.keys())
+        remaining = opts.update_known(**unknown)
+        if remaining and opts.verbosity > 1:
+            print("Ignored options: %s" % remaining)
         if args.options:
             print(optmanager.dump_defaults(opts))
             sys.exit(0)

--- a/mitmproxy/tools/main.py
+++ b/mitmproxy/tools/main.py
@@ -39,10 +39,8 @@ def process_options(parser, opts, args):
     if args.version:
         print(debug.dump_system_info())
         sys.exit(0)
-    if args.options:
-        print(optmanager.dump(opts))
-        sys.exit(0)
-    if args.quiet:
+    if args.quiet or args.options:
+        args.verbosity = 0
         args.flow_detail = 0
 
     adict = {}
@@ -75,6 +73,9 @@ def run(MasterKlass, args):  # pragma: no cover
         server = process_options(parser, opts, args)
         master = MasterKlass(opts, server)
         master.addons.configure_all(opts, opts.keys())
+        if args.options:
+            print(optmanager.dump_defaults(opts))
+            sys.exit(0)
         opts.set(*args.setoptions)
 
         def cleankill(*args, **kwargs):

--- a/test/mitmproxy/addons/test_termstatus.py
+++ b/test/mitmproxy/addons/test_termstatus.py
@@ -1,0 +1,12 @@
+from mitmproxy.addons import termstatus
+from mitmproxy.test import taddons
+
+
+def test_configure():
+    ts = termstatus.TermStatus()
+    with taddons.context() as ctx:
+        ts.running()
+        assert not ctx.master.event_log
+        ctx.configure(ts, server=True)
+        ts.running()
+        assert ctx.master.event_log

--- a/test/mitmproxy/data/addonscripts/addon.py
+++ b/test/mitmproxy/data/addonscripts/addon.py
@@ -6,7 +6,7 @@ class Addon:
     def event_log(self):
         return event_log
 
-    def start(self):
+    def start(self, opts):
         event_log.append("addonstart")
 
     def configure(self, options, updated):
@@ -17,6 +17,6 @@ def configure(options, updated):
     event_log.append("addonconfigure")
 
 
-def start():
+def start(opts):
     event_log.append("scriptstart")
     return Addon()

--- a/test/mitmproxy/data/addonscripts/concurrent_decorator_class.py
+++ b/test/mitmproxy/data/addonscripts/concurrent_decorator_class.py
@@ -9,5 +9,5 @@ class ConcurrentClass:
         time.sleep(0.1)
 
 
-def start():
+def start(opts):
     return ConcurrentClass()

--- a/test/mitmproxy/data/addonscripts/concurrent_decorator_err.py
+++ b/test/mitmproxy/data/addonscripts/concurrent_decorator_err.py
@@ -2,5 +2,5 @@ from mitmproxy.script import concurrent
 
 
 @concurrent
-def start():
+def start(opts):
     pass

--- a/test/mitmproxy/data/addonscripts/recorder.py
+++ b/test/mitmproxy/data/addonscripts/recorder.py
@@ -22,5 +22,5 @@ class CallLogger:
         raise AttributeError
 
 
-def start():
+def start(opts):
     return CallLogger(*sys.argv[1:])

--- a/test/mitmproxy/proxy/test_server.py
+++ b/test/mitmproxy/proxy/test_server.py
@@ -302,6 +302,9 @@ class TestHTTP(tservers.HTTPProxyTest, CommonMixin):
 class TestHTTPAuth(tservers.HTTPProxyTest):
     def test_auth(self):
         self.master.addons.add(proxyauth.ProxyAuth())
+        self.master.addons.configure_all(
+            self.master.options, self.master.options.keys()
+        )
         self.master.options.proxyauth = "test:test"
         assert self.pathod("202").status_code == 407
         p = self.pathoc()

--- a/test/mitmproxy/script/test_concurrent.py
+++ b/test/mitmproxy/script/test_concurrent.py
@@ -24,7 +24,7 @@ class TestConcurrent(tservers.MasterTest):
                     "mitmproxy/data/addonscripts/concurrent_decorator.py"
                 )
             )
-            sc.start()
+            sc.start(tctx.options)
 
             f1, f2 = tflow.tflow(), tflow.tflow()
             tctx.cycle(sc, f1)
@@ -42,7 +42,7 @@ class TestConcurrent(tservers.MasterTest):
                     "mitmproxy/data/addonscripts/concurrent_decorator_err.py"
                 )
             )
-            sc.start()
+            sc.start(tctx.options)
             assert "decorator not supported" in tctx.master.event_log[0][1]
 
     def test_concurrent_class(self):
@@ -52,7 +52,7 @@ class TestConcurrent(tservers.MasterTest):
                         "mitmproxy/data/addonscripts/concurrent_decorator_class.py"
                     )
                 )
-                sc.start()
+                sc.start(tctx.options)
 
                 f1, f2 = tflow.tflow(), tflow.tflow()
                 tctx.cycle(sc, f1)

--- a/test/mitmproxy/test_addonmanager.py
+++ b/test/mitmproxy/test_addonmanager.py
@@ -10,12 +10,12 @@ from mitmproxy import proxy
 class TAddon:
     def __init__(self, name):
         self.name = name
-        self.noop_member = True
+        self.tick = True
 
     def __repr__(self):
         return "Addon(%s)" % self.name
 
-    def noop(self):
+    def done(self):
         pass
 
 
@@ -30,6 +30,6 @@ def test_simple():
     assert not a.chain
 
     a.add(TAddon("one"))
-    a("noop")
+    a("done")
     with pytest.raises(exceptions.AddonError):
-        a("noop_member")
+        a("tick")

--- a/test/mitmproxy/test_optmanager.py
+++ b/test/mitmproxy/test_optmanager.py
@@ -83,10 +83,11 @@ def test_options():
 
     with pytest.raises(TypeError):
         TO(nonexistent = "value")
-    with pytest.raises(Exception, match="No such option"):
+    with pytest.raises(Exception, match="Unknown options"):
         o.nonexistent = "value"
-    with pytest.raises(Exception, match="No such option"):
+    with pytest.raises(Exception, match="Unknown options"):
         o.update(nonexistent = "value")
+    assert o.update_known(nonexistent = "value") == {"nonexistent": "value"}
 
     rec = []
 
@@ -226,9 +227,7 @@ def test_serialize():
 
     t = ""
     optmanager.load(o2, t)
-
-    with pytest.raises(exceptions.OptionsError, matches='No such option: foobar'):
-        optmanager.load(o2, "foobar: '123'")
+    assert optmanager.load(o2, "foobar: '123'") == {"foobar": "123"}
 
 
 def test_serialize_defaults():
@@ -252,7 +251,11 @@ def test_saving(tmpdir):
 
     with open(dst, 'a') as f:
         f.write("foobar: '123'")
-    with pytest.raises(exceptions.OptionsError, matches=''):
+    assert optmanager.load_paths(o, dst) == {"foobar": "123"}
+
+    with open(dst, 'a') as f:
+        f.write("'''")
+    with pytest.raises(exceptions.OptionsError):
         optmanager.load_paths(o, dst)
 
 

--- a/test/mitmproxy/test_optmanager.py
+++ b/test/mitmproxy/test_optmanager.py
@@ -280,9 +280,9 @@ def test_option():
     assert o2 != o
 
 
-def test_dump():
+def test_dump_defaults():
     o = options.Options()
-    assert optmanager.dump(o)
+    assert optmanager.dump_defaults(o)
 
 
 class TTypes(optmanager.OptManager):

--- a/test/mitmproxy/test_optmanager.py
+++ b/test/mitmproxy/test_optmanager.py
@@ -199,61 +199,61 @@ def test_simple():
 def test_serialize():
     o = TD2()
     o.three = "set"
-    assert "dfour" in o.serialize(None, defaults=True)
+    assert "dfour" in optmanager.serialize(o, None, defaults=True)
 
-    data = o.serialize(None)
+    data = optmanager.serialize(o, None)
     assert "dfour" not in data
 
     o2 = TD2()
-    o2.load(data)
+    optmanager.load(o2, data)
     assert o2 == o
 
     t = """
         unknown: foo
     """
-    data = o.serialize(t)
+    data = optmanager.serialize(o, t)
     o2 = TD2()
-    o2.load(data)
+    optmanager.load(o2, data)
     assert o2 == o
 
     t = "invalid: foo\ninvalid"
     with pytest.raises(Exception, match="Config error"):
-        o2.load(t)
+        optmanager.load(o2, t)
 
     t = "invalid"
     with pytest.raises(Exception, match="Config error"):
-        o2.load(t)
+        optmanager.load(o2, t)
 
     t = ""
-    o2.load(t)
+    optmanager.load(o2, t)
 
     with pytest.raises(exceptions.OptionsError, matches='No such option: foobar'):
-        o2.load("foobar: '123'")
+        optmanager.load(o2, "foobar: '123'")
 
 
 def test_serialize_defaults():
     o = options.Options()
-    assert o.serialize(None, defaults=True)
+    assert optmanager.serialize(o, None, defaults=True)
 
 
 def test_saving(tmpdir):
     o = TD2()
     o.three = "set"
     dst = str(tmpdir.join("conf"))
-    o.save(dst, defaults=True)
+    optmanager.save(o, dst, defaults=True)
 
     o2 = TD2()
-    o2.load_paths(dst)
+    optmanager.load_paths(o2, dst)
     o2.three = "foo"
-    o2.save(dst, defaults=True)
+    optmanager.save(o2, dst, defaults=True)
 
-    o.load_paths(dst)
+    optmanager.load_paths(o, dst)
     assert o.three == "foo"
 
     with open(dst, 'a') as f:
         f.write("foobar: '123'")
     with pytest.raises(exceptions.OptionsError, matches=''):
-        o.load_paths(dst)
+        optmanager.load_paths(o, dst)
 
 
 def test_merge():

--- a/test/mitmproxy/test_optmanager.py
+++ b/test/mitmproxy/test_optmanager.py
@@ -346,3 +346,6 @@ def test_set():
     assert opts.seqstr == ["foo", "bar"]
     opts.set("seqstr")
     assert opts.seqstr == []
+
+    with pytest.raises(exceptions.OptionsError):
+        opts.set("nonexistent=wobble")

--- a/test/mitmproxy/tools/console/test_master.py
+++ b/test/mitmproxy/tools/console/test_master.py
@@ -28,7 +28,9 @@ class TestMaster(tservers.MasterTest):
         if "verbosity" not in opts:
             opts["verbosity"] = 1
         o = options.Options(**opts)
-        return console.master.ConsoleMaster(o, proxy.DummyServer())
+        m = console.master.ConsoleMaster(o, proxy.DummyServer())
+        m.addons.configure_all(o, o.keys())
+        return m
 
     def test_basic(self):
         m = self.mkmaster()

--- a/test/mitmproxy/tservers.py
+++ b/test/mitmproxy/tservers.py
@@ -79,6 +79,8 @@ class TestMaster(master.Master):
         self.state = TestState()
         self.addons.add(self.state)
         self.addons.add(*addons)
+        self.addons.configure_all(self.options, self.options.keys())
+        self.addons.invoke_all_with_context("running")
 
     def clear_log(self):
         self.tlog = []


### PR DESCRIPTION
This PR extends and refactors our events and options mechanisms to enable custom options for addons. 

Todo:

- [x] Set custom options with --set
- [x] Set custom options from config files
- [x] Show custom options in --options output

Changes:

- Add an options parameter to the start() event. This is to be used by addons
on startup to add custom options.
- Add a running() event that is called once the proxy is up and running.
- With the new paradigm we can't log during master __init__, so add a tiny
termstatus addon to print proxy status to terminal once we're running.