### PR TITLE
[web] Update Jest config and coverage ++

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,8 +52,10 @@ matrix:
       before_install:
           - curl -o- -L https://yarnpkg.com/install.sh | bash
           - export PATH=$HOME/.yarn/bin:$PATH
-      install: cd web && yarn
-      script: npm test
+      install:
+          - cd web && yarn
+          - yarn global add codecov
+      script: npm test && codecov
       cache:
           yarn: true
           directories:

--- a/web/package.json
+++ b/web/package.json
@@ -14,11 +14,11 @@
     "unmockedModulePathPatterns": [
       "react"
     ],
-      "coverageDirectory":"./coverage",
-      "collectCoverage": true,
-      "coveragePathIgnorePatterns": [
-          "<rootDir>/src/js/filt/filt.js"
-      ]
+    "coverageDirectory":"./coverage",
+    "collectCoverage": true,
+    "coveragePathIgnorePatterns": [
+        "<rootDir>/src/js/filt/filt.js"
+    ]
   },
   "dependencies": {
     "bootstrap": "^3.3.7",

--- a/web/package.json
+++ b/web/package.json
@@ -13,7 +13,9 @@
     ],
     "unmockedModulePathPatterns": [
       "react"
-    ]
+    ],
+      "coverageDirectory":"./coverage",
+      "collectCoverage": true
   },
   "dependencies": {
     "bootstrap": "^3.3.7",

--- a/web/package.json
+++ b/web/package.json
@@ -15,7 +15,10 @@
       "react"
     ],
       "coverageDirectory":"./coverage",
-      "collectCoverage": true
+      "collectCoverage": true,
+      "coveragePathIgnorePatterns": [
+          "<rootDir>/src/js/filt/filt.js"
+      ]
   },
   "dependencies": {
     "bootstrap": "^3.3.7",

--- a/web/src/js/__tests__/ducks/settingsSpec.js
+++ b/web/src/js/__tests__/ducks/settingsSpec.js
@@ -1,8 +1,7 @@
 jest.unmock('../../ducks/settings')
 jest.mock('../../utils')
 
-import reduceSettings from '../../ducks/settings'
-import * as SettingsActions from '../../ducks/settings'
+import reduceSettings, * as SettingsActions from '../../ducks/settings'
 
 describe('setting reducer', () => {
     it('should return initial state', () => {
@@ -17,7 +16,11 @@ describe('setting reducer', () => {
     it('should handle update action', () => {
         let action = {type: SettingsActions.UPDATE, data: {id: 1} }
         expect(reduceSettings(undefined, action)).toEqual({id: 1})
+    })
+})
 
+describe('setting actions', () => {
+    it('should be possible to update setting', () => {
         expect(reduceSettings(undefined, SettingsActions.update())).toEqual({})
     })
 })

--- a/web/src/js/__tests__/ducks/settingsSpec.js
+++ b/web/src/js/__tests__/ducks/settingsSpec.js
@@ -1,0 +1,23 @@
+jest.unmock('../../ducks/settings')
+jest.mock('../../utils')
+
+import reduceSettings from '../../ducks/settings'
+import * as SettingsActions from '../../ducks/settings'
+
+describe('setting reducer', () => {
+    it('should return initial state', () => {
+        expect(reduceSettings(undefined, {})).toEqual({})
+    })
+
+    it('should handle receive action', () => {
+        let action = { type: SettingsActions.RECEIVE, data: 'foo' }
+        expect(reduceSettings(undefined, action)).toEqual('foo')
+    })
+
+    it('should handle update action', () => {
+        let action = {type: SettingsActions.UPDATE, data: {id: 1} }
+        expect(reduceSettings(undefined, action)).toEqual({id: 1})
+
+        expect(reduceSettings(undefined, SettingsActions.update())).toEqual({})
+    })
+})


### PR DESCRIPTION
This PRs is for:
+ Add a small js dependency `jest-fetch-mock`, because `node` does not support the `fetch` function, we have to mock it when running the test. This dependency would make our test jobs easier when dealing with some async actions.
+ Add `setupJest.js` to load `jest-fetch-mock` when starting Jest.
+ Add `--coverage` argument when doing `npm test`, so we could have the coverage report on travis.
+ Reach 100% coverage for `ducks/settings.js`