### PR TITLE
Fix #2767

### DIFF
--- a/mitmproxy/addons/proxyauth.py
+++ b/mitmproxy/addons/proxyauth.py
@@ -146,14 +146,14 @@ class ProxyAuth:
                         )
                 elif ctx.options.proxyauth.startswith("ldap"):
                     parts = ctx.options.proxyauth.split(':')
-                    security = parts[0]
-                    ldap_server = parts[1]
-                    dn_baseauth = parts[2]
-                    password_baseauth = parts[3]
                     if len(parts) != 5:
                         raise exceptions.OptionsError(
                             "Invalid ldap specification"
                         )
+                    security = parts[0]
+                    ldap_server = parts[1]
+                    dn_baseauth = parts[2]
+                    password_baseauth = parts[3]
                     if security == "ldaps":
                         server = ldap3.Server(ldap_server, use_ssl=True)
                     elif security == "ldap":

--- a/test/mitmproxy/addons/test_proxyauth.py
+++ b/test/mitmproxy/addons/test_proxyauth.py
@@ -190,7 +190,7 @@ class TestProxyAuth:
             with pytest.raises(exceptions.OptionsError):
                 ctx.configure(up, proxyauth="ldap:test:test:test")
 
-            with pytest.raises(IndexError):
+            with pytest.raises(exceptions.OptionsError):
                 ctx.configure(up, proxyauth="ldap:fake_serveruid=?dc=example,dc=com:person")
 
             with pytest.raises(exceptions.OptionsError):


### PR DESCRIPTION
As @Kriechi said https://github.com/mitmproxy/mitmproxy/issues/2767#issuecomment-355778307,
I just moved the [check](https://github.com/mitmproxy/mitmproxy/blob/012b938254e1bf14d47447d5f3661d3299d8f582/mitmproxy/addons/proxyauth.py#L153-L156) right after the split.

Result:
![image](https://user-images.githubusercontent.com/20267977/34653831-ab08c3ce-f3fa-11e7-94cd-c8e70bc1b339.png)
