### PR TITLE
Adding Missing Function to `urwid.ListWalker` implementation.

### DIFF
--- a/mitmproxy/tools/console/commands.py
+++ b/mitmproxy/tools/console/commands.py
@@ -53,6 +53,12 @@ class CommandListWalker(urwid.ListWalker):
         self.cmds.sort(key=lambda x: x.signature_help())
         self.set_focus(0)
 
+    def positions(self, reverse=False):
+        if reverse:
+            return range(len(self.cmds) - 1, -1, -1)
+        else:
+            return range(len(self.cmds))
+
     def get_edit_text(self):
         return self.focus_obj.get_edit_text()
 
@@ -98,7 +104,11 @@ class CommandsList(urwid.ListBox):
         elif key == "m_end":
             self.set_focus(len(self.walker.cmds) - 1)
             self.walker._modified()
-        return super().keypress(size, key)
+
+        keypress_response = super().keypress(size, key)
+        # Without it the focused item won't update
+        self.walker._modified()
+        return keypress_response
 
 
 class CommandHelp(urwid.Frame):

--- a/mitmproxy/tools/console/flowlist.py
+++ b/mitmproxy/tools/console/flowlist.py
@@ -39,6 +39,12 @@ class FlowListWalker(urwid.ListWalker):
     def __init__(self, master):
         self.master = master
 
+    def positions(self, reverse=False):
+        if reverse:
+            return range(len(self.master.view) - 1, -1, -1)
+        else:
+            return range(len(self.master.view))
+
     def view_changed(self):
         self._modified()
 

--- a/mitmproxy/tools/console/grideditor/base.py
+++ b/mitmproxy/tools/console/grideditor/base.py
@@ -133,6 +133,8 @@ class GridWalker(urwid.ListWalker):
         self.editor.show_empty_msg()
         return super()._modified()
 
+
+
     def add_value(self, lst):
         self.lst.append(
             (lst[:], set())
@@ -175,6 +177,12 @@ class GridWalker(urwid.ListWalker):
         )
         self.focus_col = 0
         self.start_edit()
+
+    def positions(self, reverse=False):
+        if reverse:
+            return range(len(self.lst) - 1, -1, -1)
+        else:
+            return range(len(self.lst))
 
     def insert(self):
         return self._insert(self.focus)
@@ -354,7 +362,10 @@ class BaseGridEditor(urwid.WidgetWrap):
         elif key == "right":
             self.walker.right()
         elif column.keypress(key, self) and not self.handle_key(key):
-            return self._w.keypress(size, key)
+            keypress_response = self._w.keypress(size, key)
+            # Without it the focused item won't update
+            self.walker._modified()
+            return keypress_response
 
     def data_out(self, data: typing.Sequence[list]) -> typing.Any:
         """

--- a/mitmproxy/tools/console/grideditor/base.py
+++ b/mitmproxy/tools/console/grideditor/base.py
@@ -133,8 +133,6 @@ class GridWalker(urwid.ListWalker):
         self.editor.show_empty_msg()
         return super()._modified()
 
-
-
     def add_value(self, lst):
         self.lst.append(
             (lst[:], set())

--- a/mitmproxy/tools/console/keybindings.py
+++ b/mitmproxy/tools/console/keybindings.py
@@ -46,6 +46,12 @@ class KeyListWalker(urwid.ListWalker):
         self.set_focus(0)
         signals.keybindings_change.connect(self.sig_modified)
 
+    def positions(self, reverse=False):
+        if reverse:
+            return range(len(self.bindings) - 1, -1, -1)
+        else:
+            return range(len(self.bindings))
+
     def sig_modified(self, sender):
         self.bindings = list(self.master.keymap.list("all"))
         self.set_focus(min(self.index, len(self.bindings) - 1))
@@ -96,7 +102,11 @@ class KeyList(urwid.ListBox):
         elif key == "m_end":
             self.set_focus(len(self.walker.bindings) - 1)
             self.walker._modified()
-        return super().keypress(size, key)
+
+        keypress_response = super().keypress(size, key)
+        # Without it the focused item won't update
+        self.walker._modified()
+        return keypress_response
 
 
 class KeyHelp(urwid.Frame):

--- a/mitmproxy/tools/console/options.py
+++ b/mitmproxy/tools/console/options.py
@@ -105,6 +105,12 @@ class OptionListWalker(urwid.ListWalker):
         self.set_focus(0)
         self.master.options.changed.connect(self.sig_mod)
 
+    def positions(self, reverse=False):
+        if reverse:
+            return range(len(self.opts) - 1, -1, -1)
+        else:
+            return range(len(self.opts))
+
     def sig_mod(self, *args, **kwargs):
         self._modified()
         self.set_focus(self.index)
@@ -219,7 +225,11 @@ class OptionsList(urwid.ListBox):
                     )
                 else:
                     raise NotImplementedError()
-        return super().keypress(size, key)
+
+        keypress_response = super().keypress(size, key)
+        # Without it the focused item won't update
+        self.walker._modified()
+        return keypress_response
 
 
 class OptionHelp(urwid.Frame):

--- a/mitmproxy/tools/console/overlay.py
+++ b/mitmproxy/tools/console/overlay.py
@@ -76,6 +76,12 @@ class ChooserListWalker(urwid.ListWalker):
         c = self.choices[idx]
         return Choice(c, focus, c == self.current, self.shortcuts[idx:idx + 1])
 
+    def positions(self, reverse=False):
+        if reverse:
+            return range(len(self.choices) - 1, -1, -1)
+        else:
+            return range(len(self.choices))
+
     def set_focus(self, index):
         self.index = index
 
@@ -148,7 +154,10 @@ class Chooser(urwid.WidgetWrap, layoutwidget.LayoutWidget):
         if binding and binding.command.startswith("console.nav"):
             self.master.keymap.handle("global", key)
         elif key in keymap.navkeys:
-            return super().keypress(size, key)
+            keypress_response = super().keypress(size, key)
+            # Without it the focused item won't update
+            self.walker._modified()
+            return keypress_response
 
 
 class OptionsOverlay(urwid.WidgetWrap, layoutwidget.LayoutWidget):


### PR DESCRIPTION
The implementation of the `urwid.ListWalker` requires a new function after a certain version update which was missing for grideditors, options tab, commands tab, keybinding tab.

- Fixes the crashes occurring while scrolling to either ends of the available view. 
- Also enables support for traversing  via the `Pg Up` and `Pg Dn` keys.  
- Fixes #2973 

