### PR TITLE
Fix #2753. Fix resetting editings.

### DIFF
--- a/mitmproxy/tools/console/grideditor/base.py
+++ b/mitmproxy/tools/console/grideditor/base.py
@@ -433,7 +433,6 @@ class FocusEditor(urwid.WidgetWrap, layoutwidget.LayoutWidget):
 
     def __init__(self, master):
         self.master = master
-        self.focus_changed()
 
     def call(self, v, name, *args, **kwargs):
         f = getattr(v, name, None)
@@ -462,7 +461,7 @@ class FocusEditor(urwid.WidgetWrap, layoutwidget.LayoutWidget):
     def layout_popping(self):
         self.call(self._w, "layout_popping")
 
-    def focus_changed(self):
+    def layout_pushed(self, prev):
         if self.master.view.focus.flow:
             self._w = BaseGridEditor(
                 self.master,

--- a/mitmproxy/tools/console/grideditor/col_subgrid.py
+++ b/mitmproxy/tools/console/grideditor/col_subgrid.py
@@ -27,15 +27,8 @@ class Column(base.Column):
             )
             return
         elif key == "m_select":
-            editor.master.view_grideditor(
-                self.subeditor(
-                    editor.master,
-                    editor.walker.get_current_value(),
-                    editor.set_subeditor_value,
-                    editor.walker.focus,
-                    editor.walker.focus_col
-                )
-            )
+            self.subeditor.grideditor = editor
+            editor.master.switch_view("edit_focus_setcookie_attrs")
         else:
             return key
 

--- a/mitmproxy/tools/console/grideditor/editors.py
+++ b/mitmproxy/tools/console/grideditor/editors.py
@@ -1,3 +1,4 @@
+import urwid
 import typing
 
 from mitmproxy import exceptions
@@ -100,12 +101,13 @@ class CookieEditor(base.FocusEditor):
         flow.request.cookies = vals
 
 
-class CookieAttributeEditor(base.GridEditor):
+class CookieAttributeEditor(base.FocusEditor):
     title = "Editing Set-Cookie attributes"
     columns = [
         col_text.Column("Name"),
         col_text.Column("Value"),
     ]
+    grideditor = None  # type: base.BaseGridEditor
 
     def data_in(self, data):
         return [(k, v or "") for k, v in data]
@@ -118,6 +120,20 @@ class CookieAttributeEditor(base.GridEditor):
             else:
                 ret.append(i)
         return ret
+
+    def layout_pushed(self, prev):
+        if self.grideditor.master.view.focus.flow:
+            self._w = base.BaseGridEditor(
+                self.grideditor.master,
+                self.title,
+                self.columns,
+                self.grideditor.walker.get_current_value(),
+                self.grideditor.set_subeditor_value,
+                self.grideditor.walker.focus,
+                self.grideditor.walker.focus_col
+            )
+        else:
+            self._w = urwid.Pile([])
 
 
 class SetCookieEditor(base.FocusEditor):

--- a/mitmproxy/tools/console/window.py
+++ b/mitmproxy/tools/console/window.py
@@ -63,6 +63,7 @@ class WindowStack:
             edit_focus_query = grideditor.QueryEditor(master),
             edit_focus_cookies = grideditor.CookieEditor(master),
             edit_focus_setcookies = grideditor.SetCookieEditor(master),
+            edit_focus_setcookie_attrs = grideditor.CookieAttributeEditor(master),
             edit_focus_form = grideditor.RequestFormEditor(master),
             edit_focus_path = grideditor.PathEditor(master),
             edit_focus_request_headers = grideditor.RequestHeaderEditor(master),


### PR DESCRIPTION
The main problem of this issue is absence of `view_grideditor` in mitmproxy v3.0.0

An exception occurs in this line https://github.com/mitmproxy/mitmproxy/blob/master/mitmproxy/tools/console/grideditor/col_subgrid.py#L30
`view_grideditor` in mitmproxy v2.0.x pushes the whole widget into the stack, but in v3.0.0 we have `push` method instead of `view_grideditor`, which pushes only the name and then mitmproxy retrieves necessary widget by its name from `self.windows`. 
I had a few variants of how to fix it and I am not sure I chose the best one :)

First of all, we must fix another related issue, which I described in the comments https://github.com/mitmproxy/mitmproxy/issues/2753#issuecomment-359825373. It happens because of this https://github.com/mitmproxy/mitmproxy/blob/master/mitmproxy/tools/console/grideditor/base.py#L465. The thing is when we switch view to other tab and then come back to grideditor, `focus_changed` is invoked and it creates completely new widget, which doesn't consider our previous editings. It is logical to assume, that we mustn't create a new object every time we come back to grideditor. I replaced `focus_changed` with `layout_pushed`, so new widget will be created every time, only when we push grideditor.

Fixing the current issue:
- put attributes editor object into `self.windows`;
- when pressing `enter` we must pass `editor` from `Column.keypress` to `CookieAttributeEditor` and switch view to attribute editor;
- `layout_pushed` is invoked and we get into attribute editor.