### PR TITLE
Better error when no type-annotations, fix #2787

### DIFF
--- a/mitmproxy/command.py
+++ b/mitmproxy/command.py
@@ -1,5 +1,5 @@
 """
-    This module manges and invokes typed commands.
+    This module manages and invokes typed commands.
 """
 import inspect
 import types
@@ -37,7 +37,7 @@ def typename(t: type) -> str:
     """
     to = mitmproxy.types.CommandTypes.get(t, None)
     if not to:
-        raise NotImplementedError(t)
+        raise SyntaxError("missing type annotations in consoleaddons.py")
     return to.display
 
 

--- a/test/mitmproxy/test_command.py
+++ b/test/mitmproxy/test_command.py
@@ -35,6 +35,10 @@ class TAddon:
     def empty(self) -> None:
         pass
 
+    @command.command("annotation_error")
+    def annotation_error(self):
+        return "ok"
+
     @command.command("varargs")
     def varargs(self, one: str, *var: str) -> typing.Sequence[str]:
         return list(var)
@@ -80,6 +84,14 @@ class TestCommand:
 
             c = command.Command(cm, "cmd.three", a.cmd3)
             assert c.call(["1"]) == 1
+
+    def test_annotation_error(self):
+        with taddons.context() as tctx:
+            cm = command.CommandManager(tctx.master)
+            a = TAddon()
+            c = command.Command(cm, "annotation_error", a.annotation_error)
+            with pytest.raises(SyntaxError):
+                c.signature_help()
 
     def test_parse_partial(self):
         tests = [


### PR DESCRIPTION
Hi,
I have replaced the `NotImplementedError` with the `SyntaxError` and this fixes #2787 . Added a test for the same.
Also there is traceback because I have made an assumption that the developers will mostly have this issue and a `traceback` would be useful. Would love to hear your opinions? :)
