### PR TITLE
Remove leftover processing_complete

### DIFF
--- a/mitmproxy/addons/readfile.py
+++ b/mitmproxy/addons/readfile.py
@@ -74,7 +74,6 @@ class ReadFile:
             raise exceptions.OptionsError(e) from e
         finally:
             self.is_reading = False
-            ctx.master.addons.trigger("processing_complete")
 
     def running(self):
         if ctx.options.rfile:

--- a/test/mitmproxy/addons/test_readfile.py
+++ b/test/mitmproxy/addons/test_readfile.py
@@ -1,6 +1,5 @@
 import asyncio
 import io
-from unittest import mock
 
 import pytest
 import asynctest
@@ -110,8 +109,7 @@ class TestReadFileStdin:
                     await rf.load_flows(stdin.buffer)
 
     @pytest.mark.asyncio
-    @mock.patch('mitmproxy.master.Master.load_flow')
-    async def test_normal(self, load_flow, tmpdir, data):
+    async def test_normal(self, tmpdir, data):
         rf = readfile.ReadFileStdin()
         with taddons.context(rf) as tctx:
             tf = tmpdir.join("tfile")


### PR DESCRIPTION
This broke `mitmdump -nr empty`.