### PR TITLE
Fix #2816

### DIFF
--- a/mitmproxy/addons/cut.py
+++ b/mitmproxy/addons/cut.py
@@ -139,4 +139,7 @@ class Cut:
                     [strutils.always_str(v) or "" for v in vals]  # type: ignore
                 )
             ctx.log.alert("Clipped %s cuts as CSV." % len(cuts))
-        pyperclip.copy(fp.getvalue())
+        try:
+            pyperclip.copy(fp.getvalue())
+        except pyperclip.PyperclipException as e:
+            ctx.log.error(str(e))

--- a/mitmproxy/addons/export.py
+++ b/mitmproxy/addons/export.py
@@ -77,4 +77,7 @@ class Export():
             raise exceptions.CommandError("No such export format: %s" % fmt)
         func = formats[fmt]  # type: typing.Any
         v = strutils.always_str(func(f))
-        pyperclip.copy(v)
+        try:
+            pyperclip.copy(v)
+        except pyperclip.PyperclipException as e:
+            ctx.log.error(str(e))

--- a/test/mitmproxy/addons/test_cut.py
+++ b/test/mitmproxy/addons/test_cut.py
@@ -92,7 +92,7 @@ def test_cut_clip():
 
         with mock.patch('pyperclip.copy') as pc:
             log_message = "Pyperclip could not find a " \
-                         "copy/paste mechanism for your system."
+                          "copy/paste mechanism for your system."
             pc.side_effect = pyperclip.PyperclipException(log_message)
             tctx.command(c.clip, "@all", "request.method")
             assert tctx.master.has_log(log_message, level="error")

--- a/test/mitmproxy/addons/test_cut.py
+++ b/test/mitmproxy/addons/test_cut.py
@@ -7,6 +7,7 @@ from mitmproxy.test import taddons
 from mitmproxy.test import tflow
 from mitmproxy.test import tutils
 import pytest
+import pyperclip
 from unittest import mock
 
 
@@ -88,6 +89,13 @@ def test_cut_clip():
         with mock.patch('pyperclip.copy') as pc:
             tctx.command(c.clip, "@all", "request.method,request.content")
             assert pc.called
+
+        with mock.patch('pyperclip.copy') as pc:
+            except_msg = "Pyperclip could not find a " \
+                         "copy/paste mechanism for your system."
+            pc.side_effect = pyperclip.PyperclipException(except_msg)
+            tctx.command(c.clip, "@all", "request.method")
+            assert tctx.master.has_log(except_msg, level="error")
 
 
 def test_cut_save(tmpdir):

--- a/test/mitmproxy/addons/test_cut.py
+++ b/test/mitmproxy/addons/test_cut.py
@@ -91,11 +91,11 @@ def test_cut_clip():
             assert pc.called
 
         with mock.patch('pyperclip.copy') as pc:
-            except_msg = "Pyperclip could not find a " \
+            log_message = "Pyperclip could not find a " \
                          "copy/paste mechanism for your system."
-            pc.side_effect = pyperclip.PyperclipException(except_msg)
+            pc.side_effect = pyperclip.PyperclipException(log_message)
             tctx.command(c.clip, "@all", "request.method")
-            assert tctx.master.has_log(except_msg, level="error")
+            assert tctx.master.has_log(log_message, level="error")
 
 
 def test_cut_save(tmpdir):

--- a/test/mitmproxy/addons/test_export.py
+++ b/test/mitmproxy/addons/test_export.py
@@ -126,8 +126,8 @@ def test_clip(tmpdir):
             assert pc.called
 
         with mock.patch('pyperclip.copy') as pc:
-            except_msg = "Pyperclip could not find a " \
+            log_message = "Pyperclip could not find a " \
                          "copy/paste mechanism for your system."
-            pc.side_effect = pyperclip.PyperclipException(except_msg)
+            pc.side_effect = pyperclip.PyperclipException(log_message)
             e.clip("raw", tflow.tflow(resp=True))
-            assert tctx.master.has_log(except_msg, level="error")
+            assert tctx.master.has_log(log_message, level="error")

--- a/test/mitmproxy/addons/test_export.py
+++ b/test/mitmproxy/addons/test_export.py
@@ -127,7 +127,7 @@ def test_clip(tmpdir):
 
         with mock.patch('pyperclip.copy') as pc:
             log_message = "Pyperclip could not find a " \
-                         "copy/paste mechanism for your system."
+                          "copy/paste mechanism for your system."
             pc.side_effect = pyperclip.PyperclipException(log_message)
             e.clip("raw", tflow.tflow(resp=True))
             assert tctx.master.has_log(log_message, level="error")


### PR DESCRIPTION
When we try to use `cut.clip` or `export.clip` commands, pyperclip module may raise `pyperclip.PyperclipException` and break Mitmproxy.

For more details -> https://pyperclip.readthedocs.io/en/latest/introduction.html#not-implemented-error

I handle this exception here. 