### PR TITLE
Add Request.make

### DIFF
--- a/mitmproxy/master.py
+++ b/mitmproxy/master.py
@@ -15,7 +15,6 @@ from mitmproxy import log
 from mitmproxy import io
 from mitmproxy.proxy.protocol import http_replay
 from mitmproxy.types import basethread
-import mitmproxy.net.http
 
 from . import ctx as mitmproxy_ctx
 
@@ -122,27 +121,18 @@ class Master:
         self.should_exit.set()
         self.addons.done()
 
-    def create_request(self, method, scheme, host, port, path):
+    def create_request(self, method, url):
         """
-            this method creates a new artificial and minimalist request also adds it to flowlist
+        Create a new artificial and minimalist request also adds it to flowlist.
+
+        Raises:
+            ValueError, if the url is malformed.
         """
+        req = http.HTTPRequest.make(method, url)
         c = connections.ClientConnection.make_dummy(("", 0))
-        s = connections.ServerConnection.make_dummy((host, port))
+        s = connections.ServerConnection.make_dummy((req.host, req.port))
 
         f = http.HTTPFlow(c, s)
-        headers = mitmproxy.net.http.Headers()
-
-        req = http.HTTPRequest(
-            "absolute",
-            method,
-            scheme,
-            host,
-            port,
-            path,
-            b"HTTP/1.1",
-            headers,
-            b""
-        )
         f.request = req
         self.load_flow(f)
         return f

--- a/mitmproxy/tools/console/flowlist.py
+++ b/mitmproxy/tools/console/flowlist.py
@@ -1,6 +1,5 @@
 import urwid
 
-import mitmproxy.net.http.url
 from mitmproxy import exceptions
 from mitmproxy.tools.console import common
 from mitmproxy.tools.console import signals
@@ -339,12 +338,10 @@ class FlowListBox(urwid.ListBox):
 
     def new_request(self, url, method):
         try:
-            parts = mitmproxy.net.http.url.parse(str(url))
+            f = self.master.create_request(method, url)
         except ValueError as e:
             signals.status_message.send(message = "Invalid URL: " + str(e))
             return
-        scheme, host, port, path = parts
-        f = self.master.create_request(method, scheme, host, port, path)
         self.master.view.focus.flow = f
 
     def keypress(self, size, key):

--- a/test/mitmproxy/test_flow.py
+++ b/test/mitmproxy/test_flow.py
@@ -140,7 +140,7 @@ class TestFlowMaster:
 
     def test_create_flow(self):
         fm = master.Master(None, DummyServer())
-        assert fm.create_request("GET", "http", "example.com", 80, "/")
+        assert fm.create_request("GET", "http://example.com/")
 
     def test_all(self):
         s = tservers.TestState()


### PR DESCRIPTION
This is a simple interface to create HTTP requests, analogous to `Response.make`. 
I deliberately placed `headers` after `content` to match the signature of `Response.make`.