### PR TITLE
Fix #2760

### DIFF
--- a/mitmproxy/addons/view.py
+++ b/mitmproxy/addons/view.py
@@ -444,8 +444,7 @@ class View(collections.Sequence):
         try:
             req = http.HTTPRequest.make(method.upper(), url)
         except ValueError as e:
-            ctx.log.error(e)
-            return
+            raise exceptions.CommandError("Invalid URL: %s" % e)
         c = connections.ClientConnection.make_dummy(("", 0))
         s = connections.ServerConnection.make_dummy((req.host, req.port))
         f = http.HTTPFlow(c, s)

--- a/mitmproxy/addons/view.py
+++ b/mitmproxy/addons/view.py
@@ -441,7 +441,11 @@ class View(collections.Sequence):
 
     @command.command("view.create")
     def create(self, method: str, url: str) -> None:
-        req = http.HTTPRequest.make(method.upper(), url)
+        try:
+            req = http.HTTPRequest.make(method.upper(), url)
+        except ValueError as e:
+            ctx.log.error(e)
+            return
         c = connections.ClientConnection.make_dummy(("", 0))
         s = connections.ServerConnection.make_dummy((req.host, req.port))
         f = http.HTTPFlow(c, s)

--- a/test/mitmproxy/addons/test_view.py
+++ b/test/mitmproxy/addons/test_view.py
@@ -147,6 +147,9 @@ def test_create():
         assert v[0].request.url == "http://foo.com/"
         v.create("get", "http://foo.com")
         assert len(v) == 2
+        v.create("get", "http://foo.com\\")
+        v.create("get", "http://")
+        assert len(v) == 2
 
 
 def test_orders():

--- a/test/mitmproxy/addons/test_view.py
+++ b/test/mitmproxy/addons/test_view.py
@@ -147,9 +147,10 @@ def test_create():
         assert v[0].request.url == "http://foo.com/"
         v.create("get", "http://foo.com")
         assert len(v) == 2
-        v.create("get", "http://foo.com\\")
-        v.create("get", "http://")
-        assert len(v) == 2
+        with pytest.raises(exceptions.CommandError, match="Invalid URL"):
+            v.create("get", "http://foo.com\\")
+        with pytest.raises(exceptions.CommandError, match="Invalid URL"):
+            v.create("get", "http://")
 
 
 def test_orders():


### PR DESCRIPTION
Caught and handled in  `ValueError` the view.create command, as @mhils suggested.
Added two error URL  test case in the test.