### PR TITLE
Fixing #1833

### DIFF
--- a/mitmproxy/tools/console/flowview.py
+++ b/mitmproxy/tools/console/flowview.py
@@ -153,7 +153,8 @@ class FlowDetails(tabs.Tabs):
     def conn_text(self, conn):
         if conn:
             txt = common.format_keyvals(
-                [(h + ":", v) for (h, v) in conn.headers.items(multi=True)],
+                [(h + ":", repr(v)[1:-1])
+                 for (h, v) in conn.headers.items(multi=True)],
                 key = "header",
                 val = "text"
             )


### PR DESCRIPTION
Fix for #1833.
There is also more readable 
`[(h + ":", v.encode("unicode_escape")) for (h, v) in conn.headers.items(multi=True)]`,
 but I thought, that there was no a good reason to change `str` type of second element of tuple to `bytes`.

Applying `pathoc -c example.com:80 localhost:8080 'get:/:u"f\too\tba\tr"'`, we will get:
![screenshot from 2018-01-05 14-59-58](https://user-images.githubusercontent.com/20267977/34610289-26962ece-f229-11e7-88a5-2f303a2a9880.png)
  