### PR TITLE
Allow more permissive cookie parsing, Fix #2829

### DIFF
--- a/mitmproxy/net/http/cookies.py
+++ b/mitmproxy/net/http/cookies.py
@@ -114,11 +114,11 @@ def _read_cookie_pairs(s, off=0):
         lhs, off = _read_key(s, off)
         lhs = lhs.lstrip()
 
-        if lhs:
-            rhs = None
-            if off < len(s) and s[off] == "=":
-                rhs, off = _read_value(s, off + 1, ";")
+        rhs = None
+        if off < len(s) and s[off] == "=":
+            rhs, off = _read_value(s, off + 1, ";")
 
+        if not (lhs, rhs) == ('', None):
             pairs.append([lhs, rhs])
 
         off += 1
@@ -143,25 +143,25 @@ def _read_set_cookie_pairs(s: str, off=0) -> Tuple[List[TPairs], int]:
         lhs, off = _read_key(s, off, ";=,")
         lhs = lhs.lstrip()
 
-        if lhs:
-            rhs = None
-            if off < len(s) and s[off] == "=":
-                rhs, off = _read_value(s, off + 1, ";,")
+        rhs = None
+        if off < len(s) and s[off] == "=":
+            rhs, off = _read_value(s, off + 1, ";,")
 
-                # Special handliing of attributes
-                if lhs.lower() == "expires":
-                    # 'expires' values can contain commas in them so they need to
-                    # be handled separately.
+            # Special handliing of attributes
+            if lhs.lower() == "expires":
+                # 'expires' values can contain commas in them so they need to
+                # be handled separately.
 
-                    # We actually bank on the fact that the expires value WILL
-                    # contain a comma. Things will fail, if they don't.
+                # We actually bank on the fact that the expires value WILL
+                # contain a comma. Things will fail, if they don't.
 
-                    # '3' is just a heuristic we use to determine whether we've
-                    # only read a part of the expires value and we should read more.
-                    if len(rhs) <= 3:
-                        trail, off = _read_value(s, off + 1, ";,")
-                        rhs = rhs + "," + trail
+                # '3' is just a heuristic we use to determine whether we've
+                # only read a part of the expires value and we should read more.
+                if len(rhs) <= 3:
+                    trail, off = _read_value(s, off + 1, ";,")
+                    rhs = rhs + "," + trail
 
+        if not (lhs, rhs) == ('', None):
             pairs.append([lhs, rhs])
 
             # comma marks the beginning of a new cookie

--- a/test/mitmproxy/net/http/test_cookies.py
+++ b/test/mitmproxy/net/http/test_cookies.py
@@ -106,6 +106,14 @@ def test_read_cookie_pairs():
             'one="\\"two"; three=four',
             [["one", '"two'], ["three", "four"]]
         ],
+        [
+            "=; foo=bar",
+            [["", ""], ["foo", "bar"]]
+        ],
+        [
+            "=ooze; foo=bar",
+            [["", "ooze"], ["foo", "bar"]]
+        ],
     ]
     for s, lst in vals:
         ret, off = cookies._read_cookie_pairs(s)
@@ -151,6 +159,20 @@ def test_parse_set_cookie_pairs():
             [[
                 ["one", "uno"],
                 ["foo", None]
+            ]]
+        ],
+        [
+            "=; foo=bar",
+            [[
+                ["", ""],
+                ["foo", "bar"]
+            ]]
+        ],
+        [
+            "=ooze; foo=bar",
+            [[
+                ["", "ooze"],
+                ["foo", "bar"]
             ]]
         ],
         [


### PR DESCRIPTION
Currently, having empty cookie key and value will lead to weird behaviour, as mentioned in #2829. Additionally, having cookie value without a key will crash the program when trying to edit the cookie header.

Initially, I thought we should reject malformed `Cookie` or `Set-Cookie` header and allow the user to edit the raw header instead. However, `cookies.py` says we are trying to be as permissive as possible, accepting even malformed header. Hence, I think `=;a=b`, `=bc` should all be accepted, as they can be interpreted as having empty cookie key (and value). The only thing that should return an empty array is something like `;` or the empty string, which will be parsed as `(lhs, rhs) == ('', None)`. That is the change I have made in this PR.

This is my first PR, so please let me know if I miss out on anything. Thank you!