### PR TITLE
Fixes issue with the pfctl config on OSX

### DIFF
--- a/docs/transparent/osx.rst
+++ b/docs/transparent/osx.rst
@@ -17,8 +17,7 @@ Note that this means we don't support transparent mode for earlier versions of O
 
     .. code-block:: none
 
-        rdr on en2 inet proto tcp to any port 80 -> 127.0.0.1 port 8080
-        rdr on en2 inet proto tcp to any port 443 -> 127.0.0.1 port 8080
+        rdr on en0 inet proto tcp to any port {80, 443} -> 127.0.0.1 port 8080
 
     These rules tell pf to redirect all traffic destined for port 80 or 443
     to the local mitmproxy instance running on port 8080. You should


### PR DESCRIPTION
The previous config threw a syntax error when saving.