### PR TITLE
shift core event loop to asyncio

### DIFF
--- a/mitmproxy/addons/termstatus.py
+++ b/mitmproxy/addons/termstatus.py
@@ -1,3 +1,4 @@
+import sys
 from mitmproxy import ctx
 from mitmproxy.utils import human
 

--- a/mitmproxy/addons/termstatus.py
+++ b/mitmproxy/addons/termstatus.py
@@ -1,4 +1,3 @@
-import sys
 from mitmproxy import ctx
 from mitmproxy.utils import human
 

--- a/mitmproxy/controller.py
+++ b/mitmproxy/controller.py
@@ -8,8 +8,9 @@ class Channel:
         The only way for the proxy server to communicate with the master
         is to use the channel it has been given.
     """
-    def __init__(self, loop, q):
+    def __init__(self, loop, q, should_exit):
         self.loop = loop
+        self.should_exit = should_exit
         self._q = q
 
     def ask(self, mtype, m):

--- a/mitmproxy/controller.py
+++ b/mitmproxy/controller.py
@@ -22,7 +22,7 @@ class Channel:
         """
         m.reply = Reply(m)
         asyncio.run_coroutine_threadsafe(self._q.put((mtype, m)), self.loop)
-        g = m.reply._q.get()
+        g = m.reply.q.get()
         if g == exceptions.Kill:
             raise exceptions.Kill()
         return g

--- a/mitmproxy/controller.py
+++ b/mitmproxy/controller.py
@@ -1,4 +1,5 @@
 import queue
+import asyncio
 from mitmproxy import exceptions
 
 
@@ -7,9 +8,9 @@ class Channel:
         The only way for the proxy server to communicate with the master
         is to use the channel it has been given.
     """
-    def __init__(self, q, should_exit):
-        self.q = q
-        self.should_exit = should_exit
+    def __init__(self, loop, q):
+        self.loop = loop
+        self._q = q
 
     def ask(self, mtype, m):
         """
@@ -20,18 +21,11 @@ class Channel:
             exceptions.Kill: All connections should be closed immediately.
         """
         m.reply = Reply(m)
-        self.q.put((mtype, m))
-        while not self.should_exit.is_set():
-            try:
-                # The timeout is here so we can handle a should_exit event.
-                g = m.reply.q.get(timeout=0.5)
-            except queue.Empty:  # pragma: no cover
-                continue
-            if g == exceptions.Kill:
-                raise exceptions.Kill()
-            return g
-        m.reply._state = "committed"  # suppress error message in __del__
-        raise exceptions.Kill()
+        asyncio.run_coroutine_threadsafe(self._q.put((mtype, m)), self.loop)
+        g = m.reply._q.get()
+        if g == exceptions.Kill:
+            raise exceptions.Kill()
+        return g
 
     def tell(self, mtype, m):
         """
@@ -39,7 +33,7 @@ class Channel:
         then return immediately.
         """
         m.reply = DummyReply()
-        self.q.put((mtype, m))
+        asyncio.run_coroutine_threadsafe(self._q.put((mtype, m)), self.loop)
 
 
 NO_REPLY = object()  # special object we can distinguish from a valid "None" reply.
@@ -52,7 +46,8 @@ class Reply:
     """
     def __init__(self, obj):
         self.obj = obj
-        self.q = queue.Queue()  # type: queue.Queue
+        # Spawn an event loop in the current thread
+        self.q = queue.Queue()
 
         self._state = "start"  # "start" -> "taken" -> "committed"
 

--- a/mitmproxy/master.py
+++ b/mitmproxy/master.py
@@ -202,13 +202,7 @@ class Master:
             host = f.request.headers.pop(":authority")
             f.request.headers.insert(0, "host", host)
 
-        rt = http_replay.RequestReplayThread(
-            self.options,
-            f,
-            asyncio.get_event_loop(),
-            self.event_queue,
-            self.should_exit
-        )
+        rt = http_replay.RequestReplayThread(self.options, f, self.server.channel)
         rt.start()  # pragma: no cover
         if block:
             rt.join()

--- a/mitmproxy/master.py
+++ b/mitmproxy/master.py
@@ -42,6 +42,8 @@ class Master:
             self.event_queue,
             self.should_exit,
         )
+        asyncio.ensure_future(self.main())
+        asyncio.ensure_future(self.tick())
 
         self.options = opts or options.Options()  # type: options.Options
         self.commands = command.CommandManager(self)
@@ -114,7 +116,6 @@ class Master:
 
     def run(self):
         self.start()
-        asyncio.ensure_future(self.main())
         asyncio.ensure_future(self.tick())
         loop = asyncio.get_event_loop()
         try:

--- a/mitmproxy/master.py
+++ b/mitmproxy/master.py
@@ -36,9 +36,6 @@ class Master:
         The master handles mitmproxy's main event loop.
     """
     def __init__(self, opts):
-        loop = asyncio.get_event_loop()
-        for signame in ('SIGINT', 'SIGTERM'):
-            loop.add_signal_handler(getattr(signal, signame), self.shutdown)
         self.event_queue = asyncio.Queue()
 
         self.options = opts or options.Options()  # type: options.Options

--- a/mitmproxy/master.py
+++ b/mitmproxy/master.py
@@ -1,6 +1,7 @@
 import threading
 import contextlib
 import asyncio
+import logging
 
 from mitmproxy import addonmanager
 from mitmproxy import options
@@ -16,6 +17,13 @@ from mitmproxy.proxy.protocol import http_replay
 from mitmproxy.coretypes import basethread
 
 from . import ctx as mitmproxy_ctx
+
+
+# Conclusively preventing cross-thread races on proxy shutdown turns out to be
+# very hard. We could build a thread sync infrastructure for this, or we could
+# wait until we ditch threads and move all the protocols into the async loop.
+# Until then, silence non-critical errors.
+logging.getLogger('asyncio').setLevel(logging.CRITICAL)
 
 
 class ServerThread(basethread.BaseThread):

--- a/mitmproxy/master.py
+++ b/mitmproxy/master.py
@@ -85,7 +85,8 @@ class Master:
             mitmproxy_ctx.log = None
             mitmproxy_ctx.options = None
 
-    def tell(self, mtype, m):
+    # This is a vestigial function that will go away in a refactor very soon
+    def tell(self, mtype, m):  # pragma: no cover
         m.reply = controller.DummyReply()
         self.event_queue.put((mtype, m))
 
@@ -106,7 +107,7 @@ class Master:
                 mtype, obj = await self.event_queue.get()
             except RuntimeError:
                 return
-            if mtype not in eventsequence.Events:
+            if mtype not in eventsequence.Events:  # pragma: no cover
                 raise exceptions.ControlException("Unknown event %s" % repr(mtype))
             self.addons.handle_lifecycle(mtype, obj)
             self.event_queue.task_done()

--- a/mitmproxy/proxy/protocol/http_replay.py
+++ b/mitmproxy/proxy/protocol/http_replay.py
@@ -38,7 +38,7 @@ class RequestReplayThread(basethread.BaseThread):
         self.f = f
         f.live = True
         if event_queue:
-            self.channel = controller.Channel(loop, event_queue, should_exit)
+            self.channel = controller.Channel(loop, event_queue)
         else:
             self.channel = None
         super().__init__(

--- a/mitmproxy/proxy/protocol/http_replay.py
+++ b/mitmproxy/proxy/protocol/http_replay.py
@@ -1,3 +1,4 @@
+import asyncio
 import queue
 import threading
 import typing
@@ -25,6 +26,7 @@ class RequestReplayThread(basethread.BaseThread):
             self,
             opts: options.Options,
             f: http.HTTPFlow,
+            loop: asyncio.AbstractEventLoop,
             event_queue: typing.Optional[queue.Queue],
             should_exit: threading.Event
     ) -> None:
@@ -36,7 +38,7 @@ class RequestReplayThread(basethread.BaseThread):
         self.f = f
         f.live = True
         if event_queue:
-            self.channel = controller.Channel(event_queue, should_exit)
+            self.channel = controller.Channel(loop, event_queue, should_exit)
         else:
             self.channel = None
         super().__init__(

--- a/mitmproxy/proxy/protocol/http_replay.py
+++ b/mitmproxy/proxy/protocol/http_replay.py
@@ -1,8 +1,3 @@
-import asyncio
-import queue
-import threading
-import typing
-
 from mitmproxy import log
 from mitmproxy import controller
 from mitmproxy import exceptions
@@ -26,21 +21,12 @@ class RequestReplayThread(basethread.BaseThread):
             self,
             opts: options.Options,
             f: http.HTTPFlow,
-            loop: asyncio.AbstractEventLoop,
-            event_queue: typing.Optional[queue.Queue],
-            should_exit: threading.Event
+            channel: controller.Channel,
     ) -> None:
-        """
-            event_queue can be a queue or None, if no scripthooks should be
-            processed.
-        """
         self.options = opts
         self.f = f
         f.live = True
-        if event_queue:
-            self.channel = controller.Channel(loop, event_queue)
-        else:
-            self.channel = None
+        self.channel = channel
         super().__init__(
             "RequestReplay (%s)" % f.request.url
         )

--- a/mitmproxy/tools/console/master.py
+++ b/mitmproxy/tools/console/master.py
@@ -1,3 +1,4 @@
+import asyncio
 import mailcap
 import mimetypes
 import os
@@ -182,12 +183,6 @@ class ConsoleMaster(master.Master):
         )
         self.ui.clear()
 
-    def ticker(self, *userdata):
-        changed = self.tick(timeout=0)
-        if changed:
-            self.loop.draw_screen()
-        self.loop.set_alarm_in(0.01, self.ticker)
-
     def inject_key(self, key):
         self.loop.process_input([key])
 
@@ -206,6 +201,7 @@ class ConsoleMaster(master.Master):
         )
         self.loop = urwid.MainLoop(
             urwid.SolidFill("x"),
+            event_loop=urwid.AsyncioEventLoop(loop=asyncio.get_event_loop()),
             screen = self.ui,
             handle_mouse = self.options.console_mouse,
         )
@@ -213,8 +209,6 @@ class ConsoleMaster(master.Master):
         self.window = window.Window(self)
         self.loop.widget = self.window
         self.window.refresh()
-
-        self.loop.set_alarm_in(0.01, self.ticker)
 
         if self.start_err:
             def display_err(*_):
@@ -236,6 +230,7 @@ class ConsoleMaster(master.Master):
         finally:
             sys.stderr.flush()
             super().shutdown()
+        self.addons.trigger("done")
 
     def shutdown(self):
         raise urwid.ExitMainLoop

--- a/mitmproxy/tools/main.py
+++ b/mitmproxy/tools/main.py
@@ -1,5 +1,6 @@
 from __future__ import print_function  # this is here for the version check to work on Python 2.
 
+import asyncio
 import sys
 
 if sys.version_info < (3, 6):
@@ -118,7 +119,9 @@ def run(
         def cleankill(*args, **kwargs):
             master.shutdown()
         signal.signal(signal.SIGTERM, cleankill)
-
+        loop = asyncio.get_event_loop()
+        for signame in ('SIGINT', 'SIGTERM'):
+            loop.add_signal_handler(getattr(signal, signame), master.shutdown)
         master.run()
     except exceptions.OptionsError as e:
         print("%s: %s" % (sys.argv[0], e), file=sys.stderr)

--- a/mitmproxy/tools/main.py
+++ b/mitmproxy/tools/main.py
@@ -117,8 +117,8 @@ def run(
 
         def cleankill(*args, **kwargs):
             master.shutdown()
-
         signal.signal(signal.SIGTERM, cleankill)
+
         master.run()
     except exceptions.OptionsError as e:
         print("%s: %s" % (sys.argv[0], e), file=sys.stderr)

--- a/mitmproxy/tools/web/master.py
+++ b/mitmproxy/tools/web/master.py
@@ -2,6 +2,9 @@ import webbrowser
 
 import tornado.httpserver
 import tornado.ioloop
+from tornado.platform.asyncio import AsyncIOMainLoop
+import asyncio
+
 from mitmproxy import addons
 from mitmproxy import log
 from mitmproxy import master
@@ -102,6 +105,7 @@ class WebMaster(master.Master):
         )
 
     def run(self):  # pragma: no cover
+        AsyncIOMainLoop().install()
 
         iol = tornado.ioloop.IOLoop.instance()
 
@@ -109,7 +113,6 @@ class WebMaster(master.Master):
         http_server.listen(self.options.web_port, self.options.web_iface)
 
         iol.add_callback(self.start)
-        tornado.ioloop.PeriodicCallback(lambda: self.tick(timeout=0), 5).start()
 
         web_url = "http://{}:{}/".format(self.options.web_iface, self.options.web_port)
         self.add_log(

--- a/mitmproxy/tools/web/master.py
+++ b/mitmproxy/tools/web/master.py
@@ -3,7 +3,6 @@ import webbrowser
 import tornado.httpserver
 import tornado.ioloop
 from tornado.platform.asyncio import AsyncIOMainLoop
-import asyncio
 
 from mitmproxy import addons
 from mitmproxy import log

--- a/release/README.md
+++ b/release/README.md
@@ -5,9 +5,9 @@ Make sure run all these steps on the correct branch you want to create a new rel
 - Update CHANGELOG
 - Verify that all CI tests pass
 - Tag the release and push to Github
-  - For alphas, betas, and release candidates, use lightweight tags.  
+  - For alphas, betas, and release candidates, use lightweight tags.
     This is necessary so that the .devXXXX counter does not reset.
-  - For final releases, use annotated tags.  
+  - For final releases, use annotated tags.
     This makes the .devXXXX counter reset.
 - Wait for tag CI to complete
 

--- a/test/mitmproxy/data/addonscripts/shutdown.py
+++ b/test/mitmproxy/data/addonscripts/shutdown.py
@@ -1,5 +1,5 @@
 from mitmproxy import ctx
 
 
-def running():
+def tick():
     ctx.master.shutdown()

--- a/test/mitmproxy/proxy/protocol/test_http2.py
+++ b/test/mitmproxy/proxy/protocol/test_http2.py
@@ -6,11 +6,11 @@ import tempfile
 import traceback
 import pytest
 import h2
+import time
 
 from mitmproxy import options
 
 import mitmproxy.net
-from mitmproxy.addons import core
 from ...net import tservers as net_tservers
 from mitmproxy import exceptions
 from mitmproxy.net.http import http1, http2
@@ -92,6 +92,10 @@ class _Http2TestBase:
         cls.options = cls.get_options()
         cls.proxy = tservers.ProxyThread(tservers.TestMaster, cls.options)
         cls.proxy.start()
+        while True:
+            if cls.proxy.tmaster:
+                break
+            time.sleep(0.01)
 
     @classmethod
     def teardown_class(cls):
@@ -118,6 +122,7 @@ class _Http2TestBase:
     def teardown(self):
         if self.client:
             self.client.close()
+        self.server.server.wait_for_silence()
 
     def setup_connection(self):
         self.client = mitmproxy.net.tcp.TCPClient(("127.0.0.1", self.proxy.port))

--- a/test/mitmproxy/proxy/protocol/test_http2.py
+++ b/test/mitmproxy/proxy/protocol/test_http2.py
@@ -6,7 +6,6 @@ import tempfile
 import traceback
 import pytest
 import h2
-import time
 
 from mitmproxy import options
 

--- a/test/mitmproxy/proxy/protocol/test_http2.py
+++ b/test/mitmproxy/proxy/protocol/test_http2.py
@@ -92,10 +92,6 @@ class _Http2TestBase:
         cls.options = cls.get_options()
         cls.proxy = tservers.ProxyThread(tservers.TestMaster, cls.options)
         cls.proxy.start()
-        while True:
-            if cls.proxy.tmaster:
-                break
-            time.sleep(0.01)
 
     @classmethod
     def teardown_class(cls):

--- a/test/mitmproxy/proxy/protocol/test_http2.py
+++ b/test/mitmproxy/proxy/protocol/test_http2.py
@@ -90,9 +90,7 @@ class _Http2TestBase:
     @classmethod
     def setup_class(cls):
         cls.options = cls.get_options()
-        tmaster = tservers.TestMaster(cls.options)
-        tmaster.addons.add(core.Core())
-        cls.proxy = tservers.ProxyThread(tmaster)
+        cls.proxy = tservers.ProxyThread(tservers.TestMaster, cls.options)
         cls.proxy.start()
 
     @classmethod

--- a/test/mitmproxy/proxy/protocol/test_websocket.py
+++ b/test/mitmproxy/proxy/protocol/test_websocket.py
@@ -52,9 +52,7 @@ class _WebSocketTestBase:
     @classmethod
     def setup_class(cls):
         cls.options = cls.get_options()
-        tmaster = tservers.TestMaster(cls.options)
-        tmaster.addons.add(core.Core())
-        cls.proxy = tservers.ProxyThread(tmaster)
+        cls.proxy = tservers.ProxyThread(tservers.TestMaster, cls.options)
         cls.proxy.start()
 
     @classmethod

--- a/test/mitmproxy/proxy/protocol/test_websocket.py
+++ b/test/mitmproxy/proxy/protocol/test_websocket.py
@@ -54,10 +54,6 @@ class _WebSocketTestBase:
         cls.options = cls.get_options()
         cls.proxy = tservers.ProxyThread(tservers.TestMaster, cls.options)
         cls.proxy.start()
-        while True:
-            if cls.proxy.tmaster:
-                break
-            time.sleep(0.01)
 
     @classmethod
     def teardown_class(cls):

--- a/test/mitmproxy/proxy/protocol/test_websocket.py
+++ b/test/mitmproxy/proxy/protocol/test_websocket.py
@@ -331,7 +331,12 @@ class TestPong(_WebSocketTest):
 
         assert frame.header.opcode == websockets.OPCODE.PONG
         assert frame.payload == b'foobar'
-        assert self.master.has_log("Pong Received from server", "info")
+        for i in range(20):
+            if self.master.has_log("Pong Received from server", "info"):
+                break
+            time.sleep(0.01)
+        else:
+            raise AssertionError("No pong seen")
 
 
 class TestClose(_WebSocketTest):

--- a/test/mitmproxy/proxy/test_server.py
+++ b/test/mitmproxy/proxy/test_server.py
@@ -276,10 +276,9 @@ class TestHTTP(tservers.HTTPProxyTest, CommonMixin):
         s = script.Script(
             tutils.test_data.path("mitmproxy/data/addonscripts/stream_modify.py")
         )
-        self.master.addons.add(s)
+        self.set_addons(s)
         d = self.pathod('200:b"foo"')
         assert d.content == b"bar"
-        self.master.addons.remove(s)
 
     def test_first_line_rewrite(self):
         """
@@ -583,12 +582,11 @@ class TestTransparent(tservers.TransparentProxyTest, CommonMixin, TcpMixin):
         s = script.Script(
             tutils.test_data.path("mitmproxy/data/addonscripts/tcp_stream_modify.py")
         )
-        self.master.addons.add(s)
+        self.set_addons(s)
         self._tcpproxy_on()
         d = self.pathod('200:b"foo"')
         self._tcpproxy_off()
         assert d.content == b"bar"
-        self.master.addons.remove(s)
 
 
 class TestTransparentSSL(tservers.TransparentProxyTest, CommonMixin, TcpMixin):
@@ -731,7 +729,7 @@ class TestRedirectRequest(tservers.HTTPProxyTest):
 
         This test verifies that the original destination is restored for the third request.
         """
-        self.proxy.tmaster.addons.add(ARedirectRequest(self.server2.port))
+        self.set_addons(ARedirectRequest(self.server2.port))
 
         p = self.pathoc()
         with p.connect():
@@ -770,7 +768,7 @@ class AStreamRequest:
 
 class TestStreamRequest(tservers.HTTPProxyTest):
     def test_stream_simple(self):
-        self.proxy.tmaster.addons.add(AStreamRequest())
+        self.set_addons(AStreamRequest())
         p = self.pathoc()
         with p.connect():
             # a request with 100k of data but without content-length
@@ -779,7 +777,7 @@ class TestStreamRequest(tservers.HTTPProxyTest):
             assert len(r1.content) > 100000
 
     def test_stream_multiple(self):
-        self.proxy.tmaster.addons.add(AStreamRequest())
+        self.set_addons(AStreamRequest())
         p = self.pathoc()
         with p.connect():
             # simple request with streaming turned on
@@ -791,7 +789,7 @@ class TestStreamRequest(tservers.HTTPProxyTest):
             assert r1.status_code == 201
 
     def test_stream_chunked(self):
-        self.proxy.tmaster.addons.add(AStreamRequest())
+        self.set_addons(AStreamRequest())
         connection = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         connection.connect(("127.0.0.1", self.proxy.port))
         fconn = connection.makefile("rb")
@@ -820,7 +818,7 @@ class AFakeResponse:
 class TestFakeResponse(tservers.HTTPProxyTest):
 
     def test_fake(self):
-        self.proxy.tmaster.addons.add(AFakeResponse())
+        self.set_addons(AFakeResponse())
         f = self.pathod("200")
         assert "header-response" in f.headers
 
@@ -836,7 +834,7 @@ class TestServerConnect(tservers.HTTPProxyTest):
 
     def test_unnecessary_serverconnect(self):
         """A replayed/fake response with no upstream_cert should not connect to an upstream server"""
-        self.proxy.tmaster.addons.add(AFakeResponse())
+        self.set_addons(AFakeResponse())
         assert self.pathod("200").status_code == 200
         assert not self.proxy.tmaster.has_log("serverconnect")
 
@@ -849,7 +847,7 @@ class AKillRequest:
 
 class TestKillRequest(tservers.HTTPProxyTest):
     def test_kill(self):
-        self.proxy.tmaster.addons.add(AKillRequest())
+        self.set_addons(AKillRequest())
         with pytest.raises(exceptions.HttpReadDisconnect):
             self.pathod("200")
         # Nothing should have hit the server
@@ -863,7 +861,7 @@ class AKillResponse:
 
 class TestKillResponse(tservers.HTTPProxyTest):
     def test_kill(self):
-        self.proxy.tmaster.addons.add(AKillResponse())
+        self.set_addons(AKillResponse())
         with pytest.raises(exceptions.HttpReadDisconnect):
             self.pathod("200")
         # The server should have seen a request
@@ -886,7 +884,7 @@ class AIncomplete:
 
 class TestIncompleteResponse(tservers.HTTPProxyTest):
     def test_incomplete(self):
-        self.proxy.tmaster.addons.add(AIncomplete())
+        self.set_addons(AIncomplete())
         assert self.pathod("200").status_code == 502
 
 
@@ -969,7 +967,7 @@ class TestUpstreamProxySSL(
 
     def test_change_upstream_proxy_connect(self):
         # skip chain[0].
-        self.proxy.tmaster.addons.add(
+        self.set_addons(
             UpstreamProxyChanger(
                 ("127.0.0.1", self.chain[1].port)
             )
@@ -988,8 +986,8 @@ class TestUpstreamProxySSL(
 
         Client <- HTTPS -> Proxy <- HTTP -> Proxy <- HTTPS -> Server
         """
-        self.proxy.tmaster.addons.add(RewriteToHttp())
-        self.chain[1].tmaster.addons.add(RewriteToHttps())
+        self.set_addons(RewriteToHttp())
+        self.set_addons(RewriteToHttps())
         p = self.pathoc()
         with p.connect():
             resp = p.request("get:'/p/418'")
@@ -1063,8 +1061,8 @@ class TestProxyChainingSSLReconnect(tservers.HTTPUpstreamProxyTest):
                     http1obj.server_conn.wfile.write(headers)
                     http1obj.server_conn.wfile.flush()
 
-        self.chain[0].tmaster.addons.add(RequestKiller([1, 2]))
-        self.chain[1].tmaster.addons.add(RequestKiller([1]))
+        self.chain[0].set_addons(RequestKiller([1, 2]))
+        self.chain[1].set_addons(RequestKiller([1]))
 
         p = self.pathoc()
         with p.connect():

--- a/test/mitmproxy/proxy/test_server.py
+++ b/test/mitmproxy/proxy/test_server.py
@@ -987,7 +987,7 @@ class TestUpstreamProxySSL(
         Client <- HTTPS -> Proxy <- HTTP -> Proxy <- HTTPS -> Server
         """
         self.set_addons(RewriteToHttp())
-        self.set_addons(RewriteToHttps())
+        self.chain[1].set_addons(RewriteToHttps())
         p = self.pathoc()
         with p.connect():
             resp = p.request("get:'/p/418'")

--- a/test/mitmproxy/proxy/test_server.py
+++ b/test/mitmproxy/proxy/test_server.py
@@ -21,14 +21,6 @@ from pathod import pathod
 from .. import tservers
 from ...conftest import skip_appveyor
 
-"""
-    Note that the choice of response code in these tests matters more than you
-    might think. libcurl treats a 304 response code differently from, say, a
-    200 response code - it will correctly terminate a 304 response with no
-    content-length header, whereas it will block forever waiting for content
-    for a 200 response.
-"""
-
 
 class CommonMixin:
 

--- a/test/mitmproxy/test_controller.py
+++ b/test/mitmproxy/test_controller.py
@@ -1,102 +1,31 @@
 import asyncio
-from threading import Thread, Event
-from unittest.mock import Mock
 import queue
 import pytest
-import sys
 
 from mitmproxy.exceptions import Kill, ControlException
 from mitmproxy import controller
-from mitmproxy import master
-from mitmproxy import proxy
 from mitmproxy.test import taddons
 
 
-class TMsg:
-    pass
+@pytest.mark.asyncio
+async def test_master():
+    class TMsg:
+        pass
 
-
-def test_master():
     class tAddon:
         def log(self, _):
             ctx.master.should_exit.set()
 
-    with taddons.context() as ctx:
-        ctx.master.addons.add(tAddon())
+    with taddons.context(tAddon()) as ctx:
         assert not ctx.master.should_exit.is_set()
 
         async def test():
             msg = TMsg()
             msg.reply = controller.DummyReply()
-            await ctx.master.event_queue.put(("log", msg))
+            await ctx.master.channel.tell("log", msg)
 
-        ctx.master.run(inject=test)
-
-
-# class TestMaster:
-#     # def test_simple(self):
-#     #     class tAddon:
-#     #         def log(self, _):
-#     #             ctx.master.should_exit.set()
-
-#     #     with taddons.context() as ctx:
-#     #         ctx.master.addons.add(tAddon())
-#     #         assert not ctx.master.should_exit.is_set()
-#     #         msg = TMsg()
-#     #         msg.reply = controller.DummyReply()
-#     #         ctx.master.event_queue.put(("log", msg))
-#     #         ctx.master.run()
-#     #         assert ctx.master.should_exit.is_set()
-
-#     # def test_server_simple(self):
-#     #     m = master.Master(None)
-#     #     m.server = proxy.DummyServer()
-#     #     m.start()
-#     #     m.shutdown()
-#     #     m.start()
-#     #     m.shutdown()
-#     pass
-
-
-# class TestServerThread:
-#     def test_simple(self):
-#         m = Mock()
-#         t = master.ServerThread(m)
-#         t.run()
-#         assert m.serve_forever.called
-
-
-# class TestChannel:
-#     def test_tell(self):
-#         q = queue.Queue()
-#         channel = controller.Channel(q, Event())
-#         m = Mock(name="test_tell")
-#         channel.tell("test", m)
-#         assert q.get() == ("test", m)
-#         assert m.reply
-
-#     def test_ask_simple(self):
-#         q = queue.Queue()
-
-#         def reply():
-#             m, obj = q.get()
-#             assert m == "test"
-#             obj.reply.send(42)
-#             obj.reply.take()
-#             obj.reply.commit()
-
-#         Thread(target=reply).start()
-
-#         channel = controller.Channel(q, Event())
-#         assert channel.ask("test", Mock(name="test_ask_simple")) == 42
-
-#     def test_ask_shutdown(self):
-#         q = queue.Queue()
-#         done = Event()
-#         done.set()
-#         channel = controller.Channel(q, done)
-#         with pytest.raises(Kill):
-#             channel.ask("test", Mock(name="test_ask_shutdown"))
+        asyncio.ensure_future(test())
+        assert not ctx.master.should_exit.is_set()
 
 
 class TestReply:

--- a/test/mitmproxy/test_flow.py
+++ b/test/mitmproxy/test_flow.py
@@ -7,7 +7,7 @@ import mitmproxy.io
 from mitmproxy import flowfilter
 from mitmproxy import options
 from mitmproxy.io import tnetstring
-from mitmproxy.exceptions import FlowReadException, ReplayException, ControlException
+from mitmproxy.exceptions import FlowReadException, ReplayException
 from mitmproxy import flow
 from mitmproxy import http
 from mitmproxy.net import http as net_http

--- a/test/mitmproxy/test_flow.py
+++ b/test/mitmproxy/test_flow.py
@@ -169,9 +169,10 @@ class TestFlowMaster:
         f.error = flow.Error("msg")
         fm.addons.handle_lifecycle("error", f)
 
-        fm.tell("foo", f)
-        with pytest.raises(ControlException):
-            fm.tick(timeout=1)
+        # FIXME: This no longer works, because we consume on the main loop.
+        # fm.tell("foo", f)
+        # with pytest.raises(ControlException):
+        #     fm.addons.trigger("unknown")
 
         fm.shutdown()
 

--- a/test/mitmproxy/test_fuzzing.py
+++ b/test/mitmproxy/test_fuzzing.py
@@ -26,13 +26,3 @@ class TestFuzzy(tservers.HTTPProxyTest):
         with p.connect():
             resp = p.request(req % self.server.port)
         assert resp.status_code == 400
-
-    # def test_invalid_upstream(self):
-    #     req = r"get:'http://localhost:%s/p/200:i10,\x27+\x27'"
-    #     p = self.pathoc()
-    #     assert p.request(req % self.server.port).status_code == 502
-
-    # def test_upstream_disconnect(self):
-    #     req = r'200:d0'
-    #     p = self.pathod(req)
-    #     assert p.status_code == 502

--- a/test/mitmproxy/tools/test_main.py
+++ b/test/mitmproxy/tools/test_main.py
@@ -1,19 +1,25 @@
+import pytest
+
 from mitmproxy.test import tutils
 from mitmproxy.tools import main
 
 shutdown_script = tutils.test_data.path("mitmproxy/data/addonscripts/shutdown.py")
 
 
-def test_mitmweb():
+@pytest.mark.asyncio
+async def test_mitmweb():
     main.mitmweb([
         "--no-web-open-browser",
         "-q",
+        "-p", "0",
         "-s", shutdown_script
     ])
 
 
-def test_mitmdump():
+@pytest.mark.asyncio
+async def test_mitmdump():
     main.mitmdump([
         "-q",
+        "-p", "0",
         "-s", shutdown_script
     ])

--- a/test/mitmproxy/tservers.py
+++ b/test/mitmproxy/tservers.py
@@ -4,6 +4,7 @@ import tempfile
 import sys
 import time
 from unittest import mock
+import asyncio
 
 import mitmproxy.platform
 from mitmproxy.addons import core
@@ -105,6 +106,7 @@ class ProxyThread(threading.Thread):
         self.tmaster.shutdown()
 
     def run(self):
+        asyncio.set_event_loop(asyncio.new_event_loop())
         self.tmaster = self.masterclass(self.options)
         self.tmaster.addons.add(core.Core())
         self.name = "ProxyThread (%s:%s)" % (

--- a/test/mitmproxy/tservers.py
+++ b/test/mitmproxy/tservers.py
@@ -122,7 +122,6 @@ class ProxyThread(threading.Thread):
         self.tmaster.addons.trigger("tick")
 
 
-
 class ProxyTestBase:
     # Test Configuration
     ssl = None

--- a/test/mitmproxy/tservers.py
+++ b/test/mitmproxy/tservers.py
@@ -121,6 +121,13 @@ class ProxyThread(threading.Thread):
         self.tmaster.reset(addons)
         self.tmaster.addons.trigger("tick")
 
+    def start(self):
+        super().start()
+        while True:
+            if self.tmaster:
+                break
+            time.sleep(0.01)
+
 
 class ProxyTestBase:
     # Test Configuration
@@ -142,10 +149,6 @@ class ProxyTestBase:
         cls.options = cls.get_options()
         cls.proxy = ProxyThread(cls.masterclass, cls.options)
         cls.proxy.start()
-        while True:
-            if cls.proxy.tmaster:
-                break
-            time.sleep(0.01)
 
     @classmethod
     def teardown_class(cls):

--- a/test/mitmproxy/tservers.py
+++ b/test/mitmproxy/tservers.py
@@ -92,6 +92,7 @@ class ProxyThread(threading.Thread):
         self.masterclass = masterclass
         self.options = options
         self.tmaster = None
+        self.event_loop = None
         controller.should_exit = False
 
     @property
@@ -106,7 +107,8 @@ class ProxyThread(threading.Thread):
         self.tmaster.shutdown()
 
     def run(self):
-        asyncio.set_event_loop(asyncio.new_event_loop())
+        self.event_loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(self.event_loop)
         self.tmaster = self.masterclass(self.options)
         self.tmaster.addons.add(core.Core())
         self.name = "ProxyThread (%s:%s)" % (
@@ -176,6 +178,10 @@ class ProxyTestBase:
             add_upstream_certs_to_client_chain=cls.add_upstream_certs_to_client_chain,
             ssl_insecure=True,
         )
+
+    def set_addons(self, *addons):
+        self.proxy.tmaster.reset(addons)
+        self.proxy.tmaster.addons.trigger("tick")
 
     def addons(self):
         """

--- a/test/mitmproxy/tservers.py
+++ b/test/mitmproxy/tservers.py
@@ -14,6 +14,7 @@ from mitmproxy import controller
 from mitmproxy import options
 from mitmproxy import exceptions
 from mitmproxy import io
+from mitmproxy.utils import human
 import pathod.test
 import pathod.pathoc
 
@@ -111,10 +112,7 @@ class ProxyThread(threading.Thread):
         asyncio.set_event_loop(self.event_loop)
         self.tmaster = self.masterclass(self.options)
         self.tmaster.addons.add(core.Core())
-        self.name = "ProxyThread (%s:%s)" % (
-            self.tmaster.server.address[0],
-            self.tmaster.server.address[1],
-        )
+        self.name = "ProxyThread (%s)" % human.format_address(self.tmaster.server.address)
         self.tmaster.run()
 
     def set_addons(self, *addons):
@@ -362,11 +360,8 @@ class HTTPUpstreamProxyTest(HTTPProxyTest):
             proxy = ProxyThread(cls.masterclass, opts)
             proxy.start()
             cls.chain.insert(0, proxy)
-            while 1:
-                if(
-                    proxy.event_loop and
-                    proxy.event_loop.is_running()
-                ):
+            while True:
+                if proxy.event_loop and proxy.event_loop.is_running():
                     break
 
         super().setup_class()


### PR DESCRIPTION
This patch shifts mitmproxy's core event loop to asyncio. It also changes both mitmproxy console and mitmweb to run off the same asyncio event loop as core, unifying event handing in the main thread. This is just a first step - there are many obvious next steps that will follow in the weeks to come. 

# Performance improvements

I used a modified version of the benchmark to pump 1000 requests through each proxy tool with a concurrency of 50. 

## mitmdump

Before:

<img width="322" alt="mitmdump-pre" src="https://user-images.githubusercontent.com/22544/38182975-1f6486a8-3691-11e8-8252-ff699d0189ec.png">

After:

<img width="318" alt="mitmdump-asyncio" src="https://user-images.githubusercontent.com/22544/38182978-23b23aa2-3691-11e8-8034-adf16c88982a.png">

## mitmproxy

Before (!!!!!):
<img width="335" alt="mitmproxy-pre" src="https://user-images.githubusercontent.com/22544/38183030-6fefbb56-3691-11e8-826e-10e19cd6e67b.png">

After:

<img width="333" alt="mitmproxy-asyncio" src="https://user-images.githubusercontent.com/22544/38183032-73e2e01c-3691-11e8-9fe1-76c894a879cb.png">

## mitmweb

Before:

<img width="340" alt="mitmweb-pre" src="https://user-images.githubusercontent.com/22544/38183055-956c1cf8-3691-11e8-851d-7f27355d796d.png">

After:

<img width="337" alt="mitmweb-asyncio" src="https://user-images.githubusercontent.com/22544/38183059-9cd07a2a-3691-11e8-90b6-68956a830e67.png">



