### PR TITLE
Fix addon tracebacks

### DIFF
--- a/mitmproxy/addonmanager.py
+++ b/mitmproxy/addonmanager.py
@@ -61,7 +61,7 @@ def safecall():
         raise
     except Exception as e:
         etype, value, tb = sys.exc_info()
-        tb = cut_traceback(tb, "invoke_addon").tb_next
+        tb = cut_traceback(tb, "invoke_addon")
         ctx.log.error(
             "Addon error: %s" % "".join(
                 traceback.format_exception(etype, value, tb)


### PR DESCRIPTION
`.tb_next` discards the first interesting frame, this shouldn't happen.