### PR TITLE
[web] Fixes the flaw in #2133

### DIFF
--- a/web/src/js/ducks/ui/flow.js
+++ b/web/src/js/ducks/ui/flow.js
@@ -60,7 +60,7 @@ export default function reducer(state = defaultState, action) {
             // There is no explicit "stop edit" event.
             // We stop editing when we receive an update for
             // the currently edited flow from the server
-            if (action.flow.id === state.modifiedFlow.id) {
+            if (action.data.id === state.modifiedFlow.id) {
                 return {
                     ...state,
                     modifiedFlow: false,
@@ -148,7 +148,7 @@ export function setContent(content){
     return { type: SET_CONTENT, content }
 }
 
-export function stopEdit(flow, modifiedFlow) {
-    let diff = getDiff(flow, modifiedFlow)
-    return {type: flowsActions.UPDATE, flow, diff }
+export function stopEdit(data, modifiedFlow) {
+    let diff = getDiff(data, modifiedFlow)
+    return {type: flowsActions.UPDATE, data, diff }
 }


### PR DESCRIPTION
It seems that I made something wrong in last PR(#2133):
![_269](https://cloud.githubusercontent.com/assets/9366279/23852873/f4319084-0824-11e7-99bf-9af80f7253ff.png)
The flows in the table can't update the size entry and the icon on the left when finish loading. It turned out that we should not change `data` to `flow` on line 63, but change the parameter name of the `stopEdit()` function.
Sorry for the trouble. 