### PR TITLE
Hack that fixes #2228

### DIFF
--- a/mitmproxy/addons/stickycookie.py
+++ b/mitmproxy/addons/stickycookie.py
@@ -78,7 +78,7 @@ class StickyCookie:
                     ]
                     if all(match):
                         c = self.jar[(domain, port, path)]
-                        l.extend([cookies.format_cookie_header(c[name].items(multi=True)) for name in c.keys()])
+                        l.extend([cookies.format_cookie_header([c[name].items(multi=True)[0]]) for name in c.keys()])
             if l:
                 # FIXME: we need to formalise this...
                 flow.request.stickycookie = True


### PR DESCRIPTION
The stickycookies implementation stores a list of lists of `(name, value)` tuples, including attributes, instead of a list of `(name, value, attributes=[(name, value), ...])` tuples that represent each cookie. This hack excludes everything except the first (name, value) pair, which is the actual cookie.

See #2228 for discussion on what would be a *proper* fix.