### PR TITLE
Move trust instructions for ios

### DIFF
--- a/docs/certinstall.rst
+++ b/docs/certinstall.rst
@@ -42,13 +42,10 @@ See http://jasdev.me/intercepting-ios-traffic
 
 and https://web.archive.org/web/20150920082614/http://kb.mit.edu/confluence/pages/viewpage.action?pageId=152600377
 
-On iOS 10.3 and onwards, you also need to enable full trust for the mitm root certificate after installing from http://mitm.it
+On iOS 10.3 and onwards, you also need to enable full trust for the mitmproxy root certificate:
 
-1. Open the Settings app
-2. Tap General
-3. Tap About
-4. Scroll to bottom. Tap Certificate Trust Settings
-5. Turn on the switch for mitmproxy
+1. Go to Settings > General > About > Certificate Trust Settings. 
+2. Under "Enable full trust for root certificates", turn on trust for the mitmproxy certificate.
 
 iOS Simulator
 ^^^^^^^^^^^^^

--- a/docs/certinstall.rst
+++ b/docs/certinstall.rst
@@ -24,10 +24,6 @@ something like this:
 Click on the relevant icon, follow the setup instructions for the platform
 you're on and you are good to go.
 
-For iOS version 10.3 or up, you need to make sure ``mitmproxy`` is enabled in 
-``Certificate Trust Settings``, you can check it by going to 
-``Settings > General > About > Certificate Trust Settings``.
-
 Installing the mitmproxy CA certificate manually
 ------------------------------------------------
 
@@ -39,13 +35,20 @@ documentation for some common platforms.
 The mitmproxy CA cert is located in ``~/.mitmproxy`` after it has been generated at the first
 start of mitmproxy.
 
-
 iOS
 ^^^
 
 See http://jasdev.me/intercepting-ios-traffic
 
 and https://web.archive.org/web/20150920082614/http://kb.mit.edu/confluence/pages/viewpage.action?pageId=152600377
+
+On iOS 10.3 and onwards, you also need to enable full trust for the mitm root certificate after installing from http://mitm.it
+
+1. Open the Settings app
+2. Tap General
+3. Tap About
+4. Scroll to bottom. Tap Certificate Trust Settings
+5. Turn on the switch for mitmproxy
 
 iOS Simulator
 ^^^^^^^^^^^^^


### PR DESCRIPTION
Actually, these instructions were mostly already there, but not under the iOS section which made them hard to find (I completely missed them). Put them in the correct section and expand them a little. 