### PR TITLE
[wip] Allow addons to nest

### DIFF
--- a/mitmproxy/addonmanager.py
+++ b/mitmproxy/addonmanager.py
@@ -46,14 +46,17 @@ class AddonManager:
     def __init__(self, master):
         self.chain = []
         self.master = master
-        master.options.changed.connect(self.configure_all)
+        master.options.changed.connect(self._configure_all)
+
+    def _configure_all(self, options, updated):
+        self.trigger("configure", options, updated)
 
     def clear(self):
         """
             Remove all addons.
         """
-        self.done()
-        self.chain = []
+        for i in self.chain:
+            self.remove(i)
 
     def get(self, name):
         """
@@ -65,12 +68,9 @@ class AddonManager:
             if name == _get_name(i):
                 return i
 
-    def configure_all(self, options, updated):
-        self.trigger("configure", options, updated)
-
     def add(self, *addons):
         """
-            Add addons to the end of the chain, and run their startup events.
+            Add addons to the end of the chain, and run their load event.
         """
         with self.master.handlecontext():
             for i in addons:
@@ -88,9 +88,6 @@ class AddonManager:
         self.chain = [i for i in self.chain if i is not addon]
         with self.master.handlecontext():
             self.invoke_addon(addon, "done")
-
-    def done(self):
-        self.trigger("done")
 
     def __len__(self):
         return len(self.chain)

--- a/mitmproxy/addons/onboarding.py
+++ b/mitmproxy/addons/onboarding.py
@@ -3,6 +3,8 @@ from mitmproxy.addons.onboardingapp import app
 
 
 class Onboarding(wsgiapp.WSGIApp):
+    name = "onboarding"
+
     def __init__(self):
         super().__init__(app.Adapter(app.application), None, None)
         self.enabled = False

--- a/mitmproxy/addons/script.py
+++ b/mitmproxy/addons/script.py
@@ -287,8 +287,7 @@ class ScriptLoader:
             ctx.master.addons.chain = ochain[:pos + 1] + ordered + ochain[pos + 1:]
 
             for s in newscripts:
-                l = addonmanager.Loader(ctx.master)
-                ctx.master.addons.invoke_addon(s, "load", l)
+                ctx.master.addons.register(s)
                 if self.is_running:
                     # If we're already running, we configure and tell the addon
                     # we're up and running.

--- a/mitmproxy/addons/wsgiapp.py
+++ b/mitmproxy/addons/wsgiapp.py
@@ -13,6 +13,10 @@ class WSGIApp:
     def __init__(self, app, host, port):
         self.app, self.host, self.port = app, host, port
 
+    @property
+    def name(self):
+        return "wsgiapp:%s:%s" % (self.host, self.port)
+
     def serve(self, app, flow):
         """
             Serves app on flow, and prevents further handling of the flow.

--- a/mitmproxy/master.py
+++ b/mitmproxy/master.py
@@ -103,7 +103,7 @@ class Master:
     def shutdown(self):
         self.server.shutdown()
         self.should_exit.set()
-        self.addons.done()
+        self.addons.trigger("done")
 
     def create_request(self, method, url):
         """

--- a/mitmproxy/tools/main.py
+++ b/mitmproxy/tools/main.py
@@ -76,7 +76,7 @@ def run(MasterKlass, args, extra=None):  # pragma: no cover
         unknown = optmanager.load_paths(opts, args.conf)
         server = process_options(parser, opts, args)
         master = MasterKlass(opts, server)
-        master.addons.configure_all(opts, opts.keys())
+        master.addons.trigger("configure", opts, opts.keys())
         remaining = opts.update_known(**unknown)
         if remaining and opts.verbosity > 1:
             print("Ignored options: %s" % remaining)

--- a/test/mitmproxy/addons/test_script.py
+++ b/test/mitmproxy/addons/test_script.py
@@ -234,9 +234,11 @@ class TestScriptLoader:
                 tutils.test_data.path("mitmproxy/data/addonscripts/recorder.py")
             ]
         )
-        assert len(m.addons) == 2
+        assert len(m.addons) == 1
+        assert len(sc.addons) == 1
         o.update(scripts = [])
         assert len(m.addons) == 1
+        assert len(sc.addons) == 0
 
     def test_dupes(self):
         sc = script.ScriptLoader()

--- a/test/mitmproxy/proxy/test_server.py
+++ b/test/mitmproxy/proxy/test_server.py
@@ -296,8 +296,8 @@ class TestHTTP(tservers.HTTPProxyTest, CommonMixin):
 class TestHTTPAuth(tservers.HTTPProxyTest):
     def test_auth(self):
         self.master.addons.add(proxyauth.ProxyAuth())
-        self.master.addons.configure_all(
-            self.master.options, self.master.options.keys()
+        self.master.addons.trigger(
+            "configure", self.master.options, self.master.options.keys()
         )
         self.master.options.proxyauth = "test:test"
         assert self.pathod("202").status_code == 407

--- a/test/mitmproxy/test_addonmanager.py
+++ b/test/mitmproxy/test_addonmanager.py
@@ -70,6 +70,9 @@ def test_lifecycle():
     a = addonmanager.AddonManager(m)
     a.add(TAddon("one"))
 
+    with pytest.raises(exceptions.AddonError):
+        a.add(TAddon("one"))
+
     f = tflow.tflow()
     a.handle_lifecycle("request", f)
 

--- a/test/mitmproxy/test_addonmanager.py
+++ b/test/mitmproxy/test_addonmanager.py
@@ -73,7 +73,7 @@ def test_lifecycle():
     f = tflow.tflow()
     a.handle_lifecycle("request", f)
 
-    a.configure_all(o, o.keys())
+    a._configure_all(o, o.keys())
 
 
 def test_simple():

--- a/test/mitmproxy/tools/console/test_master.py
+++ b/test/mitmproxy/tools/console/test_master.py
@@ -30,7 +30,7 @@ class TestMaster(tservers.MasterTest):
             opts["verbosity"] = 1
         o = options.Options(**opts)
         m = console.master.ConsoleMaster(o, proxy.DummyServer())
-        m.addons.configure_all(o, o.keys())
+        m.addons.trigger("configure", o, o.keys())
         return m
 
     def test_basic(self):

--- a/test/mitmproxy/tservers.py
+++ b/test/mitmproxy/tservers.py
@@ -74,7 +74,7 @@ class TestMaster(taddons.RecordingMaster):
         self.state = TestState()
         self.addons.add(self.state)
         self.addons.add(*addons)
-        self.addons.configure_all(self.options, self.options.keys())
+        self.addons.trigger("configure", self.options, self.options.keys())
         self.addons.trigger("running")
 
     def reset(self, addons):


### PR DESCRIPTION
A much nicer abstraction that lets us clean up the ScriptLoader addon, gives us a better way to load subaddons than the horrible `boot_into` (or the old return from start), and paves the way for further gains down the track. 