### PR TITLE
Fixing Replacement editor glitch

### DIFF
--- a/mitmproxy/tools/console/grideditor/base.py
+++ b/mitmproxy/tools/console/grideditor/base.py
@@ -321,7 +321,7 @@ class BaseGridEditor(urwid.WidgetWrap):
                     [
                         ("highlight", "No values - you should add some. Press "),
                         ("key", "?"),
-                        ("highlight", " for help."),
+                        ("highlight", " to view help."),
                     ]
                 )
             )

--- a/mitmproxy/tools/console/grideditor/editors.py
+++ b/mitmproxy/tools/console/grideditor/editors.py
@@ -178,6 +178,15 @@ class OptionsEditor(base.GridEditor, layoutwidget.LayoutWidget):
         self.name = name
         super().__init__(master, [[i] for i in vals], self.callback)
 
+    def keypress(self, size, key):
+        if key == '?':
+            # To display any other view, we need to close the overlay first.
+            self.master.commands.call('console.view.pop')
+            self.master.switch_view("help")
+            return
+        else:
+            return super().keypress(size, key)
+
     def callback(self, vals):
         try:
             setattr(self.master.options, self.name, [i[0] for i in vals])


### PR DESCRIPTION
Closing the overlay editor and switching to help view when the user presses `?` key for viewing help.

- Fixes #2952.