### PR TITLE
Fix #2329

### DIFF
--- a/mitmproxy/log.py
+++ b/mitmproxy/log.py
@@ -4,6 +4,9 @@ class LogEntry:
         self.msg = msg
         self.level = level
 
+    def __repr__(self):
+        return "LogEntry({}, {})".format(self.msg, self.level)
+
 
 class Log:
     """

--- a/mitmproxy/test/taddons.py
+++ b/mitmproxy/test/taddons.py
@@ -17,6 +17,8 @@ class TestAddons(addonmanager.AddonManager):
     def trigger(self, event, *args, **kwargs):
         if event == "log":
             self.master.logs.append(args[0])
+        elif event == "tick" and not args and not kwargs:
+            pass
         else:
             self.master.events.append((event, args, kwargs))
         super().trigger(event, *args, **kwargs)

--- a/test/mitmproxy/proxy/test_server.py
+++ b/test/mitmproxy/proxy/test_server.py
@@ -1,27 +1,26 @@
 import os
 import socket
 import time
-import pytest
 from unittest import mock
 
-from mitmproxy.test import tutils
-from mitmproxy import options
-from mitmproxy.addons import script
-from mitmproxy.addons import proxyauth
-from mitmproxy import http
-from mitmproxy.proxy.config import HostMatcher
+import pytest
+
 import mitmproxy.net.http
-from mitmproxy.net import tcp
-from mitmproxy.net import socks
 from mitmproxy import certs
 from mitmproxy import exceptions
+from mitmproxy import http
+from mitmproxy import options
+from mitmproxy.addons import proxyauth
+from mitmproxy.addons import script
+from mitmproxy.net import socks
+from mitmproxy.net import tcp
 from mitmproxy.net.http import http1
+from mitmproxy.proxy.config import HostMatcher
+from mitmproxy.test import tutils
 from pathod import pathoc
 from pathod import pathod
-
 from .. import tservers
 from ...conftest import skip_appveyor
-
 
 """
     Note that the choice of response code in these tests matters more than you

--- a/test/mitmproxy/test_log.py
+++ b/test/mitmproxy/test_log.py
@@ -1,1 +1,6 @@
-# TODO: write tests
+from mitmproxy import log
+
+
+def test_logentry():
+    e = log.LogEntry("foo", "info")
+    assert repr(e) == "LogEntry(foo, info)"


### PR DESCRIPTION
This PR makes it possible to remove TLS from upstream proxy connections. An addon can now define
```python
def http_connect(flow):
    flow.request.scheme = "http"
```
to disable TLS negotation with the upstream proxy. This should fix #2329.