### PR TITLE
Adjust options when changed

### DIFF
--- a/mitmproxy/optmanager.py
+++ b/mitmproxy/optmanager.py
@@ -107,6 +107,7 @@ class OptManager:
         choices: typing.Optional[typing.Sequence[str]] = None
     ) -> None:
         self._options[name] = _Option(name, typespec, default, help, choices)
+        self.changed.send(self, updated={name})
 
     @contextlib.contextmanager
     def rollback(self, updated, reraise=False):

--- a/mitmproxy/tools/console/options.py
+++ b/mitmproxy/tools/console/options.py
@@ -106,6 +106,8 @@ class OptionListWalker(urwid.ListWalker):
         self.master.options.changed.connect(self.sig_mod)
 
     def sig_mod(self, *args, **kwargs):
+        self.opts = sorted(self.master.options.keys())
+        self.maxlen = max(len(i) for i in self.opts)
         self._modified()
         self.set_focus(self.index)
 


### PR DESCRIPTION
The existing options for the console were not being updated when a new
addon was added. This triggers the changed blinker signal when an option
is added, and also recreates self.opts when this signal is received.

Fixes #3147