### PR TITLE
Flesh out mitmweb documentation

### DIFF
--- a/docs/mitmweb.rst
+++ b/docs/mitmweb.rst
@@ -7,7 +7,11 @@ mitmweb
 **mitmweb** is mitmproxy's web-based user interface that allows interactive
 examination and modification of HTTP traffic. Like mitmproxy, it differs from
 mitmdump in that all flows are kept in memory, which means that **it's intended
-for taking and manipulating small-ish samples.** If you need to handle larger amounts of data with mitmweb, you should run your proxy with mitmdump and write the output to a file, then run ``mitmweb --read-flows /path/to/mitmdump/output/file``.
+for taking and manipulating small-ish samples.**
+
+If you need to handle large amounts of data and want the web interface available after-the-fact, you can run your proxy with ``mitmdump`` and then use ``mitmweb -n --read-flows /path/to/mitmdump/output/file`` to read the flows from your mitmdump capture.
+
+If you need mitmweb to work in real time during the capture, but do not want to store the flows in RAM, you can simply specify an output file with ``mitmweb -w /path/to/output/file``.
 
 .. warning::
 

--- a/docs/mitmweb.rst
+++ b/docs/mitmweb.rst
@@ -6,8 +6,8 @@ mitmweb
 
 **mitmweb** is mitmproxy's web-based user interface that allows interactive
 examination and modification of HTTP traffic. Like mitmproxy, it differs from
-mitmdump in that all flows are kept in memory, which means that it's intended
-for taking and manipulating small-ish samples.
+mitmdump in that all flows are kept in memory, which means that **it's intended
+for taking and manipulating small-ish samples.** If you need to handle larger amounts of data with mitmweb, you should run your proxy with mitmdump and write the output to a file, then run ``mitmweb --read-flows /path/to/mitmdump/output/file``.
 
 .. warning::
 


### PR DESCRIPTION
Clarify that mitmweb is not intended to run the proxy for large sample sizes, and that you should run mitmdump+mitmweb in those cases to prevent massive memory usage and atrocious instability. This was a confusing issue for me but seems to be an issue of documentation rather than an actual bug/design issue.