### PR TITLE
Fixes bug where loaded certs are stored in the certs dict as str

### DIFF
--- a/mitmproxy/certs.py
+++ b/mitmproxy/certs.py
@@ -289,7 +289,7 @@ class CertStore:
             privatekey = self.default_privatekey
         self.add_cert(
             CertStoreEntry(cert, privatekey, path),
-            spec
+            bytes(spec, "utf8")
         )
 
     def add_cert(self, entry, *names):

--- a/mitmproxy/certs.py
+++ b/mitmproxy/certs.py
@@ -289,7 +289,7 @@ class CertStore:
             privatekey = self.default_privatekey
         self.add_cert(
             CertStoreEntry(cert, privatekey, path),
-            bytes(spec, "utf8")
+            bytes(spec, "utf-8")
         )
 
     def add_cert(self, entry, *names):


### PR DESCRIPTION
Certs provided through the `--cert` argument or config yaml get stored in the `certs` dictionary as a `str`.  This causes issues because the keys created by `get_certs` method are byte strings.  So any provided certs wind up being ignored and the generated certs still get stored as byte strings.

This was found when trying to modify requests while keeping certificate pinning enabled using a second cert I have pinned and have the private key to.  Once I converted the spec to bytes the domain and certificate were correctly identified.