### PR TITLE
safer url handling

### DIFF
--- a/mitmproxy/net/http/request.py
+++ b/mitmproxy/net/http/request.py
@@ -68,13 +68,9 @@ class Request(message.Message):
         self.data = RequestData(*args, **kwargs)
 
     def __repr__(self):
-        if self.host and self.port:
-            hostport = "{}:{}".format(self.host, self.port)
-        else:
-            hostport = ""
         path = self.path or ""
         return "Request({} {}{})".format(
-            self.method, hostport, path
+            self.method, mitmproxy.net.http.url.hostport(self.scheme, self.host, self.port), path
         )
 
     @classmethod
@@ -283,7 +279,7 @@ class Request(message.Message):
         The URL string, constructed from the request's URL components
         """
         if self.first_line_format == "authority":
-            return "%s:%d" % (self.host, self.port)
+            return "{}:{}".format(self.host, self.port)
         return mitmproxy.net.http.url.unparse(self.scheme, self.host, self.port, self.path)
 
     @url.setter

--- a/mitmproxy/net/http/url.py
+++ b/mitmproxy/net/http/url.py
@@ -77,9 +77,11 @@ def unparse(scheme, host, port, path=""):
     Args:
         All args must be str.
     """
-    if path == "*":
+    if not path or path == "*":
         path = ""
-    return "%s://%s%s" % (scheme, hostport(scheme, host, port), path)
+    if not scheme:
+        scheme = "<unknown-scheme>"
+    return "{}://{}{}".format(scheme, hostport(scheme, host, port), path)
 
 
 def encode(s: Sequence[Tuple[str, str]], similar_to: str=None) -> str:
@@ -131,10 +133,14 @@ def hostport(scheme, host, port):
     """
         Returns the host component, with a port specifcation if needed.
     """
+    if not host:
+        host = "<unknown-host>"
+    if not port:
+        port = "<unknown-port>"
     if (port, scheme) in [(80, "http"), (443, "https"), (80, b"http"), (443, b"https")]:
         return host
     else:
         if isinstance(host, bytes):
-            return b"%s:%d" % (host, port)
+            return b':'.join([host, str(port).encode()])
         else:
-            return "%s:%d" % (host, port)
+            return "{}:{}".format(host, port)

--- a/test/mitmproxy/net/http/test_request.py
+++ b/test/mitmproxy/net/http/test_request.py
@@ -33,7 +33,7 @@ class TestRequestCore:
         request = treq()
         assert repr(request) == "Request(GET address:22/path)"
         request.host = None
-        assert repr(request) == "Request(GET /path)"
+        assert repr(request) == "Request(GET <unknown-host>:22/path)"
 
     def test_make(self):
         r = Request.make("GET", "https://example.com/")

--- a/test/mitmproxy/net/http/test_url.py
+++ b/test/mitmproxy/net/http/test_url.py
@@ -61,6 +61,10 @@ def test_unparse():
     assert url.unparse("http", "foo.com", 80, "/bar") == "http://foo.com/bar"
     assert url.unparse("https", "foo.com", 80, "") == "https://foo.com:80"
     assert url.unparse("https", "foo.com", 443, "") == "https://foo.com"
+    assert url.unparse("http", "foo.com", None, "") == "http://foo.com:<unknown-port>"
+    assert url.unparse("http", None, 1234, "") == "http://<unknown-host>:1234"
+    assert url.unparse("http", None, None, "") == "http://<unknown-host>:<unknown-port>"
+    assert url.unparse(None, None, None, None) == "<unknown-scheme>://<unknown-host>:<unknown-port>"
 
 
 surrogates = bytes(range(256)).decode("utf8", "surrogateescape")


### PR DESCRIPTION
While playing around I got a traceback and mitmproxy crashed due to host or port not being a proper value.
This PR makes the url handling safe to use even if the values are `None`.