### PR TITLE
Real-time flow counter

### DIFF
--- a/mitmproxy/tools/console/statusbar.py
+++ b/mitmproxy/tools/console/statusbar.py
@@ -140,9 +140,10 @@ class StatusBar(urwid.WidgetWrap):
         signals.flowlist_change.connect(self.sig_update)
         master.options.changed.connect(self.sig_update)
         master.view.focus.sig_change.connect(self.sig_update)
+        master.view.sig_view_add.connect(self.sig_update)
         self.redraw()
 
-    def sig_update(self, sender, updated=None):
+    def sig_update(self, sender, flow=None, updated=None):
         self.redraw()
 
     def keypress(self, *args, **kwargs):


### PR DESCRIPTION
Now flow counter in the bottom left corner is updated only when we press `down`-`up` buttons or use mouse wheel. I think it will be more useful, if we make this counter work in real-time.

When new flow is added, it is sent to all receivers through `sig_view_add` - https://github.com/mitmproxy/mitmproxy/blob/master/mitmproxy/addons/view.py#L305
So, we just redraw our statusbar every time, when new flow is sent through `sig_view_add`
https://github.com/mitmproxy/mitmproxy/blob/master/mitmproxy/tools/console/statusbar.py#L145