### PR TITLE
add docker to the main repository

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -11,6 +11,7 @@ environment:
   matrix:
     - PYTHON: "C:\\Python36"
       TOXENV: "py36"
+      PYINSTALLER: "1"
 
 install:
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
@@ -21,7 +22,6 @@ test_script:
   - ps: "tox -- --verbose --cov-report=term"
   - ps: |
       $Env:VERSION = $(python -m mitmproxy.version)
-      $Env:SKIP_MITMPROXY = "python -c `"print('skip mitmproxy')`""
       tox -e cibuild -- build
   - ps: |
       if($Env:RTOOL_KEY) {

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,12 @@ matrix:
     - os: osx
       osx_image: xcode7.3
       language: generic
-      env: TOXENV=py36 BDIST=1
+      env: TOXENV=py36 CIBUILD=1 PYINSTALLER=1
     - python: 3.6
-      env: TOXENV=py36 BDIST=1 WHEEL=1
+      env: TOXENV=py36 CIBUILD=1 PYINSTALLER=1 WHEEL=1 DOCKER=1
+      sudo: required
+      services:
+        - docker
     - python: 3.6
       env: TOXENV=individual_coverage
     - python: "3.7-dev"
@@ -67,19 +70,16 @@ install:
   - pip install tox virtualenv setuptools
 
 script:
+  # All these steps MUST succeed for the job to be successful!
+  # Using the after_success block DOES NOT capture errors.
+  # Pull requests might break our build - we need to check this.
+  # Pull requests are not allowed to upload build artifacts - enforced by cibuild script.
   - tox -- --verbose --cov-report=term
   - |
-    if [[ $BDIST == "1" ]]
+    if [[ $CIBUILD == "1" ]]
     then
         git fetch --unshallow --tags
-        tox -e cibuild -- build
-    fi
-
-after_success:
-  - |
-    if [[ $BDIST == "1" ]]
-    then
-        tox -e cibuild -- upload
+        tox -e cibuild -- build && tox -e cibuild -- upload
     fi
 
 notifications:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,41 @@
+FROM alpine:3.7
+
+ENV LANG=en_US.UTF-8
+
+ARG WHEEL_MITMPROXY
+ARG WHEEL_BASENAME_MITMPROXY
+
+COPY $WHEEL_MITMPROXY /home/mitmproxy/
+
+# Add our user first to make sure the ID get assigned consistently,
+# regardless of whatever dependencies get added.
+RUN addgroup -S mitmproxy && adduser -S -G mitmproxy mitmproxy \
+    && apk add --no-cache \
+        su-exec \
+        git \
+        g++ \
+        libffi \
+        libffi-dev \
+        libstdc++ \
+        openssl \
+        openssl-dev \
+        python3 \
+        python3-dev \
+    && python3 -m ensurepip \
+    && LDFLAGS=-L/lib pip3 install -U /home/mitmproxy/${WHEEL_BASENAME_MITMPROXY} \
+    && apk del --purge \
+        git \
+        g++ \
+        libffi-dev \
+        openssl-dev \
+        python3-dev \
+    && rm -rf ~/.cache/pip /home/mitmproxy/${WHEEL_BASENAME_MITMPROXY}
+
+VOLUME /home/mitmproxy/.mitmproxy
+
+COPY docker/docker-entrypoint.sh /usr/local/bin/
+ENTRYPOINT ["docker-entrypoint.sh"]
+
+EXPOSE 8080 8081
+
+CMD ["mitmproxy"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,38 @@
+# mitmproxy
+
+Containerized version of [mitmproxy](https://mitmproxy.org/), an interactive SSL-capable intercepting HTTP proxy.
+
+# Usage
+
+```sh
+$ docker run --rm -it [-v ~/.mitmproxy:/home/mitmproxy/.mitmproxy] -p 8080:8080 mitmproxy/mitmproxy
+```
+The *volume mount* is optional: It's to store the generated CA certificates.
+
+Once started, mitmproxy listens as a HTTP proxy on `localhost:8080`:
+```sh
+$ http_proxy=http://localhost:8080/ curl http://example.com/
+$ https_proxy=http://localhost:8080/ curl -k https://example.com/
+```
+
+You can also start `mitmdump` by just adding that to the end of the command-line:
+```sh
+$ docker run --rm -it -p 8080:8080 mitmproxy/mitmproxy mitmdump
+```
+
+For `mitmweb`, you also need to expose port 8081:
+```sh
+# this makes :8081 accessible to the local machine only
+$ docker run --rm -it -p 8080:8080 -p 127.0.0.1:8081:8081 mitmproxy/mitmproxy mitmweb --web-iface 0.0.0.0
+```
+
+You can also pass options directly via the CLI:
+```sh
+$ docker run --rm -it -p 8080:8080 mitmproxy/mitmproxy mitmdump --set ssl_insecure=true
+```
+
+For further details, please consult the mitmproxy [documentation](http://docs.mitmproxy.org/en/stable/).
+
+# Tags
+
+The available release tags can be seen [here](https://hub.docker.com/r/mitmproxy/mitmproxy/tags/).

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -e
+
+MITMPROXY_PATH="/home/mitmproxy/.mitmproxy"
+
+if [[ "$1" = "mitmdump" || "$1" = "mitmproxy" || "$1" = "mitmweb" ]]; then
+        mkdir -p "$MITMPROXY_PATH"
+        chown -R mitmproxy:mitmproxy "$MITMPROXY_PATH"
+
+        su-exec mitmproxy "$@"
+else
+        exec "$@"
+fi

--- a/release/README.md
+++ b/release/README.md
@@ -37,22 +37,10 @@ release for! The command examples assume that you have a git remote called
   `brew bump-formula-pr --url https://github.com/mitmproxy/mitmproxy/archive/v<version number here>`
 
 ## Docker
-- Update docker-releases repo
-  - Create a new branch based of master for major versions.
-  - Update the dependencies in [alpine/requirements.txt](https://github.com/mitmproxy/docker-releases/commit/3d6a9989fde068ad0aea257823ac3d7986ff1613#diff-9b7e0eea8ae74688b1ac13ea080549ba)
-    * Creating a fresh venv, pip-installing the new wheel in there, and then export all packages:
-    * `virtualenv -ppython3.6 venv && source venv/bin/activate && pip install mitmproxy && pip freeze`
-  - Tag the commit with the correct version
-    * `v2.0.0` for new major versions
-    * `v2.0.2` for new patch versions
-- Update `latest` tag [here](https://hub.docker.com/r/mitmproxy/mitmproxy/~/settings/automated-builds/)
-- Check that the build for this tag succeeds [https://hub.docker.com/r/mitmproxy/mitmproxy/builds/](here)
-- If build failed:
-  - Fix it and commit
-  - `git tag 3.0.2` the new commit
-  - `git push origin :refs/tags/3.0.2` to delete the old remote tag
-  - `git push --tags` to push the new tag
-  - Check the build details page again
+- The docker image is built on Travis and pushed to Docker Hub automatically.
+- Please check https://hub.docker.com/r/mitmproxy/mitmproxy/tags/ about the latest version
+- Update `latest` tag: TODO write instructions
+
 
 ## Website
  - Update version here:

--- a/tox.ini
+++ b/tox.ini
@@ -33,7 +33,7 @@ commands =
   python ./test/individual_coverage.py
 
 [testenv:cibuild]
-passenv = TRAVIS_* AWS_* APPVEYOR_* TWINE_* RTOOL_KEY WHEEL
+passenv = TRAVIS_* APPVEYOR_* AWS_* TWINE_* DOCKER_* RTOOL_KEY WHEEL DOCKER PYINSTALLER
 deps =
   -rrequirements.txt
   pyinstaller==3.3.1
@@ -41,7 +41,7 @@ deps =
   awscli
 commands =
   mitmdump --version
-  python ./release/ci.py {posargs}
+  python ./release/cibuild.py {posargs}
 
 [testenv:wheeltest]
 recreate = True
@@ -55,7 +55,7 @@ commands =
   pathoc --version
 
 [testenv:docs]
-passenv = TRAVIS_* AWS_* APPVEYOR_* RTOOL_KEY WHEEL
+passenv = TRAVIS_* APPVEYOR_* AWS_*
 deps =
   -rrequirements.txt
   awscli


### PR DESCRIPTION
The plan is to ditch the "automated build" feature of Docker Hub, and instead build & push our own images. We use Travis to perform this, the same way we already build our wheels and pyinstaller files and upload them. This means we do not need the separate docker-release repository any more, and our release check-list shrinks as well, because we don't need to update and tag and push in a second repo any more.

This PR contains general improvements and cleanup things regarding our release workflow.