### PR TITLE
Match ~d and ~u filters against pretty_host too

### DIFF
--- a/mitmproxy/flowfilter.py
+++ b/mitmproxy/flowfilter.py
@@ -319,10 +319,14 @@ class FDomain(_Rex):
     code = "d"
     help = "Domain"
     flags = re.IGNORECASE
+    is_binary = False
 
     @only(http.HTTPFlow)
     def __call__(self, f):
-        return bool(self.re.search(f.request.data.host))
+        return bool(
+            self.re.search(f.request.host) or
+            self.re.search(f.request.pretty_host)
+        )
 
 
 class FUrl(_Rex):
@@ -339,7 +343,7 @@ class FUrl(_Rex):
 
     @only(http.HTTPFlow)
     def __call__(self, f):
-        return self.re.search(f.request.url)
+        return self.re.search(f.request.pretty_url)
 
 
 class FSrc(_Rex):

--- a/web/src/js/filt/filt.peg
+++ b/web/src/js/filt/filt.peg
@@ -96,7 +96,7 @@ function responseBody(regex){
 function domain(regex){
     regex = new RegExp(regex, "i");
     function domainFilter(flow){
-        return flow.request && regex.test(flow.request.host);
+        return flow.request && (regex.test(flow.request.host) || regex.test(flow.request.pretty_host));
     }
     domainFilter.desc = "domain matches " + regex;
     return domainFilter;


### PR DESCRIPTION
Changed the ~u filter in the console UI to match the behavior of
mitmweb, which only matches against pretty_url, never against url.

-----

Fixes #2146 (thanks mhils for the hint on where to fix it)