### PR TITLE
Added Support for AUR Google Chrome

### DIFF
--- a/mitmproxy/addons/browser.py
+++ b/mitmproxy/addons/browser.py
@@ -15,6 +15,7 @@ def get_chrome_executable() -> typing.Optional[str]:
             r"C:\Program Files (x86)\Google\Application\chrome.exe",
             # Linux binary names from Python's webbrowser module.
             "google-chrome",
+            "google-chrome-stable",
             "chrome",
             "chromium",
             "chromium-browser",


### PR DESCRIPTION
Hi,

I am running Arch Linux, with google chrome installed via Arch User repo the executable name is google-chrome-stable. [https://aur.archlinux.org/packages/google-chrome/](url)

This pull request allows for this to work without the error "Your platform is not supported yet - please submit a patch."

Thanks,