### PR TITLE
Fix test_format_xml with dot in path

### DIFF
--- a/test/mitmproxy/contentviews/test_xml_html.py
+++ b/test/mitmproxy/contentviews/test_xml_html.py
@@ -23,7 +23,7 @@ def test_format_xml(filename):
     path = data.path(filename)
     with open(path) as f:
         input = f.read()
-    with open(path.replace(".", "-formatted.")) as f:
+    with open("-formatted.".join(path.rsplit(".", 1))) as f:
         expected = f.read()
     tokens = xml_html.tokenize(input)
     assert xml_html.format_xml(tokens) == expected


### PR DESCRIPTION
When the path contains dot ".", replacing all dots will generate a non-exist result and raises a FileNotFoundError. Replacing only the last dot fixes this.