### PR TITLE
add har_dump example cmdline invocation

### DIFF
--- a/examples/complex/har_dump.py
+++ b/examples/complex/har_dump.py
@@ -1,5 +1,11 @@
 """
 This inline script can be used to dump flows as HAR files.
+
+example cmdline invocation:
+mitmdump -s ./har_dump.py --set hardump=./dump.har
+
+filename endwith '.zhar' will be compressed:
+mitmdump -s ./har_dump.py --set hardump=./dump.zhar
 """
 
 


### PR DESCRIPTION
When I was reading this example, I didn't know how to use it. The methods used on the Internet have expired, such as `mitmdump -s "./har_dump.py ./out.har"`. Later, after reading the document carefully, I learned how to use it. So I want to write usage in the file so that others can use it.