### PR TITLE
Fallback correctly to ipv4 when ipv6 is not supported

### DIFF
--- a/mitmproxy/net/tcp.py
+++ b/mitmproxy/net/tcp.py
@@ -855,6 +855,8 @@ class TCPServer:
         if self.address[0] == 'localhost':
             raise socket.error("Binding to 'localhost' is prohibited. Please use '::1' or '127.0.0.1' directly.")
 
+        self.socket = None
+
         try:
             # First try to bind an IPv6 socket, with possible IPv4 if the OS supports it.
             # This allows us to accept connections for ::1 and 127.0.0.1 on the same socket.


### PR DESCRIPTION
This is a one line fix so that mitmproxy (git master version) correctly works on a system where ipv6 is disabled.
Without it, I get the following exception when trying to run mitmproxy:

```
Traceback (most recent call last):
  File "/home/arch/mitm/dev/mitmproxy/mitmproxy/net/tcp.py", line 862, in __init__
    self.socket = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
  File "/usr/lib/python3.6/socket.py", line 144, in __init__
    _socket.socket.__init__(self, family, type, proto, fileno)
OSError: [Errno 97] Address family not supported by protocol

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/arch/mitm/dev/mitmproxy/mitmproxy/proxy/server.py", line 46, in __init__
    (config.options.listen_host, config.options.listen_port)
  File "/home/arch/mitm/dev/mitmproxy/mitmproxy/net/tcp.py", line 867, in __init__
    if self.socket:
AttributeError: 'ProxyServer' object has no attribute 'socket'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/arch/mitm/dev/mitmproxy/venv/bin/mitmproxy", line 11, in <module>
    load_entry_point('mitmproxy', 'console_scripts', 'mitmproxy')()
  File "/home/arch/mitm/dev/mitmproxy/mitmproxy/tools/main.py", line 137, in mitmproxy
    run(console.master.ConsoleMaster, cmdline.mitmproxy, args)
  File "/home/arch/mitm/dev/mitmproxy/mitmproxy/tools/main.py", line 92, in run
    server = proxy.server.ProxyServer(pconf)
  File "/home/arch/mitm/dev/mitmproxy/mitmproxy/proxy/server.py", line 51, in __init__
    if self.socket:
AttributeError: 'ProxyServer' object has no attribute 'socket'

```