### PR TITLE
A unified handler for user's scripts exception

### DIFF
--- a/mitmproxy/addons/script.py
+++ b/mitmproxy/addons/script.py
@@ -48,7 +48,7 @@ def script_error_handler(path, exc, msg="", tb=False):
     lineno = ""
     if hasattr(exc, "lineno"):
         lineno = str(exc.lineno)
-    log_msg = "Error in Script {}:{} {}".format(path, lineno, exception)
+    log_msg = "in Script {}:{} {}".format(path, lineno, exception)
     if tb:
         etype, value, tback = sys.exc_info()
         tback = addonmanager.cut_traceback(tback, "invoke_addon")
@@ -73,7 +73,7 @@ class Script:
         self.last_load = 0
         self.last_mtime = 0
         if not os.path.isfile(self.fullpath):
-            raise exceptions.OptionsError('No such script: "%s"' % self.fullpath)
+            raise exceptions.OptionsError('No such script')
 
     @property
     def addons(self):
@@ -148,13 +148,13 @@ class ScriptLoader:
                 for evt, arg in eventsequence.iterate(f):
                     ctx.master.addons.invoke_addon(s, evt, arg)
         except exceptions.OptionsError as e:
-            raise exceptions.CommandError("Error running script: %s" % e) from e
+            script_error_handler(path, e, msg=str(e))
 
     def configure(self, updated):
         if "scripts" in updated:
             for s in ctx.options.scripts:
                 if ctx.options.scripts.count(s) > 1:
-                    raise exceptions.OptionsError("Duplicate script: %s" % s)
+                    raise exceptions.OptionsError("Duplicate script")
 
             for a in self.addons[:]:
                 if a.path not in ctx.options.scripts:

--- a/test/mitmproxy/addons/test_script.py
+++ b/test/mitmproxy/addons/test_script.py
@@ -183,9 +183,9 @@ class TestScriptLoader:
 
     def test_script_run_nonexistent(self):
         sc = script.ScriptLoader()
-        with taddons.context(sc):
-            with pytest.raises(exceptions.CommandError):
-                sc.script_run([tflow.tflow(resp=True)], "/")
+        with taddons.context(sc) as tctx:
+            sc.script_run([tflow.tflow(resp=True)], "/")
+            tctx.master.has_log("/: No such script")
 
     def test_simple(self):
         sc = script.ScriptLoader()

--- a/test/mitmproxy/addons/test_script.py
+++ b/test/mitmproxy/addons/test_script.py
@@ -243,6 +243,18 @@ class TestScriptLoader:
             tctx.invoke(sc, "tick")
             assert len(tctx.master.addons) == 1
 
+    def test_script_error_handler(self):
+        path = "/sample/path/example.py"
+        exc = SyntaxError
+        msg = "Error raised"
+        tb = True
+        with taddons.context() as tctx:
+            script.script_error_handler(path, exc, msg, tb)
+            assert tctx.master.has_log("/sample/path/example.py")
+            assert tctx.master.has_log("Error raised")
+            assert tctx.master.has_log("lineno")
+            assert tctx.master.has_log("NoneType")
+
     def test_order(self):
         rec = tutils.test_data.path("mitmproxy/data/addonscripts/recorder")
         sc = script.ScriptLoader()


### PR DESCRIPTION
Hi,
This PR introduces a unified handler which will handle all the user's scripts exception as mentioned in #2962 .
I was finally able to include a short message in the signature which is an optional argument and if it's not provided then the name of the exception type will be printed instead.

The test is a very basic one because of the fact that once merged other tests will do an extensive testing of the function as we move forward to using this function to display error messages. 
Closes #2962 