### PR TITLE
Polite shortening of statusbar messages. Fix #1433

### DIFF
--- a/mitmproxy/tools/console/master.py
+++ b/mitmproxy/tools/console/master.py
@@ -94,7 +94,8 @@ class ConsoleMaster(master.Master):
                 self.start_err = entry
             else:
                 signals.status_message.send(
-                    message=(entry.level, "{}: {}".format(entry.level.title(), entry.msg)),
+                    message=(entry.level, "{}: {}".format(entry.level.title(),
+                                                          entry.msg.lstrip())),
                     expire=5
                 )
 

--- a/mitmproxy/tools/console/master.py
+++ b/mitmproxy/tools/console/master.py
@@ -94,8 +94,9 @@ class ConsoleMaster(master.Master):
                 self.start_err = entry
             else:
                 signals.status_message.send(
-                    message=(entry.level, "{}: {}".format(entry.level.title(),
-                                                          entry.msg.lstrip())),
+                    message=(entry.level,
+                             "{}: {}".format(entry.level.title(),
+                                             str(entry.msg).lstrip())),
                     expire=5
                 )
 

--- a/mitmproxy/tools/console/statusbar.py
+++ b/mitmproxy/tools/console/statusbar.py
@@ -72,15 +72,18 @@ class ActionBar(urwid.WidgetWrap):
 
         msg_lines = msg_text.split("\n")
         first_line = msg_lines[0]
+        if len(msg_lines) > 1:
+            # Messages with a few lines must end with prompt.
+            line_length = len(first_line) + len(prompt)
+        else:
+            line_length = len(first_line)
 
-        oneline_fits = len(first_line) > cols and len(msg_lines) == 1
-        manylines_first_fits = (len(first_line) + len(prompt) > cols and
-                                len(msg_lines) > 1)
-        if oneline_fits or manylines_first_fits:
+        if line_length > cols:
             shortening_index = max(0, cols - len(prompt) - 3)
             first_line = first_line[:shortening_index] + "..."
-        elif len(msg_lines) == 1 and len(first_line) <= cols:
-            prompt = ""
+        else:
+            if len(msg_lines) == 1:
+                prompt = ""
 
         return [(disp_attr, first_line), ("warn", prompt)]
 

--- a/mitmproxy/tools/console/statusbar.py
+++ b/mitmproxy/tools/console/statusbar.py
@@ -73,7 +73,7 @@ class ActionBar(urwid.WidgetWrap):
         msg_lines = msg_text.split("\n")
         first_line = msg_lines[0]
         if len(msg_lines) > 1:
-            # Messages with a few lines must end with prompt.
+            # First line of messages with a few lines must end with prompt.
             line_length = len(first_line) + len(prompt)
         else:
             line_length = len(first_line)

--- a/mitmproxy/tools/console/statusbar.py
+++ b/mitmproxy/tools/console/statusbar.py
@@ -49,7 +49,8 @@ class ActionBar(urwid.WidgetWrap):
     def sig_message(self, sender, message, expire=1):
         if self.prompting:
             return
-        w = urwid.Text(self.prep_message(message))
+        cols, _ = self.master.ui.get_cols_rows()
+        w = urwid.Text(self.shorten_message(message, cols))
         self._w = w
         if expire:
             def cb(*args):
@@ -60,14 +61,17 @@ class ActionBar(urwid.WidgetWrap):
     def prep_prompt(self, p):
         return p.strip() + ": "
 
-    def prep_message(self, msg):
+    def shorten_message(self, msg, max_width):
+        """
+        Shorten message so that it fits into a single line in the statusbar.
+        """
         if isinstance(msg, tuple):
             disp_attr, msg_text = msg
         elif isinstance(msg, str):
             disp_attr, msg_text = None, msg
         else:
             return msg
-        cols, _ = self.master.ui.get_cols_rows()
+        msg_end = "\u2026"  # unicode ellipsis for the end of shortened message
         prompt = "(more in eventlog)"
 
         msg_lines = msg_text.split("\n")
@@ -78,9 +82,9 @@ class ActionBar(urwid.WidgetWrap):
         else:
             line_length = len(first_line)
 
-        if line_length > cols:
-            shortening_index = max(0, cols - len(prompt) - 3)
-            first_line = first_line[:shortening_index] + "..."
+        if line_length > max_width:
+            shortening_index = max(0, max_width - len(prompt) - len(msg_end))
+            first_line = first_line[:shortening_index] + msg_end
         else:
             if len(msg_lines) == 1:
                 prompt = ""

--- a/test/mitmproxy/tools/console/test_statusbar.py
+++ b/test/mitmproxy/tools/console/test_statusbar.py
@@ -1,6 +1,8 @@
 from mitmproxy import options
 from mitmproxy.tools.console import statusbar, master
 
+from unittest import mock
+
 
 def test_statusbar(monkeypatch):
     o = options.Options()
@@ -31,3 +33,26 @@ def test_statusbar(monkeypatch):
 
     bar = statusbar.StatusBar(m)  # this already causes a redraw
     assert bar.ib._w
+
+
+def test_prep_message():
+    o = options.Options()
+    m = master.ConsoleMaster(o)
+    m.ui = mock.MagicMock()
+    m.ui.get_cols_rows = mock.MagicMock(return_value=(50, 50))
+    ab = statusbar.ActionBar(m)
+
+    prep_msg = ab.prep_message("Error: Fits into statusbar")
+    assert prep_msg == [(None, "Error: Fits into statusbar"), ("warn", "")]
+
+    prep_msg = ab.prep_message("Error: Doesn't fit into statusbar"*2)
+    assert prep_msg == [(None, "Error: Doesn't fit into statu..."),
+                        ("warn", "(more in eventlog)")]
+
+    prep_msg = ab.prep_message("Error: Two lines.\nFirst fits")
+    assert prep_msg == [(None, "Error: Two lines."),
+                        ("warn", "(more in eventlog)")]
+
+    prep_msg = ab.prep_message("Error: Two lines"*4 + "\nFirst doensn't fit")
+    assert prep_msg == [(None, "Error: Two linesError: Two li..."),
+                        ("warn", "(more in eventlog)")]

--- a/test/mitmproxy/tools/console/test_statusbar.py
+++ b/test/mitmproxy/tools/console/test_statusbar.py
@@ -2,7 +2,6 @@ import pytest
 
 from mitmproxy import options
 from mitmproxy.tools.console import statusbar, master
-from unittest import mock
 
 
 def test_statusbar(monkeypatch):
@@ -40,23 +39,23 @@ def test_statusbar(monkeypatch):
     ("", [(None, ""), ("warn", "")]),
     (("info", "Line fits into statusbar"), [("info", "Line fits into statusbar"),
                                             ("warn", "")]),
-    ("Line doesn't fit into statusbar", [(None, "Line does..."),
+    ("Line doesn't fit into statusbar", [(None, "Line doesn'\u2026"),
                                          ("warn", "(more in eventlog)")]),
     (("alert", "Two lines.\nFirst fits"), [("alert", "Two lines."),
                                            ("warn", "(more in eventlog)")]),
-    ("Two long lines\nFirst doesn't fit", [(None, "Two long ..."),
+    ("Two long lines\nFirst doesn't fit", [(None, "Two long li\u2026"),
                                            ("warn", "(more in eventlog)")])
 ])
-def test_prep_message(message, ready_message):
-    m = mock.Mock()
-    m.ui.get_cols_rows.return_value = (30, 30)
+def test_shorten_message(message, ready_message):
+    o = options.Options()
+    m = master.ConsoleMaster(o)
     ab = statusbar.ActionBar(m)
-    assert ab.prep_message(message) == ready_message
+    assert ab.shorten_message(message, max_width=30) == ready_message
 
 
-def test_prep_message_narrow():
-    m = mock.Mock()
-    m.ui.get_cols_rows.return_value = (4, 4)
+def test_shorten_message_narrow():
+    o = options.Options()
+    m = master.ConsoleMaster(o)
     ab = statusbar.ActionBar(m)
-    prep_msg = ab.prep_message("error")
-    assert prep_msg == [(None, "..."), ("warn", "(more in eventlog)")]
+    shorten_msg = ab.shorten_message("error", max_width=4)
+    assert shorten_msg == [(None, "\u2026"), ("warn", "(more in eventlog)")]


### PR DESCRIPTION
PR snips any message that came to statusbar to the first line. It also invites users to see more in eventlog according to #1433. 
**P.S.**
https://github.com/mitmproxy/mitmproxy/compare/master...kajojify:shortening?expand=1#diff-5e13e3689fcd12fb5c83c66addc0e13bR99
Sometimes statusbar gets messages with "\n" or "\t" symbols at the beginning. Thus sometimes statusbar shows just `Error: `.  We want more.

### Result:
![1222684](https://user-images.githubusercontent.com/20267977/36923461-0d1df9c8-1e74-11e8-9d12-5436b590cfb3.png)

Variant | Result
------------ | -------------
1 | ![image](https://user-images.githubusercontent.com/20267977/36923844-3fc11544-1e75-11e8-988e-2c332c7c5055.png)
2 | ![image](https://user-images.githubusercontent.com/20267977/36923888-6225dcd2-1e75-11e8-9fed-a207bdb9083b.png)
3 | ![image](https://user-images.githubusercontent.com/20267977/36924014-b94e92c4-1e75-11e8-9ff2-781bbca104f3.png)
4 | ![image](https://user-images.githubusercontent.com/20267977/36923951-8f6b9a42-1e75-11e8-820d-cf01f4431ae4.png)

**Very narrow window:**
![image](https://user-images.githubusercontent.com/20267977/36924098-0c802cdc-1e76-11e8-8b8b-33063db06ca4.png)

