### PR TITLE
Fix crash when searching

### DIFF
--- a/mitmproxy/tools/console/commander/commander.py
+++ b/mitmproxy/tools/console/commander/commander.py
@@ -178,5 +178,5 @@ class CommandEdit(urwid.WidgetWrap):
         x, y = calc_coords(self._w.get_text()[0], trans, p)
         return x, y
 
-    def get_value(self):
+    def get_edit_text(self):
         return self.cbuf.text

--- a/mitmproxy/tools/console/statusbar.py
+++ b/mitmproxy/tools/console/statusbar.py
@@ -101,7 +101,7 @@ class ActionBar(urwid.WidgetWrap):
                 elif k in self.onekey:
                     self.prompt_execute(k)
             elif k == "enter":
-                self.prompt_execute(self._w.get_value())
+                self.prompt_execute(self._w.get_edit_text())
             else:
                 if common.is_keypress(k):
                     self._w.keypress(size, k)


### PR DESCRIPTION
ref: #2776 
Not sure if it's the best fix.
Type of `self._w` can be `urwid.Edit` or `commander.CommandEdit`. 
`urwid.Edit` doesn't have a get_value method so I changed commander.CommandEdit's method to match that of urwid.Edit's 
If you want to keep the function name we can check for the type of `self._w` before extracting the text 