### PR TITLE
Replace phrase 'the the' in 2 places

### DIFF
--- a/mitmproxy/tools/web/static/vendor.js
+++ b/mitmproxy/tools/web/static/vendor.js
@@ -3208,7 +3208,7 @@ function updateWidgetHeight(line) {
 }
 
 // Compute the lines that are visible in a given viewport (defaults
-// the the current scroll position). viewport may contain top,
+// to the current scroll position). viewport may contain top,
 // height, and ensure (see op.scrollToPos) properties.
 function visibleLines(display, doc, viewport) {
   var top = viewport && viewport.top != null ? Math.max(0, viewport.top) : display.scroller.scrollTop

--- a/mitmproxy/version.py
+++ b/mitmproxy/version.py
@@ -4,7 +4,7 @@ PATHOD = "pathod " + VERSION
 MITMPROXY = "mitmproxy " + VERSION
 
 # Serialization format version. This is displayed nowhere, it just needs to be incremented by one
-# for each change the the file format.
+# for each change in the file format.
 FLOW_FORMAT_VERSION = 5
 
 if __name__ == "__main__":


### PR DESCRIPTION
Replaced with the appropriate "in the" and "to the".
There are multiple other occurences of this but they are in upstream python modules.