### PR TITLE
Fix #2620

### DIFF
--- a/mitmproxy/tools/console/window.py
+++ b/mitmproxy/tools/console/window.py
@@ -156,12 +156,14 @@ class Window(urwid.Frame):
             w = urwid.Pile(
                 [
                     wrapped(i) for i, s in enumerate(self.stacks)
-                ]
+                ],
+                focus_item=self.pane
             )
         else:
             w = urwid.Columns(
                 [wrapped(i) for i, s in enumerate(self.stacks)],
-                dividechars=1
+                dividechars=1,
+                focus_column=self.pane
             )
 
         self.body = urwid.AttrWrap(w, "background")
@@ -270,13 +272,12 @@ class Window(urwid.Frame):
             return True
 
     def keypress(self, size, k):
-        if self.focus_part == "footer":
-            return super().keypress(size, k)
-        else:
-            fs = self.focus_stack().top_widget()
-            k = fs.keypress(size, k)
-            if k:
-                return self.master.keymap.handle(fs.keyctx, k)
+        k = super().keypress(size, k)
+        if k:
+            return self.master.keymap.handle(
+                self.focus_stack().top_widget().keyctx,
+                k
+            )
 
 
 class Screen(urwid.raw_display.Screen):


### PR DESCRIPTION
We previously had the problem that overriding keypress() skipped the proper calculation of the top widget's size, leading to broken scrolling behavior in the flowlist. We now always use urwid.Frame's keypress method, but we make sure that urwid.Pile and urwid.Columns delegate to the currently focused component.

@cortesi: this seems suspiciously simple - anything I missed?