### PR TITLE
Update .travis.yml to fix the failure about yarn

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,9 @@ matrix:
       env: TOXENV=docs
     - language: node_js
       node_js: "node"
-      before_install: npm install -g yarn
+      before_install:
+          - curl -o- -L https://yarnpkg.com/install.sh | bash
+          - export PATH=$HOME/.yarn/bin:$PATH
       install: cd web && yarn
       script: npm test
       cache:


### PR DESCRIPTION
Using `npm install -g yarn` is easy to get into trouble, so we change to install yarn with the script given by their developer. [reference](https://yarnpkg.com/lang/en/docs/install-ci/#travis-tab)