### PR TITLE
commands: add the core command addon, and the command "set"

### DIFF
--- a/mitmproxy/addonmanager.py
+++ b/mitmproxy/addonmanager.py
@@ -56,7 +56,7 @@ def safecall():
     try:
         with contextlib.redirect_stdout(stdout_replacement):
             yield
-    except exceptions.AddonHalt:
+    except (exceptions.AddonHalt, exceptions.OptionsError):
         raise
     except Exception as e:
         etype, value, tb = sys.exc_info()

--- a/mitmproxy/addons/__init__.py
+++ b/mitmproxy/addons/__init__.py
@@ -4,6 +4,7 @@ from mitmproxy.addons import check_alpn
 from mitmproxy.addons import check_ca
 from mitmproxy.addons import clientplayback
 from mitmproxy.addons import core_option_validation
+from mitmproxy.addons import core
 from mitmproxy.addons import disable_h2c
 from mitmproxy.addons import onboarding
 from mitmproxy.addons import proxyauth
@@ -20,6 +21,7 @@ from mitmproxy.addons import upstream_auth
 
 def default_addons():
     return [
+        core.Core(),
         core_option_validation.CoreOptionValidation(),
         anticache.AntiCache(),
         anticomp.AntiComp(),

--- a/mitmproxy/addons/core.py
+++ b/mitmproxy/addons/core.py
@@ -1,0 +1,18 @@
+from mitmproxy import ctx
+from mitmproxy import exceptions
+
+
+class Core:
+    def set(self, spec: str) -> None:
+        """
+            Set an option of the form "key[=value]". When the value is omitted,
+            booleans are set to true, strings and integers are set to None (if
+            permitted), and sequences are emptied.
+        """
+        try:
+            ctx.options.set(spec)
+        except exceptions.OptionsError as e:
+            raise exceptions.CommandError(e) from e
+
+    def load(self, l):
+        l.add_command("set", self.set)

--- a/mitmproxy/tools/console/master.py
+++ b/mitmproxy/tools/console/master.py
@@ -83,9 +83,9 @@ class ConsoleCommands:
     def __init__(self, master):
         self.master = master
 
-    def command(self) -> None:
+    def command(self, partial: str) -> None:
         """Prompt for a command."""
-        signals.status_prompt_command.send()
+        signals.status_prompt_command.send(partial=partial)
 
     def view_commands(self) -> None:
         """View the commands list."""
@@ -120,12 +120,13 @@ class ConsoleCommands:
 
 
 def default_keymap(km):
-    km.add(":", "console.command")
+    km.add(":", "console.command ''")
     km.add("?", "console.view.help")
     km.add("C", "console.view.commands")
     km.add("O", "console.view.options")
     km.add("Q", "console.exit")
     km.add("q", "console.view.pop")
+    km.add("i", "console.command 'set intercept='")
 
 
 class ConsoleMaster(master.Master):

--- a/mitmproxy/tools/console/window.py
+++ b/mitmproxy/tools/console/window.py
@@ -82,15 +82,4 @@ class Window(urwid.Frame):
 
     def keypress(self, size, k):
         k = super().keypress(size, k)
-        k = self.master.keymap.handle("", k)
-        if not k:
-            return
-        elif k == "i":
-            signals.status_prompt.send(
-                self,
-                prompt = "Intercept filter",
-                text = self.master.options.intercept,
-                callback = self.master.options.setter("intercept")
-            )
-        else:
-            return k
+        return self.master.keymap.handle("", k)

--- a/test/mitmproxy/addons/test_core.py
+++ b/test/mitmproxy/addons/test_core.py
@@ -1,0 +1,15 @@
+from mitmproxy.addons import core
+from mitmproxy.test import taddons
+from mitmproxy import exceptions
+import pytest
+
+
+def test_set():
+    sa = core.Core()
+    with taddons.context() as tctx:
+        assert not tctx.master.options.anticomp
+        tctx.command(sa.set, "anticomp")
+        assert tctx.master.options.anticomp
+
+        with pytest.raises(exceptions.CommandError):
+            tctx.command(sa.set, "nonexistent")

--- a/test/mitmproxy/addons/test_core.py
+++ b/test/mitmproxy/addons/test_core.py
@@ -7,6 +7,8 @@ import pytest
 def test_set():
     sa = core.Core()
     with taddons.context() as tctx:
+        tctx.master.addons.add(sa)
+
         assert not tctx.master.options.anticomp
         tctx.command(sa.set, "anticomp")
         assert tctx.master.options.anticomp


### PR DESCRIPTION
The set command sets an option using the same syntax as commandline --set.