### PR TITLE
Fixes mitmweb crash when using scripts

### DIFF
--- a/mitmproxy/tools/web/master.py
+++ b/mitmproxy/tools/web/master.py
@@ -28,14 +28,15 @@ class WebMaster(master.Master):
 
         self.options.changed.connect(self._sig_options_update)
 
+        if with_termlog:
+            self.addons.add(termlog.TermLog())
+
         self.addons.add(*addons.default_addons())
         self.addons.add(
             intercept.Intercept(),
             self.view,
             self.events,
         )
-        if with_termlog:
-            self.addons.add(termlog.TermLog())
         self.app = app.Application(
             self, self.options.web_debug
         )


### PR DESCRIPTION
##### Steps to reproduce the problem:

1.  `mitmweb -s examples/simple/log_events.py` (Any script can be used here) 
```
...
  File "/home/ujjwal/Github/mitmproxy/mitmproxy/log.py", line 25, in info
    self(txt, "info")
  File "/home/ujjwal/Github/mitmproxy/mitmproxy/log.py", line 40, in __call__
    self.master.add_log(text, level)
  File "/home/ujjwal/Github/mitmproxy/mitmproxy/master.py", line 67, in add_log
    self.addons.trigger("log", log.LogEntry(e, level))
  File "/home/ujjwal/Github/mitmproxy/mitmproxy/addonmanager.py", line 116, in trigger
    self.invoke_addon(i, name, *args, **kwargs)
  File "/home/ujjwal/Github/mitmproxy/mitmproxy/addonmanager.py", line 107, in invoke_addon
    func(*args, **kwargs)
  File "/home/ujjwal/Github/mitmproxy/mitmproxy/addons/termlog.py", line 21, in log
    if self.options.verbosity >= log.log_tier(e.level):
AttributeError: 'NoneType' object has no attribute 'verbosity'
```

This is happening because inside the script addon's configure function addons.termlog.TermLog.log was being called but the TermLog addon isn't configured.
In WebMaster class default addons were being added before the termlog addon which caused the crash