### PR TITLE
Fixes #2197

### DIFF
--- a/mitmproxy/master.py
+++ b/mitmproxy/master.py
@@ -162,7 +162,7 @@ class Master:
         f.response = None
         f.error = None
 
-        if f.request.http_version == "HTTP/2.0":
+        if f.request.http_version == "HTTP/2.0":  # https://github.com/mitmproxy/mitmproxy/issues/2197
             f.request.http_version = "HTTP/1.1"
             host = f.request.headers.pop(":authority")
             f.request.headers.insert(0, "host", host)

--- a/mitmproxy/master.py
+++ b/mitmproxy/master.py
@@ -162,6 +162,11 @@ class Master:
         f.response = None
         f.error = None
 
+        if f.request.http_version == "HTTP/2.0":
+            f.request.http_version = "HTTP/1.1"
+            host = f.request.headers.pop(":authority")
+            f.request.headers.insert(0, "host", host)
+
         rt = http_replay.RequestReplayThread(
             self.server.config,
             f,


### PR DESCRIPTION
Replay works with http2 flows but uses http1.1 when replaying.
Not sure if it's the intended fix though