### PR TITLE
bump cryptography min-version

### DIFF
--- a/mitmproxy/net/tcp.py
+++ b/mitmproxy/net/tcp.py
@@ -503,8 +503,6 @@ class _Connection:
         if cipher_list:
             try:
                 context.set_cipher_list(cipher_list)
-
-                # TODO: maybe change this to with newer pyOpenSSL APIs
                 context.set_tmp_ecdh(OpenSSL.crypto.get_elliptic_curve('prime256v1'))
             except SSL.Error as v:
                 raise exceptions.TlsException("SSL cipher specification error: %s" % str(v))
@@ -617,11 +615,6 @@ class TCPClient(_Connection):
                 raise self.ssl_verification_error
             else:
                 raise exceptions.TlsException("SSL handshake error: %s" % repr(v))
-        else:
-            # Fix for pre v1.0 OpenSSL, which doesn't throw an exception on
-            # certificate validation failure
-            if verification_mode == SSL.VERIFY_PEER and self.ssl_verification_error:
-                raise self.ssl_verification_error
 
         self.cert = certs.SSLCert(self.connection.get_peer_certificate())
 

--- a/mitmproxy/utils/version_check.py
+++ b/mitmproxy/utils/version_check.py
@@ -8,17 +8,17 @@ import os.path
 
 import OpenSSL
 
-PYOPENSSL_MIN_VERSION = (0, 15)
+PYOPENSSL_MIN_VERSION = (16, 0)
 
 
 def check_pyopenssl_version(min_version=PYOPENSSL_MIN_VERSION, fp=sys.stderr):
-    min_version_str = u".".join(str(x) for x in min_version)
+    min_version_str = ".".join(str(x) for x in min_version)
     try:
         v = tuple(int(x) for x in OpenSSL.__version__.split(".")[:2])
     except ValueError:
         print(
-            u"Cannot parse pyOpenSSL version: {}"
-            u"mitmproxy requires pyOpenSSL {} or greater.".format(
+            "Cannot parse pyOpenSSL version: {}"
+            "mitmproxy requires pyOpenSSL {} or greater.".format(
                 OpenSSL.__version__, min_version_str
             ),
             file=fp
@@ -26,15 +26,15 @@ def check_pyopenssl_version(min_version=PYOPENSSL_MIN_VERSION, fp=sys.stderr):
         return
     if v < min_version:
         print(
-            u"You are using an outdated version of pyOpenSSL: "
-            u"mitmproxy requires pyOpenSSL {} or greater.".format(min_version_str),
+            "You are using an outdated version of pyOpenSSL: "
+            "mitmproxy requires pyOpenSSL {} or greater.".format(min_version_str),
             file=fp
         )
         # Some users apparently have multiple versions of pyOpenSSL installed.
         # Report which one we got.
         pyopenssl_path = os.path.dirname(inspect.getfile(OpenSSL))
         print(
-            u"Your pyOpenSSL {} installation is located at {}".format(
+            "Your pyOpenSSL {} installation is located at {}".format(
                 OpenSSL.__version__, pyopenssl_path
             ),
             file=fp

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setup(
         "click>=6.2, <7",
         "certifi>=2015.11.20.1",  # no semver here - this should always be on the last release!
         "construct>=2.8, <2.9",
-        "cryptography>=1.3, <1.9",
+        "cryptography>=1.4, <1.9",
         "cssutils>=1.0.1, <1.1",
         "h2>=3.0, <4",
         "html2text>=2016.1.8, <=2016.9.19",


### PR DESCRIPTION
This removes OpenSSL v0.9.8 support.