### PR TITLE
Enable tool-specific options

### DIFF
--- a/mitmproxy/options.py
+++ b/mitmproxy/options.py
@@ -437,24 +437,6 @@ class Options(optmanager.OptManager):
             "Limit which flows are displayed."
         )
 
-        # Web options
-        self.add_option(
-            "web_open_browser", bool, True,
-            "Start a browser."
-        )
-        self.add_option(
-            "web_debug", bool, False,
-            "Mitmweb debugging."
-        )
-        self.add_option(
-            "web_port", int, 8081,
-            "Mitmweb port."
-        )
-        self.add_option(
-            "web_iface", str, "127.0.0.1",
-            "Mitmweb interface."
-        )
-
         # Dump options
         self.add_option(
             "flow_detail", int, 1,

--- a/mitmproxy/test/taddons.py
+++ b/mitmproxy/test/taddons.py
@@ -1,12 +1,11 @@
-import sys
 import contextlib
+import sys
 
 import mitmproxy.master
 import mitmproxy.options
-from mitmproxy import proxy
 from mitmproxy import addonmanager
-from mitmproxy import eventsequence
 from mitmproxy import command
+from mitmproxy import eventsequence
 from mitmproxy.addons import script
 
 
@@ -59,10 +58,11 @@ class context:
         handlers can run as they would within mitmproxy. The context also
         provides a number of helper methods for common testing scenarios.
     """
-    def __init__(self, master = None, options = None):
+
+    def __init__(self, master=None, options=None):
         options = options or mitmproxy.options.Options()
         self.master = master or RecordingMaster(
-            options, proxy.DummyServer(options)
+            options
         )
         self.options = self.master.options
         self.wrapped = None

--- a/mitmproxy/tools/console/master.py
+++ b/mitmproxy/tools/console/master.py
@@ -32,11 +32,6 @@ class ConsoleMaster(master.Master):
     def __init__(self, opts):
         super().__init__(opts)
 
-        if not sys.stdout.isatty():
-            print("Error: mitmproxy's console interface requires a tty. "
-                  "Please run mitmproxy in an interactive shell environment.", file=sys.stderr)
-            sys.exit(1)
-
         self.view = view.View()  # type: view.View
         self.stream_path = None
         self.keymap = keymap.Keymap(self)

--- a/mitmproxy/tools/console/master.py
+++ b/mitmproxy/tools/console/master.py
@@ -15,6 +15,7 @@ import urwid
 from mitmproxy import addons
 from mitmproxy import master
 from mitmproxy import log
+from mitmproxy import options  # noqa
 from mitmproxy.addons import intercept
 from mitmproxy.addons import readfile
 from mitmproxy.addons import view
@@ -28,8 +29,8 @@ from mitmproxy.tools.console import window
 
 class ConsoleMaster(master.Master):
 
-    def __init__(self, options, server):
-        super().__init__(options, server)
+    def __init__(self, opts):
+        super().__init__(opts)
 
         if not sys.stdout.isatty():
             print("Error: mitmproxy's console interface requires a tty. "
@@ -38,8 +39,6 @@ class ConsoleMaster(master.Master):
 
         self.view = view.View()  # type: view.View
         self.stream_path = None
-        # This line is just for type hinting
-        self.options = self.options  # type: Options
         self.keymap = keymap.Keymap(self)
         defaultkeys.map(self.keymap)
         self.options.errored.connect(self.options_error)
@@ -160,10 +159,10 @@ class ConsoleMaster(master.Master):
         self.ui.start()
         os.unlink(name)
 
-    def set_palette(self, options, updated):
+    def set_palette(self, opts, updated):
         self.ui.register_palette(
-            palettes.palettes[options.console_palette].palette(
-                options.console_palette_transparent
+            palettes.palettes[opts.console_palette].palette(
+                opts.console_palette_transparent
             )
         )
         self.ui.clear()

--- a/mitmproxy/tools/console/master.py
+++ b/mitmproxy/tools/console/master.py
@@ -15,7 +15,6 @@ import urwid
 from mitmproxy import addons
 from mitmproxy import master
 from mitmproxy import log
-from mitmproxy import options  # noqa
 from mitmproxy.addons import intercept
 from mitmproxy.addons import readfile
 from mitmproxy.addons import view
@@ -172,6 +171,11 @@ class ConsoleMaster(master.Master):
         self.loop.process_input([key])
 
     def run(self):
+        if not sys.stdout.isatty():
+            print("Error: mitmproxy's console interface requires a tty. "
+                  "Please run mitmproxy in an interactive shell environment.", file=sys.stderr)
+            sys.exit(1)
+
         self.ui = urwid.raw_display.Screen()
         self.ui.set_terminal_properties(256)
         self.set_palette(self.options, None)

--- a/mitmproxy/tools/console/statusbar.py
+++ b/mitmproxy/tools/console/statusbar.py
@@ -257,11 +257,11 @@ class StatusBar(urwid.WidgetWrap):
             ('heading', ("%s %s [%s/%s]" % (arrow, marked, offset, fc)).ljust(11)),
         ]
 
-        if self.master.server.bound:
-            host = self.master.server.address[0]
-            if host == "0.0.0.0":
+        if self.master.options.server:
+            host = self.master.options.listen_host
+            if host == "0.0.0.0" or host == "":
                 host = "*"
-            boundaddr = "[%s:%s]" % (host, self.master.server.address[1])
+            boundaddr = "[%s:%s]" % (host, self.master.options.listen_port)
         else:
             boundaddr = ""
         t.extend(self.get_status())

--- a/mitmproxy/tools/dump.py
+++ b/mitmproxy/tools/dump.py
@@ -18,11 +18,10 @@ class DumpMaster(master.Master):
     def __init__(
         self,
         options: options.Options,
-        server,
         with_termlog=True,
         with_dumper=True,
     ) -> None:
-        master.Master.__init__(self, options, server)
+        super().__init__(options)
         self.errorcheck = ErrorCheck()
         if with_termlog:
             self.addons.add(termlog.TermLog(), termstatus.TermStatus())

--- a/mitmproxy/tools/main.py
+++ b/mitmproxy/tools/main.py
@@ -1,22 +1,25 @@
 from __future__ import print_function  # this is here for the version check to work on Python 2.
+
 import sys
 
-# This must be at the very top, before importing anything else that might break!
-# Keep all other imports below with the 'noqa' magic comment.
 if sys.version_info < (3, 5):
+    # This must be before any mitmproxy imports, as they already break!
+    # Keep all other imports below with the 'noqa' magic comment.
     print("#" * 49, file=sys.stderr)
     print("# mitmproxy only supports Python 3.5 and above! #", file=sys.stderr)
     print("#" * 49, file=sys.stderr)
 
+import argparse  # noqa
 import os  # noqa
 import signal  # noqa
+import typing  # noqa
 
 from mitmproxy.tools import cmdline  # noqa
-from mitmproxy import exceptions  # noqa
+from mitmproxy import exceptions, master  # noqa
 from mitmproxy import options  # noqa
 from mitmproxy import optmanager  # noqa
 from mitmproxy import proxy  # noqa
-from mitmproxy import log   # noqa
+from mitmproxy import log  # noqa
 from mitmproxy.utils import debug  # noqa
 
 
@@ -53,7 +56,12 @@ def process_options(parser, opts, args):
     return proxy.config.ProxyConfig(opts)
 
 
-def run(MasterKlass, args, extra=None):  # pragma: no cover
+def run(
+        master_cls: typing.Type[master.Master],
+        make_parser: typing.Callable[[options.Options], argparse.ArgumentParser],
+        arguments: typing.Sequence[str],
+        extra=typing.Callable[[typing.Any], dict]
+):  # pragma: no cover
     """
         extra: Extra argument processing callable which returns a dict of
         options.
@@ -61,12 +69,14 @@ def run(MasterKlass, args, extra=None):  # pragma: no cover
     debug.register_info_dumpers()
 
     opts = options.Options()
-    parser = cmdline.mitmdump(opts)
-    args = parser.parse_args(args)
-    master = None
+    master = master_cls(opts)
+
+    parser = make_parser(opts)
+    args = parser.parse_args(arguments)
     try:
         unknown = optmanager.load_paths(opts, args.conf)
         pconf = process_options(parser, opts, args)
+        server = None  # type: typing.Any
         if pconf.options.server:
             try:
                 server = proxy.server.ProxyServer(pconf)
@@ -76,7 +86,6 @@ def run(MasterKlass, args, extra=None):  # pragma: no cover
         else:
             server = proxy.server.DummyServer(pconf)
 
-        master = MasterKlass(opts)
         master.server = server
         master.addons.trigger("configure", opts.keys())
         master.addons.trigger("tick")
@@ -114,8 +123,13 @@ def mitmproxy(args=None):  # pragma: no cover
 
     assert_utf8_env()
 
+    if not sys.stdout.isatty():
+        print("Error: mitmproxy's console interface requires a tty. "
+              "Please run mitmproxy in an interactive shell environment.", file=sys.stderr)
+        sys.exit(1)
+
     from mitmproxy.tools import console
-    run(console.master.ConsoleMaster, args)
+    run(console.master.ConsoleMaster, cmdline.mitmproxy, args)
 
 
 def mitmdump(args=None):  # pragma: no cover
@@ -125,16 +139,16 @@ def mitmdump(args=None):  # pragma: no cover
         if args.filter_args:
             v = " ".join(args.filter_args)
             return dict(
-                view_filter = v,
-                save_stream_filter = v,
+                view_filter=v,
+                save_stream_filter=v,
             )
         return {}
 
-    m = run(dump.DumpMaster, args, extra)
+    m = run(dump.DumpMaster, cmdline.mitmdump, args, extra)
     if m and m.errorcheck.has_errored:
         sys.exit(1)
 
 
 def mitmweb(args=None):  # pragma: no cover
     from mitmproxy.tools import web
-    run(web.master.WebMaster, args)
+    run(web.master.WebMaster, cmdline.mitmweb, args)

--- a/mitmproxy/tools/main.py
+++ b/mitmproxy/tools/main.py
@@ -123,11 +123,6 @@ def mitmproxy(args=None):  # pragma: no cover
 
     assert_utf8_env()
 
-    if not sys.stdout.isatty():
-        print("Error: mitmproxy's console interface requires a tty. "
-              "Please run mitmproxy in an interactive shell environment.", file=sys.stderr)
-        sys.exit(1)
-
     from mitmproxy.tools import console
     run(console.master.ConsoleMaster, cmdline.mitmproxy, args)
 

--- a/mitmproxy/tools/main.py
+++ b/mitmproxy/tools/main.py
@@ -76,7 +76,8 @@ def run(MasterKlass, args, extra=None):  # pragma: no cover
         else:
             server = proxy.server.DummyServer(pconf)
 
-        master = MasterKlass(opts, server)
+        master = MasterKlass(opts)
+        master.server = server
         master.addons.trigger("configure", opts.keys())
         master.addons.trigger("tick")
         remaining = opts.update_known(**unknown)

--- a/mitmproxy/tools/web/master.py
+++ b/mitmproxy/tools/web/master.py
@@ -34,7 +34,7 @@ class WebMaster(master.Master):
 
         self.addons.add(*addons.default_addons())
         self.addons.add(
-            webaddons.WebOptions(),
+            webaddons.WebAddon(),
             intercept.Intercept(),
             readfile.ReadFile(),
             self.view,

--- a/mitmproxy/tools/web/master.py
+++ b/mitmproxy/tools/web/master.py
@@ -13,7 +13,7 @@ from mitmproxy.addons import termlog
 from mitmproxy.addons import view
 from mitmproxy.addons import termstatus
 from mitmproxy.options import Options  # noqa
-from mitmproxy.tools.web import app
+from mitmproxy.tools.web import app, webaddons
 
 
 class WebMaster(master.Master):
@@ -34,6 +34,7 @@ class WebMaster(master.Master):
 
         self.addons.add(*addons.default_addons())
         self.addons.add(
+            webaddons.WebOptions(),
             intercept.Intercept(),
             readfile.ReadFile(),
             self.view,

--- a/mitmproxy/tools/web/master.py
+++ b/mitmproxy/tools/web/master.py
@@ -17,8 +17,8 @@ from mitmproxy.tools.web import app, webaddons
 
 
 class WebMaster(master.Master):
-    def __init__(self, options, server, with_termlog=True):
-        super().__init__(options, server)
+    def __init__(self, options, with_termlog=True):
+        super().__init__(options)
         self.view = view.View()
         self.view.sig_view_add.connect(self._sig_view_add)
         self.view.sig_view_remove.connect(self._sig_view_remove)
@@ -45,8 +45,6 @@ class WebMaster(master.Master):
         self.app = app.Application(
             self, self.options.web_debug
         )
-        # This line is just for type hinting
-        self.options = self.options  # type: Options
 
     def _sig_view_add(self, view, flow):
         app.ClientConnection.broadcast(

--- a/mitmproxy/tools/web/webaddons.py
+++ b/mitmproxy/tools/web/webaddons.py
@@ -1,4 +1,4 @@
-class WebOptions:
+class WebAddon:
     def load(self, loader):
         loader.add_option(
             "web_open_browser", bool, True,
@@ -6,13 +6,13 @@ class WebOptions:
         )
         loader.add_option(
             "web_debug", bool, False,
-            "Mitmweb debugging."
+            "Enable mitmweb debugging."
         )
         loader.add_option(
             "web_port", int, 8081,
-            "Mitmweb port."
+            "Web UI port."
         )
         loader.add_option(
             "web_iface", str, "127.0.0.1",
-            "Mitmweb interface."
+            "Web UI interface."
         )

--- a/mitmproxy/tools/web/webaddons.py
+++ b/mitmproxy/tools/web/webaddons.py
@@ -1,0 +1,18 @@
+class WebOptions:
+    def load(self, loader):
+        loader.add_option(
+            "web_open_browser", bool, True,
+            "Start a browser."
+        )
+        loader.add_option(
+            "web_debug", bool, False,
+            "Mitmweb debugging."
+        )
+        loader.add_option(
+            "web_port", int, 8081,
+            "Mitmweb port."
+        )
+        loader.add_option(
+            "web_iface", str, "127.0.0.1",
+            "Mitmweb interface."
+        )

--- a/test/filename_matching.py
+++ b/test/filename_matching.py
@@ -22,7 +22,7 @@ def check_src_files_have_test():
 def check_test_files_have_src():
     unknown_test_files = []
 
-    excluded = ['test/mitmproxy/data/', 'test/mitmproxy/net/data/', '/tservers.py']
+    excluded = ['test/mitmproxy/data/', 'test/mitmproxy/net/data/', '/tservers.py', '/conftest.py']
     test_files = glob.glob('test/mitmproxy/**/*.py', recursive=True) + glob.glob('test/pathod/**/*.py', recursive=True)
     test_files = [f for f in test_files if os.path.basename(f) != '__init__.py']
     test_files = [f for f in test_files if not any(os.path.normpath(p) in f for p in excluded)]

--- a/test/mitmproxy/addons/test_termstatus.py
+++ b/test/mitmproxy/addons/test_termstatus.py
@@ -1,3 +1,4 @@
+from mitmproxy import proxy
 from mitmproxy.addons import termstatus
 from mitmproxy.test import taddons
 
@@ -5,6 +6,7 @@ from mitmproxy.test import taddons
 def test_configure():
     ts = termstatus.TermStatus()
     with taddons.context() as ctx:
+        ctx.master.server = proxy.DummyServer()
         ctx.configure(ts, server=False)
         ts.running()
         assert not ctx.master.logs

--- a/test/mitmproxy/proxy/protocol/test_http2.py
+++ b/test/mitmproxy/proxy/protocol/test_http2.py
@@ -8,7 +8,6 @@ import pytest
 import h2
 
 from mitmproxy import options
-from mitmproxy.proxy.config import ProxyConfig
 
 import mitmproxy.net
 from ...net import tservers as net_tservers
@@ -89,10 +88,8 @@ class _Http2TestBase:
 
     @classmethod
     def setup_class(cls):
-        opts = cls.get_options()
-        cls.config = ProxyConfig(opts)
-
-        tmaster = tservers.TestMaster(opts, cls.config)
+        cls.options = cls.get_options()
+        tmaster = tservers.TestMaster(cls.options)
         cls.proxy = tservers.ProxyThread(tmaster)
         cls.proxy.start()
 
@@ -319,7 +316,7 @@ class TestRequestWithPriority(_Http2Test):
         (False, (None, None, None), (None, None, None)),
     ])
     def test_request_with_priority(self, http2_priority_enabled, priority, expected_priority):
-        self.config.options.http2_priority = http2_priority_enabled
+        self.options.http2_priority = http2_priority_enabled
 
         h2_conn = self.setup_connection()
 
@@ -397,7 +394,7 @@ class TestPriority(_Http2Test):
         (False, (True, 42424242, 42), []),
     ])
     def test_priority(self, prioritize_before, http2_priority_enabled, priority, expected_priority):
-        self.config.options.http2_priority = http2_priority_enabled
+        self.options.http2_priority = http2_priority_enabled
         self.__class__.priority_data = []
 
         h2_conn = self.setup_connection()
@@ -508,8 +505,10 @@ class TestBodySizeLimit(_Http2Test):
         return True
 
     def test_body_size_limit(self):
-        self.config.options.body_size_limit = "20"
-        self.config.options._processed["body_size_limit"] = 20
+        self.options.body_size_limit = "20"
+
+        # FIXME: This should not be required?
+        self.options._processed["body_size_limit"] = 20
 
         h2_conn = self.setup_connection()
 

--- a/test/mitmproxy/proxy/protocol/test_websocket.py
+++ b/test/mitmproxy/proxy/protocol/test_websocket.py
@@ -7,7 +7,6 @@ from mitmproxy import options
 from mitmproxy import exceptions
 from mitmproxy.http import HTTPFlow
 from mitmproxy.websocket import WebSocketFlow
-from mitmproxy.proxy.config import ProxyConfig
 
 from mitmproxy.net import tcp
 from mitmproxy.net import http
@@ -49,10 +48,8 @@ class _WebSocketTestBase:
 
     @classmethod
     def setup_class(cls):
-        opts = cls.get_options()
-        cls.config = ProxyConfig(opts)
-
-        tmaster = tservers.TestMaster(opts, cls.config)
+        cls.options = cls.get_options()
+        tmaster = tservers.TestMaster(cls.options)
         cls.proxy = tservers.ProxyThread(tmaster)
         cls.proxy.start()
 

--- a/test/mitmproxy/test_addonmanager.py
+++ b/test/mitmproxy/test_addonmanager.py
@@ -6,7 +6,6 @@ from mitmproxy import exceptions
 from mitmproxy import options
 from mitmproxy import command
 from mitmproxy import master
-from mitmproxy import proxy
 from mitmproxy.test import taddons
 from mitmproxy.test import tflow
 
@@ -51,7 +50,7 @@ def test_command():
 
 def test_halt():
     o = options.Options()
-    m = master.Master(o, proxy.DummyServer(o))
+    m = master.Master(o)
     a = addonmanager.AddonManager(m)
     halt = THalt()
     end = TAddon("end")
@@ -68,7 +67,7 @@ def test_halt():
 
 def test_lifecycle():
     o = options.Options()
-    m = master.Master(o, proxy.DummyServer(o))
+    m = master.Master(o)
     a = addonmanager.AddonManager(m)
     a.add(TAddon("one"))
 
@@ -128,7 +127,7 @@ def test_simple():
 
 def test_load_option():
     o = options.Options()
-    m = master.Master(o, proxy.DummyServer(o))
+    m = master.Master(o)
     a = addonmanager.AddonManager(m)
     a.add(AOption())
     assert "custom_option" in m.options._options
@@ -136,7 +135,7 @@ def test_load_option():
 
 def test_nesting():
     o = options.Options()
-    m = master.Master(o, proxy.DummyServer(o))
+    m = master.Master(o)
     a = addonmanager.AddonManager(m)
 
     a.add(

--- a/test/mitmproxy/test_controller.py
+++ b/test/mitmproxy/test_controller.py
@@ -30,7 +30,8 @@ class TestMaster:
             assert ctx.master.should_exit.is_set()
 
     def test_server_simple(self):
-        m = master.Master(None, proxy.DummyServer(None))
+        m = master.Master(None)
+        m.server = proxy.DummyServer()
         m.start()
         m.shutdown()
         m.start()

--- a/test/mitmproxy/test_flow.py
+++ b/test/mitmproxy/test_flow.py
@@ -6,13 +6,11 @@ from mitmproxy.test import tflow, tutils
 import mitmproxy.io
 from mitmproxy import flowfilter
 from mitmproxy import options
-from mitmproxy.proxy import config
 from mitmproxy.io import tnetstring
 from mitmproxy.exceptions import FlowReadException, ReplayException, ControlException
 from mitmproxy import flow
 from mitmproxy import http
 from mitmproxy.net import http as net_http
-from mitmproxy.proxy.server import DummyServer
 from mitmproxy import master
 from . import tservers
 
@@ -93,8 +91,7 @@ class TestFlowMaster:
         opts = options.Options(
             mode="reverse:https://use-this-domain"
         )
-        conf = config.ProxyConfig(opts)
-        fm = master.Master(opts, DummyServer(conf))
+        fm = master.Master(opts)
         fm.addons.add(s)
         f = tflow.tflow(resp=True)
         fm.load_flow(f)
@@ -102,8 +99,7 @@ class TestFlowMaster:
 
     def test_replay(self):
         opts = options.Options()
-        conf = config.ProxyConfig(opts)
-        fm = master.Master(opts, DummyServer(conf))
+        fm = master.Master(opts)
         f = tflow.tflow(resp=True)
         f.request.content = None
         with pytest.raises(ReplayException, match="missing"):
@@ -131,7 +127,7 @@ class TestFlowMaster:
 
     def test_all(self):
         s = tservers.TestState()
-        fm = master.Master(None, DummyServer())
+        fm = master.Master(None)
         fm.addons.add(s)
         f = tflow.tflow(req=None)
         fm.addons.handle_lifecycle("clientconnect", f.client_conn)

--- a/test/mitmproxy/tools/console/conftest.py
+++ b/test/mitmproxy/tools/console/conftest.py
@@ -1,9 +1,0 @@
-from unittest import mock
-
-import pytest
-
-
-@pytest.fixture(scope="module", autouse=True)
-def definitely_atty():
-    with mock.patch("sys.stdout.isatty", lambda: True):
-        yield

--- a/test/mitmproxy/tools/console/test_master.py
+++ b/test/mitmproxy/tools/console/test_master.py
@@ -1,7 +1,6 @@
 import urwid
 
 from mitmproxy import options
-from mitmproxy import proxy
 from mitmproxy.test import tflow
 from mitmproxy.test import tutils
 from mitmproxy.tools import console
@@ -30,7 +29,7 @@ class TestMaster(tservers.MasterTest):
         if "verbosity" not in opts:
             opts["verbosity"] = 'warn'
         o = options.Options(**opts)
-        m = console.master.ConsoleMaster(o, proxy.DummyServer())
+        m = console.master.ConsoleMaster(o)
         m.addons.trigger("configure", o.keys())
         return m
 

--- a/test/mitmproxy/tools/console/test_statusbar.py
+++ b/test/mitmproxy/tools/console/test_statusbar.py
@@ -1,4 +1,4 @@
-from mitmproxy import options, proxy
+from mitmproxy import options
 from mitmproxy.tools.console import statusbar, master
 
 
@@ -26,7 +26,7 @@ def test_statusbar(monkeypatch):
         scripts=["nonexistent"],
         save_stream_file="foo",
     )
-    m = master.ConsoleMaster(o, proxy.DummyServer())
+    m = master.ConsoleMaster(o)
     monkeypatch.setattr(m.addons.get("clientplayback"), "count", lambda: 42)
     monkeypatch.setattr(m.addons.get("serverplayback"), "count", lambda: 42)
 

--- a/test/mitmproxy/tools/test_cmdline.py
+++ b/test/mitmproxy/tools/test_cmdline.py
@@ -1,7 +1,8 @@
 import argparse
-from mitmproxy.tools import cmdline
-from mitmproxy.tools import main
+
 from mitmproxy import options
+from mitmproxy.tools import cmdline, web, dump, console
+from mitmproxy.tools import main
 
 
 def test_common():
@@ -14,17 +15,20 @@ def test_common():
 
 def test_mitmproxy():
     opts = options.Options()
+    console.master.ConsoleMaster(opts)
     ap = cmdline.mitmproxy(opts)
     assert ap
 
 
 def test_mitmdump():
     opts = options.Options()
+    dump.DumpMaster(opts)
     ap = cmdline.mitmdump(opts)
     assert ap
 
 
 def test_mitmweb():
     opts = options.Options()
+    web.master.WebMaster(opts)
     ap = cmdline.mitmweb(opts)
     assert ap

--- a/test/mitmproxy/tools/test_dump.py
+++ b/test/mitmproxy/tools/test_dump.py
@@ -1,7 +1,6 @@
 import pytest
 from unittest import mock
 
-from mitmproxy import proxy
 from mitmproxy import log
 from mitmproxy import controller
 from mitmproxy import options
@@ -13,7 +12,7 @@ from .. import tservers
 class TestDumpMaster(tservers.MasterTest):
     def mkmaster(self, flt, **opts):
         o = options.Options(view_filter=flt, verbosity='error', flow_detail=0, **opts)
-        m = dump.DumpMaster(o, proxy.DummyServer(), with_termlog=False, with_dumper=False)
+        m = dump.DumpMaster(o, with_termlog=False, with_dumper=False)
         return m
 
     def test_has_error(self):
@@ -27,12 +26,12 @@ class TestDumpMaster(tservers.MasterTest):
     def test_addons_termlog(self, termlog):
         with mock.patch('sys.stdout'):
             o = options.Options()
-            m = dump.DumpMaster(o, proxy.DummyServer(), with_termlog=termlog)
+            m = dump.DumpMaster(o, with_termlog=termlog)
             assert (m.addons.get('termlog') is not None) == termlog
 
     @pytest.mark.parametrize("dumper", [False, True])
     def test_addons_dumper(self, dumper):
         with mock.patch('sys.stdout'):
             o = options.Options()
-            m = dump.DumpMaster(o, proxy.DummyServer(), with_dumper=dumper)
+            m = dump.DumpMaster(o, with_dumper=dumper)
             assert (m.addons.get('dumper') is not None) == dumper

--- a/test/mitmproxy/tools/web/test_app.py
+++ b/test/mitmproxy/tools/web/test_app.py
@@ -322,5 +322,5 @@ class TestApp(tornado.testing.AsyncHTTPTestCase):
         web_root = os.path.join(here, os.pardir, os.pardir, os.pardir, os.pardir, 'web')
         tflow_path = os.path.join(web_root, 'src/js/__tests__/ducks/_tflow.js')
         content = """export default function(){{\n    return {tflow_json}\n}}""".format(tflow_json=tflow_json)
-        with open(tflow_path, 'w') as f:
+        with open(tflow_path, 'w', newline="\n") as f:
             f.write(content)

--- a/test/mitmproxy/tools/web/test_app.py
+++ b/test/mitmproxy/tools/web/test_app.py
@@ -7,7 +7,6 @@ from tornado import httpclient
 from tornado import websocket
 
 from mitmproxy import exceptions
-from mitmproxy import proxy
 from mitmproxy import options
 from mitmproxy.test import tflow
 from mitmproxy.tools.web import app
@@ -21,7 +20,7 @@ def json(resp: httpclient.HTTPResponse):
 class TestApp(tornado.testing.AsyncHTTPTestCase):
     def get_app(self):
         o = options.Options(http2=False)
-        m = webmaster.WebMaster(o, proxy.DummyServer(), with_termlog=False)
+        m = webmaster.WebMaster(o, with_termlog=False)
         f = tflow.tflow(resp=True)
         f.id = "42"
         m.view.add([f])

--- a/test/mitmproxy/tools/web/test_master.py
+++ b/test/mitmproxy/tools/web/test_master.py
@@ -1,7 +1,5 @@
 from mitmproxy.tools.web import master
-from mitmproxy import proxy
 from mitmproxy import options
-from mitmproxy.proxy.config import ProxyConfig
 
 from ... import tservers
 
@@ -9,8 +7,7 @@ from ... import tservers
 class TestWebMaster(tservers.MasterTest):
     def mkmaster(self, **opts):
         o = options.Options(**opts)
-        c = ProxyConfig(o)
-        return master.WebMaster(o, proxy.DummyServer(c))
+        return master.WebMaster(o)
 
     def test_basic(self):
         m = self.mkmaster()


### PR DESCRIPTION
This started as a naive attempt to move mitmweb's options into a mitmweb-specific addon, and ended in something slightly more complex:

- **Disentagle `ProxyServer/DummyServer` from the `Master` constructor:** The proxy server should ultimately be an addon itself, so this is the first step towards this by moving it out of the function signature. 
- **Replace usage of `ProxyConfig` with `Options`:** Now that `Master` may not have a server, there also is no `ProxyConfig`, so a whole bunch of tests failed. To fix this, I replaced all usages of `ProxyConfig` with the proper equivalent in `Options`, which should have been the case from in the first place.
- **Actually move mitmweb options into mitmweb-specific addon:** We can now follow up with all other options and move them into their respective addons. I plan to update `Loader.add_option` to not log repeated `add_option` calls with _exactly_ the same arguments (same option name, type, help, ...).
- **Fix mitmproxy's and mitmweb's cmdline** to actually display tool-specific options and not just the mitmdump ones.