### PR TITLE
Fix a typo in events.rst

### DIFF
--- a/docs/scripting/events.rst
+++ b/docs/scripting/events.rst
@@ -100,10 +100,10 @@ HTTP Events
 
     *   - .. py:function:: http_connect(flow)
         - Called when we receive an HTTP CONNECT request. Setting a non 2xx
-          response on the flow will return the response to the client abort the
-          connection. CONNECT requests and responses do not generate the usual
-          HTTP handler events. CONNECT requests are only valid in regular and
-          upstream proxy modes.
+          response on the flow will return the response to the client and abort 
+          the connection. CONNECT requests and responses do not generate the 
+          usual HTTP handler events. CONNECT requests are only valid in regular 
+          and upstream proxy modes.
 
           *flow*
             A ``models.HTTPFlow`` object. The flow is guaranteed to have


### PR DESCRIPTION
This PR fixes a tiny typo in the documentation.