### PR TITLE
Remove watchdog, solidify script testing

### DIFF
--- a/mitmproxy/addonmanager.py
+++ b/mitmproxy/addonmanager.py
@@ -129,9 +129,13 @@ class AddonManager:
 
     def register(self, addon):
         """
-            Register an addon and all its sub-addons with the manager without
-            adding it to the chain. This should be used by addons that
-            dynamically manage addons. Must be called within a current context.
+            Register an addon, call its load event, and then register all its
+            sub-addons. This should be used by addons that dynamically manage
+            addons.
+
+            If the calling addon is already running, it should follow with
+            running and configure events. Must be called within a current
+            context.
         """
         for a in traverse([addon]):
             name = _get_name(a)

--- a/mitmproxy/test/taddons.py
+++ b/mitmproxy/test/taddons.py
@@ -112,9 +112,12 @@ class context:
             )
 
     def script(self, path):
+        """
+            Loads a script from path, and returns the enclosed addon.
+        """
         sc = script.Script(path)
         loader = addonmanager.Loader(self.master)
-        sc.load(loader)
-        for a in addonmanager.traverse(sc.addons):
-            getattr(a, "load", lambda x: None)(loader)
-        return sc
+        self.master.addons.invoke_addon(sc, "load", loader)
+        self.configure(sc)
+        self.master.addons.invoke_addon(sc, "tick")
+        return sc.addons[0] if sc.addons else None

--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,6 @@ setup(
         "ruamel.yaml>=0.13.2, <0.15",
         "tornado>=4.3, <4.6",
         "urwid>=1.3.1, <1.4",
-        "watchdog>=0.8.3, <0.9",
         "brotlipy>=0.5.1, <0.7",
         "sortedcontainers>=1.5.4, <1.6",
         # transitive from cryptography, we just blacklist here.

--- a/test/examples/test_examples.py
+++ b/test/examples/test_examples.py
@@ -1,9 +1,4 @@
-from mitmproxy import options
 from mitmproxy import contentviews
-from mitmproxy import proxy
-from mitmproxy import master
-from mitmproxy.addons import script
-
 from mitmproxy.test import tflow
 from mitmproxy.test import tutils
 from mitmproxy.test import taddons
@@ -14,37 +9,20 @@ from ..mitmproxy import tservers
 example_dir = tutils.test_data.push("../examples")
 
 
-class ScriptError(Exception):
-    pass
-
-
-class RaiseMaster(master.Master):
-    def add_log(self, e, level):
-        if level in ("warn", "error"):
-            raise ScriptError(e)
-
-
-def tscript(cmd, args=""):
-    o = options.Options()
-    cmd = example_dir.path(cmd)
-    m = RaiseMaster(o, proxy.DummyServer())
-    sc = script.Script(cmd)
-    m.addons.add(sc)
-    return m, sc
-
-
 class TestScripts(tservers.MasterTest):
     def test_add_header(self):
-        m, _ = tscript("simple/add_header.py")
-        f = tflow.tflow(resp=tutils.tresp())
-        m.addons.handle_lifecycle("response", f)
-        assert f.response.headers["newheader"] == "foo"
+        with taddons.context() as tctx:
+            a = tctx.script(example_dir.path("simple/add_header.py"))
+            f = tflow.tflow(resp=tutils.tresp())
+            a.response(f)
+            assert f.response.headers["newheader"] == "foo"
 
     def test_custom_contentviews(self):
-        m, sc = tscript("simple/custom_contentview.py")
-        swapcase = contentviews.get("swapcase")
-        _, fmt = swapcase(b"<html>Test!</html>")
-        assert any(b'tEST!' in val[0][1] for val in fmt)
+        with taddons.context() as tctx:
+            tctx.script(example_dir.path("simple/custom_contentview.py"))
+            swapcase = contentviews.get("swapcase")
+            _, fmt = swapcase(b"<html>Test!</html>")
+            assert any(b'tEST!' in val[0][1] for val in fmt)
 
     def test_iframe_injector(self):
         with taddons.context() as tctx:
@@ -61,57 +39,63 @@ class TestScripts(tservers.MasterTest):
             assert b'iframe' in content and b'evil_iframe' in content
 
     def test_modify_form(self):
-        m, sc = tscript("simple/modify_form.py")
+        with taddons.context() as tctx:
+            sc = tctx.script(example_dir.path("simple/modify_form.py"))
 
-        form_header = Headers(content_type="application/x-www-form-urlencoded")
-        f = tflow.tflow(req=tutils.treq(headers=form_header))
-        m.addons.handle_lifecycle("request", f)
+            form_header = Headers(content_type="application/x-www-form-urlencoded")
+            f = tflow.tflow(req=tutils.treq(headers=form_header))
+            sc.request(f)
 
-        assert f.request.urlencoded_form["mitmproxy"] == "rocks"
+            assert f.request.urlencoded_form["mitmproxy"] == "rocks"
 
-        f.request.headers["content-type"] = ""
-        m.addons.handle_lifecycle("request", f)
-        assert list(f.request.urlencoded_form.items()) == [("foo", "bar")]
+            f.request.headers["content-type"] = ""
+            sc.request(f)
+            assert list(f.request.urlencoded_form.items()) == [("foo", "bar")]
 
     def test_modify_querystring(self):
-        m, sc = tscript("simple/modify_querystring.py")
-        f = tflow.tflow(req=tutils.treq(path="/search?q=term"))
+        with taddons.context() as tctx:
+            sc = tctx.script(example_dir.path("simple/modify_querystring.py"))
+            f = tflow.tflow(req=tutils.treq(path="/search?q=term"))
 
-        m.addons.handle_lifecycle("request", f)
-        assert f.request.query["mitmproxy"] == "rocks"
+            sc.request(f)
+            assert f.request.query["mitmproxy"] == "rocks"
 
-        f.request.path = "/"
-        m.addons.handle_lifecycle("request", f)
-        assert f.request.query["mitmproxy"] == "rocks"
+            f.request.path = "/"
+            sc.request(f)
+            assert f.request.query["mitmproxy"] == "rocks"
 
     def test_redirect_requests(self):
-        m, sc = tscript("simple/redirect_requests.py")
-        f = tflow.tflow(req=tutils.treq(host="example.org"))
-        m.addons.handle_lifecycle("request", f)
-        assert f.request.host == "mitmproxy.org"
+        with taddons.context() as tctx:
+            sc = tctx.script(example_dir.path("simple/redirect_requests.py"))
+            f = tflow.tflow(req=tutils.treq(host="example.org"))
+            sc.request(f)
+            assert f.request.host == "mitmproxy.org"
 
     def test_send_reply_from_proxy(self):
-        m, sc = tscript("simple/send_reply_from_proxy.py")
-        f = tflow.tflow(req=tutils.treq(host="example.com", port=80))
-        m.addons.handle_lifecycle("request", f)
-        assert f.response.content == b"Hello World"
+        with taddons.context() as tctx:
+            sc = tctx.script(example_dir.path("simple/send_reply_from_proxy.py"))
+            f = tflow.tflow(req=tutils.treq(host="example.com", port=80))
+            sc.request(f)
+            assert f.response.content == b"Hello World"
 
     def test_dns_spoofing(self):
-        m, sc = tscript("complex/dns_spoofing.py")
-        original_host = "example.com"
+        with taddons.context() as tctx:
+            sc = tctx.script(example_dir.path("complex/dns_spoofing.py"))
 
-        host_header = Headers(host=original_host)
-        f = tflow.tflow(req=tutils.treq(headers=host_header, port=80))
+            original_host = "example.com"
 
-        m.addons.handle_lifecycle("requestheaders", f)
+            host_header = Headers(host=original_host)
+            f = tflow.tflow(req=tutils.treq(headers=host_header, port=80))
 
-        # Rewrite by reverse proxy mode
-        f.request.scheme = "https"
-        f.request.port = 443
+            tctx.master.addons.invoke_addon(sc, "requestheaders", f)
 
-        m.addons.handle_lifecycle("request", f)
+            # Rewrite by reverse proxy mode
+            f.request.scheme = "https"
+            f.request.port = 443
 
-        assert f.request.scheme == "http"
-        assert f.request.port == 80
+            tctx.master.addons.invoke_addon(sc, "request", f)
 
-        assert f.request.headers["Host"] == original_host
+            assert f.request.scheme == "http"
+            assert f.request.port == 80
+
+            assert f.request.headers["Host"] == original_host

--- a/test/mitmproxy/data/addonscripts/addon.py
+++ b/test/mitmproxy/data/addonscripts/addon.py
@@ -14,7 +14,7 @@ class Addon:
 
 
 def configure(options, updated):
-    event_log.append("addonconfigure")
+    event_log.append("scriptconfigure")
 
 
 def load(l):

--- a/test/mitmproxy/data/addonscripts/concurrent_decorator_err.py
+++ b/test/mitmproxy/data/addonscripts/concurrent_decorator_err.py
@@ -2,5 +2,5 @@ from mitmproxy.script import concurrent
 
 
 @concurrent
-def start(opts):
+def load(v):
     pass

--- a/test/mitmproxy/script/test_concurrent.py
+++ b/test/mitmproxy/script/test_concurrent.py
@@ -2,10 +2,7 @@ from mitmproxy.test import tflow
 from mitmproxy.test import tutils
 from mitmproxy.test import taddons
 
-from mitmproxy import addonmanager
 from mitmproxy import controller
-from mitmproxy.addons import script
-
 import time
 
 from .. import tservers
@@ -36,25 +33,20 @@ class TestConcurrent(tservers.MasterTest):
 
     def test_concurrent_err(self):
         with taddons.context() as tctx:
-            sc = script.Script(
+            tctx.script(
                 tutils.test_data.path(
                     "mitmproxy/data/addonscripts/concurrent_decorator_err.py"
                 )
             )
-            l = addonmanager.Loader(tctx.master)
-            sc.load(l)
             assert tctx.master.has_log("decorator not supported")
 
     def test_concurrent_class(self):
             with taddons.context() as tctx:
-                sc = script.Script(
+                sc = tctx.script(
                     tutils.test_data.path(
                         "mitmproxy/data/addonscripts/concurrent_decorator_class.py"
                     )
                 )
-                l = addonmanager.Loader(tctx.master)
-                sc.load(l)
-
                 f1, f2 = tflow.tflow(), tflow.tflow()
                 tctx.cycle(sc, f1)
                 tctx.cycle(sc, f2)


### PR DESCRIPTION
- Remove the watchdog dependency. We now just stat the script file every 2
seconds to check for an updated mtime.
- Further solidify our script testing, and in particular make the example tests
nicer. These should exemplify how we want users to test their own addon
scripts. More work on addon testing to follow.