### PR TITLE
py3: __ne__ delegates to __eq__ by default

### DIFF
--- a/mitmproxy/certs.py
+++ b/mitmproxy/certs.py
@@ -384,9 +384,6 @@ class SSLCert(serializable.Serializable):
     def __eq__(self, other):
         return self.digest("sha256") == other.digest("sha256")
 
-    def __ne__(self, other):
-        return not self.__eq__(other)
-
     def get_state(self):
         return self.to_pem()
 

--- a/mitmproxy/net/http/message.py
+++ b/mitmproxy/net/http/message.py
@@ -13,9 +13,6 @@ class MessageData(serializable.Serializable):
             return self.__dict__ == other.__dict__
         return False
 
-    def __ne__(self, other):
-        return not self.__eq__(other)
-
     def set_state(self, state):
         for k, v in state.items():
             if k == "headers":
@@ -38,9 +35,6 @@ class Message(serializable.Serializable):
         if isinstance(other, Message):
             return self.data == other.data
         return False
-
-    def __ne__(self, other):
-        return not self.__eq__(other)
 
     def get_state(self):
         return self.data.get_state()

--- a/mitmproxy/types/multidict.py
+++ b/mitmproxy/types/multidict.py
@@ -67,9 +67,6 @@ class _MultiDict(MutableMapping, serializable.Serializable, metaclass=ABCMeta):
             return self.fields == other.fields
         return False
 
-    def __ne__(self, other):
-        return not self.__eq__(other)
-
     def get_all(self, key):
         """
         Return the list of all values for a given key.

--- a/test/mitmproxy/net/http/test_message.py
+++ b/test/mitmproxy/net/http/test_message.py
@@ -38,14 +38,12 @@ def _test_decoded_attr(message, attr):
 
 
 class TestMessageData:
-    def test_eq_ne(self):
+    def test_eq(self):
         data = tutils.tresp(timestamp_start=42, timestamp_end=42).data
         same = tutils.tresp(timestamp_start=42, timestamp_end=42).data
         assert data == same
-        assert not data != same
 
         other = tutils.tresp(content=b"foo").data
-        assert not data == other
         assert data != other
 
         assert data != 0
@@ -61,10 +59,8 @@ class TestMessage:
         resp = tutils.tresp(timestamp_start=42, timestamp_end=42)
         same = tutils.tresp(timestamp_start=42, timestamp_end=42)
         assert resp == same
-        assert not resp != same
 
         other = tutils.tresp(timestamp_start=0, timestamp_end=0)
-        assert not resp == other
         assert resp != other
 
         assert resp != 0

--- a/test/mitmproxy/test_certs.py
+++ b/test/mitmproxy/test_certs.py
@@ -160,7 +160,6 @@ class TestSSLCert:
         assert c2.to_pem()
         assert c2.has_expired is not None
 
-        assert not c1 == c2
         assert c1 != c2
 
     def test_err_broken_sans(self):

--- a/test/mitmproxy/types/test_multidict.py
+++ b/test/mitmproxy/types/test_multidict.py
@@ -93,11 +93,6 @@ class TestMultiDict:
         md1.fields = md1.fields[1:] + md1.fields[:1]
         assert not (md1 == md2)
 
-    def test_ne(self):
-        assert not TMultiDict() != TMultiDict()
-        assert TMultiDict() != self._multi()
-        assert TMultiDict() != 42
-
     def test_hash(self):
         """
         If a class defines mutable objects and implements an __eq__() method,


### PR DESCRIPTION
Python 2:

> There are no implied relationships among the comparison operators. The truth of x==y does not imply that x!=y is false. Accordingly, when defining \_\_eq\_\_(), one should also define \_\_ne\_\_() so that the operators will behave as expected.

Python 3:

> By default, \_\_ne\_\_() delegates to \_\_eq\_\_() and inverts the result.

The removed tests would still pass, but they are just baggage at this point.