### PR TITLE
Don't display contentview errors too prominently.

### DIFF
--- a/mitmproxy/tools/console/eventlog.py
+++ b/mitmproxy/tools/console/eventlog.py
@@ -21,6 +21,7 @@ class EventLog(urwid.ListBox, layoutwidget.LayoutWidget):
 
         master.events.sig_add.connect(self.add_event)
         master.events.sig_refresh.connect(self.refresh_events)
+        self.master.options.subscribe(self.refresh_events, ["verbosity"])
         self.refresh_events()
 
         super().__init__(self.walker)
@@ -54,7 +55,7 @@ class EventLog(urwid.ListBox, layoutwidget.LayoutWidget):
         if self.master.options.console_focus_follow:
             self.walker.set_focus(len(self.walker) - 1)
 
-    def refresh_events(self, event_store=None):
+    def refresh_events(self, *_):
         self.walker.clear()
         for event in self.master.events.data:
             self.add_event(None, event)

--- a/mitmproxy/tools/console/flowview.py
+++ b/mitmproxy/tools/console/flowview.py
@@ -116,7 +116,7 @@ class FlowDetails(tabs.Tabs):
             viewmode, message
         )
         if error:
-            self.master.add_log(error, "error")
+            self.master.add_log(error, "debug")
         # Give hint that you have to tab for the response.
         if description == "No content" and isinstance(message, http.HTTPRequest):
             description = "No request content (press tab to view response)"


### PR DESCRIPTION
This fixes the second bullet point at https://github.com/mitmproxy/mitmproxy/issues/2658#issue-280835169