### PR TITLE
Ignore signal errors on windows + various fixes

### DIFF
--- a/mitmproxy/tools/main.py
+++ b/mitmproxy/tools/main.py
@@ -67,7 +67,7 @@ def run(
         make_parser: typing.Callable[[options.Options], argparse.ArgumentParser],
         arguments: typing.Sequence[str],
         extra: typing.Callable[[typing.Any], dict] = None
-):  # pragma: no cover
+) -> master.Master:  # pragma: no cover
     """
         extra: Extra argument processing callable which returns a dict of
         options.
@@ -121,7 +121,11 @@ def run(
         signal.signal(signal.SIGTERM, cleankill)
         loop = asyncio.get_event_loop()
         for signame in ('SIGINT', 'SIGTERM'):
-            loop.add_signal_handler(getattr(signal, signame), master.shutdown)
+            try:
+                loop.add_signal_handler(getattr(signal, signame), master.shutdown)
+            except NotImplementedError:
+                # Not supported on Windows
+                pass
         master.run()
     except exceptions.OptionsError as e:
         print("%s: %s" % (sys.argv[0], e), file=sys.stderr)
@@ -131,19 +135,18 @@ def run(
     return master
 
 
-def mitmproxy(args=None):  # pragma: no cover
+def mitmproxy(args=None) -> typing.Optional[int]:  # pragma: no cover
     if os.name == "nt":
         print("Error: mitmproxy's console interface is not supported on Windows. "
               "You can run mitmdump or mitmweb instead.", file=sys.stderr)
-        sys.exit(1)
-
+        return 1
     assert_utf8_env()
-
     from mitmproxy.tools import console
-    return run(console.master.ConsoleMaster, cmdline.mitmproxy, args)
+    run(console.master.ConsoleMaster, cmdline.mitmproxy, args)
+    return None
 
 
-def mitmdump(args=None):  # pragma: no cover
+def mitmdump(args=None) -> typing.Optional[int]:  # pragma: no cover
     from mitmproxy.tools import dump
 
     def extra(args):
@@ -157,11 +160,12 @@ def mitmdump(args=None):  # pragma: no cover
         return {}
 
     m = run(dump.DumpMaster, cmdline.mitmdump, args, extra)
-    if m and m.errorcheck.has_errored:
-        sys.exit(1)
-    return m
+    if m and m.errorcheck.has_errored:  # type: ignore
+        return 1
+    return None
 
 
-def mitmweb(args=None):  # pragma: no cover
+def mitmweb(args=None) -> typing.Optional[int]:  # pragma: no cover
     from mitmproxy.tools import web
-    return run(web.master.WebMaster, cmdline.mitmweb, args)
+    run(web.master.WebMaster, cmdline.mitmweb, args)
+    return None

--- a/test/mitmproxy/tools/test_main.py
+++ b/test/mitmproxy/tools/test_main.py
@@ -1,18 +1,19 @@
 import pytest
 
 from mitmproxy.tools import main
+from mitmproxy import ctx
 
 
 @pytest.mark.asyncio
 async def test_mitmweb(event_loop):
-    m = main.mitmweb([
+    main.mitmweb([
         "--no-web-open-browser",
         "-q", "-p", "0",
     ])
-    await m._shutdown()
+    await ctx.master._shutdown()
 
 
 @pytest.mark.asyncio
 async def test_mitmdump():
-    m = main.mitmdump(["-q", "-p", "0"])
-    await m._shutdown()
+    main.mitmdump(["-q", "-p", "0"])
+    await ctx.master._shutdown()


### PR DESCRIPTION
- Ignore the NotImplementedError raised by add_signal_handler on Windows.
- Entrypoints return an integer exit code, or None. Adjust our type annotations
and code to suit.

Fixes #3061