### PR TITLE
Re-add rawtcp mode.

### DIFF
--- a/mitmproxy/options.py
+++ b/mitmproxy/options.py
@@ -173,7 +173,7 @@ class Options(optmanager.OptManager):
         )
         self.add_option(
             "server", bool, True,
-            "Start a proxy server."
+            "Start a proxy server. Enabled by default."
         )
         self.add_option(
             "server_replay_nopop", bool, False,
@@ -406,8 +406,9 @@ class Options(optmanager.OptManager):
         )
         self.add_option(
             "rawtcp", bool, False,
-            "Enable/disable experimental raw TCP support. "
-            "Disabled by default. "
+            "Enable/disable experimental raw TCP support. TCP connections starting with non-ascii "
+            "bytes are treated as if they would match tcp_hosts. The heuristic is very rough, use "
+            "with caution. Disabled by default. "
         )
 
         self.add_option(

--- a/mitmproxy/proxy/root_context.py
+++ b/mitmproxy/proxy/root_context.py
@@ -104,7 +104,16 @@ class RootContext:
             if alpn == b'http/1.1':
                 return protocol.Http1Layer(top_layer, http.HTTPMode.transparent)
 
-        # 6. Assume HTTP1 by default
+        # 6. Check for raw tcp mode
+        is_ascii = (
+            len(d) == 3 and
+            # expect A-Za-z
+            all(65 <= x <= 90 or 97 <= x <= 122 for x in d)
+        )
+        if self.config.options.rawtcp and not is_ascii:
+            return protocol.RawTCPLayer(top_layer)
+
+        # 7. Assume HTTP1 by default
         return protocol.Http1Layer(top_layer, http.HTTPMode.transparent)
 
     def log(self, msg, level, subs=()):


### PR DESCRIPTION
See https://github.com/mhils/mitmproxy/commit/9ca6785d40ebe0293f36683250d72998f438bba9 for the motivation. This is not the final solution to the problem, but an improvement over the current state.