### PR TITLE
Misc. typos

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -221,11 +221,11 @@
 
     * All mitmproxy tools are now Python 3 only! We plan to support Python 3.5 and higher.
 
-    * Web-Based User Interface: Mitmproxy now offically has a web-based user interface
+    * Web-Based User Interface: Mitmproxy now officially has a web-based user interface
       called mitmweb. We consider it stable for all features currently exposed
       in the UI, but it still misses a lot of mitmproxy’s options.
 
-    * Windows Compatibility: With mitmweb, mitmproxy is now useable on Windows.
+    * Windows Compatibility: With mitmweb, mitmproxy is now usable on Windows.
       We are also introducing an installer (kindly sponsored by BitRock) that
       simplifies setup.
 
@@ -387,7 +387,7 @@
     * libmproxy: Avoid double-connect in case of TLS Server Name Indication.
       This yields a massive speedup for TLS handshakes.
 
-    * libmproxy: Prevent unneccessary upstream connections (macmantrl)
+    * libmproxy: Prevent unnecessary upstream connections (macmantrl)
 
     * Inline Scripts: New API for HTTP Headers:
       http://docs.mitmproxy.org/en/latest/dev/models.html#netlib.http.Headers
@@ -650,7 +650,7 @@
       JSON, Javascript, images, XML, URL-encoded forms, as well as hexadecimal
       and raw views.
 
-    * Add Set Headers, analagous to replacement hooks. Defines headers that are set
+    * Add Set Headers, analogous to replacement hooks. Defines headers that are set
       on flows, based on a matching pattern.
 
     * A graphical editor for path components in mitmproxy.
@@ -708,7 +708,7 @@
       expanding random and generated portions, and logging a reproducible
       specification.
 
-    * Streamline the specification langauge. HTTP response message is now
+    * Streamline the specification language. HTTP response message is now
       specified using the "r" mnemonic.
 
     * Add a "u" mnemonic for specifying User-Agent strings. Add a set of

--- a/examples/addons/events.py
+++ b/examples/addons/events.py
@@ -155,7 +155,7 @@ class Events:
 
     def log(self, entry: mitmproxy.log.LogEntry):
         """
-            Called whenver a new log entry is created through the mitmproxy
+            Called whenever a new log entry is created through the mitmproxy
             context. Be careful not to log from this event, which will cause an
             infinite loop!
         """

--- a/examples/complex/README.md
+++ b/examples/complex/README.md
@@ -10,7 +10,7 @@
 | mitmproxywrapper.py      | Bracket mitmproxy run with proxy enable/disable on OS X                                       |
 | nonblocking.py           | Demonstrate parallel processing with a blocking script                                        |
 | remote_debug.py          | This script enables remote debugging of the mitmproxy _UI_ with PyCharm.                      |
-| sslstrip.py              | sslstrip-like funtionality implemented with mitmproxy                                         |
+| sslstrip.py              | sslstrip-like functionality implemented with mitmproxy                                        |
 | stream.py                | Enable streaming for all responses.                                                           |
 | stream_modify.py         | Modify a streamed response body.                                                              |
 | tcp_message.py           | Modify a raw TCP connection                                                                   |

--- a/examples/complex/stream_modify.py
+++ b/examples/complex/stream_modify.py
@@ -3,7 +3,7 @@ This inline script modifies a streamed response.
 If you do not need streaming, see the modify_response_body example.
 Be aware that content replacement isn't trivial:
     - If the transfer encoding isn't chunked, you cannot simply change the content length.
-    - If you want to replace all occurences of "foobar", make sure to catch the cases
+    - If you want to replace all occurrences of "foobar", make sure to catch the cases
       where one chunk ends with [...]foo" and the next starts with "bar[...].
 """
 

--- a/examples/complex/xss_scanner.py
+++ b/examples/complex/xss_scanner.py
@@ -215,7 +215,7 @@ def get_SQLi_data(new_body: str, original_body: str, request_URL: str, injection
 
 # A qc is either ' or "
 def inside_quote(qc: str, substring_bytes: bytes, text_index: int, body_bytes: bytes) -> bool:
-    """ Whether the Numberth occurence of the first string in the second
+    """ Whether the Numberth occurrence of the first string in the second
         string is inside quotes as defined by the supplied QuoteChar """
     substring = substring_bytes.decode('utf-8')
     body = body_bytes.decode('utf-8')
@@ -246,7 +246,7 @@ def paths_to_text(html: str, string: str) -> List[str]:
           - Note that it does a BFS """
 
     def remove_last_occurence_of_sub_string(string: str, substr: str) -> str:
-        """ Delete the last occurence of substr from str
+        """ Delete the last occurrence of substr from str
         String String -> String
         """
         index = string.rfind(substr)
@@ -274,7 +274,7 @@ def paths_to_text(html: str, string: str) -> List[str]:
 def get_XSS_data(body: Union[str, bytes], request_URL: str, injection_point: str) -> Optional[XSSData]:
     """ Return a XSSDict if there is a XSS otherwise return None """
     def in_script(text, index, body) -> bool:
-        """ Whether the Numberth occurence of the first string in the second
+        """ Whether the Numberth occurrence of the first string in the second
             string is inside a script tag """
         paths = paths_to_text(body.decode('utf-8'), text.decode("utf-8"))
         try:
@@ -284,7 +284,7 @@ def get_XSS_data(body: Union[str, bytes], request_URL: str, injection_point: str
             return False
 
     def in_HTML(text: bytes, index: int, body: bytes) -> bool:
-        """ Whether the Numberth occurence of the first string in the second
+        """ Whether the Numberth occurrence of the first string in the second
             string is inside the HTML but not inside a script tag or part of
             a HTML attribute"""
         # if there is a < then lxml will interpret that as a tag, so only search for the stuff before it

--- a/mitmproxy/addons/cut.py
+++ b/mitmproxy/addons/cut.py
@@ -61,7 +61,7 @@ class Cut:
             from the base of the flow object, with a few conveniences - "port"
             and "host" retrieve parts of an address tuple, ".header[key]"
             retrieves a header value. Return values converted to strings or
-            bytes: SSL certicates are converted to PEM format, bools are "true"
+            bytes: SSL certificates are converted to PEM format, bools are "true"
             or "false", "bytes" are preserved, and all other values are
             converted to strings.
         """

--- a/mitmproxy/addons/proxyauth.py
+++ b/mitmproxy/addons/proxyauth.py
@@ -172,7 +172,7 @@ class ProxyAuth:
                         server = ldap3.Server(ldap_server)
                     else:
                         raise exceptions.OptionsError(
-                            "Invalid ldap specfication on the first part"
+                            "Invalid ldap specification on the first part"
                         )
                     conn = ldap3.Connection(
                         server,

--- a/mitmproxy/addons/upstream_auth.py
+++ b/mitmproxy/addons/upstream_auth.py
@@ -42,7 +42,7 @@ class UpstreamAuth():
         # FIXME: We're doing this because our proxy core is terminally confused
         # at the moment. Ideally, we should be able to check if we're in
         # reverse proxy mode at the HTTP layer, so that scripts can put the
-        # proxy in reverse proxy mode for specific reuests.
+        # proxy in reverse proxy mode for specific requests.
         if "upstream_auth" in updated:
             if ctx.options.upstream_auth is None:
                 self.auth = None

--- a/mitmproxy/addons/view.py
+++ b/mitmproxy/addons/view.py
@@ -325,7 +325,7 @@ class View(collections.Sequence):
         key: str
     ) -> None:
         """
-            Toggle a boolean value in the settings store, seting the value to
+            Toggle a boolean value in the settings store, setting the value to
             the string "true" or "false".
         """
         updated = []

--- a/mitmproxy/addons/wsgiapp.py
+++ b/mitmproxy/addons/wsgiapp.py
@@ -7,7 +7,7 @@ from mitmproxy import version
 
 class WSGIApp:
     """
-        An addon that hosts a WSGI app withing mitproxy, at a specified
+        An addon that hosts a WSGI app within mitproxy, at a specified
         hostname and port.
     """
     def __init__(self, app, host, port):

--- a/mitmproxy/certs.py
+++ b/mitmproxy/certs.py
@@ -160,7 +160,7 @@ class CertStore:
     def load_dhparam(path):
 
         # mitmproxy<=0.10 doesn't generate a dhparam file.
-        # Create it now if neccessary.
+        # Create it now if necessary.
         if not os.path.exists(path):
             with open(path, "wb") as f:
                 f.write(DEFAULT_DHPARAM)

--- a/mitmproxy/command.py
+++ b/mitmproxy/command.py
@@ -54,7 +54,7 @@ class Command:
 
         self.has_positional = False
         for i in sig.parameters.values():
-            # This is the kind for *args paramters
+            # This is the kind for *args parameters
             if i.kind == i.VAR_POSITIONAL:
                 self.has_positional = True
         self.paramtypes = [v.annotation for v in sig.parameters.values()]

--- a/mitmproxy/controller.py
+++ b/mitmproxy/controller.py
@@ -56,7 +56,7 @@ class Reply:
 
         self._state = "start"  # "start" -> "taken" -> "committed"
 
-        # Holds the reply value. May change before things are actually commited.
+        # Holds the reply value. May change before things are actually committed.
         self.value = NO_REPLY
 
     @property
@@ -66,7 +66,7 @@ class Reply:
         sequentially through the following lifecycle:
 
             1. start: Initial State.
-            2. taken: The reply object has been taken to be commited.
+            2. taken: The reply object has been taken to be committed.
             3. committed: The reply has been sent back to the requesting party.
 
         This attribute is read-only and can only be modified by calling one of
@@ -91,7 +91,7 @@ class Reply:
 
     def commit(self):
         """
-        Ultimately, messages are commited. This is done either automatically by
+        Ultimately, messages are committed. This is done either automatically by
         if the message is not taken or manually by the entity which called
         .take().
         """

--- a/mitmproxy/io/compat.py
+++ b/mitmproxy/io/compat.py
@@ -123,7 +123,7 @@ def convert_200_300(data):
 
 def convert_300_4(data):
     data["version"] = 4
-    # Ths is an empty migration to transition to the new versioning scheme.
+    # This is an empty migration to transition to the new versioning scheme.
     return data
 
 

--- a/mitmproxy/net/http/http1/read.py
+++ b/mitmproxy/net/http/http1/read.py
@@ -43,7 +43,7 @@ def read_request_head(rfile):
     Raises:
         exceptions.HttpReadDisconnect: No bytes can be read from rfile.
         exceptions.HttpSyntaxException: The input is malformed HTTP.
-        exceptions.HttpException: Any other error occured.
+        exceptions.HttpException: Any other error occurred.
     """
     timestamp_start = time.time()
     if hasattr(rfile, "reset_timestamps"):
@@ -82,7 +82,7 @@ def read_response_head(rfile):
     Raises:
         exceptions.HttpReadDisconnect: No bytes can be read from rfile.
         exceptions.HttpSyntaxException: The input is malformed HTTP.
-        exceptions.HttpException: Any other error occured.
+        exceptions.HttpException: Any other error occurred.
     """
 
     timestamp_start = time.time()

--- a/mitmproxy/platform/windows.py
+++ b/mitmproxy/platform/windows.py
@@ -359,7 +359,7 @@ class TransparentProxy:
         packet.dst_addr, packet.dst_port = self.proxy_addr, self.proxy_port
         packet.direction = pydivert.consts.Direction.INBOUND
 
-        # Use any handle thats on the NETWORK layer - request_local may be
+        # Use any handle that's on the NETWORK layer - request_local may be
         # unavailable.
         self.response_handle.send(packet)
 

--- a/mitmproxy/proxy/protocol/http.py
+++ b/mitmproxy/proxy/protocol/http.py
@@ -481,7 +481,7 @@ class HttpLayer(base.Layer):
             if address != self.server_conn.address or tls != self.server_tls:
                 self.set_server(address)
                 self.set_server_tls(tls, address[0])
-            # Establish connection is neccessary.
+            # Establish connection is necessary.
             if not self.server_conn.connected():
                 self.connect()
         else:

--- a/mitmproxy/proxy/protocol/http2.py
+++ b/mitmproxy/proxy/protocol/http2.py
@@ -269,7 +269,7 @@ class Http2Layer(base.Layer):
 
     def _handle_priority_updated(self, eid, event):
         if not self.config.options.http2_priority:
-            self.log("HTTP/2 PRIORITY frame surpressed. Use --http2-priority to enable forwarding.", "debug")
+            self.log("HTTP/2 PRIORITY frame suppressed. Use --http2-priority to enable forwarding.", "debug")
             return True
 
         if eid in self.streams and self.streams[eid].handled_priority_event is event:
@@ -541,7 +541,7 @@ class Http2SingleStreamLayer(httpbase._HttpTransmissionLayer, basethread.BaseThr
             # only send priority information if they actually came with the original HeadersFrame
             # and not if they got updated before/after with a PriorityFrame
             if not self.config.options.http2_priority:
-                self.log("HTTP/2 PRIORITY information in HEADERS frame surpressed. Use --http2-priority to enable forwarding.", "debug")
+                self.log("HTTP/2 PRIORITY information in HEADERS frame suppressed. Use --http2-priority to enable forwarding.", "debug")
             else:
                 priority_exclusive = self.priority_exclusive
                 priority_depends_on = self._map_depends_on_stream_id(self.server_stream_id, self.priority_depends_on)

--- a/mitmproxy/proxy/protocol/tls.py
+++ b/mitmproxy/proxy/protocol/tls.py
@@ -5,7 +5,7 @@ from mitmproxy import exceptions
 from mitmproxy.net import tls as net_tls
 from mitmproxy.proxy.protocol import base
 
-# taken from https://testssl.sh/openssl-rfc.mappping.html
+# taken from https://testssl.sh/openssl-rfc.mapping.html
 CIPHER_ID_NAME_MAP = {
     0x00: 'NULL-MD5',
     0x01: 'NULL-MD5',

--- a/mitmproxy/test/taddons.py
+++ b/mitmproxy/test/taddons.py
@@ -137,7 +137,7 @@ class context:
 
     def command(self, func, *args):
         """
-            Invoke a command function with a list of string arguments within a command context, mimicing the actual command environment.
+            Invoke a command function with a list of string arguments within a command context, mimicking the actual command environment.
         """
         cmd = command.Command(self.master.commands, "test.command", func)
         return cmd.call(args)

--- a/mitmproxy/tools/console/consoleaddons.py
+++ b/mitmproxy/tools/console/consoleaddons.py
@@ -88,7 +88,7 @@ class ConsoleAddon:
         )
         loader.add_option(
             "console_layout_headers", bool, True,
-            "Show layout comonent headers",
+            "Show layout component headers",
         )
         loader.add_option(
             "console_focus_follow", bool, False,
@@ -223,7 +223,7 @@ class ConsoleAddon:
     ) -> None:
         """
             Prompt the user to choose from a specified list of strings, then
-            invoke another command with all occurances of {choice} replaced by
+            invoke another command with all occurrences of {choice} replaced by
             the choice the user made.
         """
         def callback(opt):
@@ -249,7 +249,7 @@ class ConsoleAddon:
     ) -> None:
         """
             Prompt the user to choose from a list of strings returned by a
-            command, then invoke another command with all occurances of {choice}
+            command, then invoke another command with all occurrences of {choice}
             replaced by the choice the user made.
         """
         choices = ctx.master.commands.call_args(choicecmd, [])

--- a/pathod/pathoc.py
+++ b/pathod/pathoc.py
@@ -352,7 +352,7 @@ class Pathoc(tcp.TCPClient):
 
             timeout: If specified None may be yielded instead if timeout is
             reached. If timeout is None, wait forever. If timeout is 0, return
-            immedately if nothing is on the queue.
+            immediately if nothing is on the queue.
 
             finish: If true, consume messages until the reader shuts down.
             Otherwise, return None on timeout.
@@ -434,7 +434,7 @@ class Pathoc(tcp.TCPClient):
                 req = language.serve(r, self.wfile, self.settings)
                 self.wfile.flush()
 
-                # build a dummy request to read the reponse
+                # build a dummy request to read the response
                 # ideally this would be returned directly from language.serve
                 dummy_req = net_http.Request(
                     first_line_format="relative",
@@ -471,7 +471,7 @@ class Pathoc(tcp.TCPClient):
         """
             Performs a single request.
 
-            r: A language.message.Messsage object, or a string representing
+            r: A language.message.Message object, or a string representing
             one.
 
             Returns Response if we have a non-ignored response.

--- a/test/mitmproxy/net/test_tcp.py
+++ b/test/mitmproxy/net/test_tcp.py
@@ -485,7 +485,7 @@ class TestSSLDisconnect(tservers.ServerTestBase):
         c = tcp.TCPClient(("127.0.0.1", self.port))
         with c.connect():
             c.convert_to_tls()
-            # Excercise SSL.ZeroReturnError
+            # Exercise SSL.ZeroReturnError
             c.rfile.read(10)
             c.close()
             with pytest.raises(exceptions.TcpDisconnect):


### PR DESCRIPTION
Found via `codespell -q 3 -I ../mitmproxy-word-whitelist.txt`
Where whitelist contains:
```
cas
doubleclick
nd
ot
seeked
statics
te
thru
```