### PR TITLE
Fixes bug where loaded certs are stored in the certs dict as str

### DIFF
--- a/mitmproxy/proxy/config.py
+++ b/mitmproxy/proxy/config.py
@@ -113,7 +113,7 @@ class ProxyConfig:
                     "Certificate file does not exist: %s" % cert
                 )
             try:
-                self.certstore.add_cert_file(spec, cert)
+                self.certstore.add_cert_file(bytes(spec, "utf-8"), cert)
             except crypto.Error:
                 raise exceptions.OptionsError(
                     "Invalid certificate format: %s" % cert


### PR DESCRIPTION
### Overview
Certs provided through the --cert argument or config yaml get stored in the certs dictionary as a str. This causes issues because the keys created by get_certs method are byte strings. So any provided certs wind up being ignored and the generated certs still get stored as byte strings.

### Steps to Reproduce
1. Start the proxy and provide a cert through the command line or config.yaml options:

  ```bash
  mitmproxy --cert [domain=path to pem]
  ```

2. Attach to the process using the debugger and set a breakpoint in `certs.py` at the `get_cert` method.  
3. Step through the method until you get to `if name:`

This was found when trying to modify requests while keeping certificate pinning enabled using a second cert I have pinned and have the private key to. Once I converted the spec to bytes the domain and certificate were correctly identified.

Additional Info:
Mid 2014 MacBook Pro with 15" Retina Display
macOS Sierra 10.12.5
Python 3.6.1
mitmproxy installed through Homebrew 1.2.4.

![masked-screen-1](https://user-images.githubusercontent.com/930927/30389914-54a73bf6-9882-11e7-9c6d-73afad635518.jpg)
![masked-screen-2](https://user-images.githubusercontent.com/930927/30389915-54af5bf6-9882-11e7-94c1-dc230b6d3705.jpg)
