### PR TITLE
[WIP][web] Coverage improve

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -2,7 +2,7 @@
   "name": "mitmproxy",
   "private": true,
   "scripts": {
-    "test": "jest",
+    "test": "jest --coverage",
     "build": "gulp prod",
     "start": "gulp"
   },
@@ -15,7 +15,6 @@
       "react"
     ],
     "coverageDirectory": "./coverage",
-    "collectCoverage": true,
     "coveragePathIgnorePatterns": [
       "<rootDir>/src/js/filt/filt.js"
     ],

--- a/web/src/js/__tests__/ducks/eventLogSpec.js
+++ b/web/src/js/__tests__/ducks/eventLogSpec.js
@@ -1,5 +1,3 @@
-jest.unmock('../../ducks/eventLog')
-
 import reduceEventLog, * as eventLogActions from '../../ducks/eventLog'
 import reduceStore from '../../ducks/utils/store'
 

--- a/web/src/js/__tests__/ducks/flowsSpec.js
+++ b/web/src/js/__tests__/ducks/flowsSpec.js
@@ -1,11 +1,10 @@
-jest.unmock('../../ducks/flows');
 jest.mock('../../utils')
 
 import reduceFlows from "../../ducks/flows"
 import * as flowActions from "../../ducks/flows"
 import reduceStore from "../../ducks/utils/store"
-import {fetchApi} from "../../utils"
-import {createStore} from "./tutils"
+import { fetchApi } from "../../utils"
+import { createStore } from "./tutils"
 
 describe('flow reducer', () => {
     let state = undefined
@@ -104,7 +103,7 @@ describe('flow reducer', () => {
 
 describe('flows actions', () => {
 
-    let store = createStore({reduceFlows})
+    let store = createStore({ reduceFlows })
 
     let tflow = { id: 1 }
     it('should handle resume action', () => {

--- a/web/src/js/__tests__/ducks/indexSpec.js
+++ b/web/src/js/__tests__/ducks/indexSpec.js
@@ -1,0 +1,12 @@
+import reduceState from '../../ducks/index'
+
+describe('reduceState in js/ducks/index.js', () => {
+    it('should combine flow and header', () => {
+        let state = reduceState(undefined, {})
+        expect(state.hasOwnProperty('eventLog')).toBeTruthy()
+        expect(state.hasOwnProperty('flows')).toBeTruthy()
+        expect(state.hasOwnProperty('settings')).toBeTruthy()
+        expect(state.hasOwnProperty('connection')).toBeTruthy()
+        expect(state.hasOwnProperty('ui')).toBeTruthy()
+    })
+})

--- a/web/src/js/__tests__/ducks/settingsSpec.js
+++ b/web/src/js/__tests__/ducks/settingsSpec.js
@@ -1,4 +1,3 @@
-jest.unmock('../../ducks/settings')
 jest.mock('../../utils')
 
 import reduceSettings, * as SettingsActions from '../../ducks/settings'

--- a/web/src/js/__tests__/ducks/tutils.js
+++ b/web/src/js/__tests__/ducks/tutils.js
@@ -1,6 +1,3 @@
-jest.unmock('redux')
-jest.unmock('redux-thunk')
-
 import { combineReducers, applyMiddleware, createStore as createReduxStore } from 'redux'
 import thunk from 'redux-thunk'
 

--- a/web/src/js/__tests__/ducks/ui/flowSpec.js
+++ b/web/src/js/__tests__/ducks/ui/flowSpec.js
@@ -1,7 +1,3 @@
-jest.unmock('../../../ducks/ui/flow')
-jest.unmock('../../../ducks/flows')
-jest.unmock('lodash')
-
 import _ from 'lodash'
 import reducer, {
                     startEdit,

--- a/web/src/js/__tests__/ducks/ui/headerSpec.js
+++ b/web/src/js/__tests__/ducks/ui/headerSpec.js
@@ -1,6 +1,3 @@
-jest.unmock('../../../ducks/ui/header')
-jest.unmock('../../../ducks/flows')
-
 import reducer, { setActiveMenu } from '../../../ducks/ui/header'
 import * as flowActions from '../../../ducks/flows'
 

--- a/web/src/js/__tests__/ducks/ui/indexSpec.js
+++ b/web/src/js/__tests__/ducks/ui/indexSpec.js
@@ -1,0 +1,9 @@
+import reduceUI from '../../../ducks/ui/index'
+
+describe('reduceUI in js/ducks/ui/index.js', () => {
+    it('should combine flow and header', () => {
+        let state = reduceUI(undefined, {})
+        expect(state.hasOwnProperty('flow')).toBeTruthy()
+        expect(state.hasOwnProperty('header')).toBeTruthy()
+    })
+})

--- a/web/src/js/__tests__/ducks/ui/keyboardSpec.js
+++ b/web/src/js/__tests__/ducks/ui/keyboardSpec.js
@@ -7,151 +7,142 @@ import reduceUI from '../../../ducks/ui/index'
 import * as flowsActions from '../../../ducks/flows'
 import * as UIActions from '../../../ducks/ui/flow'
 import configureStore from 'redux-mock-store'
-import { createStore } from '../tutils'
+import thunk from 'redux-thunk'
 import { fetchApi } from '../../../utils'
 
-const mockStore = configureStore()
+const mockStore = configureStore([ thunk ])
 console.debug = jest.fn()
 
 describe('onKeyDown', () => {
     let flows = undefined
     for( let i=1; i <= 12; i++ ) {
-        flows = reduceFlows(flows, {type: flowsActions.ADD, data: {id: i}, cmd: 'add'})
+        flows = reduceFlows(flows, {type: flowsActions.ADD, data: {id: i, request: true, response: true}, cmd: 'add'})
     }
     let store = mockStore({ flows, ui: reduceUI(undefined, {}) })
     let createKeyEvent = (keyCode, shiftKey = undefined, ctrlKey = undefined) => {
-            return { keyCode, shiftKey, ctrlKey, preventDefault: jest.fn() }
+            return onKeyDown({ keyCode, shiftKey, ctrlKey, preventDefault: jest.fn() })
     }
 
     it('should handle cursor up', () => {
         store.getState().flows = reduceFlows(flows, flowsActions.select(2))
-        onKeyDown(createKeyEvent(Key.K))(store.dispatch, store.getState)
-        expect(store.getActions().pop()).toEqual({ flowIds: [1], type: flowsActions.SELECT })
+        store.dispatch(createKeyEvent(Key.K))
+        expect(store.getActions()).toEqual([{ flowIds: [1], type: flowsActions.SELECT }])
 
-        onKeyDown(createKeyEvent(Key.UP))(store.dispatch, store.getState)
+        store.dispatch(createKeyEvent(Key.UP))
         expect(store.getActions().pop()).toEqual({ flowIds: [1], type: flowsActions.SELECT })
     })
 
     it('should handle cursor down', () => {
-        onKeyDown(createKeyEvent(Key.J))(store.dispatch, store.getState)
+        store.dispatch(createKeyEvent(Key.J))
         expect(store.getActions().pop()).toEqual({ flowIds: [3], type: flowsActions.SELECT })
 
-        onKeyDown(createKeyEvent(Key.DOWN))(store.dispatch, store.getState)
+        store.dispatch(createKeyEvent(Key.DOWN))
         expect(store.getActions().pop()).toEqual({ flowIds: [3], type: flowsActions.SELECT })
     })
 
     it('should handle page down', () => {
-        onKeyDown(createKeyEvent(Key.SPACE))(store.dispatch, store.getState)
+        store.dispatch(createKeyEvent(Key.SPACE))
         expect(store.getActions().pop()).toEqual({ flowIds: [12], type: flowsActions.SELECT })
 
         store.getState().flows = reduceFlows(flows, flowsActions.select(1))
-        onKeyDown(createKeyEvent(Key.PAGE_DOWN))(store.dispatch, store.getState)
+        store.dispatch(createKeyEvent(Key.PAGE_DOWN))
         expect(store.getActions().pop()).toEqual({ flowIds: [11], type: flowsActions.SELECT })
     })
 
     it('should handle page up', () => {
         store.getState().flows = reduceFlows(flows, flowsActions.select(11))
-        onKeyDown(createKeyEvent(Key.PAGE_UP))(store.dispatch, store.getState)
+        store.dispatch(createKeyEvent(Key.PAGE_UP))
         expect(store.getActions().pop()).toEqual({ flowIds: [1], type: flowsActions.SELECT })
     })
 
     it('should handle select first', () => {
-        onKeyDown(createKeyEvent(Key.HOME))(store.dispatch, store.getState)
+        store.dispatch(createKeyEvent(Key.HOME))
         expect(store.getActions().pop()).toEqual({ flowIds: [1], type: flowsActions.SELECT })
     })
 
     it('should handle select last', () => {
         store.getState().flows = reduceFlows(flows, flowsActions.select(1))
-        onKeyDown(createKeyEvent(Key.END))(store.dispatch, store.getState)
+        store.dispatch(createKeyEvent(Key.END))
         expect(store.getActions().pop()).toEqual({ flowIds: [12], type: flowsActions.SELECT })
     })
 
     it('should handle deselect', () => {
-        onKeyDown(createKeyEvent(Key.ESC))(store.dispatch, store.getState)
+        store.dispatch(createKeyEvent(Key.ESC))
         expect(store.getActions().pop()).toEqual({ flowIds: [], type: flowsActions.SELECT })
     })
 
     it('should handle switch to left tab', () => {
-        onKeyDown(createKeyEvent(Key.LEFT))(store.dispatch, store.getState)
+        store.dispatch(createKeyEvent(Key.LEFT))
         expect(store.getActions().pop()).toEqual({ tab: 'details', type: UIActions.SET_TAB })
     })
 
     it('should handle switch to right tab', () => {
-        onKeyDown(createKeyEvent(Key.TAB))(store.dispatch, store.getState)
-        expect(store.getActions().pop()).toEqual({ tab: 'details', type: UIActions.SET_TAB })
-    })
+        store.dispatch(createKeyEvent(Key.TAB))
+        expect(store.getActions().pop()).toEqual({ tab: 'response', type: UIActions.SET_TAB })
 
-    it('should handle switch to left tab', () => {
-        onKeyDown(createKeyEvent(Key.LEFT))(store.dispatch, store.getState)
-        expect(store.getActions().pop()).toEqual({ tab: 'details', type: UIActions.SET_TAB })
+        store.dispatch(createKeyEvent(Key.RIGHT))
+        expect(store.getActions().pop()).toEqual({ tab: 'response', type: UIActions.SET_TAB })
     })
-
-    it('should handle switch to right tab', () => {
-        onKeyDown(createKeyEvent(Key.TAB))(store.dispatch, store.getState)
-        expect(store.getActions().pop()).toEqual({ tab: 'details', type: UIActions.SET_TAB })
-    })
-
-    let tStore = createStore({ reduceFlows })
-    // we need to use the real dispatch to test the actions below
 
     it('should handle delete action', () => {
-        onKeyDown(createKeyEvent(Key.D))(tStore.dispatch, store.getState)
+        store.dispatch(createKeyEvent(Key.D))
         expect(fetchApi).toBeCalledWith('/flows/1', { method: 'DELETE' })
+
     })
 
     it('should handle duplicate action', () => {
-        onKeyDown(createKeyEvent(Key.D, true))(tStore.dispatch, store.getState)
+        store.dispatch(createKeyEvent(Key.D, true))
         expect(fetchApi).toBeCalledWith('/flows/1/duplicate', { method: 'POST' })
     })
 
     it('should handle resume action', () => {
         // resume all
-        onKeyDown(createKeyEvent(Key.A, true))(tStore.dispatch, store.getState)
+        store.dispatch(createKeyEvent(Key.A, true))
         expect(fetchApi).toBeCalledWith('/flows/resume', { method: 'POST' })
         // resume
         store.getState().flows.byId[store.getState().flows.selected[0]].intercepted = true
-        onKeyDown(createKeyEvent(Key.A))(tStore.dispatch, store.getState)
+        store.dispatch(createKeyEvent(Key.A))
         expect(fetchApi).toBeCalledWith('/flows/1/resume', { method: 'POST' })
     })
 
     it('should handle replay action', () => {
-        onKeyDown(createKeyEvent(Key.R))(tStore.dispatch, store.getState)
+        store.dispatch(createKeyEvent(Key.R))
         expect(fetchApi).toBeCalledWith('/flows/1/replay', { method: 'POST' })
     })
 
     it('should handle revert action', () => {
         store.getState().flows.byId[store.getState().flows.selected[0]].modified = true
-        onKeyDown(createKeyEvent(Key.V))(tStore.dispatch, store.getState)
+        store.dispatch(createKeyEvent(Key.V))
         expect(fetchApi).toBeCalledWith('/flows/1/revert', { method: 'POST' })
     })
 
     it('should handle kill action', () => {
         // kill all
-        onKeyDown(createKeyEvent(Key.X, true))(tStore.dispatch, store.getState)
+        store.dispatch(createKeyEvent(Key.X, true))
         expect(fetchApi).toBeCalledWith('/flows/kill', { method: 'POST' })
         // kill
-        onKeyDown(createKeyEvent(Key.X))(tStore.dispatch, store.getState)
+        store.dispatch(createKeyEvent(Key.X))
         expect(fetchApi).toBeCalledWith('/flows/1/kill', { method: 'POST' })
     })
 
     it('should handle clear action', () => {
-        onKeyDown(createKeyEvent(Key.Z))(tStore.dispatch, store.getState)
+        store.dispatch(createKeyEvent(Key.Z))
         expect(fetchApi).toBeCalledWith('/clear', { method: 'POST' })
     })
 
     it('should stop on some action with no flow is selected', () => {
         fetchApi.mockClear()
         store.getState().flows = reduceFlows(undefined, {})
-        onKeyDown(createKeyEvent(Key.LEFT))(tStore.dispatch, store.getState)
-        onKeyDown(createKeyEvent(Key.TAB))(tStore.dispatch, store.getState)
-        onKeyDown(createKeyEvent(Key.RIGHT))(tStore.dispatch, store.getState)
-        onKeyDown(createKeyEvent(Key.D))(tStore.dispatch, store.getState)
+        store.dispatch(createKeyEvent(Key.LEFT))
+        store.dispatch(createKeyEvent(Key.TAB))
+        store.dispatch(createKeyEvent(Key.RIGHT))
+        store.dispatch(createKeyEvent(Key.D))
         expect(fetchApi).not.toBeCalled()
     })
 
     it('should do nothing when Ctrl and undefined key is pressed ', () => {
-        onKeyDown(createKeyEvent(Key.BACKSPACE, false, true))(tStore.dispatch, store.getState)
-        onKeyDown(createKeyEvent(0))(tStore.dispatch, store.getState)
+        store.dispatch(createKeyEvent(Key.BACKSPACE, false, true))
+        store.dispatch(createKeyEvent(0))
         expect(fetchApi).not.toBeCalled()
     })
 

--- a/web/src/js/__tests__/ducks/ui/keyboardSpec.js
+++ b/web/src/js/__tests__/ducks/ui/keyboardSpec.js
@@ -23,65 +23,74 @@ describe('onKeyDown', () => {
             return onKeyDown({ keyCode, shiftKey, ctrlKey, preventDefault: jest.fn() })
     }
 
+    afterEach(() => {
+        store.clearActions()
+        fetchApi.mockClear()
+    });
+
     it('should handle cursor up', () => {
         store.getState().flows = reduceFlows(flows, flowsActions.select(2))
         store.dispatch(createKeyEvent(Key.K))
         expect(store.getActions()).toEqual([{ flowIds: [1], type: flowsActions.SELECT }])
 
+        store.clearActions()
         store.dispatch(createKeyEvent(Key.UP))
-        expect(store.getActions().pop()).toEqual({ flowIds: [1], type: flowsActions.SELECT })
+        expect(store.getActions()).toEqual([{ flowIds: [1], type: flowsActions.SELECT }])
     })
 
     it('should handle cursor down', () => {
         store.dispatch(createKeyEvent(Key.J))
-        expect(store.getActions().pop()).toEqual({ flowIds: [3], type: flowsActions.SELECT })
+        expect(store.getActions()).toEqual([{ flowIds: [3], type: flowsActions.SELECT }])
 
+        store.clearActions()
         store.dispatch(createKeyEvent(Key.DOWN))
-        expect(store.getActions().pop()).toEqual({ flowIds: [3], type: flowsActions.SELECT })
+        expect(store.getActions()).toEqual([{ flowIds: [3], type: flowsActions.SELECT }])
     })
 
     it('should handle page down', () => {
         store.dispatch(createKeyEvent(Key.SPACE))
-        expect(store.getActions().pop()).toEqual({ flowIds: [12], type: flowsActions.SELECT })
+        expect(store.getActions()).toEqual([{ flowIds: [12], type: flowsActions.SELECT }])
 
         store.getState().flows = reduceFlows(flows, flowsActions.select(1))
+        store.clearActions()
         store.dispatch(createKeyEvent(Key.PAGE_DOWN))
-        expect(store.getActions().pop()).toEqual({ flowIds: [11], type: flowsActions.SELECT })
+        expect(store.getActions()).toEqual([{ flowIds: [11], type: flowsActions.SELECT }])
     })
 
     it('should handle page up', () => {
         store.getState().flows = reduceFlows(flows, flowsActions.select(11))
         store.dispatch(createKeyEvent(Key.PAGE_UP))
-        expect(store.getActions().pop()).toEqual({ flowIds: [1], type: flowsActions.SELECT })
+        expect(store.getActions()).toEqual([{ flowIds: [1], type: flowsActions.SELECT }])
     })
 
     it('should handle select first', () => {
         store.dispatch(createKeyEvent(Key.HOME))
-        expect(store.getActions().pop()).toEqual({ flowIds: [1], type: flowsActions.SELECT })
+        expect(store.getActions()).toEqual([{ flowIds: [1], type: flowsActions.SELECT }])
     })
 
     it('should handle select last', () => {
         store.getState().flows = reduceFlows(flows, flowsActions.select(1))
         store.dispatch(createKeyEvent(Key.END))
-        expect(store.getActions().pop()).toEqual({ flowIds: [12], type: flowsActions.SELECT })
+        expect(store.getActions()).toEqual([{ flowIds: [12], type: flowsActions.SELECT }])
     })
 
     it('should handle deselect', () => {
         store.dispatch(createKeyEvent(Key.ESC))
-        expect(store.getActions().pop()).toEqual({ flowIds: [], type: flowsActions.SELECT })
+        expect(store.getActions()).toEqual([{ flowIds: [], type: flowsActions.SELECT }])
     })
 
     it('should handle switch to left tab', () => {
         store.dispatch(createKeyEvent(Key.LEFT))
-        expect(store.getActions().pop()).toEqual({ tab: 'details', type: UIActions.SET_TAB })
+        expect(store.getActions()).toEqual([{ tab: 'details', type: UIActions.SET_TAB }])
     })
 
     it('should handle switch to right tab', () => {
         store.dispatch(createKeyEvent(Key.TAB))
-        expect(store.getActions().pop()).toEqual({ tab: 'response', type: UIActions.SET_TAB })
+        expect(store.getActions()).toEqual([{ tab: 'response', type: UIActions.SET_TAB }])
 
+        store.clearActions()
         store.dispatch(createKeyEvent(Key.RIGHT))
-        expect(store.getActions().pop()).toEqual({ tab: 'response', type: UIActions.SET_TAB })
+        expect(store.getActions()).toEqual([{ tab: 'response', type: UIActions.SET_TAB }])
     })
 
     it('should handle delete action', () => {
@@ -131,7 +140,6 @@ describe('onKeyDown', () => {
     })
 
     it('should stop on some action with no flow is selected', () => {
-        fetchApi.mockClear()
         store.getState().flows = reduceFlows(undefined, {})
         store.dispatch(createKeyEvent(Key.LEFT))
         store.dispatch(createKeyEvent(Key.TAB))

--- a/web/src/js/__tests__/ducks/ui/keyboardSpec.js
+++ b/web/src/js/__tests__/ducks/ui/keyboardSpec.js
@@ -1,0 +1,158 @@
+jest.mock('../../../utils')
+
+import { Key } from '../../../utils'
+import { onKeyDown } from '../../../ducks/ui/keyboard'
+import reduceFlows from '../../../ducks/flows'
+import reduceUI from '../../../ducks/ui/index'
+import * as flowsActions from '../../../ducks/flows'
+import * as UIActions from '../../../ducks/ui/flow'
+import configureStore from 'redux-mock-store'
+import { createStore } from '../tutils'
+import { fetchApi } from '../../../utils'
+
+const mockStore = configureStore()
+console.debug = jest.fn()
+
+describe('onKeyDown', () => {
+    let flows = undefined
+    for( let i=1; i <= 12; i++ ) {
+        flows = reduceFlows(flows, {type: flowsActions.ADD, data: {id: i}, cmd: 'add'})
+    }
+    let store = mockStore({ flows, ui: reduceUI(undefined, {}) })
+    let createKeyEvent = (keyCode, shiftKey = undefined, ctrlKey = undefined) => {
+            return { keyCode, shiftKey, ctrlKey, preventDefault: jest.fn() }
+    }
+
+    it('should handle cursor up', () => {
+        store.getState().flows = reduceFlows(flows, flowsActions.select(2))
+        onKeyDown(createKeyEvent(Key.K))(store.dispatch, store.getState)
+        expect(store.getActions().pop()).toEqual({ flowIds: [1], type: flowsActions.SELECT })
+
+        onKeyDown(createKeyEvent(Key.UP))(store.dispatch, store.getState)
+        expect(store.getActions().pop()).toEqual({ flowIds: [1], type: flowsActions.SELECT })
+    })
+
+    it('should handle cursor down', () => {
+        onKeyDown(createKeyEvent(Key.J))(store.dispatch, store.getState)
+        expect(store.getActions().pop()).toEqual({ flowIds: [3], type: flowsActions.SELECT })
+
+        onKeyDown(createKeyEvent(Key.DOWN))(store.dispatch, store.getState)
+        expect(store.getActions().pop()).toEqual({ flowIds: [3], type: flowsActions.SELECT })
+    })
+
+    it('should handle page down', () => {
+        onKeyDown(createKeyEvent(Key.SPACE))(store.dispatch, store.getState)
+        expect(store.getActions().pop()).toEqual({ flowIds: [12], type: flowsActions.SELECT })
+
+        store.getState().flows = reduceFlows(flows, flowsActions.select(1))
+        onKeyDown(createKeyEvent(Key.PAGE_DOWN))(store.dispatch, store.getState)
+        expect(store.getActions().pop()).toEqual({ flowIds: [11], type: flowsActions.SELECT })
+    })
+
+    it('should handle page up', () => {
+        store.getState().flows = reduceFlows(flows, flowsActions.select(11))
+        onKeyDown(createKeyEvent(Key.PAGE_UP))(store.dispatch, store.getState)
+        expect(store.getActions().pop()).toEqual({ flowIds: [1], type: flowsActions.SELECT })
+    })
+
+    it('should handle select first', () => {
+        onKeyDown(createKeyEvent(Key.HOME))(store.dispatch, store.getState)
+        expect(store.getActions().pop()).toEqual({ flowIds: [1], type: flowsActions.SELECT })
+    })
+
+    it('should handle select last', () => {
+        store.getState().flows = reduceFlows(flows, flowsActions.select(1))
+        onKeyDown(createKeyEvent(Key.END))(store.dispatch, store.getState)
+        expect(store.getActions().pop()).toEqual({ flowIds: [12], type: flowsActions.SELECT })
+    })
+
+    it('should handle deselect', () => {
+        onKeyDown(createKeyEvent(Key.ESC))(store.dispatch, store.getState)
+        expect(store.getActions().pop()).toEqual({ flowIds: [], type: flowsActions.SELECT })
+    })
+
+    it('should handle switch to left tab', () => {
+        onKeyDown(createKeyEvent(Key.LEFT))(store.dispatch, store.getState)
+        expect(store.getActions().pop()).toEqual({ tab: 'details', type: UIActions.SET_TAB })
+    })
+
+    it('should handle switch to right tab', () => {
+        onKeyDown(createKeyEvent(Key.TAB))(store.dispatch, store.getState)
+        expect(store.getActions().pop()).toEqual({ tab: 'details', type: UIActions.SET_TAB })
+    })
+
+    it('should handle switch to left tab', () => {
+        onKeyDown(createKeyEvent(Key.LEFT))(store.dispatch, store.getState)
+        expect(store.getActions().pop()).toEqual({ tab: 'details', type: UIActions.SET_TAB })
+    })
+
+    it('should handle switch to right tab', () => {
+        onKeyDown(createKeyEvent(Key.TAB))(store.dispatch, store.getState)
+        expect(store.getActions().pop()).toEqual({ tab: 'details', type: UIActions.SET_TAB })
+    })
+
+    let tStore = createStore({ reduceFlows })
+    // we need to use the real dispatch to test the actions below
+
+    it('should handle delete action', () => {
+        onKeyDown(createKeyEvent(Key.D))(tStore.dispatch, store.getState)
+        expect(fetchApi).toBeCalledWith('/flows/1', { method: 'DELETE' })
+    })
+
+    it('should handle duplicate action', () => {
+        onKeyDown(createKeyEvent(Key.D, true))(tStore.dispatch, store.getState)
+        expect(fetchApi).toBeCalledWith('/flows/1/duplicate', { method: 'POST' })
+    })
+
+    it('should handle resume action', () => {
+        // resume all
+        onKeyDown(createKeyEvent(Key.A, true))(tStore.dispatch, store.getState)
+        expect(fetchApi).toBeCalledWith('/flows/resume', { method: 'POST' })
+        // resume
+        store.getState().flows.byId[store.getState().flows.selected[0]].intercepted = true
+        onKeyDown(createKeyEvent(Key.A))(tStore.dispatch, store.getState)
+        expect(fetchApi).toBeCalledWith('/flows/1/resume', { method: 'POST' })
+    })
+
+    it('should handle replay action', () => {
+        onKeyDown(createKeyEvent(Key.R))(tStore.dispatch, store.getState)
+        expect(fetchApi).toBeCalledWith('/flows/1/replay', { method: 'POST' })
+    })
+
+    it('should handle revert action', () => {
+        store.getState().flows.byId[store.getState().flows.selected[0]].modified = true
+        onKeyDown(createKeyEvent(Key.V))(tStore.dispatch, store.getState)
+        expect(fetchApi).toBeCalledWith('/flows/1/revert', { method: 'POST' })
+    })
+
+    it('should handle kill action', () => {
+        // kill all
+        onKeyDown(createKeyEvent(Key.X, true))(tStore.dispatch, store.getState)
+        expect(fetchApi).toBeCalledWith('/flows/kill', { method: 'POST' })
+        // kill
+        onKeyDown(createKeyEvent(Key.X))(tStore.dispatch, store.getState)
+        expect(fetchApi).toBeCalledWith('/flows/1/kill', { method: 'POST' })
+    })
+
+    it('should handle clear action', () => {
+        onKeyDown(createKeyEvent(Key.Z))(tStore.dispatch, store.getState)
+        expect(fetchApi).toBeCalledWith('/clear', { method: 'POST' })
+    })
+
+    it('should stop on some action with no flow is selected', () => {
+        fetchApi.mockClear()
+        store.getState().flows = reduceFlows(undefined, {})
+        onKeyDown(createKeyEvent(Key.LEFT))(tStore.dispatch, store.getState)
+        onKeyDown(createKeyEvent(Key.TAB))(tStore.dispatch, store.getState)
+        onKeyDown(createKeyEvent(Key.RIGHT))(tStore.dispatch, store.getState)
+        onKeyDown(createKeyEvent(Key.D))(tStore.dispatch, store.getState)
+        expect(fetchApi).not.toBeCalled()
+    })
+
+    it('should do nothing when Ctrl and undefined key is pressed ', () => {
+        onKeyDown(createKeyEvent(Key.BACKSPACE, false, true))(tStore.dispatch, store.getState)
+        onKeyDown(createKeyEvent(0))(tStore.dispatch, store.getState)
+        expect(fetchApi).not.toBeCalled()
+    })
+
+})

--- a/web/src/js/__tests__/ducks/utils/storeSpec.js
+++ b/web/src/js/__tests__/ducks/utils/storeSpec.js
@@ -1,5 +1,3 @@
-jest.unmock('../../../ducks/utils/store')
-
 import reduceStore, * as storeActions from '../../../ducks/utils/store'
 
 describe('store reducer', () => {


### PR DESCRIPTION
Here's the brief road map about adding tests for our JavaScript code.

- [x] Clear up the code: remove `jest.unmock()`
- [x] Add full coverage to the files in the path we have touched, for example `js/ducks`, `js/ducks/ui`
    - [x] `js/ducks/index.js`
    - [x] `js/ducks/ui/index.js`
    - [x] `js/ducks/ui/keyboard.js`

Next step: Add tests for components in the `.jsx` files.

The reason why we need to remove `jest.unmock` has been discussed [here](https://github.com/mitmproxy/mitmproxy/pull/2212#issuecomment-289211106), I think we should keep the automocking disabled and manually mock the modules if necessary.