### PR TITLE
Fix verbosity mode. Fix #2885

### DIFF
--- a/mitmproxy/tools/main.py
+++ b/mitmproxy/tools/main.py
@@ -50,7 +50,7 @@ def process_options(parser, opts, args):
         args.flow_detail = 0
     if args.verbose:
         args.verbosity = 'debug'
-        args.flow_detail = 3
+        args.flow_detail = 2
 
     adict = {}
     for n in dir(args):

--- a/mitmproxy/tools/main.py
+++ b/mitmproxy/tools/main.py
@@ -43,9 +43,12 @@ def process_options(parser, opts, args):
     if args.version:
         print(debug.dump_system_info())
         sys.exit(0)
-    if args.quiet or args.options or args.commands:
+    if args.quiet:
         args.verbosity = 'error'
         args.flow_detail = 0
+    if args.verbose:
+        args.verbosity = 'debug'
+        args.flow_detail = 3
 
     adict = {}
     for n in dir(args):

--- a/mitmproxy/tools/main.py
+++ b/mitmproxy/tools/main.py
@@ -43,7 +43,9 @@ def process_options(parser, opts, args):
     if args.version:
         print(debug.dump_system_info())
         sys.exit(0)
-    if args.quiet:
+    if args.quiet or args.options or args.commands:
+        # also reduce log verbosity if --options or --commands is passed,
+        # we don't want log messages from regular startup then.
         args.verbosity = 'error'
         args.flow_detail = 0
     if args.verbose:


### PR DESCRIPTION
I delete `args.options or args.commands`, because it seemes to haven't any effect.
I suppose, the idea was to set other verbosity level and show it in `--options` output. It won't work, because only default options values are collected for output https://github.com/mitmproxy/mitmproxy/blob/master/mitmproxy/optmanager.py#L404