### PR TITLE
Fixes the issue of script reloader not unloading previous script

### DIFF
--- a/test/mitmproxy/addons/test_script.py
+++ b/test/mitmproxy/addons/test_script.py
@@ -1,6 +1,7 @@
 import traceback
 import sys
 import time
+import os
 import pytest
 
 from unittest import mock
@@ -182,6 +183,20 @@ class TestScriptLoader:
                     sc,
                     scripts = ["one", "one"]
                 )
+
+    def test_script_deletion(self):
+        tdir = tutils.test_data.path("mitmproxy/data/addonscripts/")
+        with open(tdir + "/dummy.py", 'w') as f:
+            f.write("\n")
+        with taddons.context() as tctx:
+            sl = script.ScriptLoader()
+            tctx.master.addons.add(sl)
+            tctx.configure(sl, scripts=[tutils.test_data.path("mitmproxy/data/addonscripts/dummy.py")])
+
+            os.remove(tutils.test_data.path("mitmproxy/data/addonscripts/dummy.py"))
+            tctx.invoke(sl, "tick")
+            assert not tctx.options.scripts
+            assert not sl.addons
 
     def test_order(self):
         rec = tutils.test_data.path("mitmproxy/data/addonscripts/recorder")


### PR DESCRIPTION
Fixes #2315
Well, this was a tricky one.
**The issue -** 
We use [`load_module`](https://docs.python.org/3/library/importlib.html#importlib.abc.Loader.load_module) to load the scripts. According to the docs -

> If the requested module already exists in sys.modules, that module should be used and reloaded

So, the modified script was [`reloaded`](https://docs.python.org/3/library/importlib.html#importlib.reload) 

> When a module is reloaded, its dictionary (containing the module’s global variables) is retained. Redefinitions of names will override the old definitions, so this is generally not a problem. If the new version of a module does not define a name that was defined by the old version, the old definition remains.

**How I solved it-**
Before loading a script remove it from sys.modules. 
If you have a better solution I'll implement that :slightly_smiling_face: 

This PR also fixes the issue caused when a script is deleted during execution