### PR TITLE
Hotkeys cleanup. #2877

### DIFF
--- a/examples/simple/custom_contentview.py
+++ b/examples/simple/custom_contentview.py
@@ -7,10 +7,6 @@ from mitmproxy import contentviews
 
 class ViewSwapCase(contentviews.View):
     name = "swapcase"
-
-    # We don't have a good solution for the keyboard shortcut yet -
-    # you manually need to find a free letter. Contributions welcome :)
-    prompt = ("swap case text", "z")
     content_types = ["text/plain"]
 
     def __call__(self, data, **metadata) -> contentviews.TViewResult:

--- a/mitmproxy/contentviews/__init__.py
+++ b/mitmproxy/contentviews/__init__.py
@@ -16,7 +16,6 @@ parameters are passed as the ``query`` keyword argument.
 import traceback
 from typing import Dict, Optional  # noqa
 from typing import List  # noqa
-from typing import Tuple  # noqa
 
 from mitmproxy import exceptions
 from mitmproxy.net import http
@@ -29,19 +28,11 @@ from .base import View, VIEW_CUTOFF, KEY_MAX, format_text, format_dict, TViewRes
 
 views = []  # type: List[View]
 content_types_map = {}  # type: Dict[str, List[View]]
-view_prompts = []  # type: List[Tuple[str, str]]
 
 
 def get(name: str) -> Optional[View]:
     for i in views:
         if i.name.lower() == name.lower():
-            return i
-    return None
-
-
-def get_by_shortcut(c: str) -> Optional[View]:
-    for i in views:
-        if i.prompt[1] == c:
             return i
     return None
 
@@ -52,18 +43,11 @@ def add(view: View) -> None:
         if i.name == view.name:
             raise exceptions.ContentViewException("Duplicate view: " + view.name)
 
-    # TODO: the UI should auto-prompt for a replacement shortcut
-    for prompt in view_prompts:
-        if prompt[1] == view.prompt[1]:
-            raise exceptions.ContentViewException("Duplicate view shortcut: " + view.prompt[1])
-
     views.append(view)
 
     for ct in view.content_types:
         l = content_types_map.setdefault(ct, [])
         l.append(view)
-
-    view_prompts.append(view.prompt)
 
 
 def remove(view: View) -> None:
@@ -74,7 +58,6 @@ def remove(view: View) -> None:
         if not len(l):
             del content_types_map[ct]
 
-    view_prompts.remove(view.prompt)
     views.remove(view)
 
 
@@ -178,6 +161,5 @@ add(protobuf.ViewProtobuf())
 
 __all__ = [
     "View", "VIEW_CUTOFF", "KEY_MAX", "format_text", "format_dict", "TViewResult",
-    "get", "get_by_shortcut", "add", "remove",
-    "get_content_view", "get_message_content_view",
+    "get", "add", "remove", "get_content_view", "get_message_content_view",
 ]

--- a/mitmproxy/contentviews/auto.py
+++ b/mitmproxy/contentviews/auto.py
@@ -6,7 +6,6 @@ from . import base
 
 class ViewAuto(base.View):
     name = "Auto"
-    prompt = ("auto", "a")
 
     def __call__(self, data, **metadata):
         headers = metadata.get("headers", {})

--- a/mitmproxy/contentviews/base.py
+++ b/mitmproxy/contentviews/base.py
@@ -12,7 +12,6 @@ TViewResult = typing.Tuple[str, typing.Iterator[TViewLine]]
 
 class View:
     name = None  # type: str
-    prompt = None  # type: typing.Tuple[str,str]
     content_types = []  # type: typing.List[str]
 
     def __call__(self, data: bytes, **metadata) -> TViewResult:

--- a/mitmproxy/contentviews/css.py
+++ b/mitmproxy/contentviews/css.py
@@ -50,7 +50,6 @@ def beautify(data: str, indent: str = "    "):
 
 class ViewCSS(base.View):
     name = "CSS"
-    prompt = ("css", "c")
     content_types = [
         "text/css"
     ]

--- a/mitmproxy/contentviews/hex.py
+++ b/mitmproxy/contentviews/hex.py
@@ -4,7 +4,6 @@ from . import base
 
 class ViewHex(base.View):
     name = "Hex"
-    prompt = ("hex", "e")
 
     @staticmethod
     def _format(data):

--- a/mitmproxy/contentviews/image/view.py
+++ b/mitmproxy/contentviews/image/view.py
@@ -15,7 +15,6 @@ imghdr.tests.append(test_ico)
 
 class ViewImage(base.View):
     name = "Image"
-    prompt = ("image", "i")
 
     # there is also a fallback in the auto view for image/*.
     content_types = [

--- a/mitmproxy/contentviews/javascript.py
+++ b/mitmproxy/contentviews/javascript.py
@@ -46,7 +46,6 @@ def beautify(data):
 
 class ViewJavaScript(base.View):
     name = "JavaScript"
-    prompt = ("javascript", "j")
     content_types = [
         "application/x-javascript",
         "application/javascript",

--- a/mitmproxy/contentviews/json.py
+++ b/mitmproxy/contentviews/json.py
@@ -15,7 +15,6 @@ def pretty_json(s: bytes) -> Optional[bytes]:
 
 class ViewJSON(base.View):
     name = "JSON"
-    prompt = ("json", "s")
     content_types = [
         "application/json",
         "application/vnd.api+json"

--- a/mitmproxy/contentviews/multipart.py
+++ b/mitmproxy/contentviews/multipart.py
@@ -5,7 +5,6 @@ from . import base
 
 class ViewMultipart(base.View):
     name = "Multipart Form"
-    prompt = ("multipart", "m")
     content_types = ["multipart/form-data"]
 
     @staticmethod

--- a/mitmproxy/contentviews/protobuf.py
+++ b/mitmproxy/contentviews/protobuf.py
@@ -66,7 +66,6 @@ class ViewProtobuf(base.View):
     """
 
     name = "Protocol Buffer"
-    prompt = ("protobuf", "p")
     content_types = [
         "application/x-protobuf",
         "application/x-protobuffer",

--- a/mitmproxy/contentviews/query.py
+++ b/mitmproxy/contentviews/query.py
@@ -5,7 +5,6 @@ from . import base
 
 class ViewQuery(base.View):
     name = "Query"
-    prompt = ("query", "q")
 
     def __call__(self, data, **metadata):
         query = metadata.get("query")

--- a/mitmproxy/contentviews/raw.py
+++ b/mitmproxy/contentviews/raw.py
@@ -6,7 +6,6 @@ from . import base
 
 class ViewRaw(base.View):
     name = "Raw"
-    prompt = ("raw", "r")
 
     def __call__(self, data, **metadata):
         return "Raw", base.format_text(strutils.bytes_to_escaped_str(data, True))

--- a/mitmproxy/contentviews/urlencoded.py
+++ b/mitmproxy/contentviews/urlencoded.py
@@ -5,7 +5,6 @@ from . import base
 
 class ViewURLEncoded(base.View):
     name = "URL-encoded"
-    prompt = ("urlencoded", "u")
     content_types = ["application/x-www-form-urlencoded"]
 
     def __call__(self, data, **metadata):

--- a/mitmproxy/contentviews/wbxml.py
+++ b/mitmproxy/contentviews/wbxml.py
@@ -4,7 +4,6 @@ from . import base
 
 class ViewWBXML(base.View):
     name = "WBXML"
-    prompt = ("wbxml", "w")
     content_types = [
         "application/vnd.wap.wbxml",
         "application/vnd.ms-sync.wbxml"

--- a/mitmproxy/contentviews/xml_html.py
+++ b/mitmproxy/contentviews/xml_html.py
@@ -214,7 +214,6 @@ def format_xml(tokens: Iterable[Token]) -> str:
 
 class ViewXmlHtml(base.View):
     name = "XML/HTML"
-    prompt = ("xml/html", "x")
     content_types = ["text/xml", "text/html"]
 
     def __call__(self, data, **metadata):

--- a/mitmproxy/tools/console/common.py
+++ b/mitmproxy/tools/console/common.py
@@ -10,17 +10,6 @@ from mitmproxy.utils import human
 # Detect Windows Subsystem for Linux
 IS_WSL = "Microsoft" in platform.platform()
 
-METHOD_OPTIONS = [
-    ("get", "g"),
-    ("post", "p"),
-    ("put", "u"),
-    ("head", "h"),
-    ("trace", "t"),
-    ("delete", "d"),
-    ("options", "o"),
-    ("edit raw", "e"),
-]
-
 
 def is_keypress(k):
     """

--- a/test/mitmproxy/contentviews/test_api.py
+++ b/test/mitmproxy/contentviews/test_api.py
@@ -78,5 +78,3 @@ def test_get_message_content_view():
     r.content = None
     desc, lines, err = contentviews.get_message_content_view("raw", r)
     assert list(lines) == [[("error", "content missing")]]
-
-

--- a/test/mitmproxy/contentviews/test_api.py
+++ b/test/mitmproxy/contentviews/test_api.py
@@ -9,7 +9,6 @@ from mitmproxy.test import tutils
 
 class TestContentView(contentviews.View):
     name = "test"
-    prompt = ("test", "t")
     content_types = ["test/123"]
 
 

--- a/test/mitmproxy/contentviews/test_api.py
+++ b/test/mitmproxy/contentviews/test_api.py
@@ -22,13 +22,6 @@ def test_add_remove():
     with pytest.raises(ContentViewException, match="Duplicate view"):
         contentviews.add(tcv)
 
-    tcv2 = TestContentView()
-    tcv2.name = "test2"
-    tcv2.prompt = ("test2", "t")
-    # Same shortcut doesn't work either.
-    with pytest.raises(ContentViewException, match="Duplicate view shortcut"):
-        contentviews.add(tcv2)
-
     contentviews.remove(tcv)
     assert tcv not in contentviews.views
 
@@ -88,6 +81,3 @@ def test_get_message_content_view():
     assert list(lines) == [[("error", "content missing")]]
 
 
-def test_get_by_shortcut():
-    assert contentviews.get_by_shortcut("s")
-    assert not contentviews.get_by_shortcut("b")


### PR DESCRIPTION
**Earlier:**
We pressed `m` and had to choose a necessary shortcut from the string in statusbar.

https://github.com/mitmproxy/mitmproxy/blob/3d4d580975731215d58a629755e94b5913e67dc3/mitmproxy/tools/console/flowview.py#L609-L617
Every contentview had own shortcut. All shortcuts were collected in [`mitmproxy.contentviews.view_prompts`](https://github.com/mitmproxy/mitmproxy/blob/3d4d580975731215d58a629755e94b5913e67dc3/mitmproxy/tools/console/flowview.py#L610)
Now we shouldn't have it, because we use overlay widget to choose necessary contentview.
I didn't find these prompts used anywhere.
**Now** there are cleanup of:
- hotkey prompt in every contentview class (in base class as well);
- all code, which concerns contentview prompts in `mitmproxy.contentviews.__init__.py`;
- `custom_contentview` example;
- contentviews tests;
- METHOD_OPTIONS.