### PR TITLE
addon refactoring

### DIFF
--- a/examples/complex/dns_spoofing.py
+++ b/examples/complex/dns_spoofing.py
@@ -54,5 +54,5 @@ class Rerouter:
         flow.request.port = port
 
 
-def load(opts):
-    return Rerouter()
+def load(l):
+    l.boot_into(Rerouter())

--- a/examples/complex/dns_spoofing.py
+++ b/examples/complex/dns_spoofing.py
@@ -54,5 +54,5 @@ class Rerouter:
         flow.request.port = port
 
 
-def start(opts):
+def load(opts):
     return Rerouter()

--- a/examples/complex/har_dump.py
+++ b/examples/complex/har_dump.py
@@ -25,7 +25,7 @@ HAR = {}
 SERVERS_SEEN = set()
 
 
-def load(opts):
+def load(l):
     """
         Called once on script startup before any other events.
     """

--- a/examples/complex/har_dump.py
+++ b/examples/complex/har_dump.py
@@ -25,7 +25,7 @@ HAR = {}
 SERVERS_SEEN = set()
 
 
-def start(opts):
+def load(opts):
     """
         Called once on script startup before any other events.
     """

--- a/examples/complex/remote_debug.py
+++ b/examples/complex/remote_debug.py
@@ -14,6 +14,6 @@ Usage:
 """
 
 
-def load(opts):
+def load(l):
     import pydevd
     pydevd.settrace("localhost", port=5678, stdoutToServer=True, stderrToServer=True)

--- a/examples/complex/remote_debug.py
+++ b/examples/complex/remote_debug.py
@@ -14,6 +14,6 @@ Usage:
 """
 
 
-def start(opts):
+def load(opts):
     import pydevd
     pydevd.settrace("localhost", port=5678, stdoutToServer=True, stderrToServer=True)

--- a/examples/complex/tls_passthrough.py
+++ b/examples/complex/tls_passthrough.py
@@ -112,7 +112,7 @@ class TlsFeedback(TlsLayer):
 tls_strategy = None
 
 
-def start(opts):
+def load(opts):
     global tls_strategy
     if len(sys.argv) == 2:
         tls_strategy = ProbabilisticStrategy(float(sys.argv[1]))

--- a/examples/complex/tls_passthrough.py
+++ b/examples/complex/tls_passthrough.py
@@ -112,7 +112,7 @@ class TlsFeedback(TlsLayer):
 tls_strategy = None
 
 
-def load(opts):
+def load(l):
     global tls_strategy
     if len(sys.argv) == 2:
         tls_strategy = ProbabilisticStrategy(float(sys.argv[1]))

--- a/examples/simple/add_header_class.py
+++ b/examples/simple/add_header_class.py
@@ -3,5 +3,5 @@ class AddHeader:
         flow.response.headers["newheader"] = "foo"
 
 
-def load(opts):
-    return AddHeader()
+def load(l):
+    return l.boot_into(AddHeader())

--- a/examples/simple/add_header_class.py
+++ b/examples/simple/add_header_class.py
@@ -3,5 +3,5 @@ class AddHeader:
         flow.response.headers["newheader"] = "foo"
 
 
-def start(opts):
+def load(opts):
     return AddHeader()

--- a/examples/simple/custom_contentview.py
+++ b/examples/simple/custom_contentview.py
@@ -20,7 +20,7 @@ class ViewSwapCase(contentviews.View):
 view = ViewSwapCase()
 
 
-def load(opts):
+def load(l):
     contentviews.add(view)
 
 

--- a/examples/simple/custom_contentview.py
+++ b/examples/simple/custom_contentview.py
@@ -20,7 +20,7 @@ class ViewSwapCase(contentviews.View):
 view = ViewSwapCase()
 
 
-def start(opts):
+def load(opts):
     contentviews.add(view)
 
 

--- a/examples/simple/custom_option.py
+++ b/examples/simple/custom_option.py
@@ -1,9 +1,9 @@
 from mitmproxy import ctx
 
 
-def load(options):
+def load(l):
     ctx.log.info("Registering option 'custom'")
-    options.add_option("custom", bool, False, "A custom option")
+    l.add_option("custom", bool, False, "A custom option")
 
 
 def configure(options, updated):

--- a/examples/simple/custom_option.py
+++ b/examples/simple/custom_option.py
@@ -1,7 +1,7 @@
 from mitmproxy import ctx
 
 
-def start(options):
+def load(options):
     ctx.log.info("Registering option 'custom'")
     options.add_option("custom", bool, False, "A custom option")
 

--- a/examples/simple/filter_flows.py
+++ b/examples/simple/filter_flows.py
@@ -17,7 +17,7 @@ class Filter:
             print(flow)
 
 
-def load(opts):
+def load(l):
     if len(sys.argv) != 2:
         raise ValueError("Usage: -s 'filt.py FILTER'")
-    return Filter(sys.argv[1])
+    l.boot_into(Filter(sys.argv[1]))

--- a/examples/simple/filter_flows.py
+++ b/examples/simple/filter_flows.py
@@ -17,7 +17,7 @@ class Filter:
             print(flow)
 
 
-def start(opts):
+def load(opts):
     if len(sys.argv) != 2:
         raise ValueError("Usage: -s 'filt.py FILTER'")
     return Filter(sys.argv[1])

--- a/examples/simple/io_write_dumpfile.py
+++ b/examples/simple/io_write_dumpfile.py
@@ -23,7 +23,7 @@ class Writer:
             self.w.add(flow)
 
 
-def load(opts):
+def load(l):
     if len(sys.argv) != 2:
         raise ValueError('Usage: -s "flowriter.py filename"')
-    return Writer(sys.argv[1])
+    l.boot_into(Writer(sys.argv[1]))

--- a/examples/simple/io_write_dumpfile.py
+++ b/examples/simple/io_write_dumpfile.py
@@ -23,7 +23,7 @@ class Writer:
             self.w.add(flow)
 
 
-def start(opts):
+def load(opts):
     if len(sys.argv) != 2:
         raise ValueError('Usage: -s "flowriter.py filename"')
     return Writer(sys.argv[1])

--- a/examples/simple/log_events.py
+++ b/examples/simple/log_events.py
@@ -7,6 +7,6 @@ If you want to help us out: https://github.com/mitmproxy/mitmproxy/issues/1530 :
 from mitmproxy import ctx
 
 
-def start(opts):
+def load(opts):
     ctx.log.info("This is some informative text.")
     ctx.log.error("This is an error.")

--- a/examples/simple/log_events.py
+++ b/examples/simple/log_events.py
@@ -7,6 +7,6 @@ If you want to help us out: https://github.com/mitmproxy/mitmproxy/issues/1530 :
 from mitmproxy import ctx
 
 
-def load(opts):
+def load(l):
     ctx.log.info("This is some informative text.")
     ctx.log.error("This is an error.")

--- a/examples/simple/modify_body_inject_iframe.py
+++ b/examples/simple/modify_body_inject_iframe.py
@@ -23,7 +23,7 @@ class Injector:
             flow.response.content = str(html).encode("utf8")
 
 
-def start(opts):
+def load(opts):
     if len(sys.argv) != 2:
         raise ValueError('Usage: -s "iframe_injector.py url"')
     return Injector(sys.argv[1])

--- a/examples/simple/modify_body_inject_iframe.py
+++ b/examples/simple/modify_body_inject_iframe.py
@@ -23,7 +23,7 @@ class Injector:
             flow.response.content = str(html).encode("utf8")
 
 
-def load(opts):
+def load(l):
     if len(sys.argv) != 2:
         raise ValueError('Usage: -s "iframe_injector.py url"')
-    return Injector(sys.argv[1])
+    return l.boot_into(Injector(sys.argv[1]))

--- a/examples/simple/script_arguments.py
+++ b/examples/simple/script_arguments.py
@@ -9,7 +9,7 @@ class Replacer:
         flow.response.replace(self.src, self.dst)
 
 
-def start(opts):
+def load(opts):
     parser = argparse.ArgumentParser()
     parser.add_argument("src", type=str)
     parser.add_argument("dst", type=str)

--- a/examples/simple/script_arguments.py
+++ b/examples/simple/script_arguments.py
@@ -9,9 +9,9 @@ class Replacer:
         flow.response.replace(self.src, self.dst)
 
 
-def load(opts):
+def load(l):
     parser = argparse.ArgumentParser()
     parser.add_argument("src", type=str)
     parser.add_argument("dst", type=str)
     args = parser.parse_args()
-    return Replacer(args.src, args.dst)
+    l.boot_into(Replacer(args.src, args.dst))

--- a/examples/simple/wsgi_flask_app.py
+++ b/examples/simple/wsgi_flask_app.py
@@ -14,7 +14,7 @@ def hello_world():
     return 'Hello World!'
 
 
-def load(opts):
+def load(l):
     # Host app at the magic domain "proxapp" on port 80. Requests to this
     # domain and port combination will now be routed to the WSGI app instance.
     return wsgiapp.WSGIApp(app, "proxapp", 80)

--- a/examples/simple/wsgi_flask_app.py
+++ b/examples/simple/wsgi_flask_app.py
@@ -14,7 +14,7 @@ def hello_world():
     return 'Hello World!'
 
 
-def start(opts):
+def load(opts):
     # Host app at the magic domain "proxapp" on port 80. Requests to this
     # domain and port combination will now be routed to the WSGI app instance.
     return wsgiapp.WSGIApp(app, "proxapp", 80)

--- a/mitmproxy/addonmanager.py
+++ b/mitmproxy/addonmanager.py
@@ -42,7 +42,7 @@ class AddonManager:
         self.chain.extend(addons)
         with self.master.handlecontext():
             for i in addons:
-                self.invoke_addon(i, "start", self.master.options)
+                self.invoke_addon(i, "load", self.master.options)
 
     def remove(self, addon):
         """

--- a/mitmproxy/addonmanager.py
+++ b/mitmproxy/addonmanager.py
@@ -1,3 +1,5 @@
+import typing
+
 from mitmproxy import exceptions
 from mitmproxy import eventsequence
 from mitmproxy import controller
@@ -7,6 +9,30 @@ import pprint
 
 def _get_name(itm):
     return getattr(itm, "name", itm.__class__.__name__.lower())
+
+
+class Loader:
+    """
+        A loader object is passed to the load() event when addons start up.
+    """
+    def __init__(self, master):
+        self.master = master
+
+    def add_option(
+        self,
+        name: str,
+        typespec: type,
+        default: typing.Any,
+        help: str,
+        choices: typing.Optional[typing.Sequence[str]] = None
+    ) -> None:
+        self.master.options.add_option(
+            name,
+            typespec,
+            default,
+            help,
+            choices
+        )
 
 
 class AddonManager:
@@ -41,8 +67,9 @@ class AddonManager:
         """
         self.chain.extend(addons)
         with self.master.handlecontext():
+            l = Loader(self.master)
             for i in addons:
-                self.invoke_addon(i, "load", self.master.options)
+                self.invoke_addon(i, "load", l)
 
     def remove(self, addon):
         """

--- a/mitmproxy/addons/script.py
+++ b/mitmproxy/addons/script.py
@@ -184,22 +184,22 @@ class Script:
 
     def load_script(self):
         self.ns = load_script(self.path, self.args)
-        ret = self.run("start", self.last_options)
+        ret = self.run("load", self.last_options)
         if ret:
             self.ns = ret
-            self.run("start", self.last_options)
+            self.run("load", self.last_options)
 
     def tick(self):
         if self.should_reload.is_set():
             self.should_reload.clear()
             ctx.log.info("Reloading script: %s" % self.name)
             self.ns = load_script(self.path, self.args)
-            self.start(self.last_options)
+            self.load(self.last_options)
             self.configure(self.last_options, self.last_options.keys())
         else:
             self.run("tick")
 
-    def start(self, opts):
+    def load(self, opts):
         self.last_options = opts
         self.load_script()
 
@@ -287,7 +287,7 @@ class ScriptLoader:
             ctx.master.addons.chain = ochain[:pos + 1] + ordered + ochain[pos + 1:]
 
             for s in newscripts:
-                ctx.master.addons.invoke_addon(s, "start", options)
+                ctx.master.addons.invoke_addon(s, "load", options)
                 if self.is_running:
                     # If we're already running, we configure and tell the addon
                     # we're up and running.

--- a/mitmproxy/addons/script.py
+++ b/mitmproxy/addons/script.py
@@ -6,6 +6,7 @@ import threading
 import traceback
 import types
 
+from mitmproxy import addonmanager
 from mitmproxy import exceptions
 from mitmproxy import ctx
 from mitmproxy import eventsequence
@@ -184,10 +185,11 @@ class Script:
 
     def load_script(self):
         self.ns = load_script(self.path, self.args)
-        ret = self.run("load", self.last_options)
+        l = addonmanager.Loader(ctx.master)
+        ret = self.run("load", l)
         if ret:
             self.ns = ret
-            self.run("load", self.last_options)
+            self.run("load", l)
 
     def tick(self):
         if self.should_reload.is_set():

--- a/mitmproxy/addons/script.py
+++ b/mitmproxy/addons/script.py
@@ -186,23 +186,21 @@ class Script:
     def load_script(self):
         self.ns = load_script(self.path, self.args)
         l = addonmanager.Loader(ctx.master)
-        ret = self.run("load", l)
-        if ret:
-            self.ns = ret
-            self.run("load", l)
+        self.run("load", l)
+        if l.boot_into_addon:
+            self.ns = l.boot_into_addon
 
     def tick(self):
         if self.should_reload.is_set():
             self.should_reload.clear()
             ctx.log.info("Reloading script: %s" % self.name)
             self.ns = load_script(self.path, self.args)
-            self.load(self.last_options)
             self.configure(self.last_options, self.last_options.keys())
         else:
             self.run("tick")
 
-    def load(self, opts):
-        self.last_options = opts
+    def load(self, l):
+        self.last_options = ctx.master.options
         self.load_script()
 
     def configure(self, options, updated):
@@ -289,7 +287,8 @@ class ScriptLoader:
             ctx.master.addons.chain = ochain[:pos + 1] + ordered + ochain[pos + 1:]
 
             for s in newscripts:
-                ctx.master.addons.invoke_addon(s, "load", options)
+                l = addonmanager.Loader(ctx.master)
+                ctx.master.addons.invoke_addon(s, "load", l)
                 if self.is_running:
                     # If we're already running, we configure and tell the addon
                     # we're up and running.

--- a/mitmproxy/addons/serverplayback.py
+++ b/mitmproxy/addons/serverplayback.py
@@ -16,7 +16,7 @@ class ServerPlayback:
         self.stop = False
         self.final_flow = None
 
-    def load(self, flows):
+    def load_flows(self, flows):
         for i in flows:
             if i.response:
                 l = self.flowmap.setdefault(self._hash(i), [])
@@ -100,7 +100,7 @@ class ServerPlayback:
                     flows = io.read_flows_from_paths(options.server_replay)
                 except exceptions.FlowReadException as e:
                     raise exceptions.OptionsError(str(e))
-                self.load(flows)
+                self.load_flows(flows)
 
     def tick(self):
         if self.stop and not self.final_flow.live:

--- a/mitmproxy/eventsequence.py
+++ b/mitmproxy/eventsequence.py
@@ -32,7 +32,7 @@ Events = frozenset([
     "configure",
     "done",
     "log",
-    "start",
+    "load",
     "running",
     "tick",
 ])

--- a/mitmproxy/script/concurrent.py
+++ b/mitmproxy/script/concurrent.py
@@ -12,7 +12,7 @@ class ScriptThread(basethread.BaseThread):
 
 
 def concurrent(fn):
-    if fn.__name__ not in eventsequence.Events - {"start", "configure", "tick"}:
+    if fn.__name__ not in eventsequence.Events - {"load", "configure", "tick"}:
         raise NotImplementedError(
             "Concurrent decorator not supported for '%s' method." % fn.__name__
         )

--- a/mitmproxy/tools/dump.py
+++ b/mitmproxy/tools/dump.py
@@ -16,11 +16,11 @@ class ErrorCheck:
 class DumpMaster(master.Master):
 
     def __init__(
-            self,
-            options: options.Options,
-            server,
-            with_termlog=True,
-            with_dumper=True,
+        self,
+        options: options.Options,
+        server,
+        with_termlog=True,
+        with_dumper=True,
     ) -> None:
         master.Master.__init__(self, options, server)
         self.errorcheck = ErrorCheck()

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,6 @@ exclude =
 
 [tool:individual_coverage]
 exclude =
-    mitmproxy/addonmanager.py
     mitmproxy/addons/onboardingapp/app.py
     mitmproxy/addons/termlog.py
     mitmproxy/contentviews/base.py

--- a/test/mitmproxy/addons/test_script.py
+++ b/test/mitmproxy/addons/test_script.py
@@ -9,6 +9,7 @@ from unittest import mock
 from mitmproxy.test import tflow
 from mitmproxy.test import tutils
 from mitmproxy.test import taddons
+from mitmproxy import addonmanager
 from mitmproxy import exceptions
 from mitmproxy import options
 from mitmproxy import proxy
@@ -116,7 +117,7 @@ def test_script_print_stdout():
                         "mitmproxy/data/addonscripts/print.py"
                     ), []
                 )
-                ns.start(tctx.options)
+                ns.load(addonmanager.Loader(tctx.master))
         mock_warn.assert_called_once_with("stdoutprint")
 
 
@@ -157,7 +158,8 @@ class TestScript:
             sc = script.Script(
                 tutils.test_data.path("mitmproxy/data/addonscripts/error.py")
             )
-            sc.load(tctx.options)
+            l = addonmanager.Loader(tctx.master)
+            sc.load(l)
             f = tflow.tflow(resp=True)
             sc.request(f)
             assert tctx.master.logs[0].level == "error"
@@ -173,7 +175,8 @@ class TestScript:
                     "mitmproxy/data/addonscripts/addon.py"
                 )
             )
-            sc.load(tctx.options)
+            l = addonmanager.Loader(tctx.master)
+            sc.load(l)
             tctx.configure(sc)
             assert sc.ns.event_log == [
                 'scriptload', 'addonload', 'addonconfigure'

--- a/test/mitmproxy/addons/test_script.py
+++ b/test/mitmproxy/addons/test_script.py
@@ -104,7 +104,7 @@ def test_load_script():
                 "mitmproxy/data/addonscripts/recorder.py"
             ), []
         )
-        assert ns.start
+        assert ns.load
 
 
 def test_script_print_stdout():
@@ -129,7 +129,7 @@ class TestScript:
                 )
             )
             sc.load_script()
-            assert sc.ns.call_log[0][0:2] == ("solo", "start")
+            assert sc.ns.call_log[0][0:2] == ("solo", "load")
 
             sc.ns.call_log = []
             f = tflow.tflow(resp=True)
@@ -157,7 +157,7 @@ class TestScript:
             sc = script.Script(
                 tutils.test_data.path("mitmproxy/data/addonscripts/error.py")
             )
-            sc.start(tctx.options)
+            sc.load(tctx.options)
             f = tflow.tflow(resp=True)
             sc.request(f)
             assert tctx.master.logs[0].level == "error"
@@ -173,10 +173,10 @@ class TestScript:
                     "mitmproxy/data/addonscripts/addon.py"
                 )
             )
-            sc.start(tctx.options)
+            sc.load(tctx.options)
             tctx.configure(sc)
             assert sc.ns.event_log == [
-                'scriptstart', 'addonstart', 'addonconfigure'
+                'scriptload', 'addonload', 'addonconfigure'
             ]
 
 
@@ -213,7 +213,7 @@ class TestScriptLoader:
                 ), [f]
             )
         evts = [i[1] for i in sc.ns.call_log]
-        assert evts == ['start', 'requestheaders', 'request', 'responseheaders', 'response', 'done']
+        assert evts == ['load', 'requestheaders', 'request', 'responseheaders', 'response', 'done']
 
         f = tflow.tflow(resp=True)
         with m.handlecontext():
@@ -271,15 +271,15 @@ class TestScriptLoader:
             )
             debug = [i.msg for i in tctx.master.logs if i.level == "debug"]
             assert debug == [
-                'a start',
+                'a load',
                 'a configure',
                 'a running',
 
-                'b start',
+                'b load',
                 'b configure',
                 'b running',
 
-                'c start',
+                'c load',
                 'c configure',
                 'c running',
             ]
@@ -307,7 +307,7 @@ class TestScriptLoader:
             assert debug == [
                 'c done',
                 'b done',
-                'x start',
+                'x load',
                 'x configure',
                 'x running',
             ]

--- a/test/mitmproxy/addons/test_serverplayback.py
+++ b/test/mitmproxy/addons/test_serverplayback.py
@@ -44,12 +44,12 @@ def test_server_playback():
 
     assert not sp.flowmap
 
-    sp.load([f])
+    sp.load_flows([f])
     assert sp.flowmap
     assert sp.next_flow(f)
     assert not sp.flowmap
 
-    sp.load([f])
+    sp.load_flows([f])
     assert sp.flowmap
     sp.clear()
     assert not sp.flowmap
@@ -192,7 +192,7 @@ def test_load():
     r2 = tflow.tflow(resp=True)
     r2.request.headers["key"] = "two"
 
-    s.load([r, r2])
+    s.load_flows([r, r2])
 
     assert s.count() == 2
 
@@ -218,7 +218,7 @@ def test_load_with_server_replay_nopop():
     r2 = tflow.tflow(resp=True)
     r2.request.headers["key"] = "two"
 
-    s.load([r, r2])
+    s.load_flows([r, r2])
 
     assert s.count() == 2
     s.next_flow(r)
@@ -319,7 +319,7 @@ def test_server_playback_full():
 
         f = tflow.tflow()
         f.response = mitmproxy.test.tutils.tresp(content=f.request.content)
-        s.load([f, f])
+        s.load_flows([f, f])
 
         tf = tflow.tflow()
         assert not tf.response
@@ -352,7 +352,7 @@ def test_server_playback_kill():
 
         f = tflow.tflow()
         f.response = mitmproxy.test.tutils.tresp(content=f.request.content)
-        s.load([f])
+        s.load_flows([f])
 
         f = tflow.tflow()
         f.request.host = "nonexistent"

--- a/test/mitmproxy/data/addonscripts/addon.py
+++ b/test/mitmproxy/data/addonscripts/addon.py
@@ -17,6 +17,6 @@ def configure(options, updated):
     event_log.append("addonconfigure")
 
 
-def load(opts):
+def load(l):
     event_log.append("scriptload")
-    return Addon()
+    l.boot_into(Addon())

--- a/test/mitmproxy/data/addonscripts/addon.py
+++ b/test/mitmproxy/data/addonscripts/addon.py
@@ -6,8 +6,8 @@ class Addon:
     def event_log(self):
         return event_log
 
-    def start(self, opts):
-        event_log.append("addonstart")
+    def load(self, opts):
+        event_log.append("addonload")
 
     def configure(self, options, updated):
         event_log.append("addonconfigure")
@@ -17,6 +17,6 @@ def configure(options, updated):
     event_log.append("addonconfigure")
 
 
-def start(opts):
-    event_log.append("scriptstart")
+def load(opts):
+    event_log.append("scriptload")
     return Addon()

--- a/test/mitmproxy/data/addonscripts/concurrent_decorator_class.py
+++ b/test/mitmproxy/data/addonscripts/concurrent_decorator_class.py
@@ -9,5 +9,5 @@ class ConcurrentClass:
         time.sleep(0.1)
 
 
-def load(opts):
-    return ConcurrentClass()
+def load(l):
+    l.boot_into(ConcurrentClass())

--- a/test/mitmproxy/data/addonscripts/concurrent_decorator_class.py
+++ b/test/mitmproxy/data/addonscripts/concurrent_decorator_class.py
@@ -9,5 +9,5 @@ class ConcurrentClass:
         time.sleep(0.1)
 
 
-def start(opts):
+def load(opts):
     return ConcurrentClass()

--- a/test/mitmproxy/data/addonscripts/print.py
+++ b/test/mitmproxy/data/addonscripts/print.py
@@ -1,2 +1,2 @@
-def start(opts):
+def load(l):
     print("stdoutprint")

--- a/test/mitmproxy/data/addonscripts/recorder.py
+++ b/test/mitmproxy/data/addonscripts/recorder.py
@@ -22,5 +22,5 @@ class CallLogger:
         raise AttributeError
 
 
-def start(opts):
+def load(opts):
     return CallLogger(*sys.argv[1:])

--- a/test/mitmproxy/data/addonscripts/recorder.py
+++ b/test/mitmproxy/data/addonscripts/recorder.py
@@ -22,5 +22,5 @@ class CallLogger:
         raise AttributeError
 
 
-def load(opts):
-    return CallLogger(*sys.argv[1:])
+def load(l):
+    l.boot_into(CallLogger(*sys.argv[1:]))

--- a/test/mitmproxy/script/test_concurrent.py
+++ b/test/mitmproxy/script/test_concurrent.py
@@ -2,6 +2,7 @@ from mitmproxy.test import tflow
 from mitmproxy.test import tutils
 from mitmproxy.test import taddons
 
+from mitmproxy import addonmanager
 from mitmproxy import controller
 from mitmproxy.addons import script
 
@@ -24,7 +25,8 @@ class TestConcurrent(tservers.MasterTest):
                     "mitmproxy/data/addonscripts/concurrent_decorator.py"
                 )
             )
-            sc.load(tctx.options)
+            l = addonmanager.Loader(tctx.master)
+            sc.load(l)
 
             f1, f2 = tflow.tflow(), tflow.tflow()
             tctx.cycle(sc, f1)
@@ -42,7 +44,8 @@ class TestConcurrent(tservers.MasterTest):
                     "mitmproxy/data/addonscripts/concurrent_decorator_err.py"
                 )
             )
-            sc.load(tctx.options)
+            l = addonmanager.Loader(tctx.master)
+            sc.load(l)
             assert tctx.master.has_log("decorator not supported")
 
     def test_concurrent_class(self):
@@ -52,7 +55,8 @@ class TestConcurrent(tservers.MasterTest):
                         "mitmproxy/data/addonscripts/concurrent_decorator_class.py"
                     )
                 )
-                sc.load(tctx.options)
+                l = addonmanager.Loader(tctx.master)
+                sc.load(l)
 
                 f1, f2 = tflow.tflow(), tflow.tflow()
                 tctx.cycle(sc, f1)

--- a/test/mitmproxy/script/test_concurrent.py
+++ b/test/mitmproxy/script/test_concurrent.py
@@ -24,7 +24,7 @@ class TestConcurrent(tservers.MasterTest):
                     "mitmproxy/data/addonscripts/concurrent_decorator.py"
                 )
             )
-            sc.start(tctx.options)
+            sc.load(tctx.options)
 
             f1, f2 = tflow.tflow(), tflow.tflow()
             tctx.cycle(sc, f1)
@@ -42,7 +42,7 @@ class TestConcurrent(tservers.MasterTest):
                     "mitmproxy/data/addonscripts/concurrent_decorator_err.py"
                 )
             )
-            sc.start(tctx.options)
+            sc.load(tctx.options)
             assert tctx.master.has_log("decorator not supported")
 
     def test_concurrent_class(self):
@@ -52,7 +52,7 @@ class TestConcurrent(tservers.MasterTest):
                         "mitmproxy/data/addonscripts/concurrent_decorator_class.py"
                     )
                 )
-                sc.start(tctx.options)
+                sc.load(tctx.options)
 
                 f1, f2 = tflow.tflow(), tflow.tflow()
                 tctx.cycle(sc, f1)

--- a/test/mitmproxy/test_addonmanager.py
+++ b/test/mitmproxy/test_addonmanager.py
@@ -5,6 +5,7 @@ from mitmproxy import exceptions
 from mitmproxy import options
 from mitmproxy import master
 from mitmproxy import proxy
+from mitmproxy.test import tflow
 
 
 class TAddon:
@@ -23,6 +24,58 @@ class TAddon:
         self.custom_called = True
 
 
+class THalt:
+    def event_custom(self):
+        raise exceptions.AddonHalt
+
+
+class AOption:
+    def load(self, l):
+        l.add_option("custom_option", bool, False, "help")
+
+
+class AChain:
+    def __init__(self, name, next):
+        self.name = name
+        self.next = next
+
+    def load(self, l):
+        if self.next:
+            l.boot_into(self.next)
+
+    def __repr__(self):
+        return "<%s>" % self.name
+
+
+def test_halt():
+    o = options.Options()
+    m = master.Master(o, proxy.DummyServer(o))
+    a = addonmanager.AddonManager(m)
+    halt = THalt()
+    end = TAddon("end")
+    a.add(halt)
+    a.add(end)
+
+    a.trigger("custom")
+    assert not end.custom_called
+
+    a.remove(halt)
+    a.trigger("custom")
+    assert end.custom_called
+
+
+def test_lifecycle():
+    o = options.Options()
+    m = master.Master(o, proxy.DummyServer(o))
+    a = addonmanager.AddonManager(m)
+    a.add(TAddon("one"))
+
+    f = tflow.tflow()
+    a.handle_lifecycle("request", f)
+
+    a.configure_all(o, o.keys())
+
+
 def test_simple():
     o = options.Options()
     m = master.Master(o, proxy.DummyServer(o))
@@ -30,10 +83,13 @@ def test_simple():
     with pytest.raises(exceptions.AddonError):
         a.invoke_addon(TAddon("one"), "done")
 
+    assert len(a) == 0
     a.add(TAddon("one"))
     assert a.get("one")
     assert not a.get("two")
+    assert len(a) == 1
     a.clear()
+    assert len(a) == 0
     assert not a.chain
 
     a.add(TAddon("one"))
@@ -41,7 +97,46 @@ def test_simple():
     with pytest.raises(exceptions.AddonError):
         a.trigger("tick")
 
+    a.remove(a.get("one"))
+    assert not a.get("one")
+
     ta = TAddon("one")
     a.add(ta)
     a.trigger("custom")
     assert ta.custom_called
+
+
+def test_load_option():
+    o = options.Options()
+    m = master.Master(o, proxy.DummyServer(o))
+    a = addonmanager.AddonManager(m)
+    a.add(AOption())
+    assert "custom_option" in m.options._options
+
+
+def test_loadchain():
+    o = options.Options()
+    m = master.Master(o, proxy.DummyServer(o))
+    a = addonmanager.AddonManager(m)
+
+    a.add(AChain("one", None))
+    assert a.get("one")
+    a.clear()
+
+    a.add(AChain("one", AChain("two", None)))
+    assert not a.get("one")
+    assert a.get("two")
+    a.clear()
+
+    a.add(AChain("one", AChain("two", AChain("three", None))))
+    assert not a.get("one")
+    assert not a.get("two")
+    assert a.get("three")
+    a.clear()
+
+    a.add(AChain("one", AChain("two", AChain("three", AChain("four", None)))))
+    assert not a.get("one")
+    assert not a.get("two")
+    assert not a.get("three")
+    assert a.get("four")
+    a.clear()


### PR DESCRIPTION
This PR implements the startup portion of the design I outline in #2144. 

* Rename `start` to `load`
* Add a loader with `add_option` and `boot_into` methods
* Expand and improve coverage

For now, this keeps a 1-for-1 correlation to the existing structure. The next PR will be a significant change to the way we handle and load sub-addons.
