### PR TITLE
[web] Fix unstable sorting

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -37,7 +37,8 @@
     "redux-logger": "^3.0.6",
     "redux-mock-store": "^1.3.0",
     "redux-thunk": "^2.2.0",
-    "shallowequal": "^1.0.2"
+    "shallowequal": "^1.0.2",
+    "stable": "^0.1.6"
   },
   "devDependencies": {
     "babel-core": "^6.26.0",

--- a/web/src/js/ducks/utils/store.js
+++ b/web/src/js/ducks/utils/store.js
@@ -1,3 +1,5 @@
+import stable from 'stable'
+
 export const SET_FILTER = 'LIST_SET_FILTER'
 export const SET_SORT = 'LIST_SET_SORT'
 export const ADD = 'LIST_ADD'
@@ -35,7 +37,7 @@ export default function reduce(state = defaultState, action) {
 
     switch (action.type) {
         case SET_FILTER:
-            view = list.filter(action.filter).sort(action.sort)
+            view = stable(list.filter(action.filter), action.sort)
             viewIndex = {}
             view.forEach((item, index) => {
                 viewIndex[item.id] = index
@@ -43,7 +45,7 @@ export default function reduce(state = defaultState, action) {
             break
 
         case SET_SORT:
-            view = [...view].sort(action.sort)
+            view = stable([...view], action.sort)
             viewIndex = {}
             view.forEach((item, index) => {
                 viewIndex[item.id] = index

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -5449,6 +5449,10 @@ sshpk@^1.7.0:
     jsbn "~0.1.0"
     tweetnacl "~0.14.0"
 
+stable@^0.1.6:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/stable/-/stable-0.1.6.tgz#910f5d2aed7b520c6e777499c1f32e139fdecb10"
+
 statuses@1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.3.1.tgz#faf51b9eb74aaef3b3acf4ad5f61abf24cb7b93e"


### PR DESCRIPTION
This is more complex then it looks like:
1. we want to have the descending/ascending argument, so we should use [_.orderBy](https://lodash.com/docs/4.17.4#orderBy) here.
2. The `makeSort` function will be invoked in other places like [here](https://github.com/mitmproxy/mitmproxy/blob/master/web/src/js/ducks/flows.js#L108) and [here](https://github.com/mitmproxy/mitmproxy/blob/master/web/src/js/ducks/utils/store.js#L195), so we cannot just eliminate it.

We should have a stable sort now, I tried it with a bunch of flows which have same status code, they remained the same order after the sorting.

