### PR TITLE
Add tests for set_focus

### DIFF
--- a/test/mitmproxy/console/test_flowlist.py
+++ b/test/mitmproxy/console/test_flowlist.py
@@ -1,4 +1,5 @@
 from unittest import mock
+import urwid
 
 import mitmproxy.tools.console.flowlist as flowlist
 from mitmproxy.tools import console
@@ -19,3 +20,18 @@ class TestFlowlist:
         with mock.patch('mitmproxy.tools.console.signals.status_message.send') as mock_thing:
             x.new_request("nonexistent url", "GET")
         mock_thing.assert_called_once_with(message="Invalid URL: No hostname given")
+
+    def test_logbuffer_set_focus(self):
+        m = self.mkmaster()
+        b = flowlist.LogBufferBox(m)
+        e = urwid.Text("Log message")
+        m.logbuffer.append(e)
+        m.logbuffer.append(e)
+
+        assert len(m.logbuffer) == 2
+        b.set_focus(0)
+        assert m.logbuffer.focus == 0
+        b.set_focus(1)
+        assert m.logbuffer.focus == 1
+        b.set_focus(2)
+        assert m.logbuffer.focus == 1


### PR DESCRIPTION
In continuation to #2220, this adds tests to cover `set_focus` in `LogBufferBox`. This will be conflicting with #2112, but even when that gets ready, we will be needing the tests and then they can shifted to other files.