### PR TITLE
Issue 2399

### DIFF
--- a/mitmproxy/net/http/url.py
+++ b/mitmproxy/net/http/url.py
@@ -78,7 +78,7 @@ def encode(s: Sequence[Tuple[str, str]], similar_to: str=None) -> str:
 
     if remove_trailing_equal:
         encoded = encoded.replace("=&", "&")
-        if encoded[-1] == '=':
+        if encoded and encoded[-1] == '=':
             encoded = encoded[:-1]
 
     return encoded

--- a/mitmproxy/net/http/url.py
+++ b/mitmproxy/net/http/url.py
@@ -76,9 +76,9 @@ def encode(s: Sequence[Tuple[str, str]], similar_to: str=None) -> str:
 
     encoded = urllib.parse.urlencode(s, False, errors="surrogateescape")
 
-    if remove_trailing_equal:
+    if encoded and remove_trailing_equal:
         encoded = encoded.replace("=&", "&")
-        if encoded and encoded[-1] == '=':
+        if encoded[-1] == '=':
             encoded = encoded[:-1]
 
     return encoded

--- a/test/mitmproxy/net/http/test_url.py
+++ b/test/mitmproxy/net/http/test_url.py
@@ -108,6 +108,7 @@ def test_empty_key_trailing_equal_sign():
 def test_encode():
     assert url.encode([('foo', 'bar')])
     assert url.encode([('foo', surrogates)])
+    assert not url.encode([], similar_to="justatext")
 
 
 def test_decode():


### PR DESCRIPTION
A bug appeared in this line https://github.com/mitmproxy/mitmproxy/blob/master/mitmproxy/net/http/request.py#L444
If `form_data` is an empty list and `similar_to` is a string that makes internal `remove_trailing_equal` become `True`, then an exception occurs.
I just check, whether internal `encoded` is empty or not.