### PR TITLE
Added LDAP Auth

### DIFF
--- a/mitmproxy/addons/proxyauth.py
+++ b/mitmproxy/addons/proxyauth.py
@@ -114,7 +114,6 @@ class ProxyAuth:
             if conn:
                 conn.search(parts[1][1:], '('+parts[0]+username+')', attributes=['objectclass'])
                 if ctx.options.proxyauth.split(":")[3] in conn.entries[0]['objectclass']:
-                    conn.unbind()
                     return username, password
 
         return None
@@ -135,6 +134,7 @@ class ProxyAuth:
             self.nonanonymous = False
             self.singleuser = None
             self.htpasswd = None
+            self.ldapserver = None
             if ctx.options.proxyauth:
                 if ctx.options.proxyauth == "any":
                     self.nonanonymous = True

--- a/mitmproxy/addons/proxyauth.py
+++ b/mitmproxy/addons/proxyauth.py
@@ -107,10 +107,10 @@ class ProxyAuth:
             dn = ctx.options.proxyauth.split(":")[2]
             parts = dn.split("?")
             conn = ldap3.Connection(
-                    self.ldapserver,
-                    parts[0] + username + parts[1],
-                    password,
-                    auto_bind=True)
+                self.ldapserver,
+                parts[0] + username + parts[1],
+                password,
+                auto_bind=True)
             if conn:
                 conn.search(parts[1][1:], '(' + parts[0] + username + ')', attributes=['objectclass'])
                 if ctx.options.proxyauth.split(":")[3] in conn.entries[0]['objectclass']:

--- a/mitmproxy/addons/proxyauth.py
+++ b/mitmproxy/addons/proxyauth.py
@@ -115,7 +115,6 @@ class ProxyAuth:
                 conn.search(parts[1][1:], '(' + parts[0] + username + ')', attributes=['objectclass'])
                 if ctx.options.proxyauth.split(":")[3] in conn.entries[0]['objectclass']:
                     return username, password
-
         return None
 
     def authenticate(self, f: http.HTTPFlow) -> bool:

--- a/mitmproxy/addons/proxyauth.py
+++ b/mitmproxy/addons/proxyauth.py
@@ -1,5 +1,6 @@
 import binascii
 import weakref
+import ldap3
 from typing import Optional
 from typing import MutableMapping  # noqa
 from typing import Tuple
@@ -46,11 +47,12 @@ class ProxyAuth:
         self.nonanonymous = False
         self.htpasswd = None
         self.singleuser = None
+        self.ldapserver = None
         self.authenticated = weakref.WeakKeyDictionary()  # type: MutableMapping[connections.ClientConnection, Tuple[str, str]]
         """Contains all connections that are permanently authenticated after an HTTP CONNECT"""
 
     def enabled(self) -> bool:
-        return any([self.nonanonymous, self.htpasswd, self.singleuser])
+        return any([self.nonanonymous, self.htpasswd, self.singleuser, self.ldapserver])
 
     def is_proxy_auth(self) -> bool:
         """
@@ -99,6 +101,21 @@ class ProxyAuth:
         elif self.htpasswd:
             if self.htpasswd.check_password(username, password):
                 return username, password
+        elif self.ldapserver:
+            if not username or not password:
+                return None
+            dn = ctx.options.proxyauth.split(":")[2]
+            parts = dn.split("?")
+            conn = ldap3.Connection(
+                    self.ldapserver,
+                    parts[0] + username + parts[1],
+                    password,
+                    auto_bind=True)
+            if conn:
+                conn.search(parts[1][1:], '('+parts[0]+username+')', attributes=['objectclass'])
+                if ctx.options.proxyauth.split(":")[3] in conn.entries[0]['objectclass']:
+                    conn.unbind()
+                    return username, password
 
         return None
 
@@ -129,6 +146,17 @@ class ProxyAuth:
                         raise exceptions.OptionsError(
                             "Could not open htpasswd file: %s" % p
                         )
+                elif ctx.options.proxyauth.startswith("ldap"):
+                    parts = ctx.options.proxyauth.split(":")
+                    if len(parts) != 4:
+                        raise exceptions.OptionsError(
+                            "Invalid ldap specification"
+                        )
+                    if parts[0] == "ldaps":
+                        server = ldap3.Server(parts[1], use_ssl=True)
+                    elif parts[0] == "ldap":
+                        server = ldap3.Server(parts[1])
+                    self.ldapserver = server
                 else:
                     parts = ctx.options.proxyauth.split(':')
                     if len(parts) != 2:

--- a/mitmproxy/addons/proxyauth.py
+++ b/mitmproxy/addons/proxyauth.py
@@ -112,7 +112,7 @@ class ProxyAuth:
                     password,
                     auto_bind=True)
             if conn:
-                conn.search(parts[1][1:], '('+parts[0]+username+')', attributes=['objectclass'])
+                conn.search(parts[1][1:], '(' + parts[0] + username + ')', attributes=['objectclass'])
                 if ctx.options.proxyauth.split(":")[3] in conn.entries[0]['objectclass']:
                     return username, password
 
@@ -156,6 +156,10 @@ class ProxyAuth:
                         server = ldap3.Server(parts[1], use_ssl=True)
                     elif parts[0] == "ldap":
                         server = ldap3.Server(parts[1])
+                    else:
+                        raise exceptions.OptionsError(
+                            "Invalid ldap specfication on the first part"
+                        )
                     self.ldapserver = server
                 else:
                     parts = ctx.options.proxyauth.split(':')

--- a/mitmproxy/options.py
+++ b/mitmproxy/options.py
@@ -199,8 +199,12 @@ class Options(optmanager.OptManager):
             """
             Require proxy authentication. Value may be "any" to require
             authenticaiton but accept any credentials, start with "@" to specify
-            a path to an Apache htpasswd file, or be of the form
-            "username:password".
+            a path to an Apache htpasswd file, be of the form
+            "username:password", or be of the form
+            "ldap[s]:url_server_ldap:dn:group", the dn must include "?", which will be
+            the username prompted, and the group is the group the user must belong to
+            an example would be
+            "ldap:ldap.forumsys.com:uid=?,dc=example,dc=com:person".
             """
         )
         self.add_option(

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ setup(
         "hyperframe>=5.0, <6",
         "jsbeautifier>=1.6.3, <1.7",
         "kaitaistruct>=0.7, <0.8",
-        "ldap3>=2.2.0, <2.2.1",
+        "ldap3>=2.2.0, <2.2.3",
         "passlib>=1.6.5, <1.8",
         "pyasn1>=0.1.9, <0.3",
         "pyOpenSSL>=16.0, <17.1",

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ setup(
         "hyperframe>=5.0, <6",
         "jsbeautifier>=1.6.3, <1.7",
         "kaitaistruct>=0.7, <0.8",
-        "ldap3>=2.2.0, <2.2.3",
+        "ldap3>=2.2.0, <=2.2.3",
         "passlib>=1.6.5, <1.8",
         "pyasn1>=0.1.9, <0.3",
         "pyOpenSSL>=16.0, <17.1",

--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,7 @@ setup(
         "hyperframe>=5.0, <6",
         "jsbeautifier>=1.6.3, <1.7",
         "kaitaistruct>=0.7, <0.8",
+        "ldap3>=2.2.0, <2.2.1",
         "passlib>=1.6.5, <1.8",
         "pyasn1>=0.1.9, <0.3",
         "pyOpenSSL>=16.0, <17.1",

--- a/test/mitmproxy/addons/test_proxyauth.py
+++ b/test/mitmproxy/addons/test_proxyauth.py
@@ -133,7 +133,7 @@ def test_check():
             f.request.headers["Proxy-Authorization"] = proxyauth.mkauth(
                 "einstein", "foo"
             )
-            assert not up.check(f)
+        assert not up.check(f)
 
 
 def test_authenticate():

--- a/test/mitmproxy/addons/test_proxyauth.py
+++ b/test/mitmproxy/addons/test_proxyauth.py
@@ -2,7 +2,6 @@ import binascii
 import ldap3
 
 import pytest
-from _pytest.monkeypatch import MonkeyPatch
 
 from mitmproxy import exceptions
 from mitmproxy.addons import proxyauth
@@ -45,7 +44,6 @@ def test_configure():
 
         ctx.configure(up, proxyauth="ldap:fake_server:fake_dn:fake_group")
         assert up.ldapserver
-
 
         ctx.configure(up, proxyauth="ldap:fake_server:uid=?,dc=example,dc=com:person")
         assert up.ldapserver
@@ -126,7 +124,6 @@ def test_check(monkeypatch):
         )
         assert not up.check(f)
 
-
         ctx.configure(
             up,
             proxyauth="ldap:fake-server:cn=?,ou=test,o=lab:test"
@@ -134,8 +131,10 @@ def test_check(monkeypatch):
         conn = ldap3.Connection("fake-server", user="cn=user0,ou=test,o=lab", password="password", client_strategy=ldap3.MOCK_SYNC)
         conn.bind()
         conn.strategy.add_entry('cn=user0,ou=test,o=lab', {'userPassword': 'test0', 'sn': 'user0_sn', 'revision': 0, 'objectClass': 'test'})
+
         def conn_mp(ldap, user, password, **kwargs):
             return conn
+
         monkeypatch.setattr(ldap3, "Connection", conn_mp)
         f.request.headers["Proxy-Authorization"] = proxyauth.mkauth(
             "user0", "test0"

--- a/test/mitmproxy/addons/test_proxyauth.py
+++ b/test/mitmproxy/addons/test_proxyauth.py
@@ -46,8 +46,12 @@ def test_configure():
         assert up.ldapserver
         ctx.configure(up, proxyauth="ldaps:ldap.forumsys.com:uid=?,dc=example,dc=com:person")
         assert up.ldapserver
+
         with pytest.raises(exceptions.OptionsError):
-            ctx.configure(up, proxyauth="ldapldap.forumsys.com:uid=?dc=example,dc=com:person")
+            ctx.configure(up, proxyauth="ldap:ldap.forumsys.comuid=?dc=example,dc=com:person")
+
+        with pytest.raises(exceptions.OptionsError):
+            ctx.configure(up, proxyauth="ldapssssssss:ldap.forumsys.com:uid=?,dc=example,dc=com:person")
 
         with pytest.raises(exceptions.OptionsError):
             ctx.configure(

--- a/test/mitmproxy/addons/test_proxyauth.py
+++ b/test/mitmproxy/addons/test_proxyauth.py
@@ -133,7 +133,7 @@ def test_check():
             f.request.headers["Proxy-Authorization"] = proxyauth.mkauth(
                 "einstein", "foo"
             )
-        assert not up.check(f)
+            assert not up.check(f)
 
 
 def test_authenticate():


### PR DESCRIPTION
Added basic LDAP Auth:
Based on ldap3, I just added the option ldap after --proxyauth :
--proxyauth ldap[s]:url_ldap:dn:group
example :
--proxyauth ldap:ldap.forumsys.com:uid=?,dc=example,dc=com:person
So the DN can be anything (should be based on the configuration of the ldap server), the username will be queried as ? in the dn. 
Basically it will connect and bind to the server and check that the user :
- Has proper creds for logging in the server
- Is part of a group (needs to be configured on the LDAP server) that will be allowed to use the proxy
