### PR TITLE
Parse Commands in POSIX mode

### DIFF
--- a/mitmproxy/command.py
+++ b/mitmproxy/command.py
@@ -24,7 +24,7 @@ def verify_arg_signature(f: typing.Callable, args: list, kwargs: dict) -> None:
 
 def lexer(s):
     # mypy mis-identifies shlex.shlex as abstract
-    lex = shlex.shlex(s)  # type: ignore
+    lex = shlex.shlex(s, posix=True)  # type: ignore
     lex.wordchars += "."
     lex.whitespace_split = True
     lex.commenters = ''


### PR DESCRIPTION
If posix=False, quotes are not stripped from parsed tokens:

```python
>>> list(shlex.shlex("foo 'bar baz'"))
['foo', "'bar baz'"]
>>> list(shlex.shlex("foo 'bar baz'", posix=True))
['foo', 'bar baz']
```

@cortesi, was this intentionally left in non-posix mode? I haven't fully looked into this, but I believe this breaks flowspec filter resolution at the moment: `replay.client "~m GET"` does not work, `replay.client ~s` does.