### PR TITLE
eventlog: Override set_focus to check for index error

### DIFF
--- a/mitmproxy/tools/console/flowlist.py
+++ b/mitmproxy/tools/console/flowlist.py
@@ -57,6 +57,10 @@ class LogBufferBox(urwid.ListBox):
         self.master = master
         urwid.ListBox.__init__(self, master.logbuffer)
 
+    def set_focus(self, index):
+        if 0 <= index < len(self.master.logbuffer):
+            super().set_focus(index)
+
     def keypress(self, size, key):
         key = common.shortcuts(key)
         if key == "z":


### PR DESCRIPTION
Mitmproxy crashes on pressing `g` or `G` while `eventlog` is focused and is empty. This happens due to `IndexError` in `set_focus`, so this PR just put a check by overriding it.

#### Mitmproxy version

Mitmproxy version: 3.0.0 (1.0.1dev0502-0x60b2fdfe) 
Python version: 3.6.0
Platform: Linux-4.8.13-1-ARCH-x86_64-with-arch
SSL version: OpenSSL 1.0.2j  26 Sep 2016
Linux distro: arch

PS: Should I open a issue before sending PR?