### PR TITLE
Remove socket listen backlog constraint

### DIFF
--- a/mitmproxy/net/tcp.py
+++ b/mitmproxy/net/tcp.py
@@ -547,7 +547,6 @@ class Counter:
 
 
 class TCPServer:
-    request_queue_size = 20
 
     def __init__(self, address):
         self.address = address
@@ -580,7 +579,7 @@ class TCPServer:
             self.socket.bind(self.address)
 
         self.address = self.socket.getsockname()
-        self.socket.listen(self.request_queue_size)
+        self.socket.listen()
         self.handler_counter = Counter()
 
     def connection_thread(self, connection, client_address):


### PR DESCRIPTION
I have no idea why we did this, but the default value is 128, and setting it
this low drops connections under conditions our users can reasonably be expeted
to reach.