### PR TITLE
Make load_script pure

### DIFF
--- a/test/mitmproxy/test_addonmanager.py
+++ b/test/mitmproxy/test_addonmanager.py
@@ -115,7 +115,7 @@ def test_simple():
         a.add(TAddon("one"))
         a.trigger("done")
         a.trigger("tick")
-        tctx.master.has_log("not callable")
+        assert tctx.master.has_log("not callable")
 
         a.remove(a.get("one"))
         assert not a.get("one")


### PR DESCRIPTION
`load_script` previously depended on `addonmanager.safecall` to redirect errors. It's more intuitive to catch those in the addon and make `load_script` pure and independent of the rest of mitmproxy and its addon system.