### PR TITLE
Fixed sequence options setting only last element

### DIFF
--- a/mitmproxy/optmanager.py
+++ b/mitmproxy/optmanager.py
@@ -273,10 +273,9 @@ class OptManager:
         )
 
     def set(self, *spec):
-        vals = {}
         for i in spec:
-            vals.update(self._setspec(i))
-        self.update(**vals)
+            self.update(**(self._setspec(i)))
+        
 
     def parse_setval(self, optname: str, optstr: typing.Optional[str]) -> typing.Any:
         """

--- a/mitmproxy/optmanager.py
+++ b/mitmproxy/optmanager.py
@@ -275,7 +275,6 @@ class OptManager:
     def set(self, *spec):
         for i in spec:
             self.update(**(self._setspec(i)))
-        
 
     def parse_setval(self, optname: str, optstr: typing.Optional[str]) -> typing.Any:
         """


### PR DESCRIPTION
Fixes #3015.

https://github.com/mitmproxy/mitmproxy/blob/79fc4e8ad6cab5181ba39d7f0b0d40f7c11a8389/mitmproxy/optmanager.py#L312-L316

https://github.com/mitmproxy/mitmproxy/blob/79fc4e8ad6cab5181ba39d7f0b0d40f7c11a8389/mitmproxy/optmanager.py#L276-L279

The values are saved only when the whole line has been parsed. Thus, `getattr` will never retrieve the updated sequence from the options. 

The solution I propose to fix the issue, here, is to update the options at each round, to ensure consistent retrieval of previous set effects. 

I understand that this makes a call of `update_known()` just for a couple each time, but the idea was to avoid changing the logic in `parse_setval()`, which in turn would have required some control code in `set` to manually update vals dictionary when the typespec was Sequence[str].
 
Let me know about anything that could/should be changed/improved :)