### PR TITLE
Issue #2785. New shortcuts.

### DIFF
--- a/mitmproxy/tools/console/overlay.py
+++ b/mitmproxy/tools/console/overlay.py
@@ -2,7 +2,6 @@ import math
 
 import urwid
 
-from mitmproxy import ctx
 from mitmproxy.tools.console import signals
 from mitmproxy.tools.console import grideditor
 from mitmproxy.tools.console import layoutwidget
@@ -74,7 +73,7 @@ class ChooserListWalker(urwid.ListWalker):
 
     def _get(self, idx, focus):
         c = self.choices[idx]
-        return Choice(c, focus, c == self.current, self.shortcuts[idx:idx+1])
+        return Choice(c, focus, c == self.current, self.shortcuts[idx:idx + 1])
 
     def set_focus(self, index):
         self.index = index

--- a/mitmproxy/tools/console/overlay.py
+++ b/mitmproxy/tools/console/overlay.py
@@ -133,8 +133,8 @@ class Chooser(urwid.WidgetWrap, layoutwidget.LayoutWidget):
             self.callback(self.choices[self.walker.index])
             signals.pop_view_state.send(self)
             return
-        elif key in self.possible_shortcuts:
-            shortcut_index = self.possible_shortcuts.find(key)
+        elif key in self.shortcuts:
+            shortcut_index = self.shortcuts.index(key)
             self.callback(self.choices[shortcut_index])
             signals.pop_view_state.send(self)
             return

--- a/mitmproxy/tools/console/overlay.py
+++ b/mitmproxy/tools/console/overlay.py
@@ -96,7 +96,7 @@ class ChooserListWalker(urwid.ListWalker):
 
     def choice_by_shortcut(self, shortcut):
         for i, choice in enumerate(self.choices):
-            if shortcut == self.shortcuts[i:i+1]:
+            if shortcut == self.shortcuts[i:i + 1]:
                 return choice
         return None
 

--- a/mitmproxy/tools/console/overlay.py
+++ b/mitmproxy/tools/console/overlay.py
@@ -98,8 +98,8 @@ class Chooser(urwid.WidgetWrap, layoutwidget.LayoutWidget):
         self.callback = callback
         shortcutwidth = 3
         choicewidth = max([len(i) for i in choices])
-        self.width = max(shortcutwidth+choicewidth, len(title)) + 5
-        self.possible_shortcuts = "123456789abcdefghijklmnopqrstuvwxyz"
+        self.width = max(shortcutwidth + choicewidth, len(title)) + 5
+        self.possible_shortcuts = "12345"
         self.shortcuts = self.get_shortcuts(choices)
 
         shortcuts_walker = urwid.SimpleListWalker([
@@ -109,7 +109,7 @@ class Chooser(urwid.WidgetWrap, layoutwidget.LayoutWidget):
         shortcuts_listbox._selectable = False  # We don't want to focus on it
         self.walker = ChooserListWalker(choices, current)
         content = urwid.Columns([(shortcutwidth, shortcuts_listbox),
-                                 (choicewidth+3, urwid.ListBox(self.walker))],
+                                 (choicewidth + 3, urwid.ListBox(self.walker))],
                                 focus_column=1)
         super().__init__(
             urwid.AttrWrap(


### PR DESCRIPTION
Shortcuts for all overlays. 
Now it is much easier to choose menu item at the bottom of any overlay.

If there is a situation, when your overlay has so many items, that mitmproxy doesn't have so many shortcuts (what if!), you will see the warning message: `Too few available shortcuts.` and anyway you will be able to use remaining shortcuts.
Examples:
![1](https://user-images.githubusercontent.com/20267977/35691414-197f1efe-0781-11e8-9e90-b1de04701633.png)

![2](https://user-images.githubusercontent.com/20267977/35691419-1ca8512c-0781-11e8-8894-0571d3cf62ce.png)

![4](https://user-images.githubusercontent.com/20267977/35691432-24b6e022-0781-11e8-8934-4f24307ca3f2.png)

If there aren't available shortcuts:
![image](https://user-images.githubusercontent.com/20267977/35691611-9820f4ee-0781-11e8-9758-6e58287279dd.png)

P.S. Now you can leave overlay by pressing `q` as well.