### PR TITLE
Fix a bug with two-words contentview modes

### DIFF
--- a/mitmproxy/tools/console/consoleaddons.py
+++ b/mitmproxy/tools/console/consoleaddons.py
@@ -498,10 +498,11 @@ class ConsoleAddon:
 
     @command.command("console.flowview.mode.set")
     @command.argument("mode", type=mitmproxy.types.Choice("console.flowview.mode.options"))
-    def flowview_mode_set(self, mode: str) -> None:
+    def flowview_mode_set(self, *mode: str) -> None:
         """
             Set the display mode for the current flow view.
         """
+        mode = " ".join(mode)
         fv = self.master.window.current_window("flowview")
         if not fv:
             raise exceptions.CommandError("Not viewing a flow.")

--- a/mitmproxy/tools/console/consoleaddons.py
+++ b/mitmproxy/tools/console/consoleaddons.py
@@ -1,4 +1,5 @@
 import csv
+import shlex
 import typing
 
 from mitmproxy import ctx
@@ -259,7 +260,7 @@ class ConsoleAddon:
 
         def callback(opt):
             # We're now outside of the call context...
-            repl = "\"" + " ".join(args) + "\""
+            repl = shlex.quote(" ".join(args))
             repl = repl.replace("{choice}", opt)
             try:
                 self.master.commands.call(subcmd + " " + repl)

--- a/mitmproxy/tools/console/consoleaddons.py
+++ b/mitmproxy/tools/console/consoleaddons.py
@@ -259,7 +259,7 @@ class ConsoleAddon:
 
         def callback(opt):
             # We're now outside of the call context...
-            repl = " ".join(args)
+            repl = "\"" + " ".join(args) + "\""
             repl = repl.replace("{choice}", opt)
             try:
                 self.master.commands.call(subcmd + " " + repl)
@@ -498,11 +498,10 @@ class ConsoleAddon:
 
     @command.command("console.flowview.mode.set")
     @command.argument("mode", type=mitmproxy.types.Choice("console.flowview.mode.options"))
-    def flowview_mode_set(self, *mode: str) -> None:
+    def flowview_mode_set(self, mode: str) -> None:
         """
             Set the display mode for the current flow view.
         """
-        mode = " ".join(mode)
         fv = self.master.window.current_window("flowview")
         if not fv:
             raise exceptions.CommandError("Not viewing a flow.")


### PR DESCRIPTION
There was a bug:
1. Create a flow and  enter its details.
2. Press `m` and choose `multipart form` or `protocol buffer`.
You will see `command argument mismatch: too many positional arguments`

We call `console.flowview.mode.set` here https://github.com/mitmproxy/mitmproxy/blob/master/mitmproxy/tools/console/consoleaddons.py#L264-L267
When `repl` is `multipart form` or `protocol buffer`, it is splitted into two parts inside. Thus `console.flowview.mode.set` gets more args that it can accept.