### PR TITLE
Handle head request on onboarding app: Fix #2324

### DIFF
--- a/mitmproxy/addons/onboardingapp/app.py
+++ b/mitmproxy/addons/onboardingapp/app.py
@@ -44,6 +44,19 @@ class PEM(tornado.web.RequestHandler):
     def filename(self):
         return config.CONF_BASENAME + "-ca-cert.pem"
 
+    def head(self):
+        p = os.path.join(self.request.master.options.cadir, self.filename)
+        p = os.path.expanduser(p)
+        with open(p, "rb") as f:
+            content_length = len(f.read())
+
+        self.set_header("Content-Type", "application/x-x509-ca-cert")
+        self.set_header(
+            "Content-Disposition",
+            "inline; filename={}".format(
+                self.filename))
+        self.set_header("Content-Length", content_length)
+
     def get(self):
         p = os.path.join(self.request.master.options.cadir, self.filename)
         p = os.path.expanduser(p)
@@ -62,6 +75,20 @@ class P12(tornado.web.RequestHandler):
     @property
     def filename(self):
         return config.CONF_BASENAME + "-ca-cert.p12"
+
+    def head(self):
+        p = os.path.join(self.request.master.options.cadir, self.filename)
+        p = os.path.expanduser(p)
+        with open(p, "rb") as f:
+            content_length = len(f.read())
+
+        self.set_header("Content-Type", "application/x-pkcs12")
+        self.set_header(
+            "Content-Disposition",
+            "inline; filename={}".format(
+                self.filename))
+
+        self.set_header("Content-Length", content_length)
 
     def get(self):
         p = os.path.join(self.request.master.options.cadir, self.filename)

--- a/mitmproxy/addons/onboardingapp/app.py
+++ b/mitmproxy/addons/onboardingapp/app.py
@@ -47,8 +47,7 @@ class PEM(tornado.web.RequestHandler):
     def head(self):
         p = os.path.join(self.request.master.options.cadir, self.filename)
         p = os.path.expanduser(p)
-        with open(p, "rb") as f:
-            content_length = len(f.read())
+        content_length = os.path.getsize(p)
 
         self.set_header("Content-Type", "application/x-x509-ca-cert")
         self.set_header(
@@ -79,8 +78,7 @@ class P12(tornado.web.RequestHandler):
     def head(self):
         p = os.path.join(self.request.master.options.cadir, self.filename)
         p = os.path.expanduser(p)
-        with open(p, "rb") as f:
-            content_length = len(f.read())
+        content_length = os.path.getsize(p)
 
         self.set_header("Content-Type", "application/x-pkcs12")
         self.set_header(

--- a/test/mitmproxy/addons/test_onboarding.py
+++ b/test/mitmproxy/addons/test_onboarding.py
@@ -1,5 +1,6 @@
 from mitmproxy.addons import onboarding
 from mitmproxy.test import taddons
+from mitmproxy import options
 from .. import tservers
 
 
@@ -19,3 +20,13 @@ class TestApp(tservers.HTTPProxyTest):
                 resp = self.app("/cert/%s" % ext)
                 assert resp.status_code == 200
                 assert resp.content
+
+    def test_head(self):
+        with taddons.context() as tctx:
+            tctx.configure(self.addons()[0])
+            p = self.pathoc()
+            for ext in ["pem", "p12"]:
+                with p.connect():
+                    resp = p.request("head:'http://%s/cert/%s'" % (options.APP_HOST, ext))
+                    assert resp.status_code == 200
+                    assert not resp.content


### PR DESCRIPTION
fixes #2324

@Kriechi The test is failing sometimes on my local machine.
It throws a TypeError `TypeError: getsockaddrarg() takes exactly 2 arguments (4 given)` in tcp.create_connection on [this line](https://github.com/mitmproxy/mitmproxy/blob/master/mitmproxy/net/tcp.py#L668) when the af is AF_INET and source address is ('::1', 52418, 0, 0) 
Is it something wrong wtih the test or create_connection function? 
None of the other test fail :confused: 