### PR TITLE
[web] Add coverage for js/urlState.js

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -14,23 +14,24 @@
     "unmockedModulePathPatterns": [
       "react"
     ],
-    "coverageDirectory":"./coverage",
+    "coverageDirectory": "./coverage",
     "collectCoverage": true,
     "coveragePathIgnorePatterns": [
-        "<rootDir>/src/js/filt/filt.js"
+      "<rootDir>/src/js/filt/filt.js"
     ]
   },
   "dependencies": {
     "bootstrap": "^3.3.7",
     "classnames": "^2.2.5",
     "lodash": "^4.17.4",
-    "react": "^15.4.2",
     "prop-types": "^15.5.0",
+    "react": "^15.4.2",
     "react-codemirror": "^0.3.0",
     "react-dom": "^15.4.2",
     "react-redux": "^5.0.2",
     "redux": "^3.6.0",
     "redux-logger": "^2.8.1",
+    "redux-mock-store": "^1.2.3",
     "redux-thunk": "^2.2.0",
     "shallowequal": "^0.2.2"
   },

--- a/web/src/js/__tests__/urlStateSpec.js
+++ b/web/src/js/__tests__/urlStateSpec.js
@@ -1,4 +1,5 @@
 import initialize from '../urlState'
+import { updateStoreFromUrl, updateUrlFromStore } from '../urlState'
 
 import reduceFlows from '../ducks/flows'
 import reduceUI from '../ducks/ui/index'
@@ -8,47 +9,44 @@ import * as flowsActions from '../ducks/flows'
 import configureStore from 'redux-mock-store'
 
 const mockStore = configureStore()
+history.replaceState = jest.fn()
 
 describe('updateStoreFromUrl', () => {
-    history.replaceState = jest.fn()
-    let initialState = {
-            flows:    reduceFlows(undefined, {}),
-            ui:       reduceUI(undefined, {}),
-            eventLog: reduceEventLog(undefined, {})
-    }
 
     it('should handle search query', () => {
         window.location.hash = "#/flows?s=foo"
-        let store = mockStore(initialState)
-        initialize(store)
+        let store = mockStore()
+        updateStoreFromUrl(store)
         expect(store.getActions()).toEqual([{ filter: "foo", type: "FLOWS_SET_FILTER" }])
     })
 
     it('should handle highlight query', () => {
         window.location.hash = "#/flows?h=foo"
-        let store = mockStore(initialState)
-        initialize(store)
+        let store = mockStore()
+        updateStoreFromUrl(store)
         expect(store.getActions()).toEqual([{ highlight: "foo", type: "FLOWS_SET_HIGHLIGHT" }])
     })
 
     it('should handle show event log', () => {
         window.location.hash = "#/flows?e=true"
-        let store = mockStore(initialState)
-        initialize(store)
-        expect(store.getActions()).toEqual([{ type: "EVENTS_TOGGLE_VISIBILITY" }]) })
+        let initialState = { eventLog: reduceEventLog(undefined, {}) },
+            store = mockStore(initialState)
+        updateStoreFromUrl(store)
+        expect(store.getActions()).toEqual([{ type: "EVENTS_TOGGLE_VISIBILITY" }])
+    })
 
     it('should handle unimplemented query argument', () => {
         window.location.hash = "#/flows?foo=bar"
         console.error = jest.fn()
-        let store = mockStore(initialState)
-        initialize(store)
+        let store = mockStore()
+        updateStoreFromUrl(store)
         expect(console.error).toBeCalledWith("unimplemented query arg: foo=bar")
     })
 
     it('should select flow and tab', () => {
         window.location.hash = "#/flows/123/request"
-        let store = mockStore(initialState)
-        initialize(store)
+        let store = mockStore()
+        updateStoreFromUrl(store)
         expect(store.getActions()).toEqual([
             {
                 flowIds: ["123"],
@@ -63,17 +61,40 @@ describe('updateStoreFromUrl', () => {
 })
 
 describe('updateUrlFromStore', () => {
-    history.replaceState = jest.fn()
-    let flows = reduceFlows(undefined, flowsActions.select(123)),
-    initialState = {
-        flows:    reduceFlows(flows, flowsActions.setFilter('~u foo')),
+    let initialState = {
+        flows:    reduceFlows(undefined, {}),
         ui:       reduceUI(undefined, {}),
         eventLog: reduceEventLog(undefined, {})
     }
 
+    it('should update initial url', () => {
+        let store = mockStore(initialState)
+        updateUrlFromStore(store)
+        expect(history.replaceState).toBeCalledWith(undefined, '', '/#/flows')
+    })
+
     it('should update url', () => {
+        let flows = reduceFlows(undefined, flowsActions.select(123)),
+            state = {
+                ...initialState,
+                flows: reduceFlows(flows, flowsActions.setFilter('~u foo'))
+            },
+            store = mockStore(state)
+        updateUrlFromStore(store)
+        expect(history.replaceState).toBeCalledWith(undefined, '', '/#/flows/123/request?s=~u foo')
+    })
+})
+
+describe('initialize', () => {
+    let initialState = {
+        flows:    reduceFlows(undefined, {}),
+        ui:       reduceUI(undefined, {}),
+        eventLog: reduceEventLog(undefined, {})
+    }
+
+    it('should handle initial state', () => {
         let store = mockStore(initialState)
         initialize(store)
-        expect(history.replaceState).toBeCalledWith(undefined, '', '/#/flows/123/request?s=~u foo')
+        store.dispatch({ type: "foo" })
     })
 })

--- a/web/src/js/__tests__/urlStateSpec.js
+++ b/web/src/js/__tests__/urlStateSpec.js
@@ -1,0 +1,66 @@
+import initialize from '../urlState'
+
+import reduceFlows from '../ducks/flows'
+import reduceUI from '../ducks/ui/index'
+import reduceEventLog from '../ducks/eventLog'
+
+import * as flowsAction from '../ducks/flows'
+import * as uiFlowAction from '../ducks/ui/flow'
+import * as eventLogAction from '../ducks/eventLog'
+
+import {createStore} from './ducks/tutils'
+
+
+describe('test updateStoreFromUrl and updateUrlFromStore', () => {
+
+    let store = createStore({
+        flows: reduceFlows,
+        ui: reduceUI,
+        eventLog: reduceEventLog
+    })
+
+    history.replaceState = jest.fn()
+
+    it('should handle search query', () => {
+        window.location.hash = "#/flows?s=foo"
+        let setFilter = jest.spyOn(flowsAction, 'setFilter')
+
+        initialize(store)
+        expect(setFilter).toBeCalledWith('foo')
+    })
+
+    it('should handle highlight query', () => {
+        window.location.hash = "#/flows?h=foo"
+        let setHighlight = jest.spyOn(flowsAction, 'setHighlight')
+
+        initialize(store)
+        expect(setHighlight).toBeCalledWith('foo')
+    })
+
+    it('should handle show event log', () => {
+        window.location.hash = "#/flows?e=true"
+        let toggleVisibility = jest.spyOn(eventLogAction, 'toggleVisibility')
+
+        initialize(store)
+        expect(toggleVisibility).toHaveBeenCalled()
+    })
+
+    it('should handle unimplemented query argument', () => {
+        window.location.hash = "#/flows?foo=bar"
+        console.error = jest.fn()
+
+        initialize(store)
+        expect(console.error).toBeCalledWith("unimplemented query arg: foo=bar")
+    })
+
+    it('should select flow and tab', () => {
+        window.location.hash = "#/flows/123/request"
+        let select      = jest.spyOn(flowsAction, 'select'),
+            selectTab   = jest.spyOn(uiFlowAction, 'selectTab')
+
+        initialize(store)
+        expect(select).toBeCalledWith('123')
+        expect(selectTab).toBeCalledWith('request')
+    })
+
+})

--- a/web/src/js/urlState.js
+++ b/web/src/js/urlState.js
@@ -15,7 +15,7 @@ const Query = {
     SHOW_EVENTLOG: "e"
 };
 
-function updateStoreFromUrl(store) {
+export function updateStoreFromUrl(store) {
     const [path, query]   = window.location.hash.substr(1).split("?", 2)
     const path_components = path.substr(1).split("/")
 
@@ -50,7 +50,7 @@ function updateStoreFromUrl(store) {
     }
 }
 
-function updateUrlFromStore(store) {
+export function updateUrlFromStore(store) {
     const state    = store.getState()
     let query      = {
         [Query.SEARCH]: state.flows.filter,
@@ -78,6 +78,6 @@ function updateUrlFromStore(store) {
 }
 
 export default function initialize(store) {
-    store.subscribe(() => updateUrlFromStore(store))
     updateStoreFromUrl(store)
+    store.subscribe(() => updateUrlFromStore(store))
 }

--- a/web/src/js/urlState.js
+++ b/web/src/js/urlState.js
@@ -78,6 +78,6 @@ function updateUrlFromStore(store) {
 }
 
 export default function initialize(store) {
-    updateStoreFromUrl(store)
     store.subscribe(() => updateUrlFromStore(store))
+    updateStoreFromUrl(store)
 }

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -1279,13 +1279,13 @@ content-type@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.2.tgz#b7d113aee7a8dd27bd21133c4dc2529df1721eed"
 
-convert-source-map@1.X, convert-source-map@^1.2.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.4.0.tgz#e3dad195bf61bfe13a7a3c73e9876ec14a0268f3"
-
-convert-source-map@^1.1.0, convert-source-map@~1.1.0:
+convert-source-map@1.X, convert-source-map@^1.1.0, convert-source-map@~1.1.0:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.1.3.tgz#4829c877e9fe49b3161f3bf3673888e204699860"
+
+convert-source-map@^1.2.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.4.0.tgz#e3dad195bf61bfe13a7a3c73e9876ec14a0268f3"
 
 core-js@^1.0.0:
   version "1.2.7"
@@ -1860,7 +1860,7 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "^2.0.0"
 
-fbjs@^0.8.1, fbjs@^0.8.4:
+fbjs@^0.8.1, fbjs@^0.8.4, fbjs@^0.8.9:
   version "0.8.9"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.9.tgz#180247fbd347dcc9004517b904f865400a0c8f14"
   dependencies:
@@ -2461,13 +2461,9 @@ https-browserify@~0.0.0:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-0.0.1.tgz#3f91365cabe60b77ed0ebba24b454e3e09d95a82"
 
-iconv-lite@0.4.13:
+iconv-lite@0.4.13, iconv-lite@~0.4.13:
   version "0.4.13"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.13.tgz#1f88aba4ab0b1508e8312acc39345f36e992e2f2"
-
-iconv-lite@~0.4.13:
-  version "0.4.15"
-  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.15.tgz#fe265a218ac6a57cfe854927e9d04c19825eddeb"
 
 ieee754@^1.1.4:
   version "1.1.8"
@@ -4068,6 +4064,12 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
+prop-types@^15.5.0:
+  version "15.5.8"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.8.tgz#6b7b2e141083be38c8595aa51fc55775c7199394"
+  dependencies:
+    fbjs "^0.8.9"
+
 prr@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/prr/-/prr-0.0.0.tgz#1a84b85908325501411853d0081ee3fa86e2926a"
@@ -4288,6 +4290,10 @@ redux-logger@^2.8.1:
   resolved "https://registry.yarnpkg.com/redux-logger/-/redux-logger-2.8.1.tgz#c00e689ba00342f44858701d76b1d73fbade72bd"
   dependencies:
     deep-diff "0.3.4"
+
+redux-mock-store@^1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/redux-mock-store/-/redux-mock-store-1.2.3.tgz#1b3ad299da91cb41ba30d68e3b6f024475fb9e1b"
 
 redux-thunk@^2.2.0:
   version "2.2.0"


### PR DESCRIPTION
It's a little bit tricky to complete the tests for this, so I want to explain a bit here.
The reducers(`reduceFlows`...) are require here to create a store object which our target function will operate on, so we could not mock the whole js file as we usually do. However, we don't care about the implementation of certain actions (`setFilter`...) and want to mock them up.

In this case, `jest.mock()` does not work. After looking up the documentation, I found a solution which uses `jest.spyOn()`. We could import all the reducers and actions first, and mock the action functions before calling the target function. Then we could use the handy `toBeCalledWith()` function to test if we are passing the right arguments to the action functions.

***
Now that we have covered almost all of the `.js` files, it's time to move on to the `.jsx` file. :rocket: 
According to the official guide of Jest, we could either use [snapshot test](http://facebook.github.io/jest/docs/tutorial-react.html#snapshot-testing) or traditional [dom test](http://facebook.github.io/jest/docs/tutorial-react.html#dom-testing) on this task. 
@mhils @cle1000 Which way do you prefer?
