### PR TITLE
Display "*" when listening on all interfaces

### DIFF
--- a/mitmproxy/utils/human.py
+++ b/mitmproxy/utils/human.py
@@ -80,6 +80,8 @@ def format_address(address: tuple) -> str:
     """
     try:
         host = ipaddress.ip_address(address[0])
+        if host.is_unspecified:
+            return "*:{}".format(address[1])
         if isinstance(host, ipaddress.IPv4Address):
             return "{}:{}".format(str(host), address[1])
         # If IPv6 is mapped to IPv4

--- a/test/mitmproxy/utils/test_human.py
+++ b/test/mitmproxy/utils/test_human.py
@@ -54,3 +54,5 @@ def test_format_address():
     assert human.format_address(("::ffff:127.0.0.1", "54010", "0", "0")) == "127.0.0.1:54010"
     assert human.format_address(("127.0.0.1", "54010")) == "127.0.0.1:54010"
     assert human.format_address(("example.com", "54010")) == "example.com:54010"
+    assert human.format_address(("::", "8080")) == "*:8080"
+    assert human.format_address(("0.0.0.0", "8080")) == "*:8080"


### PR DESCRIPTION
The set of people who understand "0.0.0.0" (and/or "::") is a subset of
the set of people who understand "*", so we can make things easier to understand
by using the less technical notation.

Empirical Evidence:
 - https://discourse.mitmproxy.org/t/unable-to-use-mitmproxy-on-windows/735
 - https://discourse.mitmproxy.org/t/how-to-view-the-proxy-servers-url/23