### PR TITLE
[web] Fixes all existed tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,6 @@ git:
 
 matrix:
   fast_finish: true
-  allow_failures:
-    - language: node_js
-      node_js: "node"
   include:
     - python: 3.5
       env: TOXENV=lint

--- a/web/src/js/__tests__/ducks/flowsSpec.js
+++ b/web/src/js/__tests__/ducks/flowsSpec.js
@@ -1,13 +1,14 @@
 jest.unmock('../../ducks/flows');
 
 import reduceFlows, * as flowActions from '../../ducks/flows'
+import * as storeActions from '../../ducks/utils/store'
 
 
 describe('select flow', () => {
 
     let state = reduceFlows(undefined, {})
     for (let i of [1, 2, 3, 4]) {
-        state = reduceFlows(state, flowActions.addFlow({ id: i }))
+        state = reduceFlows(state, storeActions.add({ id: i }))
     }
 
     it('should be possible to select a single flow', () => {

--- a/web/src/js/__tests__/ducks/ui/flowSpec.js
+++ b/web/src/js/__tests__/ducks/ui/flowSpec.js
@@ -8,7 +8,8 @@ import reducer, {
                     setContentViewDescription,
                     setShowFullContent,
                     setContent,
-                    updateEdit
+                    updateEdit,
+                    stopEdit
                 } from '../../../ducks/ui/flow'
 
 import { select, updateFlow } from '../../../ducks/flows'
@@ -65,12 +66,12 @@ describe('flow reducer', () => {
     it('should not change the state when a flow is updated which is not selected', () => {
         let modifiedFlow = {id: 1}
         let updatedFlow = {id: 0}
-        expect(reducer({modifiedFlow}, updateFlow(updatedFlow)).modifiedFlow).toEqual(modifiedFlow)
+        expect(reducer({modifiedFlow}, stopEdit(updatedFlow, modifiedFlow)).modifiedFlow).toEqual(modifiedFlow)
     })
 
-     it('should stop editing when the selected flow is updated', () => {
+    it('should stop editing when the selected flow is updated', () => {
         let modifiedFlow = {id: 1}
         let updatedFlow = {id: 1}
-        expect(reducer({modifiedFlow}, updateFlow(updatedFlow)).modifiedFlow).toBeFalsy()
+        expect(reducer({modifiedFlow}, stopEdit(updatedFlow, modifiedFlow)).modifiedFlow).toBeFalsy()
     })
 })

--- a/web/src/js/ducks/ui/flow.js
+++ b/web/src/js/ducks/ui/flow.js
@@ -60,7 +60,7 @@ export default function reducer(state = defaultState, action) {
             // There is no explicit "stop edit" event.
             // We stop editing when we receive an update for
             // the currently edited flow from the server
-            if (action.data.id === state.modifiedFlow.id) {
+            if (action.flow.id === state.modifiedFlow.id) {
                 return {
                     ...state,
                     modifiedFlow: false,
@@ -145,9 +145,10 @@ export function setShowFullContent() {
 }
 
 export function setContent(content){
-    return { type: SET_CONTENT, content}
+    return { type: SET_CONTENT, content }
 }
 
 export function stopEdit(flow, modifiedFlow) {
-    return flowsActions.update(flow, getDiff(flow, modifiedFlow))
+    let diff = getDiff(flow, modifiedFlow)
+    return {type: flowsActions.UPDATE, flow, diff }
 }


### PR DESCRIPTION
This PR include two modifications:
1. I found the `updatFlow` action was out of dated, we should test `stopEdit` instead, however, `stopEdit` has a flaw, so I fix it as well as its test.
2. Solve all test errors.
The javascript tests on travis should be passed now.