### PR TITLE
Remove over-zealous assert on metadata types

### DIFF
--- a/mitmproxy/stateobject.py
+++ b/mitmproxy/stateobject.py
@@ -77,8 +77,6 @@ def _process(typeinfo: typecheck.Type, val: typing.Any, make: bool) -> typing.An
             for k, v in val.items()
         }
     elif typename.startswith("typing.Any"):
-        # FIXME: Remove this when we remove flow.metadata
-        assert isinstance(val, (int, str, bool, bytes))
         return val
     else:
         return typeinfo(val)


### PR DESCRIPTION
The only real rule here is that we want the metadata to be serializable, and
the current constraint fails in the face of compound types. We don't want to
re-implement a type checker here, so just remove the assert for now.

Once the session mechanism is in core, we'll have better ways to deal with
this.

Fixes #3180