### PR TITLE
Handling user script's exceptions, fix #2839

### DIFF
--- a/test/mitmproxy/addons/test_script.py
+++ b/test/mitmproxy/addons/test_script.py
@@ -12,18 +12,27 @@ from mitmproxy.test import tflow
 from mitmproxy.test import tutils
 
 
-def test_load_script():
-    ns = script.load_script(
-        tutils.test_data.path(
-            "mitmproxy/data/addonscripts/recorder/recorder.py"
+@pytest.mark.asyncio
+async def test_load_script():
+    with taddons.context() as tctx:
+        ns = script.load_script(
+            tutils.test_data.path(
+                "mitmproxy/data/addonscripts/recorder/recorder.py"
+            )
         )
-    )
-    assert ns.addons
+        assert ns.addons
 
-    with pytest.raises(FileNotFoundError):
         script.load_script(
             "nonexistent"
         )
+        assert await tctx.master.await_log("No such file or directory")
+
+        script.load_script(
+            tutils.test_data.path(
+                "mitmproxy/data/addonscripts/recorder/error.py"
+            )
+        )
+        assert await tctx.master.await_log("invalid syntax")
 
 
 def test_load_fullname():

--- a/test/mitmproxy/data/addonscripts/recorder/error.py
+++ b/test/mitmproxy/data/addonscripts/recorder/error.py
@@ -1,0 +1,7 @@
+"""
+This file is intended to have syntax errors for test purposes
+"""
+
+impotr recorder # Intended Syntax Error
+
+addons = [recorder.Recorder("e")]


### PR DESCRIPTION
Hi,
Have used `script_error_handler` to fix #2839.