### PR TITLE
Catch file exceptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ MANIFEST
 .cache/
 .tox*/
 build/
+dist/
 mitmproxy/contrib/kaitaistruct/*.ksy
 
 # UI

--- a/mitmproxy/addons/export.py
+++ b/mitmproxy/addons/export.py
@@ -3,6 +3,7 @@ import typing
 from mitmproxy import command
 from mitmproxy import flow
 from mitmproxy import exceptions
+from mitmproxy import ctx
 from mitmproxy.utils import strutils
 from mitmproxy.net.http.http1 import assemble
 import mitmproxy.types
@@ -58,11 +59,14 @@ class Export():
             raise exceptions.CommandError("No such export format: %s" % fmt)
         func = formats[fmt]  # type: typing.Any
         v = func(f)
-        with open(path, "wb") as fp:
-            if isinstance(v, bytes):
-                fp.write(v)
-            else:
-                fp.write(v.encode("utf-8"))
+        try:
+            with open(path, "wb") as fp:
+                if isinstance(v, bytes):
+                    fp.write(v)
+                else:
+                    fp.write(v.encode("utf-8"))
+        except (IsADirectoryError, PermissionError) as e:
+            ctx.log.error(e)
 
     @command.command("export.clip")
     def clip(self, fmt: str, f: flow.Flow) -> None:

--- a/mitmproxy/tools/console/consoleaddons.py
+++ b/mitmproxy/tools/console/consoleaddons.py
@@ -460,13 +460,16 @@ class ConsoleAddon:
             Save data to file as a CSV.
         """
         rows = self._grideditor().value
-        with open(path, "w", newline='', encoding="utf8") as fp:
-            writer = csv.writer(fp)
-            for row in rows:
-                writer.writerow(
-                    [strutils.always_str(x) or "" for x in row]  # type: ignore
-                )
-        ctx.log.alert("Saved %s rows as CSV." % (len(rows)))
+        try:
+            with open(path, "w", newline='', encoding="utf8") as fp:
+                writer = csv.writer(fp)
+                for row in rows:
+                    writer.writerow(
+                        [strutils.always_str(x) or "" for x in row]  # type: ignore
+                    )
+            ctx.log.alert("Saved %s rows as CSV." % (len(rows)))
+        except (IsADirectoryError, PermissionError) as e:
+            ctx.log.error(e)
 
     @command.command("console.grideditor.editor")
     def grideditor_editor(self) -> None:

--- a/test/mitmproxy/test_taddons.py
+++ b/test/mitmproxy/test_taddons.py
@@ -11,6 +11,8 @@ def test_recordingmaster():
         ctx.log.error("foo")
         assert not tctx.master.has_log("foo", level="debug")
         assert tctx.master.has_log("foo", level="error")
+        assert tctx.master.has_log("Permission denied", level="error")
+        assert tctx.master.has_log("Is a directory", level="error")
 
 
 def test_dumplog():


### PR DESCRIPTION
Fixes #2750.

This PR catches and logs any exceptions when exporting flow either by selecting a specific flow or through the parent user interface (and it also generated an `.egg` file in `dist/` for me, so `dist/` goes to `.gitignore`).