### PR TITLE
Command improvements

### DIFF
--- a/mitmproxy/addons/core.py
+++ b/mitmproxy/addons/core.py
@@ -8,6 +8,13 @@ from mitmproxy import optmanager
 from mitmproxy.net.http import status_codes
 
 
+FlowSetChoice = typing.NewType("FlowSetChoice", command.Choice)
+FlowSetChoice.options_command = "flow.set.options"
+
+FlowEncodeChoice = typing.NewType("FlowEncodeChoice", command.Choice)
+FlowEncodeChoice.options_command = "flow.encode.options"
+
+
 class Core:
     @command.command("set")
     def set(self, *spec: str) -> None:
@@ -98,17 +105,13 @@ class Core:
     @command.command("flow.set")
     def flow_set(
         self,
-        flows: typing.Sequence[flow.Flow], spec: str, sval: str
+        flows: typing.Sequence[flow.Flow],
+        spec: FlowSetChoice,
+        sval: str
     ) -> None:
         """
             Quickly set a number of common values on flows.
         """
-        opts = self.flow_set_options()
-        if spec not in opts:
-            raise exceptions.CommandError(
-                "Set spec must be one of: %s." % ", ".join(opts)
-            )
-
         val = sval  # type: typing.Union[int, str]
         if spec == "status_code":
             try:
@@ -190,13 +193,15 @@ class Core:
         ctx.log.alert("Toggled encoding on %s flows." % len(updated))
 
     @command.command("flow.encode")
-    def encode(self, flows: typing.Sequence[flow.Flow], part: str, enc: str) -> None:
+    def encode(
+        self,
+        flows: typing.Sequence[flow.Flow],
+        part: str,
+        enc: FlowEncodeChoice,
+    ) -> None:
         """
             Encode flows with a specified encoding.
         """
-        if enc not in self.encode_options():
-            raise exceptions.CommandError("Invalid encoding format: %s" % enc)
-
         updated = []
         for f in flows:
             p = getattr(f, part, None)
@@ -212,7 +217,6 @@ class Core:
     def encode_options(self) -> typing.Sequence[str]:
         """
             The possible values for an encoding specification.
-
         """
         return ["gzip", "deflate", "br"]
 

--- a/mitmproxy/addons/view.py
+++ b/mitmproxy/addons/view.py
@@ -238,7 +238,7 @@ class View(collections.Sequence):
     @command.command("view.order.options")
     def order_options(self) -> typing.Sequence[str]:
         """
-            A list of all the orders we support.
+            Choices supported by the console_order option.
         """
         return list(sorted(self.orders.keys()))
 

--- a/mitmproxy/tools/console/consoleaddons.py
+++ b/mitmproxy/tools/console/consoleaddons.py
@@ -31,6 +31,12 @@ console_layouts = [
     "horizontal",
 ]
 
+FocusChoice = typing.NewType("FocusChoice", command.Choice)
+FocusChoice.options_command = "console.edit.focus.options"
+
+FlowViewModeChoice = typing.NewType("FlowViewModeChoice", command.Choice)
+FlowViewModeChoice.options_command = "console.flowview.mode.options"
+
 
 class Logger:
     def log(self, evt):
@@ -111,8 +117,7 @@ class ConsoleAddon:
     @command.command("console.layout.options")
     def layout_options(self) -> typing.Sequence[str]:
         """
-            Returns the valid options for console layout. Use these by setting
-            the console_layout option.
+            Returns the available options for the consoler_layout option.
         """
         return ["single", "vertical", "horizontal"]
 
@@ -358,7 +363,7 @@ class ConsoleAddon:
         ]
 
     @command.command("console.edit.focus")
-    def edit_focus(self, part: str) -> None:
+    def edit_focus(self, part: FocusChoice) -> None:
         """
             Edit a component of the currently focused flow.
         """
@@ -431,7 +436,7 @@ class ConsoleAddon:
         self._grideditor().cmd_spawn_editor()
 
     @command.command("console.flowview.mode.set")
-    def flowview_mode_set(self, mode: str) -> None:
+    def flowview_mode_set(self, mode: FlowViewModeChoice) -> None:
         """
             Set the display mode for the current flow view.
         """

--- a/mitmproxy/tools/console/consoleaddons.py
+++ b/mitmproxy/tools/console/consoleaddons.py
@@ -431,26 +431,32 @@ class ConsoleAddon:
         self._grideditor().cmd_spawn_editor()
 
     @command.command("console.flowview.mode.set")
-    def flowview_mode_set(self) -> None:
+    def flowview_mode_set(self, mode: str) -> None:
         """
             Set the display mode for the current flow view.
         """
-        fv = self.master.window.current("flowview")
+        fv = self.master.window.current_window("flowview")
         if not fv:
             raise exceptions.CommandError("Not viewing a flow.")
         idx = fv.body.tab_offset
 
-        def callback(opt):
-            try:
-                self.master.commands.call_args(
-                    "view.setval",
-                    ["@focus", "flowview_mode_%s" % idx, opt]
-                )
-            except exceptions.CommandError as e:
-                signals.status_message.send(message=str(e))
+        if mode not in [i.name.lower() for i in contentviews.views]:
+            raise exceptions.CommandError("Invalid flowview mode.")
 
-        opts = [i.name.lower() for i in contentviews.views]
-        self.master.overlay(overlay.Chooser(self.master, "Mode", opts, "", callback))
+        try:
+            self.master.commands.call_args(
+                "view.setval",
+                ["@focus", "flowview_mode_%s" % idx, mode]
+            )
+        except exceptions.CommandError as e:
+            signals.status_message.send(message=str(e))
+
+    @command.command("console.flowview.mode.options")
+    def flowview_mode_options(self) -> typing.Sequence[str]:
+        """
+            Returns the valid options for the flowview mode.
+        """
+        return [i.name.lower() for i in contentviews.views]
 
     @command.command("console.flowview.mode")
     def flowview_mode(self) -> str:

--- a/mitmproxy/tools/console/consoleaddons.py
+++ b/mitmproxy/tools/console/consoleaddons.py
@@ -340,6 +340,9 @@ class ConsoleAddon:
 
     @command.command("console.edit.focus.options")
     def edit_focus_options(self) -> typing.Sequence[str]:
+        """
+            Possible components for console.edit.focus.
+        """
         return [
             "cookies",
             "form",
@@ -357,7 +360,7 @@ class ConsoleAddon:
     @command.command("console.edit.focus")
     def edit_focus(self, part: str) -> None:
         """
-            Edit the query of the current focus.
+            Edit a component of the currently focused flow.
         """
         if part == "cookies":
             self.master.switch_view("edit_focus_cookies")

--- a/mitmproxy/tools/console/defaultkeys.py
+++ b/mitmproxy/tools/console/defaultkeys.py
@@ -116,7 +116,15 @@ def map(km):
         "View flow body in an external viewer"
     )
     km.add("p", "view.focus.prev", ["flowview"], "Go to previous flow")
-    km.add("m", "console.flowview.mode.set", ["flowview"], "Set flow view mode")
+    km.add(
+        "m",
+        """
+        console.choose.cmd Mode console.flowview.mode.options
+        console.flowview.mode.set {choice}
+        """,
+        ["flowview"],
+        "Set flow view mode"
+    )
     km.add(
         "z",
         """

--- a/mitmproxy/utils/typecheck.py
+++ b/mitmproxy/utils/typecheck.py
@@ -31,7 +31,7 @@ def check_command_type(value: typing.Any, typeinfo: typing.Any) -> bool:
                 return False
     elif value is None and typeinfo is None:
         return True
-    elif not isinstance(value, typeinfo):
+    elif (not isinstance(typeinfo, type)) or (not isinstance(value, typeinfo)):
         return False
     return True
 

--- a/test/mitmproxy/addons/test_core.py
+++ b/test/mitmproxy/addons/test_core.py
@@ -69,9 +69,6 @@ def test_flow_set():
         f = tflow.tflow(resp=True)
         assert sa.flow_set_options()
 
-        with pytest.raises(exceptions.CommandError):
-            sa.flow_set([f], "flibble", "post")
-
         assert f.request.method != "post"
         sa.flow_set([f], "method", "post")
         assert f.request.method == "POST"
@@ -125,9 +122,6 @@ def test_encoding():
         assert f.request.headers["content-encoding"] == "deflate"
         sa.encode_toggle([f], "request")
         assert "content-encoding" not in f.request.headers
-
-        with pytest.raises(exceptions.CommandError):
-            sa.encode([f], "request", "invalid")
 
 
 def test_options(tmpdir):


### PR DESCRIPTION
The big thing in this PR is a mechanism that lets us specify that a command argument should be one of a set of options returned by another command. This is used for runtime checking of invoked commands.

The mechanism here is extremely ugly, but works. We want to construct types that have two attributes - they should be resolved as *str* by mypy, and they need an additional attribute for us to work with at runtime. The annotations mechanism is very general, and makes this a piece of cake. Unfortunately mypy itself is super restrictive about what it accepts as a type specification. Almost any attempt to construct these types at runtime is doomed to fail. There is some discussion about this on the mypy issue tracker, but nothing immediate on the cards to improve things. I'm open to suggestions. 


