### PR TITLE
Add coverage for eventLog.js and update Jest config.

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -8,7 +8,7 @@
   },
   "jest": {
     "testRegex": "__tests__/.*Spec.js$",
-    "testPathDirs": [
+    "roots": [
       "<rootDir>/src/js"
     ],
     "unmockedModulePathPatterns": [

--- a/web/src/js/__tests__/ducks/eventLogSpec.js
+++ b/web/src/js/__tests__/ducks/eventLogSpec.js
@@ -1,0 +1,40 @@
+jest.unmock('../../ducks/eventLog')
+
+import reduceEventLog, * as eventLogActions from '../../ducks/eventLog'
+import reduceStore from '../../ducks/utils/store'
+
+describe('event log reducer', () => {
+    it('should return initial state', () => {
+        expect(reduceEventLog(undefined, {})).toEqual({
+            visible: false,
+            filters: { debug: false, info: true, web: true, warn: true, error: true },
+            ...reduceStore(undefined, {}),
+        })
+    })
+
+    it('should be possible to toggle filter', () => {
+        let state = reduceEventLog(undefined, eventLogActions.add('foo'))
+        expect(reduceEventLog(state, eventLogActions.toggleFilter('info'))).toEqual({
+            visible: false,
+            filters: { ...state.filters, info: false},
+            ...reduceStore(state, {})
+        })
+    })
+
+    it('should be possible to toggle visibility', () => {
+        let state = reduceEventLog(undefined, {})
+        expect(reduceEventLog(state, eventLogActions.toggleVisibility())).toEqual({
+            visible: true,
+            filters: {...state.filters},
+            ...reduceStore(undefined, {})
+        })
+    })
+
+    it('should be possible to add message', () => {
+        let state = reduceEventLog(undefined, eventLogActions.add('foo'))
+        expect(state.visible).toBeFalsy()
+        expect(state.filters).toEqual({
+            debug: false, info: true, web: true, warn: true, error: true
+        })
+    })
+})


### PR DESCRIPTION
This one is easy to test.
![default](https://cloud.githubusercontent.com/assets/9366279/24193776/7553fc96-0f2e-11e7-9877-d6c275909dce.png)

The `testPathDirs` in Jest configuration has been replaced by `roots`, so we update that to avoid the deprecation warning.