### PR TITLE
docs: clarify filter syntax for mitmproxy

### DIFF
--- a/docs/features/filters.rst
+++ b/docs/features/filters.rst
@@ -15,6 +15,7 @@ Filter expressions consist of the following operators:
 - Header matching (~h, ~hq, ~hs) is against a string of the form "name: value".
 - Strings with no operators are matched against the request URL.
 - The default binary operator is &.
+- When specifying filter in `mitmproxy`, the leading `~` is omitted.
 
 Examples
 --------


### PR DESCRIPTION
Filters in mitmproxy don't work with a leading "~" symbol and the user
gets a cryptic error message "Invalid filter pattern" when following the
docs. This patch tries to make the docs better in that respect.