### PR TITLE
Tame cibuild (somewhat)

### DIFF
--- a/release/cibuild.py
+++ b/release/cibuild.py
@@ -197,11 +197,11 @@ class BuildEnviron:
 
     @property
     def should_upload_docker(self) -> bool:
-        return (
-            (self.tag or self.branch == "master") and
+        return all([
+            (self.tag or self.branch == "master"),
             self.should_build_docker,
             self.has_docker_creds,
-        )
+        ])
 
     @property
     def should_upload_pypi(self) -> bool:

--- a/release/cibuild.py
+++ b/release/cibuild.py
@@ -210,16 +210,25 @@ class BuildEnviron:
         return False
 
     def dump_info(self, fp=sys.stdout):
-        print("BUILD PLATFORM_TAG=%s" % self.platform_tag, file=fp)
-        print("BUILD ROOT_DIR=%s" % self.root_dir, file=fp)
-        print("BUILD RELEASE_DIR=%s" % self.release_dir, file=fp)
-        print("BUILD BUILD_DIR=%s" % self.build_dir, file=fp)
-        print("BUILD DIST_DIR=%s" % self.dist_dir, file=fp)
-        print("BUILD BDISTS=%s" % self.bdists, file=fp)
-        print("BUILD TAG=%s" % self.tag, file=fp)
-        print("BUILD BRANCH=%s" % self.branch, file=fp)
-        print("BUILD VERSION=%s" % self.version, file=fp)
-        print("BUILD UPLOAD_DIR=%s" % self.upload_dir, file=fp)
+        lst = [
+            "version",
+            "tag",
+            "branch",
+            "platform_tag",
+            "root_dir",
+            "release_dir",
+            "build_dir",
+            "dist_dir",
+            "bdists",
+            "upload_dir",
+            "should_build_wheel",
+            "should_build_pyinstaller",
+            "should_build_docker",
+            "should_upload_docker",
+            "should_upload_pypi",
+        ]
+        for attr in lst:
+            print("cibuild.%s=%s" % (attr, getattr(self, attr)), file=fp)
 
 
 def build_wheel(be: BuildEnviron):  # pragma: no cover

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,6 +38,8 @@ exclude =
     pathod/pathod.py
     pathod/test.py
     pathod/protocols/http2.py
+    release/hooks
+
 
 [tool:individual_coverage]
 exclude =
@@ -89,3 +91,4 @@ exclude =
     pathod/protocols/http2.py
     pathod/protocols/websockets.py
     pathod/test.py
+    release/hooks

--- a/test/release/test_cibuild.py
+++ b/test/release/test_cibuild.py
@@ -59,21 +59,28 @@ def test_buildenviron_commit():
         travis_pull_request = "false",
     )
     assert be.docker_tag == "dev"
+    assert be.should_upload_docker
+    assert not be.should_upload_pypi
 
 
-def test_buildenviron_tag():
+def test_buildenviron_rleasetag():
     be = cibuild.BuildEnviron(
         system = "Linux",
         root_dir = "/foo",
 
         travis_tag = "v0.0.1",
         travis_branch = "v0.x",
+        should_build_wheel = True,
+        should_build_docker = True,
+        should_build_pyinstaller = True,
+        has_twine_creds = True,
     )
     assert be.tag == "v0.0.1"
     assert be.branch == "v0.x"
     assert be.version == "0.0.1"
     assert be.upload_dir == "0.0.1"
     assert be.docker_tag == "0.0.1"
+    assert be.should_upload_pypi
 
 
 def test_buildenviron_branch():

--- a/test/release/test_cibuild.py
+++ b/test/release/test_cibuild.py
@@ -43,8 +43,8 @@ def test_buildenviron_pr():
     # Simulates a PR. We build everything, but don't have access to secret
     # credential env variables.
     be = cibuild.BuildEnviron(
-        travis_tag = "v0.0.1",
-        travis_branch = "v0.x",
+        travis_tag = "",
+        travis_branch = "master",
         travis_pull_request = "true",
 
         should_build_wheel = True,

--- a/test/release/test_cibuild.py
+++ b/test/release/test_cibuild.py
@@ -1,0 +1,95 @@
+import os
+import io
+from release import cibuild
+
+
+def test_buildenviron_common():
+    be = cibuild.BuildEnviron(
+        system = "Linux",
+        root_dir = "/foo",
+
+        travis_tag = "v0.0.1",
+        travis_branch = "v0.x",
+    )
+    assert be.release_dir == os.path.join(be.root_dir, "release")
+    assert be.dist_dir == os.path.join(be.root_dir, "release", "dist")
+    assert be.build_dir == os.path.join(be.root_dir, "release", "build")
+    assert be.is_pull_request is False
+
+    cs = io.StringIO()
+    be.dump_info(cs)
+    assert cs.getvalue()
+
+
+def test_buildenviron_pr():
+    be = cibuild.BuildEnviron(
+        travis_tag = "v0.0.1",
+        travis_branch = "v0.x",
+        travis_pull_request = "true",
+    )
+    assert be.is_pull_request
+
+    be = cibuild.BuildEnviron(
+        appveyor_pull_request_number = "xxxx",
+    )
+    assert be.is_pull_request
+
+
+def test_buildenviron_tag():
+    be = cibuild.BuildEnviron(
+        system = "Linux",
+        root_dir = "/foo",
+
+        travis_tag = "v0.0.1",
+        travis_branch = "v0.x",
+    )
+    assert be.tag == "v0.0.1"
+    assert be.branch == "v0.x"
+    assert be.version == "0.0.1"
+    assert be.upload_dir == "0.0.1"
+
+
+def test_buildenviron_branch():
+    be = cibuild.BuildEnviron(
+        system = "Linux",
+        root_dir = "/foo",
+
+        travis_tag = "",
+        travis_branch = "v0.x",
+    )
+    assert be.tag == ""
+    assert be.branch == "v0.x"
+    assert be.version == "0.x"
+    assert be.upload_dir == "branches/0.x"
+
+
+def test_buildenviron_osx():
+    be = cibuild.BuildEnviron(
+        system = "Darwin",
+        root_dir = "/foo",
+
+        travis_tag = "v0.0.1",
+        travis_branch = "v0.x",
+    )
+    assert be.platform_tag == "osx"
+    assert be.bdists == {
+        "mitmproxy": ["mitmproxy", "mitmdump", "mitmweb"],
+        "pathod": ["pathoc", "pathod"],
+    }
+    assert be.archive_name("mitmproxy") == "mitmproxy-0.0.1-osx.tar.gz"
+
+
+def test_buildenviron_windows():
+    be = cibuild.BuildEnviron(
+        system = "Windows",
+        root_dir = "/foo",
+
+        travis_tag = "v0.0.1",
+        travis_branch = "v0.x",
+    )
+    assert be.platform_tag == "windows"
+    assert be.bdists == {
+        "mitmproxy": ["mitmdump", "mitmweb"],
+        "pathod": ["pathoc", "pathod"],
+    }
+    assert be.archive_name("mitmproxy") == "mitmproxy-0.0.1-windows.zip"

--- a/test/release/test_cibuild.py
+++ b/test/release/test_cibuild.py
@@ -53,6 +53,14 @@ def test_buildenviron_pr():
     assert be.is_pull_request
 
 
+def test_buildenviron_commit():
+    be = cibuild.BuildEnviron(
+        travis_branch = "master",
+        travis_pull_request = "false",
+    )
+    assert be.docker_tag == "dev"
+
+
 def test_buildenviron_tag():
     be = cibuild.BuildEnviron(
         system = "Linux",
@@ -65,6 +73,7 @@ def test_buildenviron_tag():
     assert be.branch == "v0.x"
     assert be.version == "0.0.1"
     assert be.upload_dir == "0.0.1"
+    assert be.docker_tag == "0.0.1"
 
 
 def test_buildenviron_branch():

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ setenv = HOME = {envtmpdir}
 commands =
   mitmdump --version
   pytest --timeout 60 --cov-report='' \
-    --cov=mitmproxy --cov=pathod \
+    --cov=mitmproxy --cov=pathod --cov=release \
     --full-cov=mitmproxy/ --full-cov=pathod/ \
     {posargs}
   {env:CI_COMMANDS:python -c ""}


### PR DESCRIPTION
Pull all the cibuild state management and computation into a testable class. Isolate environment access to a single function. Add unit tests simulating common CI scenarios. General cleanups.

There's more to be done, but this is a good start. 