### PR TITLE
Allow shorthands for command.Choice strings

### DIFF
--- a/mitmproxy/command.py
+++ b/mitmproxy/command.py
@@ -233,9 +233,19 @@ def parsearg(manager: CommandManager, spec: str, argtype: type) -> typing.Any:
         cmd = argtype.options_command
         opts = manager.call(cmd)
         if spec not in opts:
-            raise exceptions.CommandError(
-                "Invalid choice: see %s for options" % cmd
-            )
+            matches = [
+                x for x in opts
+                if x.startswith(spec)
+            ]
+            if len(matches) == 1:
+                return matches[0]
+            else:
+                raise exceptions.CommandError(
+                    "%s choice: see %s for options" % (
+                        "Ambigious" if matches else "Invalid",
+                        cmd
+                    )
+                )
         return spec
     elif issubclass(argtype, str):
         return spec

--- a/test/mitmproxy/test_command.py
+++ b/test/mitmproxy/test_command.py
@@ -218,9 +218,16 @@ def test_parsearg():
         assert command.parsearg(
             tctx.master.commands, "one", command.Choice("choices"),
         ) == "one"
-        with pytest.raises(exceptions.CommandError):
+        assert command.parsearg(
+            tctx.master.commands, "o", command.Choice("choices"),
+        ) == "one"
+        with pytest.raises(exceptions.CommandError, message="Invalid"):
             assert command.parsearg(
                 tctx.master.commands, "invalid", command.Choice("choices"),
+            )
+        with pytest.raises(exceptions.CommandError, message="Ambigious"):
+            assert command.parsearg(
+                tctx.master.commands, "t", command.Choice("choices"),
             )
 
         assert command.parsearg(


### PR DESCRIPTION
Not feeling very strong about this, but this seems to be a useful addition to me.