### PR TITLE
Fix #2786

### DIFF
--- a/mitmproxy/tools/console/flowview.py
+++ b/mitmproxy/tools/console/flowview.py
@@ -58,7 +58,6 @@ class FlowDetails(tabs.Tabs):
             self.show()
         else:
             self.master.window.pop()
-            self.master.switch_view("flowlist")
 
     @property
     def view(self):

--- a/mitmproxy/tools/console/flowview.py
+++ b/mitmproxy/tools/console/flowview.py
@@ -55,7 +55,10 @@ class FlowDetails(tabs.Tabs):
                 (self.tab_response, self.view_response),
                 (self.tab_details, self.view_details),
             ]
-        self.show()
+            self.show()
+        else:
+            self.master.window.pop()
+            self.master.switch_view("flowlist")
 
     @property
     def view(self):


### PR DESCRIPTION
I hope, I didn't miss any details and didn't break anything :)

What's the point?
When we press `d` button, `view.remove` command is triggered. 
We send the flow and its index inside this command through `sig_view_remove` signal (https://github.com/mitmproxy/mitmproxy/blob/master/mitmproxy/addons/view.py#L414).
We are interested in this method (https://github.com/mitmproxy/mitmproxy/blob/master/mitmproxy/addons/view.py#L565), wich accepts the flow and index we've just sent.
When we delete all flows and there are nothing left, `None` is assigned to the flow. Flow setter sends a notification to `sig_change` inside `window.py` -> https://github.com/mitmproxy/mitmproxy/blob/master/mitmproxy/tools/console/window.py#L136-L137
`view_changed` and `focus_changed` are invoked for top window. Top window is FlowView. FlowView hasn't `view_changed` but has `focus_changed`. `focus_changed` has `self.show()` statement and it doesn't work, when flow is None.

So I just made it work only, when flow is not None. When flow is None, I just pop last element from `focus_stack` - coming back to the previous tab.