### PR TITLE
net.tcp: server should be in shut-down state before start

### DIFF
--- a/mitmproxy/net/tcp.py
+++ b/mitmproxy/net/tcp.py
@@ -847,6 +847,7 @@ class TCPServer:
     def __init__(self, address):
         self.address = address
         self.__is_shut_down = threading.Event()
+        self.__is_shut_down.set()
         self.__shutdown_request = False
 
         if self.address == 'localhost':


### PR DESCRIPTION
The .configure and .tick events can be called before the server is running. If
an addon calls ctx.master.shutdown() at this point, the server hangs forever
waiting on __is_shutdown_set. This patch fixes this by starting off with it
already set.