### PR TITLE
Revamp dup_and_replay example

### DIFF
--- a/examples/complex/dup_and_replay.py
+++ b/examples/complex/dup_and_replay.py
@@ -2,7 +2,13 @@ from mitmproxy import ctx
 
 
 def request(flow):
-    f = flow.copy()
-    ctx.master.view.add(f)
-    f.request.path = "/changed"
-    ctx.master.replay_request(f, block=True)
+    # Avoid an infinite loop by not replaying already replayed requests
+    if flow.request.is_replay:
+        return
+    flow = flow.copy()
+    # Only interactive tools have a view. If we have one, add a duplicate entry
+    # for our flow.
+    if "view" in ctx.master.addons:
+        ctx.master.commands.call("view.add", [flow])
+    flow.request.path = "/changed"
+    ctx.master.commands.call("replay.client", [flow])

--- a/mitmproxy/addons/view.py
+++ b/mitmproxy/addons/view.py
@@ -293,6 +293,7 @@ class View(collections.Sequence):
         self._refilter()
         self.sig_store_refresh.send(self)
 
+    @command.command("view.marked.toggle")
     def add(self, flows: typing.Sequence[mitmproxy.flow.Flow]) -> None:
         """
             Adds a flow to the state. If the flow already exists, it is


### PR DESCRIPTION
- Exposes view.add as a command
- Copes with cases where a view addon isn't present
- Avoids infinite loop caused by replaying replays

Fixes #3096