### PR TITLE
Gracefully ignore imports with hook names

### DIFF
--- a/test/mitmproxy/test_addonmanager.py
+++ b/test/mitmproxy/test_addonmanager.py
@@ -117,6 +117,11 @@ def test_simple():
         a.trigger("tick")
         tctx.master.has_log("not callable")
 
+        tctx.master.clear()
+        a.get("one").tick = addons
+        a.trigger("tick")
+        assert not tctx.master.has_log("not callable")
+
         a.remove(a.get("one"))
         assert not a.get("one")
 


### PR DESCRIPTION
The following script previously caused an infinite error loop:
```python
from mitmproxy import log
```
I can't test with the "log" event in the tests because that's special cased, so I just re-use `.tick`.