### PR TITLE
Fix buggy keybindings in Data Viewer overlays 

### DIFF
--- a/mitmproxy/tools/console/keymap.py
+++ b/mitmproxy/tools/console/keymap.py
@@ -6,6 +6,7 @@ from mitmproxy.tools.console import signals
 Contexts = {
     "chooser",
     "commands",
+    "dataviewer",
     "eventlog",
     "flowlist",
     "flowview",

--- a/mitmproxy/tools/console/overlay.py
+++ b/mitmproxy/tools/console/overlay.py
@@ -179,7 +179,7 @@ class OptionsOverlay(urwid.WidgetWrap, layoutwidget.LayoutWidget):
 
 
 class DataViewerOverlay(urwid.WidgetWrap, layoutwidget.LayoutWidget):
-    keyctx = "grideditor"
+    keyctx = "dataviewer"
 
     def __init__(self, master, vals):
         """


### PR DESCRIPTION
Fixes #3011.

I supposed that "grideditor" keybindings in DataViewerOverlay were unwanted. 
I thought that adding a new context (empty, actually) for Data Viewer widgets was in line with the approach followed in the codebase. If this does not apply, or there's some keybinding (not in global) that should be processed inside those overlay, let me know and I'll try to fix :)