### PR TITLE
Persist flowfilter when editing it, fix #2777

### DIFF
--- a/mitmproxy/tools/console/commander/commander.py
+++ b/mitmproxy/tools/console/commander/commander.py
@@ -47,9 +47,12 @@ CompletionState = typing.NamedTuple(
 )
 
 
-class CommandBuffer():
+class CommandBuffer:
     def __init__(self, master: mitmproxy.master.Master, start: str = "") -> None:
         self.master = master
+        option_setting = start.startswith("set") and start.endswith("=")
+        if option_setting:
+            start += self.get_option_value(start)
         self.text = self.flatten(start)
         # Cursor is always within the range [0:len(buffer)].
         self._cursor = len(self.text)
@@ -93,6 +96,11 @@ class CommandBuffer():
             for v in remhelp:
                 ret.append(("commander_hint", "%s " % v))
         return ret
+
+    def get_option_value(self, txt):
+        option = txt.rstrip("=").split()[1]
+        option_value = getattr(self.master.options, option, None)
+        return option_value if option_value else ""
 
     def flatten(self, txt):
         parts, _ = self.master.commands.parse_partial(txt)

--- a/mitmproxy/tools/console/commander/commander.py
+++ b/mitmproxy/tools/console/commander/commander.py
@@ -50,9 +50,6 @@ CompletionState = typing.NamedTuple(
 class CommandBuffer:
     def __init__(self, master: mitmproxy.master.Master, start: str = "") -> None:
         self.master = master
-        option_setting = start.startswith("set") and start.endswith("=")
-        if option_setting:
-            start += self.get_option_value(start)
         self.text = self.flatten(start)
         # Cursor is always within the range [0:len(buffer)].
         self._cursor = len(self.text)
@@ -96,11 +93,6 @@ class CommandBuffer:
             for v in remhelp:
                 ret.append(("commander_hint", "%s " % v))
         return ret
-
-    def get_option_value(self, txt):
-        option = txt.rstrip("=").split()[1]
-        option_value = getattr(self.master.options, option, None)
-        return option_value if option_value else ""
 
     def flatten(self, txt):
         parts, _ = self.master.commands.parse_partial(txt)

--- a/mitmproxy/tools/console/consoleaddons.py
+++ b/mitmproxy/tools/console/consoleaddons.py
@@ -277,6 +277,15 @@ class ConsoleAddon:
         """
         signals.status_prompt_command.send(partial=" ".join(partial))  # type: ignore
 
+    @command.command("console.command.set")
+    def console_command_set(self, option: str) -> None:
+        """Doc"""
+        option_value = getattr(self.master.options, option, None)
+        current_value = option_value if option_value else ""
+        self.master.commands.call(
+            "console.command set {}={}".format(option, current_value)
+        )
+
     @command.command("console.view.keybindings")
     def view_keybindings(self) -> None:
         """View the commands list."""

--- a/mitmproxy/tools/console/consoleaddons.py
+++ b/mitmproxy/tools/console/consoleaddons.py
@@ -279,11 +279,13 @@ class ConsoleAddon:
 
     @command.command("console.command.set")
     def console_command_set(self, option: str) -> None:
-        """Doc"""
+        """
+        Prompt the user to set an option of the form "key[=value]".
+        """
         option_value = getattr(self.master.options, option, None)
         current_value = option_value if option_value else ""
         self.master.commands.call(
-            "console.command set {}={}".format(option, current_value)
+            "console.command set %s=%s" % (option, current_value)
         )
 
     @command.command("console.view.keybindings")

--- a/mitmproxy/tools/console/defaultkeys.py
+++ b/mitmproxy/tools/console/defaultkeys.py
@@ -26,8 +26,8 @@ def map(km):
     km.add("ctrl b", "console.nav.pageup", ["global"], "Page up")
 
     km.add("I", "console.intercept.toggle", ["global"], "Toggle intercept")
-    km.add("i", "console.command set intercept=", ["global"], "Set intercept")
-    km.add("W", "console.command set save_stream_file=", ["global"], "Stream to file")
+    km.add("i", "console.command.set intercept", ["global"], "Set intercept")
+    km.add("W", "console.command.set save_stream_file", ["global"], "Stream to file")
     km.add("A", "flow.resume @all", ["flowlist", "flowview"], "Resume all intercepted flows")
     km.add("a", "flow.resume @focus", ["flowlist", "flowview"], "Resume this intercepted flow")
     km.add(
@@ -46,7 +46,7 @@ def map(km):
         ["flowlist", "flowview"],
         "Export this flow to file"
     )
-    km.add("f", "console.command set view_filter=", ["flowlist"], "Set view filter")
+    km.add("f", "console.command.set view_filter", ["flowlist"], "Set view filter")
     km.add("F", "set console_focus_follow=toggle", ["flowlist"], "Set focus follow")
     km.add(
         "ctrl l",

--- a/test/mitmproxy/tools/console/test_commander.py
+++ b/test/mitmproxy/tools/console/test_commander.py
@@ -1,4 +1,4 @@
-
+from mitmproxy import options
 from mitmproxy.tools.console.commander import commander
 from mitmproxy.test import taddons
 
@@ -96,3 +96,11 @@ class TestCommandBuffer:
         with taddons.context() as tctx:
             cb = commander.CommandBuffer(tctx.master)
             assert cb.flatten("foo  bar") == "foo bar"
+
+    def test_get_option_value(self):
+        opts = options.Options(view_filter="value")
+        with taddons.context(options=opts) as tctx:
+            cb = commander.CommandBuffer(tctx.master)
+            assert cb.get_option_value("set unknown_option=") == ""
+            assert cb.get_option_value("set intercept=") == ""
+            assert cb.get_option_value("set view_filter=") == "value"

--- a/test/mitmproxy/tools/console/test_commander.py
+++ b/test/mitmproxy/tools/console/test_commander.py
@@ -1,4 +1,4 @@
-from mitmproxy import options
+
 from mitmproxy.tools.console.commander import commander
 from mitmproxy.test import taddons
 
@@ -96,11 +96,3 @@ class TestCommandBuffer:
         with taddons.context() as tctx:
             cb = commander.CommandBuffer(tctx.master)
             assert cb.flatten("foo  bar") == "foo bar"
-
-    def test_get_option_value(self):
-        opts = options.Options(view_filter="value")
-        with taddons.context(options=opts) as tctx:
-            cb = commander.CommandBuffer(tctx.master)
-            assert cb.get_option_value("set unknown_option=") == ""
-            assert cb.get_option_value("set intercept=") == ""
-            assert cb.get_option_value("set view_filter=") == "value"


### PR DESCRIPTION
The issue says only about _view filter_. But I think we should extend it. The issue is relevant to intercept option(`i`) and stream to file(`W`) as well.

Now after pressing `f`, `i` or `W` and setting any value, you can press the button again and correct a typo or set new similar value without reprinting the whole value from scratch.