### PR TITLE
Parse Set-Cookie header more permissively. Fix #2829

### DIFF
--- a/mitmproxy/net/http/cookies.py
+++ b/mitmproxy/net/http/cookies.py
@@ -159,13 +159,17 @@ def _read_set_cookie_pairs(s: str, off=0) -> Tuple[List[TPairs], int]:
                 if len(rhs) <= 3:
                     trail, off = _read_value(s, off + 1, ";,")
                     rhs = rhs + "," + trail
-        if rhs or lhs:
+
+            # as long as there's a "=", we consider it a pair
             pairs.append([lhs, rhs])
 
-            # comma marks the beginning of a new cookie
-            if off < len(s) and s[off] == ",":
-                cookies.append(pairs)
-                pairs = []
+        elif lhs:
+            pairs.append([lhs, rhs])
+
+        # comma marks the beginning of a new cookie
+        if off < len(s) and s[off] == ",":
+            cookies.append(pairs)
+            pairs = []
 
         off += 1
 

--- a/test/mitmproxy/net/http/test_cookies.py
+++ b/test/mitmproxy/net/http/test_cookies.py
@@ -143,6 +143,27 @@ def test_cookie_roundtrips():
 def test_parse_set_cookie_pairs():
     pairs = [
         [
+            "=",
+            [[
+                ["", ""]
+            ]]
+        ],
+        [
+            "=;foo=bar",
+            [[
+                ["", ""],
+                ["foo", "bar"]
+            ]]
+        ],
+        [
+            "=;=;foo=bar",
+            [[
+                ["", ""],
+                ["", ""],
+                ["foo", "bar"]
+            ]]
+        ],
+        [
             "=uno",
             [[
                 ["", "uno"]


### PR DESCRIPTION
Currently, when mitmproxy parses a Set-Cookie header with no cookie key and value but some attributes, the attribute will be interpreted as the cookie key and value (#2829). This PR fixes the problem by recognizing any string with the character `=` as a valid key/value pair. This also means that, even the attributes can be an empty key/value pair. Of course, this won't happen in legitimate HTTP responses, but the change is in the spirit of being as permissive as possible so we should accept any string that can be interpreted by human.