### PR TITLE
check charset in HTML meta tags

### DIFF
--- a/mitmproxy/net/http/message.py
+++ b/mitmproxy/net/http/message.py
@@ -167,7 +167,7 @@ class Message(serializable.Serializable):
 
     def _guess_encoding(self, content=b"") -> str:
         enc = self._get_content_type_charset()
-        
+
         if not enc:
             if "json" in self.headers.get("content-type", ""):
                 return "utf8"
@@ -181,7 +181,7 @@ class Message(serializable.Serializable):
         # fix encoding bug when some special characters exceed the character set, such as www.qq.com
         enc = enc.lower()
         enc = "gb18030" if enc == "gb2312" or enc == "gbk" else enc
-        return enc            
+        return enc
 
     def get_text(self, strict: bool=True) -> Optional[str]:
         """

--- a/mitmproxy/net/http/message.py
+++ b/mitmproxy/net/http/message.py
@@ -174,9 +174,9 @@ class Message(serializable.Serializable):
             else:
                 # check for HTML meta tags here at some point.
                 REGEX_ENCODING = re.compile(rb"""<meta[^>]+charset=['"]?([^'"]+)""")
-                enc = REGEX_ENCODING.findall(content)[0]
+                enc_found = REGEX_ENCODING.findall(content)
                 # if not found charset in HTML meta tags
-                enc = "latin-1" if not enc else enc.decode()
+                enc = "latin-1" if not enc_found else enc_found[0].decode()
 
         # fix encoding bug when some special characters exceed the character set, such as www.qq.com
         enc = enc.lower()

--- a/mitmproxy/net/http/message.py
+++ b/mitmproxy/net/http/message.py
@@ -68,7 +68,7 @@ class Message(serializable.Serializable):
     @property
     def raw_content(self) -> bytes:
         """
-        The raw (encoded) HTTP message body
+        The raw (potentially compressed) HTTP message body as bytes.
 
         See also: :py:attr:`content`, :py:class:`text`
         """
@@ -80,10 +80,10 @@ class Message(serializable.Serializable):
 
     def get_content(self, strict: bool=True) -> bytes:
         """
-        The HTTP message body decoded with the content-encoding header (e.g. gzip)
+        The uncompressed HTTP message body as bytes.
 
         Raises:
-            ValueError, when the content-encoding is invalid and strict is True.
+            ValueError, when the HTTP content-encoding is invalid and strict is True.
 
         See also: :py:class:`raw_content`, :py:attr:`text`
         """
@@ -186,9 +186,7 @@ class Message(serializable.Serializable):
 
     def get_text(self, strict: bool=True) -> Optional[str]:
         """
-        The HTTP message body decoded with both content-encoding header (e.g. gzip)
-        and content-type header charset.
-        and HTML meta charset.
+        The uncompressed and decoded HTTP message body as text.
 
         Raises:
             ValueError, when either content-encoding or charset is invalid and strict is True.


### PR DESCRIPTION
In some cases, there is no charset in response headers, such as www.baidu.com.
so I edited the `_guess_encoding` method to check charset in HTML meta tags.

And in some cases, sites using 'gb2312' encoding can cause decoding errors, such as www.qq.com.
So I changed 'gb2312' and 'gbk' to 'gb18030'. The latter is the superset of the first two.