### PR TITLE
Fix examples/simple/custom_contentview.py to work

### DIFF
--- a/examples/simple/custom_contentview.py
+++ b/examples/simple/custom_contentview.py
@@ -14,19 +14,14 @@ class ViewSwapCase(contentviews.View):
 
     # We don't have a good solution for the keyboard shortcut yet -
     # you manually need to find a free letter. Contributions welcome :)
-    prompt = ("swap case text", "z")
+    prompt = ("swap case text", "t")
     content_types = ["text/plain"]
 
     def __call__(self, data: typing.AnyStr, **metadata) -> CVIEWSWAPCASE:
-        return "case-swapped text", contentviews.format_text(data.swapcase())
+        return "text", contentviews.format_text(data.swapcase())
 
 
 view = ViewSwapCase()
 
 
-def load(l):
-    contentviews.add(view)
-
-
-def done():
-    contentviews.remove(view)
+contentviews.add(view)


### PR DESCRIPTION
I was looking at the examples to use mitmproxy inside a small project,
but this example wasn't quite working:

While trying to run this script on both Linux/Mac with python 3.6.1, mitmproxy
installed with venv and pip, this script had few problems and would not run.

- load(l) was not being called, trying to ctx.log.error() inside load(l) did
  not show anything on the Event Log.

- shortcut key in prompt had to be changed into something inside the title
  "swap case text" -- otherwise it would result in IndexError.

- "case-swapped text" inside __call__ is not defined in palette -- thus
  changed into generic "text".