### PR TITLE
Fix #2140

### DIFF
--- a/mitmproxy/options.py
+++ b/mitmproxy/options.py
@@ -78,7 +78,7 @@ class Options(optmanager.OptManager):
             "Kill extra requests during replay."
         )
         self.add_option(
-            "keepserving", bool, True,
+            "keepserving", bool, False,
             "Continue serving after client playback or file read."
         )
         self.add_option(


### PR DESCRIPTION
While `keepserving` defaulted to `True` in `options.py`, this was previously overridden for all command line tools (argparse's `store_true` sets  the default to `False`). This restores the old behavior.