### PR TITLE
Fix load flows crash

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,32 +23,10 @@ matrix:
       language: generic
       env: TOXENV=py35 BDIST=1
     - python: 3.5
-      env: TOXENV=py35 OPENSSL=old
-      addons:
-        apt:
-          packages:
-            - libssl-dev
-    - python: 3.5
-      env: TOXENV=py35 BDIST=1 OPENSSL=with-alpn
-      addons:
-        apt:
-          sources:
-            # Debian sid currently holds OpenSSL 1.1.0
-            # change this with future releases!
-            - debian-sid
-          packages:
-            - libssl-dev
+      env: TOXENV=py35 BDIST=1
     - python: 3.6
-      env: TOXENV=py36 OPENSSL=with-alpn
-      addons:
-        apt:
-          sources:
-            # Debian sid currently holds OpenSSL 1.1.0
-            # change this with future releases!
-            - debian-sid
-          packages:
-            - libssl-dev
-    - python: 3.5
+      env: TOXENV=py36
+    - python: 3.6
       env: TOXENV=individual_coverage
     - python: 3.5
       env: TOXENV=docs
@@ -73,9 +51,9 @@ install:
       brew update || brew update
       brew outdated pyenv || brew upgrade pyenv
       eval "$(pyenv init -)"
-      env PYTHON_CONFIGURE_OPTS="--enable-framework" pyenv install --skip-existing 3.5.2
-      pyenv global 3.5.2
-      pyenv shell 3.5.2
+      env PYTHON_CONFIGURE_OPTS="--enable-framework" pyenv install --skip-existing 3.5.3
+      pyenv global 3.5.3
+      pyenv shell 3.5.3
       pip install -U pip setuptools wheel virtualenv
     fi
   - pip install tox

--- a/mitmproxy/addonmanager.py
+++ b/mitmproxy/addonmanager.py
@@ -61,7 +61,7 @@ def safecall():
         raise
     except Exception as e:
         etype, value, tb = sys.exc_info()
-        tb = cut_traceback(tb, "invoke_addon").tb_next
+        tb = cut_traceback(tb, "invoke_addon")
         ctx.log.error(
             "Addon error: %s" % "".join(
                 traceback.format_exception(etype, value, tb)

--- a/mitmproxy/addons/view.py
+++ b/mitmproxy/addons/view.py
@@ -339,12 +339,16 @@ class View(collections.Sequence):
         """
             Load flows into the view, without processing them with addons.
         """
-        with open(path, "rb") as f:
-            for i in io.FlowReader(f).stream():
-                # Do this to get a new ID, so we can load the same file N times and
-                # get new flows each time. It would be more efficient to just have a
-                # .newid() method or something.
-                self.add([i.copy()])
+        try:
+            with open(path, "rb") as f:
+                for i in io.FlowReader(f).stream():
+                    # Do this to get a new ID, so we can load the same file N times and
+                    # get new flows each time. It would be more efficient to just have a
+                    # .newid() method or something.
+                    self.add([i.copy()])
+        except IOError as e:
+            ctx.log.error(e.strerror)
+            return
 
     @command.command("view.go")
     def go(self, dst: int) -> None:

--- a/mitmproxy/addons/view.py
+++ b/mitmproxy/addons/view.py
@@ -10,6 +10,7 @@ The View:
 """
 import collections
 import typing
+import os
 
 import blinker
 import sortedcontainers
@@ -339,6 +340,7 @@ class View(collections.Sequence):
         """
             Load flows into the view, without processing them with addons.
         """
+        path = os.path.expanduser(path)
         try:
             with open(path, "rb") as f:
                 for i in io.FlowReader(f).stream():

--- a/mitmproxy/optmanager.py
+++ b/mitmproxy/optmanager.py
@@ -518,6 +518,7 @@ def save(opts, path, defaults=False):
 
         Raises OptionsError if the existing data is corrupt.
     """
+    path = os.path.expanduser(path)
     if os.path.exists(path) and os.path.isfile(path):
         with open(path, "rt", encoding="utf8") as f:
             try:

--- a/pathod/language/generators.py
+++ b/pathod/language/generators.py
@@ -75,7 +75,7 @@ class RandomGenerator:
 
 class FileGenerator:
     def __init__(self, path):
-        self.path = path
+        self.path = os.path.expanduser(path)
 
     def __len__(self):
         return os.path.getsize(self.path)

--- a/pathod/pathoc_cmdline.py
+++ b/pathod/pathoc_cmdline.py
@@ -208,6 +208,7 @@ def args_pathoc(argv, stdout=sys.stdout, stderr=sys.stderr):
 
     reqs = []
     for r in args.requests:
+        r = os.path.expanduser(r)
         if os.path.isfile(r):
             with open(r) as f:
                 r = f.read()

--- a/pathod/pathod_cmdline.py
+++ b/pathod/pathod_cmdline.py
@@ -215,6 +215,7 @@ def args_pathod(argv, stdout_=sys.stdout, stderr_=sys.stderr):
 
     anchors = []
     for patt, spec in args.anchors:
+        spec = os.path.expanduser(spec)
         if os.path.isfile(spec):
             with open(spec) as f:
                 data = f.read()

--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,7 @@ setup(
         'dev': [
             "flake8>=3.2.1, <3.4",
             "Flask>=0.10.1, <0.13",
-            "mypy>=0.501, <0.521",
+            "mypy>=0.520, <0.521",
             "pytest-cov>=2.2.1, <3",
             "pytest-faulthandler>=1.3.0, <2",
             "pytest-timeout>=1.0.0, <2",

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setup(
         "brotlipy>=0.5.1, <0.8",
         "certifi>=2015.11.20.1",  # no semver here - this should always be on the last release!
         "click>=6.2, <7",
-        "cryptography>=1.4, <1.10",
+        "cryptography>=2.0,<2.1",
         "cssutils>=1.0.1, <1.1",
         "h2>=3.0, <4",
         "html2text>=2016.1.8, <=2016.9.19",
@@ -74,7 +74,7 @@ setup(
         "ldap3>=2.2.0, <2.3",
         "passlib>=1.6.5, <1.8",
         "pyasn1>=0.1.9, <0.3",
-        "pyOpenSSL>=16.0,<17.2",
+        "pyOpenSSL>=17.2,<17.3",
         "pyparsing>=2.1.3, <2.3",
         "pyperclip>=1.5.22, <1.6",
         "requests>=2.9.1, <3",

--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,7 @@ setup(
         'dev': [
             "flake8>=3.2.1, <3.4",
             "Flask>=0.10.1, <0.13",
-            "mypy>=0.520, <0.521",
+            "mypy>=0.521,<0.522",
             "pytest-cov>=2.2.1, <3",
             "pytest-faulthandler>=1.3.0, <2",
             "pytest-timeout>=1.0.0, <2",

--- a/test/mitmproxy/addons/test_view.py
+++ b/test/mitmproxy/addons/test_view.py
@@ -170,6 +170,10 @@ def test_load(tmpdir):
         assert len(v) == 2
         v.load_file(path)
         assert len(v) == 4
+        try:
+            v.load_file("nonexistent_file_path")
+        except IOError:
+            assert False
 
 
 def test_resolve():


### PR DESCRIPTION
Fixed a crash when trying to load flows from a file that doesn't exist.
Added os.path.expanduser() before open() calls with user supplied paths.