### PR TITLE
re-add --http2 switch

### DIFF
--- a/mitmproxy/tools/cmdline.py
+++ b/mitmproxy/tools/cmdline.py
@@ -73,6 +73,7 @@ def common_options(parser, opts):
     opts.make_parser(group, "upstream_auth", metavar="USER:PASS")
     opts.make_parser(group, "proxyauth", metavar="SPEC")
     opts.make_parser(group, "rawtcp")
+    opts.make_parser(group, "http2")
 
     # Proxy SSL options
     group = parser.add_argument_group("SSL")


### PR DESCRIPTION
I think this is one of the more important ones we should not omit, e.g. as `--no-http2` is still needed for scripted redirection.

@Kriechi?