### PR TITLE
Respect response to CONNECT created in http_connect function in upstream mode

### DIFF
--- a/mitmproxy/proxy/protocol/http.py
+++ b/mitmproxy/proxy/protocol/http.py
@@ -217,16 +217,17 @@ class HttpLayer(base.Layer):
         return False
 
     def handle_upstream_connect(self, f):
-        self.establish_server_connection(
-            f.request.host,
-            f.request.port,
-            f.request.scheme
-        )
-        self.send_request(f.request)
-        f.response = self.read_response_headers()
-        f.response.data.content = b"".join(
-            self.read_response_body(f.request, f.response)
-        )
+        if not f.response:
+            self.establish_server_connection(
+                f.request.host,
+                f.request.port,
+                f.request.scheme
+            )
+            self.send_request(f.request)
+            f.response = self.read_response_headers()
+            f.response.data.content = b"".join(
+                self.read_response_body(f.request, f.response)
+            )
         self.send_response(f.response)
         if is_ok(f.response.status_code):
             layer = UpstreamConnectLayer(self, f.request)

--- a/mitmproxy/proxy/protocol/http.py
+++ b/mitmproxy/proxy/protocol/http.py
@@ -217,6 +217,8 @@ class HttpLayer(base.Layer):
         return False
 
     def handle_upstream_connect(self, f):
+        # if the user specifies a response in the http_connect hook, we do not connect upstream here.
+        # https://github.com/mitmproxy/mitmproxy/pull/2473
         if not f.response:
             self.establish_server_connection(
                 f.request.host,


### PR DESCRIPTION
Example script that creates response to CONNECT: 

```
from mitmproxy.http import make_connect_response
def http_connect(flow):
  if flow.request.method == 'CONNECT':
    # You may also selectively deny CONNECT request from certain IPs here.
    flow.response = make_connect_response(flow.request.http_version)
```

Fixes #2464 