### PR TITLE
Prominently link to examples in script docs

### DIFF
--- a/docs/scripting/overview.rst
+++ b/docs/scripting/overview.rst
@@ -29,6 +29,12 @@ will be added to all responses passing through the proxy:
 >>> mitmdump -s add_header.py
 
 
+Examples
+--------
+
+A collection of addons that demonstrate popular features can be found at :src:`examples/simple`.
+
+
 Using classes
 -------------
 


### PR DESCRIPTION
I think our simple example scripts are a very useful resource for new addon developers, so I'd like to link to them very prominently. We of course should not see them as a replacement for textual documentation, but I think they are a very useful complement.

@cortesi, ok with you?