### PR TITLE
Fix for #2750 and #2783

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ MANIFEST
 .cache/
 .tox*/
 build/
+dist/
 mitmproxy/contrib/kaitaistruct/*.ksy
 
 # UI

--- a/mitmproxy/addons/cut.py
+++ b/mitmproxy/addons/cut.py
@@ -109,7 +109,7 @@ class Cut:
                             [strutils.always_str(x) or "" for x in vals]  # type: ignore
                         )
                 ctx.log.alert("Saved %s cuts over %d flows as CSV." % (len(cuts), len(flows)))
-        except (PermissionError, IsADirectoryError, FileNotFoundError) as e:
+        except IOError as e:
             ctx.log.error(str(e))
 
     @command.command("cut.clip")

--- a/mitmproxy/addons/cut.py
+++ b/mitmproxy/addons/cut.py
@@ -88,26 +88,29 @@ class Cut:
         if path.startswith("+"):
             append = True
             path = mitmproxy.types.Path(path[1:])
-        if len(cuts) == 1 and len(flows) == 1:
-            with open(path, "ab" if append else "wb") as fp:
-                if fp.tell() > 0:
-                    # We're appending to a file that already exists and has content
-                    fp.write(b"\n")
-                v = extract(cuts[0], flows[0])
-                if isinstance(v, bytes):
-                    fp.write(v)
-                else:
-                    fp.write(v.encode("utf8"))
-            ctx.log.alert("Saved single cut.")
-        else:
-            with open(path, "a" if append else "w", newline='', encoding="utf8") as fp:
-                writer = csv.writer(fp)
-                for f in flows:
-                    vals = [extract(c, f) for c in cuts]
-                    writer.writerow(
-                        [strutils.always_str(x) or "" for x in vals]  # type: ignore
-                    )
-            ctx.log.alert("Saved %s cuts over %d flows as CSV." % (len(cuts), len(flows)))
+        try:
+            if len(cuts) == 1 and len(flows) == 1:
+                with open(path, "ab" if append else "wb") as fp:
+                    if fp.tell() > 0:
+                        # We're appending to a file that already exists and has content
+                        fp.write(b"\n")
+                    v = extract(cuts[0], flows[0])
+                    if isinstance(v, bytes):
+                        fp.write(v)
+                    else:
+                        fp.write(v.encode("utf8"))
+                ctx.log.alert("Saved single cut.")
+            else:
+                with open(path, "a" if append else "w", newline='', encoding="utf8") as fp:
+                    writer = csv.writer(fp)
+                    for f in flows:
+                        vals = [extract(c, f) for c in cuts]
+                        writer.writerow(
+                            [strutils.always_str(x) or "" for x in vals]  # type: ignore
+                        )
+                ctx.log.alert("Saved %s cuts over %d flows as CSV." % (len(cuts), len(flows)))
+        except (PermissionError, IsADirectoryError, FileNotFoundError) as e:
+            ctx.log.error(e)
 
     @command.command("cut.clip")
     def clip(

--- a/mitmproxy/addons/cut.py
+++ b/mitmproxy/addons/cut.py
@@ -110,7 +110,7 @@ class Cut:
                         )
                 ctx.log.alert("Saved %s cuts over %d flows as CSV." % (len(cuts), len(flows)))
         except (PermissionError, IsADirectoryError, FileNotFoundError) as e:
-            ctx.log.error(e)
+            ctx.log.error(str(e))
 
     @command.command("cut.clip")
     def clip(

--- a/mitmproxy/addons/export.py
+++ b/mitmproxy/addons/export.py
@@ -65,7 +65,7 @@ class Export():
                     fp.write(v)
                 else:
                     fp.write(v.encode("utf-8"))
-        except (PermissionError, IsADirectoryError, FileNotFoundError) as e:
+        except IOError as e:
             ctx.log.error(str(e))
 
     @command.command("export.clip")

--- a/mitmproxy/addons/export.py
+++ b/mitmproxy/addons/export.py
@@ -1,5 +1,6 @@
 import typing
 
+from mitmproxy import ctx
 from mitmproxy import command
 from mitmproxy import flow
 from mitmproxy import exceptions
@@ -58,11 +59,14 @@ class Export():
             raise exceptions.CommandError("No such export format: %s" % fmt)
         func = formats[fmt]  # type: typing.Any
         v = func(f)
-        with open(path, "wb") as fp:
-            if isinstance(v, bytes):
-                fp.write(v)
-            else:
-                fp.write(v.encode("utf-8"))
+        try:
+            with open(path, "wb") as fp:
+                if isinstance(v, bytes):
+                    fp.write(v)
+                else:
+                    fp.write(v.encode("utf-8"))
+        except (PermissionError, IsADirectoryError, FileNotFoundError) as e:
+            ctx.log.error(e)
 
     @command.command("export.clip")
     def clip(self, fmt: str, f: flow.Flow) -> None:

--- a/mitmproxy/addons/export.py
+++ b/mitmproxy/addons/export.py
@@ -66,7 +66,7 @@ class Export():
                 else:
                     fp.write(v.encode("utf-8"))
         except (PermissionError, IsADirectoryError, FileNotFoundError) as e:
-            ctx.log.error(e)
+            ctx.log.error(str(e))
 
     @command.command("export.clip")
     def clip(self, fmt: str, f: flow.Flow) -> None:

--- a/mitmproxy/tools/console/consoleaddons.py
+++ b/mitmproxy/tools/console/consoleaddons.py
@@ -465,13 +465,16 @@ class ConsoleAddon:
             Save data to file as a CSV.
         """
         rows = self._grideditor().value
-        with open(path, "w", newline='', encoding="utf8") as fp:
-            writer = csv.writer(fp)
-            for row in rows:
-                writer.writerow(
-                    [strutils.always_str(x) or "" for x in row]  # type: ignore
-                )
-        ctx.log.alert("Saved %s rows as CSV." % (len(rows)))
+        try:
+            with open(path, "w", newline='', encoding="utf8") as fp:
+                writer = csv.writer(fp)
+                for row in rows:
+                    writer.writerow(
+                        [strutils.always_str(x) or "" for x in row]  # type: ignore
+                    )
+            ctx.log.alert("Saved %s rows as CSV." % (len(rows)))
+        except (PermissionError, IsADirectoryError, FileNotFoundError) as e:
+            ctx.log.error(e)
 
     @command.command("console.grideditor.editor")
     def grideditor_editor(self) -> None:

--- a/mitmproxy/tools/console/consoleaddons.py
+++ b/mitmproxy/tools/console/consoleaddons.py
@@ -474,7 +474,7 @@ class ConsoleAddon:
                     )
             ctx.log.alert("Saved %s rows as CSV." % (len(rows)))
         except (PermissionError, IsADirectoryError, FileNotFoundError) as e:
-            ctx.log.error(e)
+            ctx.log.error(str(e))
 
     @command.command("console.grideditor.editor")
     def grideditor_editor(self) -> None:

--- a/mitmproxy/tools/console/consoleaddons.py
+++ b/mitmproxy/tools/console/consoleaddons.py
@@ -473,7 +473,7 @@ class ConsoleAddon:
                         [strutils.always_str(x) or "" for x in row]  # type: ignore
                     )
             ctx.log.alert("Saved %s rows as CSV." % (len(rows)))
-        except (PermissionError, IsADirectoryError, FileNotFoundError) as e:
+        except IOError as e:
             ctx.log.error(str(e))
 
     @command.command("console.grideditor.editor")

--- a/test/mitmproxy/addons/test_cut.py
+++ b/test/mitmproxy/addons/test_cut.py
@@ -111,22 +111,10 @@ def test_cut_save(tmpdir):
         tctx.command(c.save, "@all", "request.method,request.content", f)
         assert qr(f).splitlines() == [b"GET,content", b"GET,content"]
 
-        with mock.patch("mitmproxy.addons.cut.open") as m:
-            m.side_effect = [PermissionError("Permission denied"),
-                             IsADirectoryError("Is a directory"),
-                             FileNotFoundError("No such file or directory")]
-            for i in range(3):
-                tctx.command(c.save, "@all", "request.method", f)
-            assert tctx.master.has_log("Permission denied", level="error")
-            assert tctx.master.has_log("Is a directory", level="error")
-            assert tctx.master.has_log("No such file or directory",
-                                       level="error")
-
 
 @pytest.mark.parametrize("exception, log_message", [
     (PermissionError, "Permission denied"),
-    (IsADirectoryError, "Is a directory"),
-    (FileNotFoundError, "No such file or directory")
+    (IsADirectoryError, "Is a directory")
 ])
 def test_cut_save_open(exception, log_message, tmpdir):
     f = str(tmpdir.join("path"))

--- a/test/mitmproxy/addons/test_cut.py
+++ b/test/mitmproxy/addons/test_cut.py
@@ -115,11 +115,12 @@ def test_cut_save(tmpdir):
             m.side_effect = [PermissionError("Permission denied"),
                              IsADirectoryError("Is a directory"),
                              FileNotFoundError("No such file or directory")]
-            for effect in range(3):
+            for i in range(3):
                 tctx.command(c.save, "@all", "request.method", f)
-            assert tctx.master.has_log("Permission denied")
-            assert tctx.master.has_log("Is a directory")
-            assert tctx.master.has_log("No such file or directory")
+            assert tctx.master.has_log("Permission denied", level="error")
+            assert tctx.master.has_log("Is a directory", level="error")
+            assert tctx.master.has_log("No such file or directory",
+                                       level="error")
 
 
 def test_cut():

--- a/test/mitmproxy/addons/test_cut.py
+++ b/test/mitmproxy/addons/test_cut.py
@@ -111,6 +111,16 @@ def test_cut_save(tmpdir):
         tctx.command(c.save, "@all", "request.method,request.content", f)
         assert qr(f).splitlines() == [b"GET,content", b"GET,content"]
 
+        with mock.patch("mitmproxy.addons.cut.open") as m:
+            m.side_effect = [PermissionError("Permission denied"),
+                             IsADirectoryError("Is a directory"),
+                             FileNotFoundError("No such file or directory")]
+            for effect in range(3):
+                tctx.command(c.save, "@all", "request.method", f)
+            assert tctx.master.has_log("Permission denied")
+            assert tctx.master.has_log("Is a directory")
+            assert tctx.master.has_log("No such file or directory")
+
 
 def test_cut():
     c = cut.Cut()

--- a/test/mitmproxy/addons/test_cut.py
+++ b/test/mitmproxy/addons/test_cut.py
@@ -114,7 +114,8 @@ def test_cut_save(tmpdir):
 
 @pytest.mark.parametrize("exception, log_message", [
     (PermissionError, "Permission denied"),
-    (IsADirectoryError, "Is a directory")
+    (IsADirectoryError, "Is a directory"),
+    (FileNotFoundError, "No such file or directory")
 ])
 def test_cut_save_open(exception, log_message, tmpdir):
     f = str(tmpdir.join("path"))

--- a/test/mitmproxy/addons/test_export.py
+++ b/test/mitmproxy/addons/test_export.py
@@ -96,7 +96,8 @@ def test_export(tmpdir):
 
 @pytest.mark.parametrize("exception, log_message", [
     (PermissionError, "Permission denied"),
-    (IsADirectoryError, "Is a directory")
+    (IsADirectoryError, "Is a directory"),
+    (FileNotFoundError, "No such file or directory")
 ])
 def test_export_open(exception, log_message, tmpdir):
     f = str(tmpdir.join("path"))

--- a/test/mitmproxy/addons/test_export.py
+++ b/test/mitmproxy/addons/test_export.py
@@ -80,7 +80,7 @@ def qr(f):
 def test_export(tmpdir):
     f = str(tmpdir.join("path"))
     e = export.Export()
-    with taddons.context() as tctx:
+    with taddons.context():
         assert e.formats() == ["curl", "raw"]
         with pytest.raises(exceptions.CommandError):
             e.file("nonexistent", tflow.tflow(resp=True), f)

--- a/test/mitmproxy/addons/test_export.py
+++ b/test/mitmproxy/addons/test_export.py
@@ -96,8 +96,7 @@ def test_export(tmpdir):
 
 @pytest.mark.parametrize("exception, log_message", [
     (PermissionError, "Permission denied"),
-    (IsADirectoryError, "Is a directory"),
-    (FileNotFoundError, "No such file or directory")
+    (IsADirectoryError, "Is a directory")
 ])
 def test_export_open(exception, log_message, tmpdir):
     f = str(tmpdir.join("path"))

--- a/test/mitmproxy/addons/test_export.py
+++ b/test/mitmproxy/addons/test_export.py
@@ -97,11 +97,12 @@ def test_export(tmpdir):
             m.side_effect = [PermissionError("Permission denied"),
                              IsADirectoryError("Is a directory"),
                              FileNotFoundError("No such file or directory")]
-            for effect in range(3):
+            for i in range(3):
                 e.file("raw", tflow.tflow(resp=True), f)
-            assert tctx.master.has_log("Permission denied")
-            assert tctx.master.has_log("Is a directory")
-            assert tctx.master.has_log("No such file or directory")
+            assert tctx.master.has_log("Permission denied", level="error")
+            assert tctx.master.has_log("Is a directory", level="error")
+            assert tctx.master.has_log("No such file or directory",
+                                       level="error")
 
 
 def test_clip(tmpdir):

--- a/test/mitmproxy/addons/test_export.py
+++ b/test/mitmproxy/addons/test_export.py
@@ -93,16 +93,20 @@ def test_export(tmpdir):
         assert qr(f)
         os.unlink(f)
 
+
+@pytest.mark.parametrize("exception, log_message", [
+    (PermissionError, "Permission denied"),
+    (IsADirectoryError, "Is a directory"),
+    (FileNotFoundError, "No such file or directory")
+])
+def test_export_open(exception, log_message, tmpdir):
+    f = str(tmpdir.join("path"))
+    e = export.Export()
+    with taddons.context() as tctx:
         with mock.patch("mitmproxy.addons.export.open") as m:
-            m.side_effect = [PermissionError("Permission denied"),
-                             IsADirectoryError("Is a directory"),
-                             FileNotFoundError("No such file or directory")]
-            for i in range(3):
-                e.file("raw", tflow.tflow(resp=True), f)
-            assert tctx.master.has_log("Permission denied", level="error")
-            assert tctx.master.has_log("Is a directory", level="error")
-            assert tctx.master.has_log("No such file or directory",
-                                       level="error")
+            m.side_effect = exception(log_message)
+            e.file("raw", tflow.tflow(resp=True), f)
+            assert tctx.master.has_log(log_message, level="error")
 
 
 def test_clip(tmpdir):


### PR DESCRIPTION
Continuation of https://github.com/mitmproxy/mitmproxy/pull/2761 
I added tests with mocked `open` function. I hope it is the right way to test such things. 

Now, when you press `w`, `e` or `b` and input invalid file path, you will get something like:

![image](https://user-images.githubusercontent.com/20267977/35219969-49e32e48-ff7d-11e7-85b0-d2dcddf1163a.png)
