### PR TITLE
Skip ipv6 tests on sudo-enabled travis builds

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,4 +1,6 @@
 import os
+import socket
+
 import pytest
 
 pytest_plugins = ('test.full_coverage_plugin',)
@@ -16,4 +18,18 @@ skip_not_windows = pytest.mark.skipif(
 skip_appveyor = pytest.mark.skipif(
     "APPVEYOR" in os.environ,
     reason='Skipping due to Appveyor'
+)
+
+try:
+    s = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
+    s.bind(("::1", 0))
+    s.close()
+except OSError:
+    no_ipv6 = True
+else:
+    no_ipv6 = False
+
+skip_no_ipv6 = pytest.mark.skipif(
+    no_ipv6,
+    reason='Host has no IPv6 support'
 )

--- a/test/mitmproxy/net/test_tcp.py
+++ b/test/mitmproxy/net/test_tcp.py
@@ -12,6 +12,7 @@ from mitmproxy import certs
 from mitmproxy.net import tcp
 from mitmproxy import exceptions
 from mitmproxy.test import tutils
+from ...conftest import skip_no_ipv6
 
 from . import tservers
 
@@ -112,6 +113,7 @@ class TestServerBind(tservers.ServerTestBase):
                 pass
 
 
+@skip_no_ipv6
 class TestServerIPv6(tservers.ServerTestBase):
     handler = EchoHandler
     addr = ("::1", 0)


### PR DESCRIPTION
Travis tests are currently failing because travis migrated their precise builds [1] from their container-based infrastructure to full virtual machines, which apparently don't support IPv6. This PR skips the IPv6 tests on systems where no IPv6 support is present.

[1] We use those so that our PyInstaller inaries are compiled with an old glibc version. Otherwise, they do not work on old systems (and AWS Lambda).