### PR TITLE
Always pretend to have a tty in tests

### DIFF
--- a/test/mitmproxy/tools/console/test_master.py
+++ b/test/mitmproxy/tools/console/test_master.py
@@ -1,3 +1,5 @@
+import pytest
+
 from mitmproxy.test import tflow
 from mitmproxy.test import tutils
 from mitmproxy.tools import console
@@ -6,6 +8,13 @@ from mitmproxy import options
 from mitmproxy.tools.console import common
 from ... import tservers
 import urwid
+from unittest import mock
+
+
+@pytest.fixture(scope="module", autouse=True)
+def definitely_atty():
+    with mock.patch("sys.stdout.isatty", lambda: True):
+        yield
 
 
 def test_format_keyvals():


### PR DESCRIPTION
This should fix appveyor. 
Pytest's monkeypatch [doesn't work out of the box](https://github.com/pytest-dev/pytest/issues/363), so I'm just using `unittest.mock` from stdlib.