### PR TITLE
Introduce @command.argument

### DIFF
--- a/mitmproxy/addons/core.py
+++ b/mitmproxy/addons/core.py
@@ -8,13 +8,6 @@ from mitmproxy import optmanager
 from mitmproxy.net.http import status_codes
 
 
-FlowSetChoice = typing.NewType("FlowSetChoice", command.Choice)
-FlowSetChoice.options_command = "flow.set.options"
-
-FlowEncodeChoice = typing.NewType("FlowEncodeChoice", command.Choice)
-FlowEncodeChoice.options_command = "flow.encode.options"
-
-
 class Core:
     @command.command("set")
     def set(self, *spec: str) -> None:
@@ -103,10 +96,11 @@ class Core:
         ]
 
     @command.command("flow.set")
+    @command.argument("spec", type=command.Choice("flow.set.options"))
     def flow_set(
         self,
         flows: typing.Sequence[flow.Flow],
-        spec: FlowSetChoice,
+        spec: str,
         sval: str
     ) -> None:
         """
@@ -193,11 +187,12 @@ class Core:
         ctx.log.alert("Toggled encoding on %s flows." % len(updated))
 
     @command.command("flow.encode")
+    @command.argument("enc", type=command.Choice("flow.encode.options"))
     def encode(
         self,
         flows: typing.Sequence[flow.Flow],
         part: str,
-        enc: FlowEncodeChoice,
+        enc: str,
     ) -> None:
         """
             Encode flows with a specified encoding.

--- a/mitmproxy/command.py
+++ b/mitmproxy/command.py
@@ -19,7 +19,8 @@ Cuts = typing.Sequence[
 ]
 
 
-Path = typing.NewType("Path", str)
+class Path(str):
+    pass
 
 
 def typename(t: type, ret: bool) -> str:
@@ -37,10 +38,8 @@ def typename(t: type, ret: bool) -> str:
         return "[cuts]" if ret else "cutspec"
     elif t == flow.Flow:
         return "flow"
-    elif t == Path:
-        return "path"
     elif issubclass(t, (str, int, bool)):
-        return t.__name__
+        return t.__name__.lower()
     else:  # pragma: no cover
         raise NotImplementedError(t)
 
@@ -172,8 +171,6 @@ def parsearg(manager: CommandManager, spec: str, argtype: type) -> typing.Any:
             raise exceptions.CommandError(
                 "Invalid choice: see %s for options" % cmd
             )
-        return spec
-    if argtype == Path:
         return spec
     elif issubclass(argtype, str):
         return spec

--- a/mitmproxy/tools/console/consoleaddons.py
+++ b/mitmproxy/tools/console/consoleaddons.py
@@ -31,12 +31,6 @@ console_layouts = [
     "horizontal",
 ]
 
-FocusChoice = typing.NewType("FocusChoice", command.Choice)
-FocusChoice.options_command = "console.edit.focus.options"
-
-FlowViewModeChoice = typing.NewType("FlowViewModeChoice", command.Choice)
-FlowViewModeChoice.options_command = "console.flowview.mode.options"
-
 
 class Logger:
     def log(self, evt):
@@ -363,7 +357,8 @@ class ConsoleAddon:
         ]
 
     @command.command("console.edit.focus")
-    def edit_focus(self, part: FocusChoice) -> None:
+    @command.argument("part", type=command.Choice("console.edit.focus.options"))
+    def edit_focus(self, part: str) -> None:
         """
             Edit a component of the currently focused flow.
         """
@@ -436,7 +431,8 @@ class ConsoleAddon:
         self._grideditor().cmd_spawn_editor()
 
     @command.command("console.flowview.mode.set")
-    def flowview_mode_set(self, mode: FlowViewModeChoice) -> None:
+    @command.argument("mode", type=command.Choice("console.flowview.mode.options"))
+    def flowview_mode_set(self, mode: str) -> None:
         """
             Set the display mode for the current flow view.
         """

--- a/mitmproxy/utils/typecheck.py
+++ b/mitmproxy/utils/typecheck.py
@@ -31,7 +31,7 @@ def check_command_type(value: typing.Any, typeinfo: typing.Any) -> bool:
                 return False
     elif value is None and typeinfo is None:
         return True
-    elif (not isinstance(typeinfo, type)) or (not isinstance(value, typeinfo)):
+    elif not isinstance(value, typeinfo):
         return False
     return True
 


### PR DESCRIPTION
This makes it possible to specify more specific type annotations at runtime, so that both mypy and our command system are happy. The `.argument(name, type=)` syntax is similar to click's, so it should be fairly extensible if we need it.