### PR TITLE
mark tutils.tmpdir as deprecated

### DIFF
--- a/mitmproxy/test/tutils.py
+++ b/mitmproxy/test/tutils.py
@@ -1,3 +1,4 @@
+import warnings
 from io import BytesIO
 import tempfile
 import os
@@ -15,6 +16,11 @@ test_data = data.Data(__name__).push("../../test/")
 
 @contextmanager
 def tmpdir(*args, **kwargs):
+    warnings.warn(
+        "tutils.tmpdir is deprecated, use pytest's tmpdir fixture instead",
+        DeprecationWarning
+    )
+
     orig_workdir = os.getcwd()
     temp_workdir = tempfile.mkdtemp(*args, **kwargs)
     os.chdir(temp_workdir)


### PR DESCRIPTION
All further code should use pytest's fixture. Raising a DeprecationWarning here makes this clear to anyone reading the code and in particular to anyone using PyCharm:

![image](https://cloud.githubusercontent.com/assets/1019198/23835377/885fcb78-0766-11e7-8611-323a35fe8d11.png)
 