### PR TITLE
Fix #2598

### DIFF
--- a/examples/simple/wsgi_flask_app.py
+++ b/examples/simple/wsgi_flask_app.py
@@ -14,12 +14,7 @@ def hello_world() -> str:
     return 'Hello World!'
 
 
-def load(l):
+def start():
     # Host app at the magic domain "proxapp.local" on port 80. Requests to this
     # domain and port combination will now be routed to the WSGI app instance.
     return wsgiapp.WSGIApp(app, "proxapp.local", 80)
-
-    # SSL works too, but the magic domain needs to be resolvable from the mitmproxy machine due to mitmproxy's design.
-    # mitmproxy will connect to said domain and use serve its certificate (unless --no-upstream-cert is set)
-    # but won't send any data.
-    # mitmproxy.ctx.master.apps.add(app, "example.com", 443)


### PR DESCRIPTION
When placing the action at the `start` event the sample works as expected
Also removes reference to SSL example because its not working