### PR TITLE
Update cut.py

### DIFF
--- a/mitmproxy/addons/cut.py
+++ b/mitmproxy/addons/cut.py
@@ -129,7 +129,7 @@ class Cut:
             if isinstance(v, bytes):
                 fp.write(strutils.always_str(v))
             else:
-                fp.write("utf8")
+                fp.write(v)
             ctx.log.alert("Clipped single cut.")
         else:
             writer = csv.writer(fp)


### PR DESCRIPTION
Line 132: cut.clip command always copy "utf-8" when single cut specified (ie :cut.clip @focus request.method gets "utf-8")