### PR TITLE
Fix #2766.

### DIFF
--- a/mitmproxy/addons/clientplayback.py
+++ b/mitmproxy/addons/clientplayback.py
@@ -35,6 +35,9 @@ class ClientPlayback:
         """
             Replay requests from flows.
         """
+        for f in flows:
+            if f.live:
+                raise exceptions.CommandError("Can't replay live flow.")
         self.flows = list(flows)
         ctx.log.alert("Replaying %s flows." % len(self.flows))
         ctx.master.addons.trigger("update", [])

--- a/test/mitmproxy/addons/test_clientplayback.py
+++ b/test/mitmproxy/addons/test_clientplayback.py
@@ -52,6 +52,10 @@ class TestClientPlayback:
             cp.stop_replay()
             assert not cp.flows
 
+            df = tflow.DummyFlow(tflow.tclient_conn(), tflow.tserver_conn(), True)
+            with pytest.raises(exceptions.CommandError, match="Can't replay live flow."):
+                cp.start_replay([df])
+
     def test_load_file(self, tmpdir):
         cp = clientplayback.ClientPlayback()
         with taddons.context():


### PR DESCRIPTION
Check whether the flows are live before doing a replay.