### PR TITLE
[web] Adjust pop-up docs position

### DIFF
--- a/web/src/css/header.less
+++ b/web/src/css/header.less
@@ -106,9 +106,17 @@ header {
 
 .filter-input .popover {
     top: 27px;
+    left: 43px;
     display: block;
     max-width: none;
     opacity: 0.9;
+
+    @media (max-width: @screen-xs-max) {
+
+        top: 16px;
+        left: 29px;
+        right: 2px;
+    }
 
     .popover-content {
         max-height: 500px;


### PR DESCRIPTION
Hello, I'm frank ahn. 
This is my first PR. ( even in my life lol )
Recently, I asked about changing positions of pop-up docs in the mitmweb to @mhils. 
He said yes, so I tinkered a couple of css codes. 

**Before change**

![before_small](https://cloud.githubusercontent.com/assets/17471430/23940892/f45fa736-09a9-11e7-89fc-25146d29d9ce.png)
![before_full](https://cloud.githubusercontent.com/assets/17471430/23940893/f4772276-09a9-11e7-8ba9-719f0f8a1f36.png)

**After  change**
![after_small](https://cloud.githubusercontent.com/assets/17471430/23940919/09fbd592-09aa-11e7-9f7b-eb50035c34d8.png)
![after_full](https://cloud.githubusercontent.com/assets/17471430/23940918/09f97dd8-09aa-11e7-8af8-d96927826355.png)

