### PR TITLE
[web] Add  _flow.js for component tests.

### DIFF
--- a/test/mitmproxy/tools/web/test_app.py
+++ b/test/mitmproxy/tools/web/test_app.py
@@ -1,5 +1,6 @@
 import json as _json
 from unittest import mock
+import os
 
 import tornado.testing
 from tornado import httpclient
@@ -11,7 +12,6 @@ from mitmproxy import options
 from mitmproxy.test import tflow
 from mitmproxy.tools.web import app
 from mitmproxy.tools.web import master as webmaster
-
 
 def json(resp: httpclient.HTTPResponse):
     return _json.loads(resp.body.decode())
@@ -275,3 +275,13 @@ class TestApp(tornado.testing.AsyncHTTPTestCase):
         # trigger on_close by opening a second connection.
         ws_client2 = yield websocket.websocket_connect(ws_url)
         ws_client2.close()
+
+    def test_generate_tflow_js(self):
+        tflow_json = _json.dumps(
+            app.flow_to_json(tflow.tflow(resp=True, err=True)), indent=4, sort_keys=True
+        )
+        web_root = os.path.join(os.getcwd(), 'web')
+        tflow_path = os.path.join(web_root, 'src/js/__tests__/ducks/_tflow.js')
+        content = """export default function(){{\n    return {tflow_json}\n}}""".format(tflow_json=tflow_json)
+        with open(tflow_path, 'w') as f:
+            f.write(content)

--- a/test/mitmproxy/tools/web/test_app.py
+++ b/test/mitmproxy/tools/web/test_app.py
@@ -281,7 +281,8 @@ class TestApp(tornado.testing.AsyncHTTPTestCase):
         tflow_json = _json.dumps(
             app.flow_to_json(tflow.tflow(resp=True, err=True)), indent=4, sort_keys=True
         )
-        web_root = os.path.join(os.getcwd(), 'web')
+        here = os.path.abspath(os.path.dirname(__file__))
+        web_root = os.path.join(here, os.pardir, os.pardir, os.pardir, os.pardir, 'web')
         tflow_path = os.path.join(web_root, 'src/js/__tests__/ducks/_tflow.js')
         content = """export default function(){{\n    return {tflow_json}\n}}""".format(tflow_json=tflow_json)
         with open(tflow_path, 'w') as f:

--- a/test/mitmproxy/tools/web/test_app.py
+++ b/test/mitmproxy/tools/web/test_app.py
@@ -278,9 +278,15 @@ class TestApp(tornado.testing.AsyncHTTPTestCase):
         ws_client2.close()
 
     def test_generate_tflow_js(self):
-        tflow_json = _json.dumps(
-            app.flow_to_json(tflow.tflow(resp=True, err=True)), indent=4, sort_keys=True
-        )
+        _tflow = app.flow_to_json(tflow.tflow(resp=True, err=True))
+        # Set some value as constant, so that _tflow.js would not change every time.
+        _tflow['client_conn']['id'] = "4a18d1a0-50a1-48dd-9aa6-d45d74282939"
+        _tflow['id'] = "d91165be-ca1f-4612-88a9-c0f8696f3e29"
+        _tflow['error']['timestamp'] = 1495370312.4814785
+        _tflow['response']['timestamp_end'] = 1495370312.4814625
+        _tflow['response']['timestamp_start'] = 1495370312.481462
+        _tflow['server_conn']['id'] = "f087e7b2-6d0a-41a8-a8f0-e1a4761395f8"
+        tflow_json = _json.dumps(_tflow, indent=4, sort_keys=True)
         here = os.path.abspath(os.path.dirname(__file__))
         web_root = os.path.join(here, os.pardir, os.pardir, os.pardir, os.pardir, 'web')
         tflow_path = os.path.join(web_root, 'src/js/__tests__/ducks/_tflow.js')

--- a/test/mitmproxy/tools/web/test_app.py
+++ b/test/mitmproxy/tools/web/test_app.py
@@ -13,6 +13,7 @@ from mitmproxy.test import tflow
 from mitmproxy.tools.web import app
 from mitmproxy.tools.web import master as webmaster
 
+
 def json(resp: httpclient.HTTPResponse):
     return _json.loads(resp.body.decode())
 

--- a/web/src/js/__tests__/components/FlowTable/FlowColumnsSpec.js
+++ b/web/src/js/__tests__/components/FlowTable/FlowColumnsSpec.js
@@ -1,101 +1,101 @@
 import React from 'react'
 import renderer from 'react-test-renderer'
 import * as Columns from '../../../components/FlowTable/FlowColumns'
-import { TFlow } from '../../ducks/tutils'
+import _tflow from '../../ducks/_tflow'
 
 describe('FlowColumns Components', () => {
 
-    let tFlow = new TFlow()
+    let tflow = _tflow()
     it('should render TLSColumn', () => {
-        let tlsColumn = renderer.create(<Columns.TLSColumn flow={tFlow}/>),
+        let tlsColumn = renderer.create(<Columns.TLSColumn flow={tflow}/>),
             tree = tlsColumn.toJSON()
         expect(tree).toMatchSnapshot()
     })
 
     it('should render IconColumn', () => {
-        let iconColumn = renderer.create(<Columns.IconColumn flow={tFlow}/>),
+        let iconColumn = renderer.create(<Columns.IconColumn flow={tflow}/>),
             tree = iconColumn.toJSON()
         // plain
         expect(tree).toMatchSnapshot()
         // not modified
-        tFlow.response.status_code = 304
-        iconColumn = renderer.create(<Columns.IconColumn flow={tFlow}/>)
+        tflow.response.status_code = 304
+        iconColumn = renderer.create(<Columns.IconColumn flow={tflow}/>)
         tree = iconColumn.toJSON()
         expect(tree).toMatchSnapshot()
         // redirect
-        tFlow.response.status_code = 302
-        iconColumn = renderer.create(<Columns.IconColumn flow={tFlow}/>)
+        tflow.response.status_code = 302
+        iconColumn = renderer.create(<Columns.IconColumn flow={tflow}/>)
         tree = iconColumn.toJSON()
         expect(tree).toMatchSnapshot()
         // image
-        let imageFlow = new TFlow()
+        let imageFlow = _tflow()
         imageFlow.response.headers = [['Content-Type', 'image/jpeg']]
         iconColumn = renderer.create(<Columns.IconColumn flow={imageFlow}/>)
         tree = iconColumn.toJSON()
         expect(tree).toMatchSnapshot()
         // javascript
-        let jsFlow = new TFlow()
+        let jsFlow = _tflow()
         jsFlow.response.headers = [['Content-Type', 'application/x-javascript']]
         iconColumn = renderer.create(<Columns.IconColumn flow={jsFlow}/>)
         tree = iconColumn.toJSON()
         expect(tree).toMatchSnapshot()
         // css
-        let cssFlow = new TFlow()
+        let cssFlow = _tflow()
         cssFlow.response.headers = [['Content-Type', 'text/css']]
         iconColumn = renderer.create(<Columns.IconColumn flow={cssFlow}/>)
         tree = iconColumn.toJSON()
         expect(tree).toMatchSnapshot()
         // default
-        let fooFlow = new TFlow()
+        let fooFlow = _tflow()
         fooFlow.response.headers = [['Content-Type', 'foo']]
         iconColumn = renderer.create(<Columns.IconColumn flow={fooFlow}/>)
         tree = iconColumn.toJSON()
         expect(tree).toMatchSnapshot()
         // no response
-        tFlow.response = null
-        iconColumn = renderer.create(<Columns.IconColumn flow={tFlow}/>)
+        tflow.response = null
+        iconColumn = renderer.create(<Columns.IconColumn flow={tflow}/>)
         tree = iconColumn.toJSON()
         expect(tree).toMatchSnapshot()
     })
 
     it('should render pathColumn', () => {
-        let pathColumn = renderer.create(<Columns.PathColumn flow={tFlow}/>),
+        let pathColumn = renderer.create(<Columns.PathColumn flow={tflow}/>),
             tree = pathColumn.toJSON()
         expect(tree).toMatchSnapshot()
 
-        tFlow.error.msg = 'Connection killed'
-        tFlow.intercepted = true
-        pathColumn = renderer.create(<Columns.PathColumn flow={tFlow}/>)
+        tflow.error.msg = 'Connection killed'
+        tflow.intercepted = true
+        pathColumn = renderer.create(<Columns.PathColumn flow={tflow}/>)
         tree = pathColumn.toJSON()
         expect(tree).toMatchSnapshot()
     })
 
     it('should render MethodColumn', () => {
-        let methodColumn =renderer.create(<Columns.MethodColumn flow={tFlow}/>),
+        let methodColumn =renderer.create(<Columns.MethodColumn flow={tflow}/>),
             tree = methodColumn.toJSON()
         expect(tree).toMatchSnapshot()
     })
 
     it('should render StatusColumn', () => {
-        let statusColumn = renderer.create(<Columns.StatusColumn flow={tFlow}/>),
+        let statusColumn = renderer.create(<Columns.StatusColumn flow={tflow}/>),
             tree = statusColumn.toJSON()
         expect(tree).toMatchSnapshot()
     })
 
     it('should render SizeColumn', () => {
-        tFlow = new TFlow()
-        let sizeColumn = renderer.create(<Columns.SizeColumn flow={tFlow}/>),
+        tflow = _tflow()
+        let sizeColumn = renderer.create(<Columns.SizeColumn flow={tflow}/>),
             tree = sizeColumn.toJSON()
         expect(tree).toMatchSnapshot()
     })
 
     it('should render TimeColumn', () => {
-        let timeColumn = renderer.create(<Columns.TimeColumn flow={tFlow}/>),
+        let timeColumn = renderer.create(<Columns.TimeColumn flow={tflow}/>),
             tree = timeColumn.toJSON()
         expect(tree).toMatchSnapshot()
 
-        tFlow.response = null
-        timeColumn = renderer.create(<Columns.TimeColumn flow={tFlow}/>),
+        tflow.response = null
+        timeColumn = renderer.create(<Columns.TimeColumn flow={tflow}/>),
         tree = timeColumn.toJSON()
         expect(tree).toMatchSnapshot()
     })

--- a/web/src/js/__tests__/components/FlowTable/FlowColumnsSpec.js
+++ b/web/src/js/__tests__/components/FlowTable/FlowColumnsSpec.js
@@ -45,6 +45,12 @@ describe('FlowColumns Components', () => {
         iconColumn = renderer.create(<Columns.IconColumn flow={cssFlow}/>)
         tree = iconColumn.toJSON()
         expect(tree).toMatchSnapshot()
+        // html
+        let htmlFlow = TFlow()
+        htmlFlow.response.headers = [['Content-Type', 'text/html']]
+        iconColumn = renderer.create(<Columns.IconColumn flow={htmlFlow}/>)
+        tree = iconColumn.toJSON()
+        expect(tree).toMatchSnapshot()
         // default
         let fooFlow = TFlow()
         fooFlow.response.headers = [['Content-Type', 'foo']]

--- a/web/src/js/__tests__/components/FlowTable/FlowColumnsSpec.js
+++ b/web/src/js/__tests__/components/FlowTable/FlowColumnsSpec.js
@@ -1,11 +1,11 @@
 import React from 'react'
 import renderer from 'react-test-renderer'
 import * as Columns from '../../../components/FlowTable/FlowColumns'
-import _tflow from '../../ducks/_tflow'
+import { TFlow } from '../../ducks/tutils'
 
 describe('FlowColumns Components', () => {
 
-    let tflow = _tflow()
+    let tflow = TFlow()
     it('should render TLSColumn', () => {
         let tlsColumn = renderer.create(<Columns.TLSColumn flow={tflow}/>),
             tree = tlsColumn.toJSON()
@@ -28,25 +28,25 @@ describe('FlowColumns Components', () => {
         tree = iconColumn.toJSON()
         expect(tree).toMatchSnapshot()
         // image
-        let imageFlow = _tflow()
+        let imageFlow = TFlow()
         imageFlow.response.headers = [['Content-Type', 'image/jpeg']]
         iconColumn = renderer.create(<Columns.IconColumn flow={imageFlow}/>)
         tree = iconColumn.toJSON()
         expect(tree).toMatchSnapshot()
         // javascript
-        let jsFlow = _tflow()
+        let jsFlow = TFlow()
         jsFlow.response.headers = [['Content-Type', 'application/x-javascript']]
         iconColumn = renderer.create(<Columns.IconColumn flow={jsFlow}/>)
         tree = iconColumn.toJSON()
         expect(tree).toMatchSnapshot()
         // css
-        let cssFlow = _tflow()
+        let cssFlow = TFlow()
         cssFlow.response.headers = [['Content-Type', 'text/css']]
         iconColumn = renderer.create(<Columns.IconColumn flow={cssFlow}/>)
         tree = iconColumn.toJSON()
         expect(tree).toMatchSnapshot()
         // default
-        let fooFlow = _tflow()
+        let fooFlow = TFlow()
         fooFlow.response.headers = [['Content-Type', 'foo']]
         iconColumn = renderer.create(<Columns.IconColumn flow={fooFlow}/>)
         tree = iconColumn.toJSON()
@@ -83,7 +83,7 @@ describe('FlowColumns Components', () => {
     })
 
     it('should render SizeColumn', () => {
-        tflow = _tflow()
+        tflow = TFlow()
         let sizeColumn = renderer.create(<Columns.SizeColumn flow={tflow}/>),
             tree = sizeColumn.toJSON()
         expect(tree).toMatchSnapshot()

--- a/web/src/js/__tests__/components/FlowTable/__snapshots__/FlowColumnsSpec.js.snap
+++ b/web/src/js/__tests__/components/FlowTable/__snapshots__/FlowColumnsSpec.js.snap
@@ -112,7 +112,7 @@ exports[`FlowColumns Components should render TimeColumn 1`] = `
 <td
   className="col-time"
 >
-  415322h
+  415381h
 </td>
 `;
 

--- a/web/src/js/__tests__/components/FlowTable/__snapshots__/FlowColumnsSpec.js.snap
+++ b/web/src/js/__tests__/components/FlowTable/__snapshots__/FlowColumnsSpec.js.snap
@@ -65,12 +65,22 @@ exports[`FlowColumns Components should render IconColumn 7`] = `
   className="col-icon"
 >
   <div
-    className="resource-icon resource-icon-plain"
+    className="resource-icon resource-icon-document"
   />
 </td>
 `;
 
 exports[`FlowColumns Components should render IconColumn 8`] = `
+<td
+  className="col-icon"
+>
+  <div
+    className="resource-icon resource-icon-plain"
+  />
+</td>
+`;
+
+exports[`FlowColumns Components should render IconColumn 9`] = `
 <td
   className="col-icon"
 >

--- a/web/src/js/__tests__/components/FlowTable/__snapshots__/FlowColumnsSpec.js.snap
+++ b/web/src/js/__tests__/components/FlowTable/__snapshots__/FlowColumnsSpec.js.snap
@@ -5,7 +5,7 @@ exports[`FlowColumns Components should render IconColumn 1`] = `
   className="col-icon"
 >
   <div
-    className="resource-icon resource-icon-document"
+    className="resource-icon resource-icon-plain"
   />
 </td>
 `;
@@ -92,7 +92,7 @@ exports[`FlowColumns Components should render SizeColumn 1`] = `
 <td
   className="col-size"
 >
-  100b
+  14b
 </td>
 `;
 
@@ -112,7 +112,7 @@ exports[`FlowColumns Components should render TimeColumn 1`] = `
 <td
   className="col-time"
 >
-  2min
+  415322h
 </td>
 `;
 
@@ -129,12 +129,9 @@ exports[`FlowColumns Components should render pathColumn 1`] = `
   className="col-path"
 >
   <i
-    className="fa fa-fw fa-repeat pull-right"
-  />
-  <i
     className="fa fa-fw fa-exclamation pull-right"
   />
-  http://undefined:undefinedundefined
+  http://address:22/path
 </td>
 `;
 
@@ -143,14 +140,11 @@ exports[`FlowColumns Components should render pathColumn 2`] = `
   className="col-path"
 >
   <i
-    className="fa fa-fw fa-repeat pull-right"
-  />
-  <i
     className="fa fa-fw fa-pause pull-right"
   />
   <i
     className="fa fa-fw fa-times pull-right"
   />
-  http://undefined:undefinedundefined
+  http://address:22/path
 </td>
 `;

--- a/web/src/js/__tests__/ducks/_tflow.js
+++ b/web/src/js/__tests__/ducks/_tflow.js
@@ -1,0 +1,97 @@
+export default function(){
+    return {
+    "client_conn": {
+        "address": [
+            "address",
+            22
+        ],
+        "alpn_proto_negotiated": "http/1.1",
+        "cipher_name": "cipher",
+        "clientcert": null,
+        "id": "75bfd3cd-a084-4d84-a063-b0804dc91342",
+        "sni": "address",
+        "ssl_established": false,
+        "timestamp_end": 3.0,
+        "timestamp_ssl_setup": 2.0,
+        "timestamp_start": 1.0,
+        "tls_version": "TLSv1.2"
+    },
+    "error": {
+        "msg": "error",
+        "timestamp": 1495158272.596447
+    },
+    "id": "8035b342-c916-44f7-93fa-293b40a7d3ad",
+    "intercepted": false,
+    "marked": false,
+    "modified": false,
+    "request": {
+        "contentHash": "ed7002b439e9ac845f22357d822bac1444730fbdb6016d3ec9432297b9ec9f73",
+        "contentLength": 7,
+        "headers": [
+            [
+                "header",
+                "qvalue"
+            ],
+            [
+                "content-length",
+                "7"
+            ]
+        ],
+        "host": "address",
+        "http_version": "HTTP/1.1",
+        "is_replay": false,
+        "method": "GET",
+        "path": "/path",
+        "port": 22,
+        "pretty_host": "address",
+        "scheme": "http",
+        "timestamp_end": null,
+        "timestamp_start": null
+    },
+    "response": {
+        "contentHash": "ab530a13e45914982b79f9b7e3fba994cfd1f3fb22f71cea1afbf02b460c6d1d",
+        "contentLength": 7,
+        "headers": [
+            [
+                "header-response",
+                "svalue"
+            ],
+            [
+                "content-length",
+                "7"
+            ]
+        ],
+        "http_version": "HTTP/1.1",
+        "is_replay": false,
+        "reason": "OK",
+        "status_code": 200,
+        "timestamp_end": 1495158272.5964308,
+        "timestamp_start": 1495158272.5964305
+    },
+    "server_conn": {
+        "address": [
+            "address",
+            22
+        ],
+        "alpn_proto_negotiated": null,
+        "id": "9a5d01d7-ede8-4409-b064-230305bfa29d",
+        "ip_address": [
+            "192.168.0.1",
+            22
+        ],
+        "sni": "address",
+        "source_address": [
+            "address",
+            22
+        ],
+        "ssl_established": false,
+        "timestamp_end": 4.0,
+        "timestamp_ssl_setup": 3.0,
+        "timestamp_start": 1.0,
+        "timestamp_tcp_setup": 2.0,
+        "tls_version": "TLSv1.2",
+        "via": null
+    },
+    "type": "http"
+}
+}

--- a/web/src/js/__tests__/ducks/_tflow.js
+++ b/web/src/js/__tests__/ducks/_tflow.js
@@ -8,7 +8,7 @@ export default function(){
         "alpn_proto_negotiated": "http/1.1",
         "cipher_name": "cipher",
         "clientcert": null,
-        "id": "75bfd3cd-a084-4d84-a063-b0804dc91342",
+        "id": "4a18d1a0-50a1-48dd-9aa6-d45d74282939",
         "sni": "address",
         "ssl_established": false,
         "timestamp_end": 3.0,
@@ -18,9 +18,9 @@ export default function(){
     },
     "error": {
         "msg": "error",
-        "timestamp": 1495158272.596447
+        "timestamp": 1495370312.4814785
     },
-    "id": "8035b342-c916-44f7-93fa-293b40a7d3ad",
+    "id": "d91165be-ca1f-4612-88a9-c0f8696f3e29",
     "intercepted": false,
     "marked": false,
     "modified": false,
@@ -65,8 +65,8 @@ export default function(){
         "is_replay": false,
         "reason": "OK",
         "status_code": 200,
-        "timestamp_end": 1495158272.5964308,
-        "timestamp_start": 1495158272.5964305
+        "timestamp_end": 1495370312.4814625,
+        "timestamp_start": 1495370312.481462
     },
     "server_conn": {
         "address": [
@@ -74,7 +74,7 @@ export default function(){
             22
         ],
         "alpn_proto_negotiated": null,
-        "id": "9a5d01d7-ede8-4409-b064-230305bfa29d",
+        "id": "f087e7b2-6d0a-41a8-a8f0-e1a4761395f8",
         "ip_address": [
             "192.168.0.1",
             22

--- a/web/src/js/__tests__/ducks/tutils.js
+++ b/web/src/js/__tests__/ducks/tutils.js
@@ -7,30 +7,3 @@ export function createStore(parts) {
         applyMiddleware(...[thunk])
     )
 }
-
-export function TFlow(intercepted=false, marked=false, modified=false) {
-    return {
-        intercepted ,
-        marked,
-        modified,
-        id: "foo",
-        request: {
-            scheme: 'http',
-            is_replay: true,
-            method: 'GET',
-            contentLength: 100
-        },
-        response: {
-            status_code: 200,
-            headers: [["Content-Type", 'text/html']],
-            timestamp_end: 200
-        },
-        error: {
-            msg: ''
-        },
-        server_conn: {
-            timestamp_start: 100
-        },
-        type: 'http'
-    }
-}

--- a/web/src/js/__tests__/ducks/tutils.js
+++ b/web/src/js/__tests__/ducks/tutils.js
@@ -7,3 +7,5 @@ export function createStore(parts) {
         applyMiddleware(...[thunk])
     )
 }
+
+export { default as TFlow } from './_tflow'


### PR DESCRIPTION
Suggested by @mhils [here](https://github.com/mitmproxy/mitmproxy/pull/2337#discussion_r117033821), we add a python test to generate `js/__tests__/ducks/_flow.js` for the components tests. In this way, each time when we run the python test, it will produce a generator function for our js tests.