### PR TITLE
Note to enable `Certificate Trust Settings` in iOS 10.3 or up

### DIFF
--- a/docs/certinstall.rst
+++ b/docs/certinstall.rst
@@ -24,7 +24,7 @@ something like this:
 Click on the relevant icon, follow the setup instructions for the platform
 you're on and you are good to go.
 
-For iOS version 10.3 or up, you need to make sure `mitmproxy` is enabled in `Certificate Trust Settings`, you can check it by going to `Settings > General > About > Certificate Trust Settings`
+For iOS version 10.3 or up, you need to make sure ``mitmproxy`` is enabled in ``Certificate Trust Settings``, you can check it by going to ``Settings > General > About > Certificate Trust Settings``
 
 Installing the mitmproxy CA certificate manually
 ------------------------------------------------

--- a/docs/certinstall.rst
+++ b/docs/certinstall.rst
@@ -23,8 +23,8 @@ something like this:
 
 Click on the relevant icon, follow the setup instructions for the platform
 you're on and you are good to go.
-For iOS version 10.3 or up, you need to make sure `mitmproxy` is enabled in `Certificate Trust Settings`.
-You can check by going to `Settings > General > About > Certificate Trust Settings`
+
+For iOS version 10.3 or up, you need to make sure `mitmproxy` is enabled in `Certificate Trust Settings`, you can check it by going to `Settings > General > About > Certificate Trust Settings`
 
 Installing the mitmproxy CA certificate manually
 ------------------------------------------------

--- a/docs/certinstall.rst
+++ b/docs/certinstall.rst
@@ -24,7 +24,9 @@ something like this:
 Click on the relevant icon, follow the setup instructions for the platform
 you're on and you are good to go.
 
-For iOS version 10.3 or up, you need to make sure ``mitmproxy`` is enabled in ``Certificate Trust Settings``, you can check it by going to ``Settings > General > About > Certificate Trust Settings``
+For iOS version 10.3 or up, you need to make sure ``mitmproxy`` is enabled in 
+``Certificate Trust Settings``, you can check it by going to 
+``Settings > General > About > Certificate Trust Settings``.
 
 Installing the mitmproxy CA certificate manually
 ------------------------------------------------

--- a/docs/certinstall.rst
+++ b/docs/certinstall.rst
@@ -23,7 +23,8 @@ something like this:
 
 Click on the relevant icon, follow the setup instructions for the platform
 you're on and you are good to go.
-
+For iOS version 10.3 or up, you need to make sure `mitmproxy` is enabled in `Certificate Trust Settings`.
+You can check by going to `Settings > General > About > Certificate Trust Settings`
 
 Installing the mitmproxy CA certificate manually
 ------------------------------------------------


### PR DESCRIPTION
Even after installing certs from `mitm.it`, it's not trusted by default, user need to enable this on their own.

http://stackoverflow.com/a/43303169/1433273

![simulator screen shot may 5 2017 5 13 34 pm](https://cloud.githubusercontent.com/assets/1057756/25739841/3b2fd148-31b6-11e7-95b9-77a2c873979c.png)
