### PR TITLE
Fixing the `set` option in command line arguments.

### DIFF
--- a/mitmproxy/tools/main.py
+++ b/mitmproxy/tools/main.py
@@ -90,6 +90,17 @@ def run(
         sys.exit(1)
     try:
         unknown = optmanager.load_paths(opts, args.conf)
+        opts.update_known(**unknown)
+        if args.options:
+            print(optmanager.dump_defaults(opts))
+            sys.exit(0)
+        if args.commands:
+            master.commands.dump()
+            sys.exit(0)
+        opts.set(*args.setoptions)
+        if extra:
+            opts.update(**extra(args))
+
         pconf = process_options(parser, opts, args)
         server = None  # type: typing.Any
         if pconf.options.server:
@@ -104,16 +115,6 @@ def run(
         master.server = server
         master.addons.trigger("configure", opts.keys())
         master.addons.trigger("tick")
-        opts.update_known(**unknown)
-        if args.options:
-            print(optmanager.dump_defaults(opts))
-            sys.exit(0)
-        if args.commands:
-            master.commands.dump()
-            sys.exit(0)
-        opts.set(*args.setoptions)
-        if extra:
-            opts.update(**extra(args))
 
         def cleankill(*args, **kwargs):
             master.shutdown()


### PR DESCRIPTION
I tried to solve both the issues but could not get the new proxy to work without messing up the UI. But I could solve the second issue. After this fix `set` option will function normally. 

- Fixes #2932 ( Could only solve 1 of the 2 issues )