### PR TITLE
Improve intercept toggle

### DIFF
--- a/mitmproxy/tools/console/consoleaddons.py
+++ b/mitmproxy/tools/console/consoleaddons.py
@@ -68,12 +68,14 @@ class ConsoleAddon:
         """
         return ["single", "vertical", "horizontal"]
 
-    @command.command("intercept_toggle")
+    @command.command("console.intercept.toggle")
     def intercept_toggle(self) -> None:
         """
             Toggles interception on/off leaving intercept filters intact.
         """
-        ctx.options.intercept_active = not ctx.options.intercept_active
+        ctx.options.update(
+            intercept_active = not ctx.options.intercept_active
+        )
 
     @command.command("console.layout.cycle")
     def layout_cycle(self) -> None:

--- a/mitmproxy/tools/console/defaultkeys.py
+++ b/mitmproxy/tools/console/defaultkeys.py
@@ -24,7 +24,7 @@ def map(km):
     km.add("ctrl f", "console.nav.pagedown", ["global"], "Page down")
     km.add("ctrl b", "console.nav.pageup", ["global"], "Page up")
 
-    km.add("I", "console.command intercept_toggle", ["global"], "Toggle intercept")
+    km.add("I", "console.intercept.toggle", ["global"], "Toggle intercept")
     km.add("i", "console.command set intercept=", ["global"], "Set intercept")
     km.add("W", "console.command set save_stream_file=", ["global"], "Stream to file")
     km.add("A", "flow.resume @all", ["flowlist", "flowview"], "Resume all intercepted flows")


### PR DESCRIPTION
This PR does 2 things - 
* Renamed intercept_toggle command to console.intercept.toggle to be consistent with existing commands  
* Update options when <kbd>I</kbd> is pressed. Currently we need to press <kbd>I</kbd> and <kbd>Enter</kbd> to toggle