### PR TITLE
Exception when running inappropriate file as a script, fix 2839

### DIFF
--- a/mitmproxy/addons/script.py
+++ b/mitmproxy/addons/script.py
@@ -30,11 +30,11 @@ def load_script(path: str) -> types.ModuleType:
         loader.exec_module(m)
         if not getattr(m, "name", None):
             m.name = path  # type: ignore
-        return m
     except Exception as e:
         ctx.log.error(str(e))
     finally:
         sys.path[:] = oldpath
+        return m
 
 
 class Script:

--- a/mitmproxy/addons/script.py
+++ b/mitmproxy/addons/script.py
@@ -14,7 +14,7 @@ from mitmproxy import eventsequence
 from mitmproxy import ctx
 
 
-def load_script(path: str) -> types.ModuleType:
+def load_script(path: str) -> typing.Optional[types.ModuleType]:
     fullname = "__mitmproxy_script__.{}".format(
         os.path.splitext(os.path.basename(path))[0]
     )
@@ -23,6 +23,7 @@ def load_script(path: str) -> types.ModuleType:
     sys.modules.pop(fullname, None)
     oldpath = sys.path
     sys.path.insert(0, os.path.dirname(path))
+    m = None
     try:
         loader = importlib.machinery.SourceFileLoader(fullname, path)
         spec = importlib.util.spec_from_loader(fullname, loader=loader)

--- a/mitmproxy/addons/script.py
+++ b/mitmproxy/addons/script.py
@@ -31,6 +31,8 @@ def load_script(path: str) -> types.ModuleType:
         if not getattr(m, "name", None):
             m.name = path  # type: ignore
         return m
+    except Exception as e:
+        ctx.log.error(str(e))
     finally:
         sys.path[:] = oldpath
 

--- a/test/mitmproxy/addons/test_script.py
+++ b/test/mitmproxy/addons/test_script.py
@@ -33,7 +33,7 @@ def test_load_script():
                 "mitmproxy/data/addonscripts/recorder/error.py"
             )
         )
-        assert tctx.master.has_log("invalid syntax (error.py, line 1)")
+        assert tctx.master.has_log("invalid syntax (error.py, line 5)")
 
 
 def test_load_fullname():

--- a/test/mitmproxy/addons/test_script.py
+++ b/test/mitmproxy/addons/test_script.py
@@ -15,17 +15,25 @@ from mitmproxy.test import tutils
 
 
 def test_load_script():
-    ns = script.load_script(
-        tutils.test_data.path(
-            "mitmproxy/data/addonscripts/recorder/recorder.py"
+    with taddons.context() as tctx:
+        ns = script.load_script(
+            tutils.test_data.path(
+                "mitmproxy/data/addonscripts/recorder/recorder.py"
+            )
         )
-    )
-    assert ns.addons
+        assert ns.addons
 
-    with pytest.raises(FileNotFoundError):
         script.load_script(
             "nonexistent"
         )
+        assert tctx.master.has_log("No such file or directory")
+
+        script.load_script(
+            tutils.test_data.path(
+                "mitmproxy/data/addonscripts/recorder/error.py"
+            )
+        )
+        assert tctx.master.has_log("invalid syntax (error.py, line 1)")
 
 
 def test_load_fullname():

--- a/test/mitmproxy/data/addonscripts/recorder/error.py
+++ b/test/mitmproxy/data/addonscripts/recorder/error.py
@@ -1,3 +1,7 @@
-impotr recorder
+"""
+This file is intended to have syntax errors for test purposes
+"""
+
+impotr recorder # Intended Syntax Error
 
 addons = [recorder.Recorder("e")]

--- a/test/mitmproxy/data/addonscripts/recorder/error.py
+++ b/test/mitmproxy/data/addonscripts/recorder/error.py
@@ -1,0 +1,3 @@
+impotr recorder
+
+addons = [recorder.Recorder("e")]


### PR DESCRIPTION
@kajojify and I had a discussion on this and this was a very difficult choice for us to make.
With the solution that this PR brings forward, although it's a neat solution but it might disturb the user experience when the error from his/her script is not a `SyntaxError` because it won't be informative enough

Another solution is not a neat solution which is proposed in #2839 comments.

