### PR TITLE
Improve Clientreplay

### DIFF
--- a/mitmproxy/flow.py
+++ b/mitmproxy/flow.py
@@ -99,6 +99,7 @@ class Flow(stateobject.StateObject):
         return d
 
     def set_state(self, state):
+        state = state.copy()
         state.pop("version")
         if "backup" in state:
             self._backup = state.pop("backup")

--- a/mitmproxy/http.py
+++ b/mitmproxy/http.py
@@ -56,6 +56,7 @@ class HTTPRequest(http.Request):
         return state
 
     def set_state(self, state):
+        state = state.copy()
         self.is_replay = state.pop("is_replay")
         super().set_state(state)
 

--- a/mitmproxy/proxy/protocol/http_replay.py
+++ b/mitmproxy/proxy/protocol/http_replay.py
@@ -42,6 +42,7 @@ class RequestReplayThread(basethread.BaseThread):
         super().__init__(
             "RequestReplay (%s)" % f.request.url
         )
+        self.daemon = True
 
     def run(self):
         r = self.f.request

--- a/test/mitmproxy/addons/test_clientplayback.py
+++ b/test/mitmproxy/addons/test_clientplayback.py
@@ -36,9 +36,12 @@ class TestClientPlayback:
                 assert rp.called
                 assert cp.current_thread
 
-            cp.flows = None
-            cp.current_thread = None
+            cp.flows = []
+            cp.current_thread.is_alive.return_value = False
+            assert cp.count() == 1
             cp.tick()
+            assert cp.count() == 0
+            assert tctx.master.has_event("update")
             assert tctx.master.has_event("processing_complete")
 
             cp.current_thread = MockThread()

--- a/test/mitmproxy/test_flow.py
+++ b/test/mitmproxy/test_flow.py
@@ -84,6 +84,17 @@ class TestSerialize:
         with pytest.raises(Exception, match="version"):
             list(r.stream())
 
+    def test_copy(self):
+        """
+        _backup may be shared across instances. That should not raise errors.
+        """
+        f = tflow.tflow()
+        f.backup()
+        f.request.path = "/foo"
+        f2 = f.copy()
+        f2.revert()
+        f.revert()
+
 
 class TestFlowMaster:
     def test_load_flow_reverse(self):


### PR DESCRIPTION
 - always refresh UI after flow is finished (refs #2616)
 - count currently active replay
 - make replay thread daemonic so that users can exit mitmproxy
   if replay hangs. This is not perfect yet, but vastly better
   than how it has been.