### PR TITLE
Commit reply object in Flow.kill if flow is intercepted

### DIFF
--- a/mitmproxy/controller.py
+++ b/mitmproxy/controller.py
@@ -91,7 +91,7 @@ class Reply:
 
     def commit(self):
         """
-        Ultimately, messages are committed. This is done either automatically by
+        Ultimately, messages are committed. This is done either automatically by the handler
         if the message is not taken or manually by the entity which called
         .take().
         """

--- a/mitmproxy/flow.py
+++ b/mitmproxy/flow.py
@@ -155,8 +155,12 @@ class Flow(stateobject.StateObject):
             Kill this request.
         """
         self.error = Error("Connection killed")
-        self.intercepted = False
         self.reply.kill(force=True)
+        if self.intercepted:
+            # If a flow is intercepted and killed, the reply will be taken
+            # so it will not be commited by addonManager
+            self.reply.commit()
+            self.intercepted = False
         self.live = False
 
     def intercept(self):


### PR DESCRIPTION
Fixes #2879

If a flow is intercepted, the reply object will be taken. Thus, if the flow is then killed, the reply will not be committed by addonmanager. (Since 62326227740d3808c0886ed381cb976a6b2f8b03, committing reply is not done by `Flow.kill` but by the addonmanager, and the addonmanager only commit if reply is in start state). This will leave the proxy thread waiting forever. In addition, new interactions with the flow which set a new flow.reply (e.g.replaying) will raise an exception, as the reply's destructor expects it to be commited. This is the bug in #2879 .

This PR attempts to fix the problem by committing in `Flow.kill` if the flow is intercepted. However, this may undo part of what 62326227740d3808c0886ed381cb976a6b2f8b03 wanted to do, so please advice me on that. My understanding of [the code](https://github.com/mitmproxy/mitmproxy/blob/623f9b694d9f9ddc9130d03b7ffb079c1c492dc6/mitmproxy/controller.py#L19-L31) is that, when the reply message is `exception.Kill`, the proxy process will terminate immediately so it shouldn't set new flow.reply attribute as mentioned in 62326227740d3808c0886ed381cb976a6b2f8b03 .

On a  minor note, I added back some documentation that was unintentionally removed in c5e0dc64b9b367eae8f4af66a4917c738dd87569. It helped me to understand the flow of mitmproxy.