### PR TITLE
Added --dump-header option to curl export

### DIFF
--- a/mitmproxy/addons/export.py
+++ b/mitmproxy/addons/export.py
@@ -18,7 +18,7 @@ def raise_if_missing_request(f: flow.Flow) -> None:
 
 def curl_command(f: flow.Flow) -> str:
     raise_if_missing_request(f)
-    data = "curl "
+    data = "curl --dump-header "
     request = f.request.copy()  # type: ignore
     request.decode(strict=False)
     for k, v in request.headers.items(multi=True):


### PR DESCRIPTION
Hi, you have build awesome software! 
My commit is about little hack for exporting to `curl`. 
When request has a lot of `cookie` which dumps with option `-H 'cookie: .......` we need additions option `--dump-header` [curl --dump-header](https://curl.haxx.se/docs/httpscripting.html#Cookie_Basics) for make curl request successful.
