### PR TITLE
fixes ipv6 authority form parsing in CONNECT

### DIFF
--- a/mitmproxy/net/http/http1/read.py
+++ b/mitmproxy/net/http/http1/read.py
@@ -271,7 +271,9 @@ def _parse_authority_form(hostport):
             ValueError, if the input is malformed
     """
     try:
-        host, port = hostport.split(b":")
+        host, port = hostport.rsplit(b":", 1)
+        if host.startswith(b"[") and host.endswith(b"]"):
+            host = host[1:-1]
         port = int(port)
         if not check.is_valid_host(host) or not check.is_valid_port(port):
             raise ValueError()

--- a/test/mitmproxy/net/http/http1/test_read.py
+++ b/test/mitmproxy/net/http/http1/test_read.py
@@ -243,6 +243,7 @@ def test_read_request_line():
 
 def test_parse_authority_form():
     assert _parse_authority_form(b"foo:42") == (b"foo", 42)
+    assert _parse_authority_form(b"[2001:db8:42::]:443") == (b"2001:db8:42::", 443)
     with pytest.raises(exceptions.HttpSyntaxException):
         _parse_authority_form(b"foo")
     with pytest.raises(exceptions.HttpSyntaxException):


### PR DESCRIPTION
I noticed the following output in the event log:

```
127.0.0.1:58169: HTTP protocol error in client request: Invalid host specification: b'[2a03:2880:f003:c07:face:b00c::2]:443'
```

It appears that the authority form parser does not handle ipv6 hostnames properly. I changed the parser to:

* Split on a single colon from the right-hand-side
* Strip brackets when an ipv6 hostname is detected

I also added a test for this condition.