### PR TITLE
Explicitly declare pyperclip requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ setup(
         "pyasn1>=0.3.1,<0.5",
         "pyOpenSSL>=17.5,<17.6",
         "pyparsing>=2.1.3, <2.3",
-        "pyperclip>=1.5.22, <1.7",
+        "pyperclip>=1.6.0, <1.7",
         "requests>=2.9.1, <3",
         "ruamel.yaml>=0.13.2, <0.16",
         "sortedcontainers>=1.5.4, <1.6",


### PR DESCRIPTION
pyperclip version 1.6.0 introduces an API change: the class `pyperclip.exceptions.PyperclipException` is moved to `pyperclip.PyperclipException`. As mitmproxy uses the latter, it's better to explicitly declare the requirement.

https://github.com/mitmproxy/mitmproxy/blob/7733252/mitmproxy/addons/cut.py#L144