### PR TITLE
Fix #2752

### DIFF
--- a/mitmproxy/tools/console/consoleaddons.py
+++ b/mitmproxy/tools/console/consoleaddons.py
@@ -380,7 +380,8 @@ class ConsoleAddon:
         if not flow:
             raise exceptions.CommandError("No flow selected.")
         if part in ("response-headers", "response-body", "set-cookies"):
-            flow.response = http.HTTPResponse.make()
+            if flow.response is None:
+                flow.response = http.HTTPResponse.make()
         if part == "cookies":
             self.master.switch_view("edit_focus_cookies")
         elif part == "form":

--- a/mitmproxy/tools/console/consoleaddons.py
+++ b/mitmproxy/tools/console/consoleaddons.py
@@ -379,9 +379,10 @@ class ConsoleAddon:
         # but for now it is.
         if not flow:
             raise exceptions.CommandError("No flow selected.")
-        if part in ("response-headers", "response-body", "set-cookies"):
-            if flow.response is None:
-                flow.response = http.HTTPResponse.make()
+        is_response_related = part in ("response-headers", "response-body",
+                                       "set-cookies")
+        if is_response_related and flow.response is None:
+            flow.response = http.HTTPResponse.make()
         if part == "cookies":
             self.master.switch_view("edit_focus_cookies")
         elif part == "form":

--- a/mitmproxy/tools/console/consoleaddons.py
+++ b/mitmproxy/tools/console/consoleaddons.py
@@ -379,9 +379,11 @@ class ConsoleAddon:
         # but for now it is.
         if not flow:
             raise exceptions.CommandError("No flow selected.")
-        is_response_related = part in ("response-headers", "response-body",
-                                       "set-cookies")
-        if is_response_related and flow.response is None:
+        require_dummy_response = (
+            part in ("response-headers", "response-body", "set-cookies") and
+            flow.response is None
+        )
+        if require_dummy_response:
             flow.response = http.HTTPResponse.make()
         if part == "cookies":
             self.master.switch_view("edit_focus_cookies")

--- a/mitmproxy/tools/console/consoleaddons.py
+++ b/mitmproxy/tools/console/consoleaddons.py
@@ -5,6 +5,7 @@ from mitmproxy import ctx
 from mitmproxy import command
 from mitmproxy import exceptions
 from mitmproxy import flow
+from mitmproxy import http
 from mitmproxy import contentviews
 from mitmproxy.utils import strutils
 import mitmproxy.types
@@ -378,6 +379,8 @@ class ConsoleAddon:
         # but for now it is.
         if not flow:
             raise exceptions.CommandError("No flow selected.")
+        if part in ("response-headers", "response-body", "set-cookies"):
+            flow.response = http.HTTPResponse.make()
         if part == "cookies":
             self.master.switch_view("edit_focus_cookies")
         elif part == "form":
@@ -395,8 +398,6 @@ class ConsoleAddon:
                 message = flow.request
             else:
                 message = flow.response
-            if not message:
-                raise exceptions.CommandError("Flow has no {}.".format(part.split("-")[0]))
             c = self.master.spawn_editor(message.get_content(strict=False) or b"")
             # Fix an issue caused by some editors when editing a
             # request/response body. Many editors make it hard to save a


### PR DESCRIPTION
There were 2 variants of how to fix it:
1) Raise `CommandError`, if flow hasn't response. So, when we try to edit response-related part of flow, mitmproxy will display `Flow has no response` in status bar. But it contradicts the text in empty response tab - `Press e and edit any aspect to add one` and the behaviour of 2.0.X version.
2) Make something like dummy response.

I chose second variant according to 2.0.X version
(https://github.com/mitmproxy/mitmproxy/blob/2.0.x/mitmproxy/tools/console/flowview.py#L368-L372). 
When we choose `response-headers`, `response-body` or `set-cookies` to edit, an empty response(https://github.com/mitmproxy/mitmproxy/blob/master/mitmproxy/net/http/response.py#L69) is added into the flow.
