### PR TITLE
Fix minor typing mistake in mitmproxy/tools/main.py

### DIFF
--- a/mitmproxy/tools/main.py
+++ b/mitmproxy/tools/main.py
@@ -60,7 +60,7 @@ def run(
         master_cls: typing.Type[master.Master],
         make_parser: typing.Callable[[options.Options], argparse.ArgumentParser],
         arguments: typing.Sequence[str],
-        extra=typing.Callable[[typing.Any], dict]
+        extra: typing.Callable[[typing.Any], dict] = None
 ):  # pragma: no cover
     """
         extra: Extra argument processing callable which returns a dict of


### PR DESCRIPTION
`mitmproxy` and `mitmweb` failed to start with following error message:
```
Traceback (most recent call last):
  File "/home/matthew/mitmproxy/venv/bin/mitmproxy", line 11, in <module>
    load_entry_point('mitmproxy', 'console_scripts', 'mitmproxy')()
  File "/home/matthew/mitmproxy/mitmproxy/tools/main.py", line 127, in mitmproxy
    run(console.master.ConsoleMaster, cmdline.mitmproxy, args)
  File "/home/matthew/mitmproxy/mitmproxy/tools/main.py", line 103, in run
    opts.update(**extra(args))
  File "/usr/lib/python3.5/typing.py", line 135, in __new__
    raise TypeError("Cannot instantiate %r" % self.__class__)
TypeError: Cannot instantiate <class 'typing.CallableMeta'>
```
It was caused by the error syntax of the default value, this PR should fix that.