### PR TITLE
Make master.add_log threadsafe

### DIFF
--- a/mitmproxy/addonmanager.py
+++ b/mitmproxy/addonmanager.py
@@ -8,6 +8,7 @@ from mitmproxy import exceptions
 from mitmproxy import eventsequence
 from mitmproxy import controller
 from mitmproxy import flow
+from mitmproxy import log
 from . import ctx
 import pprint
 
@@ -54,7 +55,13 @@ class StreamLog:
 
 @contextlib.contextmanager
 def safecall():
-    stdout_replacement = StreamLog(ctx.log.warn)
+    # resolve ctx.master here.
+    # we want to be threadsafe, and ctx.master may already be cleared when an addon prints().
+    tell = ctx.master.tell
+    # don't use master.add_log (which is not thread-safe). Instead, put on event queue.
+    stdout_replacement = StreamLog(
+        lambda message: tell("log", log.LogEntry(message, "warn"))
+    )
     try:
         with contextlib.redirect_stdout(stdout_replacement):
             yield

--- a/test/mitmproxy/addons/test_script.py
+++ b/test/mitmproxy/addons/test_script.py
@@ -7,6 +7,7 @@ import pytest
 
 from mitmproxy import addonmanager
 from mitmproxy import exceptions
+from mitmproxy import log
 from mitmproxy.addons import script
 from mitmproxy.test import taddons
 from mitmproxy.test import tflow
@@ -50,7 +51,7 @@ def test_load_fullname():
 
 def test_script_print_stdout():
     with taddons.context() as tctx:
-        with mock.patch('mitmproxy.ctx.log.warn') as mock_warn:
+        with mock.patch('mitmproxy.ctx.master.tell') as mock_warn:
             with addonmanager.safecall():
                 ns = script.load_script(
                     tutils.test_data.path(
@@ -58,7 +59,7 @@ def test_script_print_stdout():
                     )
                 )
                 ns.load(addonmanager.Loader(tctx.master))
-        mock_warn.assert_called_once_with("stdoutprint")
+        mock_warn.assert_called_once_with("log", log.LogEntry("stdoutprint", "warn"))
 
 
 class TestScript:


### PR DESCRIPTION
This is invoked by print() statements within addons, so it better be safe.