### PR TITLE
Removed redundant type

### DIFF
--- a/mitmproxy/contrib/kaitaistruct/tls_client_hello.py
+++ b/mitmproxy/contrib/kaitaistruct/tls_client_hello.py
@@ -73,7 +73,7 @@ class TlsClientHello(KaitaiStruct):
             self.len = self._io.read_u2be()
             self.cipher_suites = [None] * (self.len // 2)
             for i in range(self.len // 2):
-                self.cipher_suites[i] = self._root.CipherSuite(self._io, self, self._root)
+                self.cipher_suites[i] = self._io.read_u2be()
 
     class CompressionMethods(KaitaiStruct):
         def __init__(self, _io, _parent=None, _root=None):
@@ -110,13 +110,6 @@ class TlsClientHello(KaitaiStruct):
             self._root = _root if _root else self
             self.major = self._io.read_u1()
             self.minor = self._io.read_u1()
-
-    class CipherSuite(KaitaiStruct):
-        def __init__(self, _io, _parent=None, _root=None):
-            self._io = _io
-            self._parent = _parent
-            self._root = _root if _root else self
-            self.cipher_suite = self._io.read_u2be()
 
     class Protocol(KaitaiStruct):
         def __init__(self, _io, _parent=None, _root=None):

--- a/mitmproxy/contrib/tls_client_hello.ksy
+++ b/mitmproxy/contrib/tls_client_hello.ksy
@@ -59,14 +59,9 @@ types:
         type: u2
       
       - id: cipher_suites
-        type: cipher_suite
+        type: u2
         repeat: expr
         repeat-expr: len/2
-  
-  cipher_suite:
-    seq:
-      - id: cipher_suite
-        type: u2
 
   compression_methods:
     seq:

--- a/mitmproxy/proxy/protocol/tls.py
+++ b/mitmproxy/proxy/protocol/tls.py
@@ -539,8 +539,8 @@ class TlsLayer(base.Layer):
             if not ciphers_server and self._client_tls:
                 ciphers_server = []
                 for id in self._client_hello.cipher_suites:
-                    if id.cipher_suite in CIPHER_ID_NAME_MAP.keys():
-                        ciphers_server.append(CIPHER_ID_NAME_MAP[id.cipher_suite])
+                    if id in CIPHER_ID_NAME_MAP.keys():
+                        ciphers_server.append(CIPHER_ID_NAME_MAP[id])
                 ciphers_server = ':'.join(ciphers_server)
 
             self.server_conn.establish_ssl(


### PR DESCRIPTION
Removes a redundant type in tls client hello parser
Earlier -
```
for cs in cipher_suites.cipher_suites:
    print(cs.cipher_suite)
```
![screenshot from 2017-06-22 06-15-37](https://user-images.githubusercontent.com/16747982/27412471-842e303e-5712-11e7-81df-82febcfb7f60.png)
Now -
```
for cs in cipher_suites.cipher_suites:
    print(cs)
```
![screenshot from 2017-06-22 06-16-38](https://user-images.githubusercontent.com/16747982/27412481-8e55e278-5712-11e7-8e4e-5c6834a34a91.png)
