### PR TITLE
asyncio consolidation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ build/
 dist/
 mitmproxy/contrib/kaitaistruct/*.ksy
 .pytest_cache
+__pycache__
 
 # UI
 

--- a/mitmproxy/addonmanager.py
+++ b/mitmproxy/addonmanager.py
@@ -41,8 +41,8 @@ class StreamLog:
     """
         A class for redirecting output using contextlib.
     """
-    def __init__(self, log):
-        self.log = log
+    def __init__(self, lg):
+        self.log = lg
 
     def write(self, buf):
         if buf.strip():
@@ -55,13 +55,7 @@ class StreamLog:
 
 @contextlib.contextmanager
 def safecall():
-    # resolve ctx.master here.
-    # we want to be threadsafe, and ctx.master may already be cleared when an addon prints().
-    channel = ctx.master.channel
-    # don't use master.add_log (which is not thread-safe). Instead, put on event queue.
-    stdout_replacement = StreamLog(
-        lambda message: channel("log", log.LogEntry(message, "warn"))
-    )
+    stdout_replacement = StreamLog(lambda message: ctx.log.warn(message))
     try:
         with contextlib.redirect_stdout(stdout_replacement):
             yield

--- a/mitmproxy/addonmanager.py
+++ b/mitmproxy/addonmanager.py
@@ -3,7 +3,6 @@ import typing
 import traceback
 import contextlib
 import sys
-import asyncio
 
 from mitmproxy import exceptions
 from mitmproxy import eventsequence

--- a/mitmproxy/addonmanager.py
+++ b/mitmproxy/addonmanager.py
@@ -57,10 +57,10 @@ class StreamLog:
 def safecall():
     # resolve ctx.master here.
     # we want to be threadsafe, and ctx.master may already be cleared when an addon prints().
-    tell = ctx.master.tell
+    channel = ctx.master.channel
     # don't use master.add_log (which is not thread-safe). Instead, put on event queue.
     stdout_replacement = StreamLog(
-        lambda message: tell("log", log.LogEntry(message, "warn"))
+        lambda message: channel("log", log.LogEntry(message, "warn"))
     )
     try:
         with contextlib.redirect_stdout(stdout_replacement):

--- a/mitmproxy/addonmanager.py
+++ b/mitmproxy/addonmanager.py
@@ -3,6 +3,7 @@ import typing
 import traceback
 import contextlib
 import sys
+import asyncio
 
 from mitmproxy import exceptions
 from mitmproxy import eventsequence
@@ -220,7 +221,7 @@ class AddonManager:
         name = _get_name(item)
         return name in self.lookup
 
-    def handle_lifecycle(self, name, message):
+    async def handle_lifecycle(self, name, message):
         """
             Handle a lifecycle event.
         """

--- a/mitmproxy/addons/check_ca.py
+++ b/mitmproxy/addons/check_ca.py
@@ -1,4 +1,5 @@
 import mitmproxy
+from mitmproxy import ctx
 
 
 class CheckCA:
@@ -15,10 +16,9 @@ class CheckCA:
         if has_ca:
             self.failed = mitmproxy.ctx.master.server.config.certstore.default_ca.has_expired()
             if self.failed:
-                mitmproxy.ctx.master.add_log(
+                ctx.log.warn(
                     "The mitmproxy certificate authority has expired!\n"
                     "Please delete all CA-related files in your ~/.mitmproxy folder.\n"
                     "The CA will be regenerated automatically after restarting mitmproxy.\n"
                     "Then make sure all your clients have the new CA installed.",
-                    "warn",
                 )

--- a/mitmproxy/command.py
+++ b/mitmproxy/command.py
@@ -95,11 +95,7 @@ class Command:
             Call the command with a list of arguments. At this point, all
             arguments are strings.
         """
-        pargs = self.prepare_args(args)
-
-        with self.manager.master.handlecontext():
-            ret = self.func(*pargs)
-
+        ret = self.func(*self.prepare_args(args))
         if ret is None and self.returntype is None:
             return
         typ = mitmproxy.types.CommandTypes.get(self.returntype)

--- a/mitmproxy/log.py
+++ b/mitmproxy/log.py
@@ -1,3 +1,5 @@
+import asyncio
+
 
 class LogEntry:
     def __init__(self, msg, level):
@@ -54,7 +56,9 @@ class Log:
         self(txt, "error")
 
     def __call__(self, text, level="info"):
-        self.master.add_log(text, level)
+        asyncio.get_event_loop().call_soon(
+            self.master.addons.trigger, "log", LogEntry(text, level)
+        )
 
 
 LogTierOrder = [

--- a/mitmproxy/master.py
+++ b/mitmproxy/master.py
@@ -49,7 +49,6 @@ class Master:
             asyncio.get_event_loop(),
             self.should_exit,
         )
-        asyncio.ensure_future(self.tick())
 
         self.options = opts or options.Options()  # type: options.Options
         self.commands = command.CommandManager(self)

--- a/mitmproxy/master.py
+++ b/mitmproxy/master.py
@@ -85,11 +85,6 @@ class Master:
             mitmproxy_ctx.log = None
             mitmproxy_ctx.options = None
 
-    # This is a vestigial function that will go away in a refactor very soon
-    def tell(self, mtype, m):  # pragma: no cover
-        m.reply = controller.DummyReply()
-        self.event_queue.put((mtype, m))
-
     def add_log(self, e, level):
         """
             level: debug, alert, info, warn, error

--- a/mitmproxy/master.py
+++ b/mitmproxy/master.py
@@ -1,5 +1,4 @@
 import threading
-import contextlib
 import asyncio
 import logging
 
@@ -58,6 +57,10 @@ class Master:
         self.waiting_flows = []
         self.log = log.Log(self)
 
+        mitmproxy_ctx.master = self
+        mitmproxy_ctx.log = self.log
+        mitmproxy_ctx.options = self.options
+
     @property
     def server(self):
         return self._server
@@ -66,22 +69,6 @@ class Master:
     def server(self, server):
         server.set_channel(self.channel)
         self._server = server
-
-    @contextlib.contextmanager
-    def handlecontext(self):
-        # Handlecontexts also have to nest - leave cleanup to the outermost
-        if mitmproxy_ctx.master:
-            yield
-            return
-        mitmproxy_ctx.master = self
-        mitmproxy_ctx.log = self.log
-        mitmproxy_ctx.options = self.options
-        try:
-            yield
-        finally:
-            mitmproxy_ctx.master = None
-            mitmproxy_ctx.log = None
-            mitmproxy_ctx.options = None
 
     def start(self):
         self.should_exit.clear()

--- a/mitmproxy/master.py
+++ b/mitmproxy/master.py
@@ -56,6 +56,7 @@ class Master:
         self._server = None
         self.first_tick = True
         self.waiting_flows = []
+        self.log = log.Log(self)
 
     @property
     def server(self):
@@ -73,7 +74,7 @@ class Master:
             yield
             return
         mitmproxy_ctx.master = self
-        mitmproxy_ctx.log = log.Log(self)
+        mitmproxy_ctx.log = self.log
         mitmproxy_ctx.options = self.options
         try:
             yield
@@ -81,12 +82,6 @@ class Master:
             mitmproxy_ctx.master = None
             mitmproxy_ctx.log = None
             mitmproxy_ctx.options = None
-
-    def add_log(self, e, level):
-        """
-            level: debug, alert, info, warn, error
-        """
-        self.addons.trigger("log", log.LogEntry(e, level))
 
     def start(self):
         self.should_exit.clear()

--- a/mitmproxy/test/taddons.py
+++ b/mitmproxy/test/taddons.py
@@ -35,7 +35,7 @@ class RecordingMaster(mitmproxy.master.Master):
         for i in self.logs:
             print("%s: %s" % (i.level, i.msg), file=outf)
 
-    def has_log(self, txt, level=None):
+    def _has_log(self, txt, level=None):
         for i in self.logs:
             if level and i.level != level:
                 continue
@@ -45,7 +45,7 @@ class RecordingMaster(mitmproxy.master.Master):
 
     async def await_log(self, txt, level=None):
         for i in range(20):
-            if self.has_log(txt, level):
+            if self._has_log(txt, level):
                 return True
             else:
                 await asyncio.sleep(0.1)

--- a/mitmproxy/test/taddons.py
+++ b/mitmproxy/test/taddons.py
@@ -1,4 +1,5 @@
 import contextlib
+import asyncio
 import sys
 
 import mitmproxy.master
@@ -40,6 +41,14 @@ class RecordingMaster(mitmproxy.master.Master):
                 continue
             if txt.lower() in i.msg.lower():
                 return True
+        return False
+
+    async def await_log(self, txt, level=None):
+        for i in range(20):
+            if self.has_log(txt, level):
+                return True
+            else:
+                await asyncio.sleep(0.1)
         return False
 
     def has_event(self, name):

--- a/mitmproxy/test/taddons.py
+++ b/mitmproxy/test/taddons.py
@@ -74,7 +74,6 @@ class context:
             options
         )
         self.options = self.master.options
-        self.wrapped = None
 
         if loadcore:
             self.master.addons.add(core.Core())
@@ -82,20 +81,10 @@ class context:
         for a in addons:
             self.master.addons.add(a)
 
-    def ctx(self):
-        """
-            Returns a new handler context.
-        """
-        return self.master.handlecontext()
-
     def __enter__(self):
-        self.wrapped = self.ctx()
-        self.wrapped.__enter__()
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
-        self.wrapped.__exit__(exc_type, exc_value, traceback)
-        self.wrapped = None
         return False
 
     @contextlib.contextmanager

--- a/mitmproxy/tools/console/flowview.py
+++ b/mitmproxy/tools/console/flowview.py
@@ -121,7 +121,7 @@ class FlowDetails(tabs.Tabs):
             viewmode, message
         )
         if error:
-            self.master.add_log(error, "debug")
+            self.master.log.debug(error)
         # Give hint that you have to tab for the response.
         if description == "No content" and isinstance(message, http.HTTPRequest):
             description = "No request content (press tab to view response)"

--- a/mitmproxy/tools/web/app.py
+++ b/mitmproxy/tools/web/app.py
@@ -4,6 +4,7 @@ import logging
 import os.path
 import re
 from io import BytesIO
+import asyncio
 
 import mitmproxy.flow
 import tornado.escape
@@ -235,7 +236,7 @@ class DumpFlows(RequestHandler):
         self.view.clear()
         bio = BytesIO(self.filecontents)
         for i in io.FlowReader(bio).stream():
-            self.master.load_flow(i)
+            asyncio.call_soon(self.master.load_flow, i)
         bio.close()
 
 

--- a/mitmproxy/tools/web/master.py
+++ b/mitmproxy/tools/web/master.py
@@ -114,17 +114,15 @@ class WebMaster(master.Master):
         iol.add_callback(self.start)
 
         web_url = "http://{}:{}/".format(self.options.web_iface, self.options.web_port)
-        self.add_log(
-            "Web   server listening at {}".format(web_url),
-            "info"
+        self.log.info(
+            "Web server listening at {}".format(web_url),
         )
 
         if self.options.web_open_browser:
             success = open_browser(web_url)
             if not success:
-                self.add_log(
+                self.log.info(
                     "No web browser found. Please open a browser and point it to {}".format(web_url),
-                    "info"
                 )
         try:
             iol.start()

--- a/setup.py
+++ b/setup.py
@@ -88,6 +88,7 @@ setup(
             "flake8>=3.5, <3.6",
             "Flask>=0.10.1, <0.13",
             "mypy>=0.580,<0.581",
+            "pytest-asyncio>=0.8",
             "pytest-cov>=2.5.1,<3",
             "pytest-faulthandler>=1.3.1,<2",
             "pytest-timeout>=1.2.1,<2",

--- a/test/mitmproxy/addons/test_allowremote.py
+++ b/test/mitmproxy/addons/test_allowremote.py
@@ -17,7 +17,8 @@ from mitmproxy.test import taddons
     (False, "fe80::", False),
     (False, "2001:4860:4860::8888", True),
 ])
-def test_allowremote(allow_remote, ip, should_be_killed):
+@pytest.mark.asyncio
+async def test_allowremote(allow_remote, ip, should_be_killed):
     ar = allowremote.AllowRemote()
     up = proxyauth.ProxyAuth()
     with taddons.context(ar, up) as tctx:
@@ -28,7 +29,7 @@ def test_allowremote(allow_remote, ip, should_be_killed):
 
             ar.clientconnect(layer)
             if should_be_killed:
-                assert tctx.master.has_log("Client connection was killed", "warn")
+                assert await tctx.master.await_log("Client connection was killed", "warn")
             else:
                 assert tctx.master.logs == []
             tctx.master.clear()

--- a/test/mitmproxy/addons/test_browser.py
+++ b/test/mitmproxy/addons/test_browser.py
@@ -1,10 +1,12 @@
 from unittest import mock
+import pytest
 
 from mitmproxy.addons import browser
 from mitmproxy.test import taddons
 
 
-def test_browser():
+@pytest.mark.asyncio
+async def test_browser():
     with mock.patch("subprocess.Popen") as po, mock.patch("shutil.which") as which:
         which.return_value = "chrome"
         b = browser.Browser()
@@ -16,16 +18,17 @@ def test_browser():
             assert not tctx.master.has_log("already running")
             b.browser.poll = lambda: None
             b.start()
-            assert tctx.master.has_log("already running")
+            assert await tctx.master.await_log("already running")
             b.done()
             assert not b.browser
 
 
-def test_no_browser():
+@pytest.mark.asyncio
+async def test_no_browser():
     with mock.patch("shutil.which") as which:
         which.return_value = False
 
         b = browser.Browser()
         with taddons.context() as tctx:
             b.start()
-            assert tctx.master.has_log("platform is not supported")
+            assert await tctx.master.await_log("platform is not supported")

--- a/test/mitmproxy/addons/test_browser.py
+++ b/test/mitmproxy/addons/test_browser.py
@@ -13,9 +13,8 @@ async def test_browser():
         with taddons.context() as tctx:
             b.start()
             assert po.called
-            b.start()
 
-            assert not tctx.master.has_log("already running")
+            b.start()
             b.browser.poll = lambda: None
             b.start()
             assert await tctx.master.await_log("already running")

--- a/test/mitmproxy/addons/test_check_ca.py
+++ b/test/mitmproxy/addons/test_check_ca.py
@@ -8,12 +8,15 @@ from mitmproxy.test import taddons
 class TestCheckCA:
 
     @pytest.mark.parametrize('expired', [False, True])
-    def test_check_ca(self, expired):
+    @pytest.mark.asyncio
+    async def test_check_ca(self, expired):
         msg = 'The mitmproxy certificate authority has expired!'
 
         with taddons.context() as tctx:
             tctx.master.server = mock.MagicMock()
-            tctx.master.server.config.certstore.default_ca.has_expired = mock.MagicMock(return_value=expired)
+            tctx.master.server.config.certstore.default_ca.has_expired = mock.MagicMock(
+                return_value = expired
+            )
             a = check_ca.CheckCA()
             tctx.configure(a)
-            assert tctx.master.has_log(msg) is expired
+            assert await tctx.master.await_log(msg) == expired

--- a/test/mitmproxy/addons/test_cut.py
+++ b/test/mitmproxy/addons/test_cut.py
@@ -71,7 +71,8 @@ def qr(f):
         return fp.read()
 
 
-def test_cut_clip():
+@pytest.mark.asyncio
+async def test_cut_clip():
     v = view.View()
     c = cut.Cut()
     with taddons.context() as tctx:
@@ -95,7 +96,7 @@ def test_cut_clip():
                           "copy/paste mechanism for your system."
             pc.side_effect = pyperclip.PyperclipException(log_message)
             tctx.command(c.clip, "@all", "request.method")
-            assert tctx.master.has_log(log_message, level="error")
+            assert await tctx.master.await_log(log_message, level="error")
 
 
 def test_cut_save(tmpdir):
@@ -125,7 +126,8 @@ def test_cut_save(tmpdir):
     (IsADirectoryError, "Is a directory"),
     (FileNotFoundError, "No such file or directory")
 ])
-def test_cut_save_open(exception, log_message, tmpdir):
+@pytest.mark.asyncio
+async def test_cut_save_open(exception, log_message, tmpdir):
     f = str(tmpdir.join("path"))
     v = view.View()
     c = cut.Cut()
@@ -136,7 +138,7 @@ def test_cut_save_open(exception, log_message, tmpdir):
         with mock.patch("mitmproxy.addons.cut.open") as m:
             m.side_effect = exception(log_message)
             tctx.command(c.save, "@all", "request.method", f)
-            assert tctx.master.has_log(log_message, level="error")
+            assert await tctx.master.await_log(log_message, level="error")
 
 
 def test_cut():

--- a/test/mitmproxy/addons/test_dumper.py
+++ b/test/mitmproxy/addons/test_dumper.py
@@ -141,15 +141,16 @@ def test_echo_request_line():
 
 
 class TestContentView:
-    @mock.patch("mitmproxy.contentviews.auto.ViewAuto.__call__")
-    def test_contentview(self, view_auto):
-        view_auto.side_effect = exceptions.ContentViewException("")
-        sio = io.StringIO()
-        d = dumper.Dumper(sio)
-        with taddons.context(d) as ctx:
-            ctx.configure(d, flow_detail=4)
-            d.response(tflow.tflow())
-            assert ctx.master.has_log("content viewer failed")
+    @pytest.mark.asyncio
+    async def test_contentview(self):
+        with mock.patch("mitmproxy.contentviews.auto.ViewAuto.__call__") as va:
+            va.side_effect = exceptions.ContentViewException("")
+            sio = io.StringIO()
+            d = dumper.Dumper(sio)
+            with taddons.context(d) as ctx:
+                ctx.configure(d, flow_detail=4)
+                d.response(tflow.tflow())
+                assert await ctx.master.await_log("content viewer failed")
 
 
 def test_tcp():

--- a/test/mitmproxy/addons/test_export.py
+++ b/test/mitmproxy/addons/test_export.py
@@ -125,17 +125,19 @@ def test_export(tmpdir):
     (IsADirectoryError, "Is a directory"),
     (FileNotFoundError, "No such file or directory")
 ])
-def test_export_open(exception, log_message, tmpdir):
+@pytest.mark.asyncio
+async def test_export_open(exception, log_message, tmpdir):
     f = str(tmpdir.join("path"))
     e = export.Export()
     with taddons.context() as tctx:
         with mock.patch("mitmproxy.addons.export.open") as m:
             m.side_effect = exception(log_message)
             e.file("raw", tflow.tflow(resp=True), f)
-            assert tctx.master.has_log(log_message, level="error")
+            assert await tctx.master.await_log(log_message, level="error")
 
 
-def test_clip(tmpdir):
+@pytest.mark.asyncio
+async def test_clip(tmpdir):
     e = export.Export()
     with taddons.context() as tctx:
         with pytest.raises(exceptions.CommandError):
@@ -158,4 +160,4 @@ def test_clip(tmpdir):
                           "copy/paste mechanism for your system."
             pc.side_effect = pyperclip.PyperclipException(log_message)
             e.clip("raw", tflow.tflow(resp=True))
-            assert tctx.master.has_log(log_message, level="error")
+            assert await tctx.master.await_log(log_message, level="error")

--- a/test/mitmproxy/addons/test_replace.py
+++ b/test/mitmproxy/addons/test_replace.py
@@ -79,7 +79,8 @@ class TestReplaceFile:
             r.request(f)
             assert f.request.content == b"bar"
 
-    def test_nonexistent(self, tmpdir):
+    @pytest.mark.asyncio
+    async def test_nonexistent(self, tmpdir):
         r = replace.Replace()
         with taddons.context(r) as tctx:
             with pytest.raises(Exception, match="Invalid file path"):
@@ -97,6 +98,5 @@ class TestReplaceFile:
             tmpfile.remove()
             f = tflow.tflow()
             f.request.content = b"foo"
-            assert not tctx.master.logs
             r.request(f)
-            assert tctx.master.logs
+            assert await tctx.master.await_log("could not read")

--- a/test/mitmproxy/addons/test_script.py
+++ b/test/mitmproxy/addons/test_script.py
@@ -180,11 +180,12 @@ class TestScriptLoader:
                 'recorder responseheaders', 'recorder response'
             ]
 
-    def test_script_run_nonexistent(self):
+    @pytest.mark.asyncio
+    async def test_script_run_nonexistent(self):
         sc = script.ScriptLoader()
         with taddons.context(sc) as tctx:
             sc.script_run([tflow.tflow(resp=True)], "/")
-            tctx.master.has_log("/: No such script")
+            assert await tctx.master.await_log("/: No such script")
 
     def test_simple(self):
         sc = script.ScriptLoader()

--- a/test/mitmproxy/addons/test_script.py
+++ b/test/mitmproxy/addons/test_script.py
@@ -2,6 +2,7 @@ import os
 import sys
 import traceback
 from unittest import mock
+import time
 
 import pytest
 
@@ -49,17 +50,15 @@ def test_load_fullname():
     assert not hasattr(ns2, "addons")
 
 
-def test_script_print_stdout():
+@pytest.mark.asyncio
+async def test_script_print_stdout():
     with taddons.context() as tctx:
-        with mock.patch('mitmproxy.ctx.master.tell') as mock_warn:
-            with addonmanager.safecall():
-                ns = script.load_script(
-                    tutils.test_data.path(
-                        "mitmproxy/data/addonscripts/print.py"
-                    )
-                )
-                ns.load(addonmanager.Loader(tctx.master))
-        mock_warn.assert_called_once_with("log", log.LogEntry("stdoutprint", "warn"))
+        with addonmanager.safecall():
+            ns = script.load_script(
+                tutils.test_data.path("mitmproxy/data/addonscripts/print.py")
+            )
+            ns.load(addonmanager.Loader(tctx.master))
+        assert tctx.master.has_log("stdoutprint")
 
 
 class TestScript:

--- a/test/mitmproxy/addons/test_termstatus.py
+++ b/test/mitmproxy/addons/test_termstatus.py
@@ -1,15 +1,17 @@
+import pytest
+
 from mitmproxy import proxy
 from mitmproxy.addons import termstatus
 from mitmproxy.test import taddons
 
 
-def test_configure():
+@pytest.mark.asyncio
+async def test_configure():
     ts = termstatus.TermStatus()
     with taddons.context() as ctx:
         ctx.master.server = proxy.DummyServer()
         ctx.configure(ts, server=False)
         ts.running()
-        assert not ctx.master.logs
         ctx.configure(ts, server=True)
         ts.running()
-        assert ctx.master.logs
+        await ctx.master.await_log("server listening")

--- a/test/mitmproxy/addons/test_view.py
+++ b/test/mitmproxy/addons/test_view.py
@@ -159,7 +159,8 @@ def test_orders():
         assert v.order_options()
 
 
-def test_load(tmpdir):
+@pytest.mark.asyncio
+async def test_load(tmpdir):
     path = str(tmpdir.join("path"))
     v = view.View()
     with taddons.context() as tctx:
@@ -182,7 +183,7 @@ def test_load(tmpdir):
         with open(path, "wb") as f:
             f.write(b"invalidflows")
         v.load_file(path)
-        assert tctx.master.has_log("Invalid data format.")
+        assert await tctx.master.await_log("Invalid data format.")
 
 
 def test_resolve():

--- a/test/mitmproxy/proxy/protocol/test_websocket.py
+++ b/test/mitmproxy/proxy/protocol/test_websocket.py
@@ -285,7 +285,8 @@ class TestPing(_WebSocketTest):
         wfile.flush()
         websockets.Frame.from_file(rfile)
 
-    def test_ping(self):
+    @pytest.mark.asyncio
+    async def test_ping(self):
         self.setup_connection()
 
         frame = websockets.Frame.from_file(self.client.rfile)
@@ -295,7 +296,7 @@ class TestPing(_WebSocketTest):
         assert frame.header.opcode == websockets.OPCODE.PING
         assert frame.payload == b''  # We don't send payload to other end
 
-        assert self.master.has_log("Pong Received from server", "info")
+        assert await self.master.await_log("Pong Received from server", "info")
 
 
 class TestPong(_WebSocketTest):

--- a/test/mitmproxy/proxy/protocol/test_websocket.py
+++ b/test/mitmproxy/proxy/protocol/test_websocket.py
@@ -47,6 +47,7 @@ class _WebSocketServerBase(net_tservers.ServerTestBase):
 
 
 class _WebSocketTestBase:
+    client = None
 
     @classmethod
     def setup_class(cls):

--- a/test/mitmproxy/proxy/test_server.py
+++ b/test/mitmproxy/proxy/test_server.py
@@ -123,8 +123,6 @@ class TcpMixin:
         i2 = self.pathod("306")
         self._ignore_off()
 
-        self.master.event_queue.join()
-
         assert n.status_code == 304
         assert i.status_code == 305
         assert i2.status_code == 306
@@ -167,8 +165,6 @@ class TcpMixin:
         i = self.pathod("305")
         i2 = self.pathod("306")
         self._tcpproxy_off()
-
-        self.master.event_queue.join()
 
         assert n.status_code == 304
         assert i.status_code == 305

--- a/test/mitmproxy/script/test_concurrent.py
+++ b/test/mitmproxy/script/test_concurrent.py
@@ -1,3 +1,5 @@
+import pytest
+
 from mitmproxy.test import tflow
 from mitmproxy.test import tutils
 from mitmproxy.test import taddons
@@ -31,14 +33,15 @@ class TestConcurrent(tservers.MasterTest):
                     return
             raise ValueError("Script never acked")
 
-    def test_concurrent_err(self):
+    @pytest.mark.asyncio
+    async def test_concurrent_err(self):
         with taddons.context() as tctx:
             tctx.script(
                 tutils.test_data.path(
                     "mitmproxy/data/addonscripts/concurrent_decorator_err.py"
                 )
             )
-            assert tctx.master.has_log("decorator not supported")
+            assert await tctx.master.await_log("decorator not supported")
 
     def test_concurrent_class(self):
             with taddons.context() as tctx:

--- a/test/mitmproxy/test_addonmanager.py
+++ b/test/mitmproxy/test_addonmanager.py
@@ -65,7 +65,8 @@ def test_halt():
     assert end.custom_called
 
 
-def test_lifecycle():
+@pytest.mark.asyncio
+async def test_lifecycle():
     o = options.Options()
     m = master.Master(o)
     a = addonmanager.AddonManager(m)
@@ -77,7 +78,7 @@ def test_lifecycle():
         a.remove(TAddon("nonexistent"))
 
     f = tflow.tflow()
-    a.handle_lifecycle("request", f)
+    await a.handle_lifecycle("request", f)
 
     a._configure_all(o, o.keys())
 

--- a/test/mitmproxy/test_addonmanager.py
+++ b/test/mitmproxy/test_addonmanager.py
@@ -87,7 +87,8 @@ def test_defaults():
     assert addons.default_addons()
 
 
-def test_loader():
+@pytest.mark.asyncio
+async def test_loader():
     with taddons.context() as tctx:
         l = addonmanager.Loader(tctx.master)
         l.add_option("custom_option", bool, False, "help")
@@ -99,7 +100,7 @@ def test_loader():
 
         # a different signature should emit a warning though.
         l.add_option("custom_option", bool, True, "help")
-        assert tctx.master.has_log("Over-riding existing option")
+        assert await tctx.master.await_log("Over-riding existing option")
 
         def cmd(a: str) -> str:
             return "foo"
@@ -107,7 +108,8 @@ def test_loader():
         l.add_command("test.command", cmd)
 
 
-def test_simple():
+@pytest.mark.asyncio
+async def test_simple():
     with taddons.context(loadcore=False) as tctx:
         a = tctx.master.addons
 
@@ -121,14 +123,14 @@ def test_simple():
         assert not a.chain
 
         a.add(TAddon("one"))
-        a.trigger("done")
+        a.trigger("running")
         a.trigger("tick")
-        assert tctx.master.has_log("not callable")
+        assert await tctx.master.await_log("not callable")
 
         tctx.master.clear()
         a.get("one").tick = addons
         a.trigger("tick")
-        assert not tctx.master.has_log("not callable")
+        assert not await tctx.master.await_log("not callable")
 
         a.remove(a.get("one"))
         assert not a.get("one")

--- a/test/mitmproxy/test_controller.py
+++ b/test/mitmproxy/test_controller.py
@@ -5,12 +5,11 @@ import pytest
 from mitmproxy.exceptions import Kill, ControlException
 from mitmproxy import controller
 from mitmproxy.test import taddons
+import mitmproxy.ctx
 
 
 @pytest.mark.asyncio
 async def test_master():
-    class TMsg:
-        pass
 
     class tAddon:
         def log(self, _):
@@ -20,12 +19,11 @@ async def test_master():
         assert not ctx.master.should_exit.is_set()
 
         async def test():
-            msg = TMsg()
-            msg.reply = controller.DummyReply()
-            await ctx.master.channel.tell("log", msg)
+            mitmproxy.ctx.log("test")
 
         asyncio.ensure_future(test())
-        assert not ctx.master.should_exit.is_set()
+        assert await ctx.master.await_log("test")
+        assert ctx.master.should_exit.is_set()
 
 
 class TestReply:

--- a/test/mitmproxy/test_flow.py
+++ b/test/mitmproxy/test_flow.py
@@ -2,7 +2,7 @@ import io
 from unittest import mock
 import pytest
 
-from mitmproxy.test import tflow, tutils
+from mitmproxy.test import tflow, tutils, taddons
 import mitmproxy.io
 from mitmproxy import flowfilter
 from mitmproxy import options
@@ -97,30 +97,30 @@ class TestSerialize:
 
 
 class TestFlowMaster:
-    def test_load_http_flow_reverse(self):
-        s = tservers.TestState()
+    @pytest.mark.asyncio
+    async def test_load_http_flow_reverse(self):
         opts = options.Options(
             mode="reverse:https://use-this-domain"
         )
-        fm = master.Master(opts)
-        fm.addons.add(s)
-        f = tflow.tflow(resp=True)
-        fm.load_flow(f)
-        assert s.flows[0].request.host == "use-this-domain"
+        s = tservers.TestState()
+        with taddons.context(s, options=opts) as ctx:
+            f = tflow.tflow(resp=True)
+            await ctx.master.load_flow(f)
+            assert s.flows[0].request.host == "use-this-domain"
 
-    def test_load_websocket_flow(self):
-        s = tservers.TestState()
+    @pytest.mark.asyncio
+    async def test_load_websocket_flow(self):
         opts = options.Options(
             mode="reverse:https://use-this-domain"
         )
-        fm = master.Master(opts)
-        fm.addons.add(s)
-        f = tflow.twebsocketflow()
-        fm.load_flow(f.handshake_flow)
-        fm.load_flow(f)
-        assert s.flows[0].request.host == "use-this-domain"
-        assert s.flows[1].handshake_flow == f.handshake_flow
-        assert len(s.flows[1].messages) == len(f.messages)
+        s = tservers.TestState()
+        with taddons.context(s, options=opts) as ctx:
+            f = tflow.twebsocketflow()
+            await ctx.master.load_flow(f.handshake_flow)
+            await ctx.master.load_flow(f)
+            assert s.flows[0].request.host == "use-this-domain"
+            assert s.flows[1].handshake_flow == f.handshake_flow
+            assert len(s.flows[1].messages) == len(f.messages)
 
     def test_replay(self):
         opts = options.Options()
@@ -150,31 +150,27 @@ class TestFlowMaster:
             assert rt.f.request.http_version == "HTTP/1.1"
             assert ":authority" not in rt.f.request.headers
 
-    def test_all(self):
+    @pytest.mark.asyncio
+    async def test_all(self):
+        opts = options.Options(
+            mode="reverse:https://use-this-domain"
+        )
         s = tservers.TestState()
-        fm = master.Master(None)
-        fm.addons.add(s)
-        f = tflow.tflow(req=None)
-        fm.addons.handle_lifecycle("clientconnect", f.client_conn)
-        f.request = http.HTTPRequest.wrap(mitmproxy.test.tutils.treq())
-        fm.addons.handle_lifecycle("request", f)
-        assert len(s.flows) == 1
+        with taddons.context(s, options=opts) as ctx:
+            f = tflow.tflow(req=None)
+            await ctx.master.addons.handle_lifecycle("clientconnect", f.client_conn)
+            f.request = http.HTTPRequest.wrap(mitmproxy.test.tutils.treq())
+            await ctx.master.addons.handle_lifecycle("request", f)
+            assert len(s.flows) == 1
 
-        f.response = http.HTTPResponse.wrap(mitmproxy.test.tutils.tresp())
-        fm.addons.handle_lifecycle("response", f)
-        assert len(s.flows) == 1
+            f.response = http.HTTPResponse.wrap(mitmproxy.test.tutils.tresp())
+            await ctx.master.addons.handle_lifecycle("response", f)
+            assert len(s.flows) == 1
 
-        fm.addons.handle_lifecycle("clientdisconnect", f.client_conn)
+            await ctx.master.addons.handle_lifecycle("clientdisconnect", f.client_conn)
 
-        f.error = flow.Error("msg")
-        fm.addons.handle_lifecycle("error", f)
-
-        # FIXME: This no longer works, because we consume on the main loop.
-        # fm.tell("foo", f)
-        # with pytest.raises(ControlException):
-        #     fm.addons.trigger("unknown")
-
-        fm.shutdown()
+            f.error = flow.Error("msg")
+            await ctx.master.addons.handle_lifecycle("error", f)
 
 
 class TestError:

--- a/test/mitmproxy/test_taddons.py
+++ b/test/mitmproxy/test_taddons.py
@@ -10,10 +10,10 @@ from mitmproxy import ctx
 @pytest.mark.asyncio
 async def test_recordingmaster():
     with taddons.context() as tctx:
-        assert not tctx.master.has_log("nonexistent")
+        assert not tctx.master._has_log("nonexistent")
         assert not tctx.master.has_event("nonexistent")
         ctx.log.error("foo")
-        assert not tctx.master.has_log("foo", level="debug")
+        assert not tctx.master._has_log("foo", level="debug")
         assert await tctx.master.await_log("foo", level="error")
 
 

--- a/test/mitmproxy/test_taddons.py
+++ b/test/mitmproxy/test_taddons.py
@@ -1,21 +1,27 @@
 import io
+
+import pytest
+
 from mitmproxy.test import taddons
 from mitmproxy.test import tutils
 from mitmproxy import ctx
 
 
-def test_recordingmaster():
+@pytest.mark.asyncio
+async def test_recordingmaster():
     with taddons.context() as tctx:
         assert not tctx.master.has_log("nonexistent")
         assert not tctx.master.has_event("nonexistent")
         ctx.log.error("foo")
         assert not tctx.master.has_log("foo", level="debug")
-        assert tctx.master.has_log("foo", level="error")
+        assert await tctx.master.await_log("foo", level="error")
 
 
-def test_dumplog():
+@pytest.mark.asyncio
+async def test_dumplog():
     with taddons.context() as tctx:
         ctx.log.info("testing")
+        await ctx.master.await_log("testing")
         s = io.StringIO()
         tctx.master.dump_log(s)
         assert s.getvalue()

--- a/test/mitmproxy/tools/console/test_defaultkeys.py
+++ b/test/mitmproxy/tools/console/test_defaultkeys.py
@@ -6,6 +6,7 @@ from mitmproxy import command
 
 import pytest
 
+
 @pytest.mark.asyncio
 async def test_commands_exist():
     km = keymap.Keymap(None)

--- a/test/mitmproxy/tools/console/test_defaultkeys.py
+++ b/test/mitmproxy/tools/console/test_defaultkeys.py
@@ -4,13 +4,15 @@ from mitmproxy.tools.console import keymap
 from mitmproxy.tools.console import master
 from mitmproxy import command
 
+import pytest
 
-def test_commands_exist():
+@pytest.mark.asyncio
+async def test_commands_exist():
     km = keymap.Keymap(None)
     defaultkeys.map(km)
     assert km.bindings
     m = master.ConsoleMaster(None)
-    m.load_flow(tflow())
+    await m.load_flow(tflow())
 
     for binding in km.bindings:
         cmd, *args = command.lexer(binding.command)

--- a/test/mitmproxy/tools/console/test_master.py
+++ b/test/mitmproxy/tools/console/test_master.py
@@ -4,6 +4,10 @@ from mitmproxy import options
 from mitmproxy.tools import console
 from ... import tservers
 
+import pytest
+
+@pytest.mark.asyncio
+
 
 class TestMaster(tservers.MasterTest):
     def mkmaster(self, **opts):
@@ -12,11 +16,11 @@ class TestMaster(tservers.MasterTest):
         m.addons.trigger("configure", o.keys())
         return m
 
-    def test_basic(self):
+    async def test_basic(self):
         m = self.mkmaster()
         for i in (1, 2, 3):
             try:
-                self.dummy_cycle(m, 1, b"")
+                await self.dummy_cycle(m, 1, b"")
             except urwid.ExitMainLoop:
                 pass
             assert len(m.view) == i

--- a/test/mitmproxy/tools/console/test_master.py
+++ b/test/mitmproxy/tools/console/test_master.py
@@ -6,9 +6,8 @@ from ... import tservers
 
 import pytest
 
+
 @pytest.mark.asyncio
-
-
 class TestMaster(tservers.MasterTest):
     def mkmaster(self, **opts):
         o = options.Options(**opts)

--- a/test/mitmproxy/tools/web/test_app.py
+++ b/test/mitmproxy/tools/web/test_app.py
@@ -45,7 +45,7 @@ class TestApp(tornado.testing.AsyncHTTPTestCase):
         f.id = "42"
         m.view.add([f])
         m.view.add([tflow.tflow(err=True)])
-        m.add_log("test log", "info")
+        m.log.info("test log")
         self.master = m
         self.view = m.view
         self.events = m.events

--- a/test/mitmproxy/tools/web/test_master.py
+++ b/test/mitmproxy/tools/web/test_master.py
@@ -1,6 +1,8 @@
 from mitmproxy.tools.web import master
 from mitmproxy import options
 
+import pytest
+
 from ... import tservers
 
 
@@ -9,8 +11,9 @@ class TestWebMaster(tservers.MasterTest):
         o = options.Options(**opts)
         return master.WebMaster(o)
 
-    def test_basic(self):
+    @pytest.mark.asyncio
+    async def test_basic(self):
         m = self.mkmaster()
         for i in (1, 2, 3):
-            self.dummy_cycle(m, 1, b"")
+            await self.dummy_cycle(m, 1, b"")
             assert len(m.view) == i

--- a/test/mitmproxy/tservers.py
+++ b/test/mitmproxy/tservers.py
@@ -26,20 +26,20 @@ from mitmproxy.test import taddons
 
 class MasterTest:
 
-    def cycle(self, master, content):
+    async def cycle(self, master, content):
         f = tflow.tflow(req=tutils.treq(content=content))
         layer = mock.Mock("mitmproxy.proxy.protocol.base.Layer")
         layer.client_conn = f.client_conn
         layer.reply = controller.DummyReply()
-        master.addons.handle_lifecycle("clientconnect", layer)
+        await master.addons.handle_lifecycle("clientconnect", layer)
         for i in eventsequence.iterate(f):
-            master.addons.handle_lifecycle(*i)
-        master.addons.handle_lifecycle("clientdisconnect", layer)
+            await master.addons.handle_lifecycle(*i)
+        await master.addons.handle_lifecycle("clientdisconnect", layer)
         return f
 
-    def dummy_cycle(self, master, n, content):
+    async def dummy_cycle(self, master, n, content):
         for i in range(n):
-            self.cycle(master, content)
+            await self.cycle(master, content)
         master.shutdown()
 
     def flowfile(self, path):


### PR DESCRIPTION
This patchset contains some next steps for our shift to asyncio in the core:

- Remove the queue used for messages from proxy threads to the main thread. We now simply schedule callbacks onto the event loop.
- The log mechanism is now asynchronous, and pushes messages onto the thread local event loop.
- Ditch the handler context. Our entire mechanism is now based on a thread local event loop. This means there's no longer any need for a handler context that sets up and tears down log and master objects. 

Together, my testing shows another 10% or so in performance gain after these changes. 

