### PR TITLE
@concurrent decorator works for class methods.

### DIFF
--- a/mitmproxy/script/concurrent.py
+++ b/mitmproxy/script/concurrent.py
@@ -18,7 +18,9 @@ def concurrent(fn):
         )
 
     def _concurrent(*args):
-        # Support @concurrent for class-based addons
+        # When annotating classmethods, "self" is passed as the first argument.
+        # To support both class and static methods, we accept a variable number of arguments
+        # and take the last one as our actual hook object.
         obj = args[-1]
 
         def run():

--- a/mitmproxy/script/concurrent.py
+++ b/mitmproxy/script/concurrent.py
@@ -17,9 +17,11 @@ def concurrent(fn):
             "Concurrent decorator not supported for '%s' method." % fn.__name__
         )
 
-    def _concurrent(obj):
+    def _concurrent(*args):
+        obj = args[0] if len(args) == 1 else args[1]
+
         def run():
-            fn(obj)
+            fn(*args)
             if obj.reply.state == "taken":
                 if not obj.reply.has_message:
                     obj.reply.ack()
@@ -29,8 +31,5 @@ def concurrent(fn):
             "script.concurrent (%s)" % fn.__name__,
             target=run
         ).start()
-    # Support @concurrent for class-based addons
-    if "." in fn.__qualname__:
-        return staticmethod(_concurrent)
-    else:
-        return _concurrent
+
+    return _concurrent

--- a/mitmproxy/script/concurrent.py
+++ b/mitmproxy/script/concurrent.py
@@ -18,7 +18,8 @@ def concurrent(fn):
         )
 
     def _concurrent(*args):
-        obj = args[0] if len(args) == 1 else args[1]
+        # Support @concurrent for class-based addons
+        obj = args[-1]
 
         def run():
             fn(*args)

--- a/test/mitmproxy/data/addonscripts/concurrent_decorator_class.py
+++ b/test/mitmproxy/data/addonscripts/concurrent_decorator_class.py
@@ -5,7 +5,7 @@ from mitmproxy.script import concurrent
 class ConcurrentClass:
 
     @concurrent
-    def request(flow):
+    def request(self, flow):
         time.sleep(0.1)
 
 


### PR DESCRIPTION
``` python
import time

from mitmproxy.script import concurrent


class ConcurrentClass:

    @concurrent  # Remove this and see what happens
    def request(self, flow):
        # You don't want to use mitmproxy.ctx from a different thread
        print("handle request: %s%s" % (flow.request.host, flow.request.path))
        time.sleep(5)
        print("start  request: %s%s" % (flow.request.host, flow.request.path))


addons = [ConcurrentClass()]
```

`@concurrent` only works for class staticmethod for now, I make it works for normal class method.