### PR TITLE
make --keep-host-header available from command line

### DIFF
--- a/mitmproxy/tools/cmdline.py
+++ b/mitmproxy/tools/cmdline.py
@@ -79,6 +79,7 @@ def common_options(parser, opts):
     opts.make_parser(group, "upstream_auth", metavar="USER:PASS")
     opts.make_parser(group, "proxyauth", metavar="SPEC")
     opts.make_parser(group, "rawtcp")
+    opts.make_parser(group, "keep_host_header")
 
     # Proxy SSL options
     group = parser.add_argument_group("SSL")


### PR DESCRIPTION
Hi! I noticed --keep-host-header was not available from command line and didn't display in help. This trivial patch should fix this.

Cheers,
Alex