### PR TITLE
[web] Add settings.json to Static viewer

### DIFF
--- a/mitmproxy/tools/web/static_viewer.py
+++ b/mitmproxy/tools/web/static_viewer.py
@@ -9,6 +9,7 @@ from mitmproxy import contentviews
 from mitmproxy import ctx
 from mitmproxy import flowfilter
 from mitmproxy import io, flow
+from mitmproxy import version
 from mitmproxy.tools.web.app import flow_to_json
 
 web_dir = pathlib.Path(__file__).absolute().parent
@@ -31,6 +32,11 @@ def save_static(path: pathlib.Path) -> None:
 def save_filter_help(path: pathlib.Path) -> None:
     with open(str(path / 'filter-help.json'), 'w') as f:
         json.dump(dict(commands=flowfilter.help), f)
+
+
+def save_settings(path: pathlib.Path) -> None:
+    with open(str(path / 'settings.json'), 'w') as f:
+        json.dump(dict(version=version.VERSION), f)
 
 
 def save_flows(path: pathlib.Path, flows: typing.Iterable[flow.Flow]) -> None:

--- a/test/mitmproxy/tools/web/test_static_viewer.py
+++ b/test/mitmproxy/tools/web/test_static_viewer.py
@@ -26,6 +26,12 @@ def test_save_filter_help(tmpdir):
     assert f.read() == json.dumps(dict(commands=flowfilter.help))
 
 
+def test_save_settings(tmpdir):
+    static_viewer.save_settings(tmpdir)
+    f = tmpdir.join('/settings.json')
+    assert f.check(file=1)
+
+
 def test_save_flows(tmpdir):
     flows = [tflow.tflow(req=True, resp=None), tflow.tflow(req=True, resp=True)]
     static_viewer.save_flows(tmpdir, flows)

--- a/web/src/js/backends/static.js
+++ b/web/src/js/backends/static.js
@@ -12,6 +12,7 @@ export default class StaticBackend {
 
    onOpen() {
         this.fetchData("flows")
+        this.fetchData("settings")
         // this.fetchData("events") # TODO: Add events log to static viewer.
    }
 


### PR DESCRIPTION
The generation of `setting.json` improve the extensibility of static viewer, for now, it could display the version of mtimproxy. We could include other settings in `settings.json` in the future.