### PR TITLE
Test that default key bindings are valid commands

### DIFF
--- a/test/mitmproxy/tools/console/test_defaultkeys.py
+++ b/test/mitmproxy/tools/console/test_defaultkeys.py
@@ -1,0 +1,23 @@
+from mitmproxy.test.tflow import tflow
+from mitmproxy.tools.console import defaultkeys
+from mitmproxy.tools.console import keymap
+from mitmproxy.tools.console import master
+from mitmproxy import command
+
+
+def test_commands_exist():
+    km = keymap.Keymap(None)
+    defaultkeys.map(km)
+    assert km.bindings
+    m = master.ConsoleMaster(None)
+    m.load_flow(tflow())
+
+    for binding in km.bindings:
+        cmd, *args = command.lexer(binding.command)
+        assert cmd in m.commands.commands
+
+        cmd_obj = m.commands.commands[cmd]
+        try:
+            cmd_obj.prepare_args(args)
+        except Exception as e:
+            raise ValueError("Invalid command: {}".format(binding.command)) from e


### PR DESCRIPTION
This seems to generally work, but it's currently complains about https://github.com/mitmproxy/mitmproxy/issues/2693 and fails. Not sure if there are further issues beyond that.