### PR TITLE
Fix for wrapping up extra-long urls in flowdetailview

### DIFF
--- a/mitmproxy/tools/console/flowview.py
+++ b/mitmproxy/tools/console/flowview.py
@@ -30,12 +30,14 @@ class FlowViewHeader(urwid.WidgetWrap):
         self.focus_changed()
 
     def focus_changed(self):
+        cols, _ = self.master.ui.get_cols_rows()
         if self.master.view.focus.flow:
             self._w = common.format_flow(
                 self.master.view.focus.flow,
                 False,
                 extended=True,
-                hostheader=self.master.options.showhost
+                hostheader=self.master.options.showhost,
+                max_url_len=cols,
             )
         else:
             self._w = urwid.Pile([])


### PR DESCRIPTION
While displaying extra-extra long urls in Flow Detail View, there was a no max_url_len value set causing a n overflow of url on the screen. The fixes get the max_cols from the ui and sets it to max_url_len

- Fixes #2818