### PR TITLE
docs: start move to docs.mitmproxy.org

### DIFF
--- a/docs/bucketassets/error.html
+++ b/docs/bucketassets/error.html
@@ -1,0 +1,9 @@
+Not found
+<html>
+    <head>
+        <meta http-equiv="refresh" content="0;URL='/stable'" />
+    </head>
+    <body>
+        Not found - redirecting you to <a href="/stable">latest stable docs</a>.
+    </body>
+</html>

--- a/docs/bucketassets/robots.txt
+++ b/docs/bucketassets/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Disallow: /archive/
+Disallow: /master/

--- a/docs/build
+++ b/docs/build
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+cd src; hugo

--- a/docs/setup
+++ b/docs/setup
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+aws configure set preview.cloudfront true
+aws --profile mitmproxy \
+    s3 cp --acl public-read ./bucketassets/error.html s3://docs.mitmproxy.org/error.html
+aws --profile mitmproxy \
+    s3 cp --acl public-read ./bucketassets/robots.txt s3://docs.mitmproxy.org/robots.txt

--- a/docs/src/themes/mitmproxydocs/static/css/style.css
+++ b/docs/src/themes/mitmproxydocs/static/css/style.css
@@ -6731,20 +6731,16 @@ label.panel-block {
     text-align: right; }
 
 .sidebar {
-  background-color: #F1F1F1;
-}
-
-.sidebar .version {
-  padding: 1em; }
-
-.sidebar .brand {
-  background-color: #303030;
-  color: #c0c0c0;
-  padding: 1em;
-  top: 0; }
-
-.sidebar .menu {
-  padding: 1em; }
+  background-color: #F1F1F1; }
+  .sidebar .version {
+    padding: 1em; }
+  .sidebar .brand {
+    background-color: #303030;
+    color: #c0c0c0;
+    padding: 1em;
+    top: 0; }
+  .sidebar .menu {
+    padding: 1em; }
 
 .mainbody {
   padding: 3em; }

--- a/docs/style/style.scss
+++ b/docs/style/style.scss
@@ -27,7 +27,6 @@ $family-sans-serif: BlinkMacSystemFont, -apple-system, "Segoe UI", "Roboto", "Ox
     margin-bottom: 1em;
 }
 
-
 .sidebar {
     background-color: #F1F1F1;
     .version {

--- a/docs/style/style.scss
+++ b/docs/style/style.scss
@@ -11,7 +11,6 @@ $family-sans-serif: BlinkMacSystemFont, -apple-system, "Segoe UI", "Roboto", "Ox
 @import "../node_modules/bulma/sass/layout/_all";
 
 .sidebody {
-    height: 100vh;
     overflow-x: hidden;
     overflow-y: scroll;
 }
@@ -30,6 +29,7 @@ $family-sans-serif: BlinkMacSystemFont, -apple-system, "Segoe UI", "Roboto", "Ox
 
 
 .sidebar {
+    background-color: #F1F1F1;
     .version {
         padding: 1em;
     }

--- a/docs/upload-archive
+++ b/docs/upload-archive
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+if [[ $# -eq 0 ]] ; then
+    echo "Please supply a version, e.g. 'v3'"
+    exit 1
+fi
+
+# This script uploads docs to a specified archive version.
+
+SPATH="/archive/$1"
+
+aws configure set preview.cloudfront true
+aws --profile mitmproxy \
+    s3 sync --acl public-read ./public s3://docs.mitmproxy.org$SPATH
+# aws --profile mitmproxy \
+#     cloudfront create-invalidation --distribution-id E3UCZ4MLN4TO7U \
+#     --paths "$SPATH"

--- a/docs/upload-master
+++ b/docs/upload-master
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+aws configure set preview.cloudfront true
+aws --profile mitmproxy \
+    s3 sync --acl public-read ./public s3://docs.mitmproxy.org/master
+# aws --profile mitmproxy \
+#     cloudfront create-invalidation --distribution-id E3UCZ4MLN4TO7U \
+#     --paths "/master"

--- a/docs/upload-stable
+++ b/docs/upload-stable
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+aws configure set preview.cloudfront true
+aws --profile mitmproxy \
+    s3 sync --acl public-read ./public s3://docs.mitmproxy.org/stable
+# aws --profile mitmproxy \
+#     cloudfront create-invalidation --distribution-id E3UCZ4MLN4TO7U \
+#     --paths "/master"


### PR DESCRIPTION
This begins to set up the infrastructure for docs.mitmproxy.org. It includes some upload scripts, plus a set of base assets for the domain (robots.txt and error.html). The CDN is not set up yet, so invalidation is commented out for now.

The next step is to have our CI render the docs with ./build, and then upload to master with ./upload-master. 