### PR TITLE
Fix#2184, mitmweb -n dispalys incorrect message.

### DIFF
--- a/mitmproxy/tools/web/app.py
+++ b/mitmproxy/tools/web/app.py
@@ -421,6 +421,7 @@ class Settings(RequestHandler):
             contentViews=[v.name.replace(' ', '_') for v in contentviews.views],
             listen_host=self.master.options.listen_host,
             listen_port=self.master.options.listen_port,
+            server=self.master.options.server,
         ))
 
     def put(self):

--- a/mitmproxy/tools/web/master.py
+++ b/mitmproxy/tools/web/master.py
@@ -9,6 +9,7 @@ from mitmproxy.addons import eventstore
 from mitmproxy.addons import intercept
 from mitmproxy.addons import termlog
 from mitmproxy.addons import view
+from mitmproxy.addons import termstatus
 from mitmproxy.options import Options  # noqa
 from mitmproxy.tools.web import app
 
@@ -35,7 +36,7 @@ class WebMaster(master.Master):
             self.events,
         )
         if with_termlog:
-            self.addons.add(termlog.TermLog())
+            self.addons.add(termlog.TermLog(), termstatus.TermStatus())
         self.app = app.Application(
             self, self.options.web_debug
         )
@@ -98,11 +99,6 @@ class WebMaster(master.Master):
 
         iol.add_callback(self.start)
         tornado.ioloop.PeriodicCallback(lambda: self.tick(timeout=0), 5).start()
-
-        self.add_log(
-            "Proxy server listening at http://{}:{}/".format(self.server.address[0], self.server.address[1]),
-            "info"
-        )
 
         web_url = "http://{}:{}/".format(self.options.web_iface, self.options.web_port)
         self.add_log(

--- a/web/src/js/components/Footer.jsx
+++ b/web/src/js/components/Footer.jsx
@@ -48,9 +48,11 @@ function Footer({ settings }) {
                 <span className="label label-success">stream: {formatSize(stream_large_bodies)}</span>
             )}
             <div className="pull-right">
-            <span className="label label-primary" title="HTTP Proxy Server Address">
-                { server ? ((listen_host||"*") + ":" + listen_port) : "" }
-            </span>
+                {server && (
+                    <span className="label label-primary" title="HTTP Proxy Server Address">
+                        {listen_host||"*"}:{listen_port}
+                    </span>
+                )}
             <span className="label label-info" title="Mitmproxy Version">
             v{version}
             </span>

--- a/web/src/js/components/Footer.jsx
+++ b/web/src/js/components/Footer.jsx
@@ -8,7 +8,7 @@ Footer.propTypes = {
 
 function Footer({ settings }) {
     let {mode, intercept, showhost, no_upstream_cert, rawtcp, http2, websocket, anticache, anticomp,
-            stickyauth, stickycookie, stream_large_bodies, listen_host, listen_port, version} = settings;
+            stickyauth, stickycookie, stream_large_bodies, listen_host, listen_port, version, server} = settings;
     return (
         <footer>
             {mode && mode != "regular" && (
@@ -49,7 +49,7 @@ function Footer({ settings }) {
             )}
             <div className="pull-right">
             <span className="label label-primary" title="HTTP Proxy Server Address">
-            {listen_host || "*"}:{listen_port}
+                { server ? ((listen_host||"*") + ":" + listen_port) : "" }
             </span>
             <span className="label label-info" title="Mitmproxy Version">
             v{version}


### PR DESCRIPTION
Check if the `option.server` is on before printing the information about the proxy server.
In mitmweb, add `server` to `state.setting`, so we could display the correct message in the termstatus.
![default](https://cloud.githubusercontent.com/assets/9366279/24077523/d06eb63a-0c8a-11e7-8112-f73d73639c13.png)
