### PR TITLE
[WIP] Add RESTful API for mitmweb option

### DIFF
--- a/mitmproxy/optmanager.py
+++ b/mitmproxy/optmanager.py
@@ -420,12 +420,27 @@ def dump_dicts(opts):
     """
         Dumps the options into a list of dict object.
 
-        Return: A list like: [ { name: "anticahce", type: "bool", default: false, value: true, help: "help text"}]
+        Return: A list like: [ { name: "anticache", type: "bool", default: false, value: true, help: "help text"} ]
     """
     options_list = []
     for k in sorted(opts.keys()):
         o = opts._options[k]
-        option = {'name': k, 'type': o.typespec.__name__, 'default': o.default, 'value': o.current(), 'help': o.help.strip()}
+        if o.typespec in (str, int, bool):
+            t = o.typespec.__name__
+        elif o.typespec == typing.Optional[str]:
+            t = 'Union'
+        elif o.typespec == typing.Sequence[str]:
+            t = 'Sequence'
+        else:
+            raise NotImplementedError
+        option = {
+            'name': k,
+            'type': t,
+            'default': o.default,
+            'value': o.current(),
+            'help': o.help,
+            'choices': o.choices
+        }
         options_list.append(option)
     return options_list
 

--- a/mitmproxy/optmanager.py
+++ b/mitmproxy/optmanager.py
@@ -425,14 +425,7 @@ def dump_dicts(opts):
     options_list = []
     for k in sorted(opts.keys()):
         o = opts._options[k]
-        if o.typespec in (str, int, bool):
-            t = o.typespec.__name__
-        elif o.typespec == typing.Optional[str]:
-            t = 'Union'
-        elif o.typespec == typing.Sequence[str]:
-            t = 'Sequence'
-        else:
-            raise NotImplementedError
+        t = typecheck.typespec_to_str(o.typespec)
         option = {
             'name': k,
             'type': t,

--- a/mitmproxy/optmanager.py
+++ b/mitmproxy/optmanager.py
@@ -416,6 +416,20 @@ def dump_defaults(opts):
     return ruamel.yaml.round_trip_dump(s)
 
 
+def dump_dicts(opts):
+    """
+        Dumps the options into a list of dict object.
+
+        Return: A list like: [ { name: "anticahce", type: "bool", default: false, value: true, help: "help text"}]
+    """
+    options_list = []
+    for k in sorted(opts.keys()):
+        o = opts._options[k]
+        option = {'name': k, 'type': o.typespec.__name__, 'default': o.default, 'value': o.current(), 'help': o.help.strip()}
+        options_list.append(option)
+    return options_list
+
+
 def parse(text):
     if not text:
         return {}

--- a/mitmproxy/optmanager.py
+++ b/mitmproxy/optmanager.py
@@ -401,18 +401,11 @@ def dump_defaults(opts):
         if o.choices:
             txt += " Valid values are %s." % ", ".join(repr(c) for c in o.choices)
         else:
-            if o.typespec in (str, int, bool):
-                t = o.typespec.__name__
-            elif o.typespec == typing.Optional[str]:
-                t = "optional str"
-            elif o.typespec == typing.Sequence[str]:
-                t = "sequence of str"
-            else:  # pragma: no cover
-                raise NotImplementedError
+            t = typecheck.typespec_to_str(o.typespec)
             txt += " Type %s." % t
 
         txt = "\n".join(textwrap.wrap(txt))
-        s.yaml_set_comment_before_after_key(k, before = "\n" + txt)
+        s.yaml_set_comment_before_after_key(k, before="\n" + txt)
     return ruamel.yaml.round_trip_dump(s)
 
 

--- a/mitmproxy/tools/web/app.py
+++ b/mitmproxy/tools/web/app.py
@@ -443,6 +443,14 @@ class Options(RequestHandler):
     def get(self):
         self.write(optmanager.dump_dicts(self.master.options))
 
+    def put(self):
+        update = self.json
+        try:
+            self.master.options.update(**update)
+        except (KeyError, TypeError) as err:
+            raise APIError(400, "{}".format(err))
+
+
 
 class Application(tornado.web.Application):
     def __init__(self, master, debug):

--- a/mitmproxy/tools/web/app.py
+++ b/mitmproxy/tools/web/app.py
@@ -17,7 +17,6 @@ from mitmproxy import http
 from mitmproxy import io
 from mitmproxy import log
 from mitmproxy import version
-from mitmproxy import options
 from mitmproxy import optmanager
 import mitmproxy.tools.web.master # noqa
 

--- a/mitmproxy/tools/web/app.py
+++ b/mitmproxy/tools/web/app.py
@@ -451,7 +451,6 @@ class Options(RequestHandler):
             raise APIError(400, "{}".format(err))
 
 
-
 class Application(tornado.web.Application):
     def __init__(self, master, debug):
         self.master = master

--- a/mitmproxy/tools/web/app.py
+++ b/mitmproxy/tools/web/app.py
@@ -17,6 +17,8 @@ from mitmproxy import http
 from mitmproxy import io
 from mitmproxy import log
 from mitmproxy import version
+from mitmproxy import options
+from mitmproxy import optmanager
 import mitmproxy.tools.web.master # noqa
 
 
@@ -438,6 +440,11 @@ class Settings(RequestHandler):
         self.master.options.update(**update)
 
 
+class Options(RequestHandler):
+    def get(self):
+        self.write(optmanager.dump_dicts(self.master.options))
+
+
 class Application(tornado.web.Application):
     def __init__(self, master, debug):
         self.master = master
@@ -462,6 +469,7 @@ class Application(tornado.web.Application):
                 FlowContentView),
             (r"/settings", Settings),
             (r"/clear", ClearAll),
+            (r"/options", Options)
         ]
         settings = dict(
             template_path=os.path.join(os.path.dirname(__file__), "templates"),

--- a/mitmproxy/utils/typecheck.py
+++ b/mitmproxy/utils/typecheck.py
@@ -104,9 +104,9 @@ def typespec_to_str(typespec: typing.Any) -> str:
     if typespec in (str, int, bool):
         t = typespec.__name__
     elif typespec == typing.Optional[str]:
-        t = 'Union'
+        t = 'optional str'
     elif typespec == typing.Sequence[str]:
-        t = 'Sequence'
+        t = 'sequence of str'
     else:
         raise NotImplementedError
     return t

--- a/mitmproxy/utils/typecheck.py
+++ b/mitmproxy/utils/typecheck.py
@@ -98,3 +98,15 @@ def check_option_type(name: str, value: typing.Any, typeinfo: typing.Any) -> Non
         return
     elif not isinstance(value, typeinfo):
         raise e
+
+
+def typespec_to_str(typespec: typing.Any) -> str:
+    if typespec in (str, int, bool):
+        t = typespec.__name__
+    elif typespec == typing.Optional[str]:
+        t = 'Union'
+    elif typespec == typing.Sequence[str]:
+        t = 'Sequence'
+    else:
+        raise NotImplementedError
+    return t

--- a/test/mitmproxy/test_optmanager.py
+++ b/test/mitmproxy/test_optmanager.py
@@ -334,6 +334,11 @@ def test_dump_defaults():
     assert optmanager.dump_defaults(o)
 
 
+def test_dump_dicts():
+    o = options.Options()
+    assert optmanager.dump_dicts(o)
+
+
 class TTypes(optmanager.OptManager):
     def __init__(self):
         super().__init__()

--- a/test/mitmproxy/tools/web/test_app.py
+++ b/test/mitmproxy/tools/web/test_app.py
@@ -253,6 +253,11 @@ class TestApp(tornado.testing.AsyncHTTPTestCase):
         assert self.put_json("/settings", {"anticache": True}).code == 200
         assert self.put_json("/settings", {"wtf": True}).code == 400
 
+    def test_options(self):
+        j = json(self.fetch("/options"))
+        assert type(j) == list
+        assert type(j[0]) == dict
+
     def test_err(self):
         with mock.patch("mitmproxy.tools.web.app.IndexHandler.get") as f:
             f.side_effect = RuntimeError

--- a/test/mitmproxy/tools/web/test_app.py
+++ b/test/mitmproxy/tools/web/test_app.py
@@ -261,6 +261,7 @@ class TestApp(tornado.testing.AsyncHTTPTestCase):
     def test_option_update(self):
         assert self.put_json("/options", {"anticache": True}).code == 200
         assert self.put_json("/options", {"wtf": True}).code == 400
+        assert self.put_json("/options", {"anticache": "foo"}).code == 400
 
     def test_err(self):
         with mock.patch("mitmproxy.tools.web.app.IndexHandler.get") as f:

--- a/test/mitmproxy/tools/web/test_app.py
+++ b/test/mitmproxy/tools/web/test_app.py
@@ -258,6 +258,10 @@ class TestApp(tornado.testing.AsyncHTTPTestCase):
         assert type(j) == list
         assert type(j[0]) == dict
 
+    def test_option_update(self):
+        assert self.put_json("/options", {"anticache": True}).code == 200
+        assert self.put_json("/options", {"wtf": True}).code == 400
+
     def test_err(self):
         with mock.patch("mitmproxy.tools.web.app.IndexHandler.get") as f:
             f.side_effect = RuntimeError

--- a/test/mitmproxy/utils/test_typecheck.py
+++ b/test/mitmproxy/utils/test_typecheck.py
@@ -111,3 +111,11 @@ def test_check_command_type():
     m.__str__ = lambda self: "typing.Union"
     m.__union_params__ = (int,)
     assert not typecheck.check_command_type([22], m)
+
+
+def test_typesec_to_str():
+    assert(typecheck.typespec_to_str(str)) == "str"
+    assert(typecheck.typespec_to_str(typing.Sequence[str])) == "Sequence"
+    assert(typecheck.typespec_to_str(typing.Optional[str])) == "Union"
+    with pytest.raises(NotImplementedError):
+        typecheck.typespec_to_str(dict)

--- a/test/mitmproxy/utils/test_typecheck.py
+++ b/test/mitmproxy/utils/test_typecheck.py
@@ -115,7 +115,7 @@ def test_check_command_type():
 
 def test_typesec_to_str():
     assert(typecheck.typespec_to_str(str)) == "str"
-    assert(typecheck.typespec_to_str(typing.Sequence[str])) == "Sequence"
-    assert(typecheck.typespec_to_str(typing.Optional[str])) == "Union"
+    assert(typecheck.typespec_to_str(typing.Sequence[str])) == "sequence of str"
+    assert(typecheck.typespec_to_str(typing.Optional[str])) == "optional str"
     with pytest.raises(NotImplementedError):
         typecheck.typespec_to_str(dict)


### PR DESCRIPTION
- [x] Implement GET /options
- [x] Implement POST /options
The return json looks like this:
```python
[
    {
        "default": false, 
        "help": "Add all certificates of the upstream server to the certificate chain that will be served to the proxy client, as extras.", 
        "name": "add_upstream_certs_to_client_chain", 
        "type": "bool", 
        "value": false
    }, 
    {
        "default": false, 
        "help": "Strip out request headers that might cause the server to return 304-not-modified.", 
        "name": "anticache", 
        "type": "bool", 
        "value": false
    }, 
...]
```
The tests passed on my local repo, but kept falling on Travis... Is that because of some compatibility problem?