### PR TITLE
View Cleanup - Initial steps

### DIFF
--- a/examples/complex/dup_and_replay.py
+++ b/examples/complex/dup_and_replay.py
@@ -9,6 +9,6 @@ def request(flow):
     # Only interactive tools have a view. If we have one, add a duplicate entry
     # for our flow.
     if "view" in ctx.master.addons:
-        ctx.master.commands.call("view.add", [flow])
+        ctx.master.commands.call("view.flows.add", [flow])
     flow.request.path = "/changed"
     ctx.master.commands.call("replay.client", [flow])

--- a/mitmproxy/addons/view.py
+++ b/mitmproxy/addons/view.py
@@ -260,12 +260,12 @@ class View(collections.Sequence):
         return list(sorted(self.orders.keys()))
 
     @command.command("view.order.reverse")
-    def set_reversed(self, value: bool):
+    def set_reversed(self, value: bool) -> None:
         self.order_reversed = value
         self.sig_view_refresh.send(self)
 
     @command.command("view.order.set")
-    def set_order(self, order: str):
+    def set_order(self, order: str) -> None:
         """
             Sets the current view order.
         """

--- a/mitmproxy/addons/view.py
+++ b/mitmproxy/addons/view.py
@@ -284,9 +284,11 @@ class View(collections.Sequence):
         """
         Returns the current view order.
         """
+        order = ""
         for k in self.orders.keys():
             if self.order_key == self.orders[k]:
-                return k
+                order = k
+        return order
 
     # Filter
     @command.command("view.filter.set")

--- a/mitmproxy/addons/view.py
+++ b/mitmproxy/addons/view.py
@@ -292,7 +292,7 @@ class View(collections.Sequence):
 
     # Filter
     @command.command("view.filter.set")
-    def filter_set(self, f: str) -> None:
+    def set_filter_cmd(self, f: str) -> None:
         """
             Sets the current view filter.
         """

--- a/mitmproxy/tools/console/consoleaddons.py
+++ b/mitmproxy/tools/console/consoleaddons.py
@@ -515,7 +515,7 @@ class ConsoleAddon:
 
         try:
             self.master.commands.call_strings(
-                "view.setval",
+                "view.settings.setval",
                 ["@focus", "flowview_mode_%s" % idx, mode]
             )
         except exceptions.CommandError as e:
@@ -538,7 +538,7 @@ class ConsoleAddon:
             raise exceptions.CommandError("Not viewing a flow.")
         idx = fv.body.tab_offset
         return self.master.commands.call_strings(
-            "view.getval",
+            "view.settings.getval",
             [
                 "@focus",
                 "flowview_mode_%s" % idx,

--- a/mitmproxy/tools/console/defaultkeys.py
+++ b/mitmproxy/tools/console/defaultkeys.py
@@ -36,8 +36,8 @@ def map(km):
         ["flowlist", "flowview"],
         "Save response body to file"
     )
-    km.add("d", "view.remove @focus", ["flowlist", "flowview"], "Delete flow from view")
-    km.add("D", "view.duplicate @focus", ["flowlist", "flowview"], "Duplicate flow")
+    km.add("d", "view.flows.remove @focus", ["flowlist", "flowview"], "Delete flow from view")
+    km.add("D", "view.flows.duplicate @focus", ["flowlist", "flowview"], "Duplicate flow")
     km.add(
         "e",
         """
@@ -57,7 +57,7 @@ def map(km):
     )
     km.add("L", "console.command view.load ", ["flowlist"], "Load flows from file")
     km.add("m", "flow.mark.toggle @focus", ["flowlist"], "Toggle mark on this flow")
-    km.add("M", "view.marked.toggle", ["flowlist"], "Toggle viewing marked flows")
+    km.add("M", "view.properties.marked.toggle", ["flowlist"], "Toggle viewing marked flows")
     km.add(
         "n",
         "console.command view.create get https://example.com/",
@@ -80,8 +80,8 @@ def map(km):
     km.add("w", "console.command save.file @shown ", ["flowlist"], "Save listed flows to file")
     km.add("V", "flow.revert @focus", ["flowlist", "flowview"], "Revert changes to this flow")
     km.add("X", "flow.kill @focus", ["flowlist"], "Kill this flow")
-    km.add("z", "view.remove @all", ["flowlist"], "Clear flow list")
-    km.add("Z", "view.remove @hidden", ["flowlist"], "Purge all flows not showing")
+    km.add("z", "view.flows.remove @all", ["flowlist"], "Clear flow list")
+    km.add("Z", "view.flows.remove @hidden", ["flowlist"], "Purge all flows not showing")
     km.add(
         "|",
         "console.command script.run @focus ",
@@ -100,7 +100,7 @@ def map(km):
     )
     km.add(
         "f",
-        "view.setval.toggle @focus fullcontents",
+        "view.settings.setval.toggle @focus fullcontents",
         ["flowview"],
         "Toggle viewing full contents on this flow",
     )

--- a/mitmproxy/tools/console/flowlist.py
+++ b/mitmproxy/tools/console/flowlist.py
@@ -42,7 +42,7 @@ class FlowListWalker(urwid.ListWalker):
     def positions(self, reverse=False):
         # The stub implementation of positions can go once this issue is resolved:
         # https://github.com/urwid/urwid/issues/294
-        ret = range(len(self.master.view))
+        ret = range(self.master.commands.execute("view.properties.length"))
         if reverse:
             return reversed(ret)
         return ret
@@ -57,19 +57,19 @@ class FlowListWalker(urwid.ListWalker):
         return f, self.master.view.focus.index
 
     def set_focus(self, index):
-        if self.master.view.inbounds(index):
+        if self.master.commands.execute("view.properties.inbounds %d" % index):
             self.master.view.focus.index = index
 
     def get_next(self, pos):
         pos = pos + 1
-        if not self.master.view.inbounds(pos):
+        if not self.master.commands.execute("view.properties.inbounds %d" % pos):
             return None, None
         f = FlowItem(self.master, self.master.view[pos])
         return f, pos
 
     def get_prev(self, pos):
         pos = pos - 1
-        if not self.master.view.inbounds(pos):
+        if not self.master.commands.execute("view.properties.inbounds %d" % pos):
             return None, None
         f = FlowItem(self.master, self.master.view[pos])
         return f, pos
@@ -87,9 +87,9 @@ class FlowListBox(urwid.ListBox, layoutwidget.LayoutWidget):
 
     def keypress(self, size, key):
         if key == "m_start":
-            self.master.commands.execute("view.go 0")
+            self.master.commands.execute("view.focus.go 0")
         elif key == "m_end":
-            self.master.commands.execute("view.go -1")
+            self.master.commands.execute("view.focus.go -1")
         elif key == "m_select":
             self.master.commands.execute("console.view.flow @focus")
         return urwid.ListBox.keypress(self, size, key)

--- a/mitmproxy/tools/console/flowview.py
+++ b/mitmproxy/tools/console/flowview.py
@@ -98,7 +98,7 @@ class FlowDetails(tabs.Tabs):
             msg, body = "", [urwid.Text([("error", "[content missing]")])]
             return msg, body
         else:
-            full = self.master.commands.execute("view.getval @focus fullcontents false")
+            full = self.master.commands.execute("view.settings.getval @focus fullcontents false")
             if full == "true":
                 limit = sys.maxsize
             else:

--- a/mitmproxy/tools/console/statusbar.py
+++ b/mitmproxy/tools/console/statusbar.py
@@ -271,7 +271,7 @@ class StatusBar(urwid.WidgetWrap):
         return r
 
     def redraw(self):
-        fc = len(self.master.view)
+        fc = self.master.commands.execute("view.properties.length")
         if self.master.view.focus.flow is None:
             offset = 0
         else:
@@ -283,7 +283,7 @@ class StatusBar(urwid.WidgetWrap):
             arrow = common.SYMBOL_DOWN
 
         marked = ""
-        if self.master.view.show_marked:
+        if self.master.commands.execute("view.properties.marked"):
             marked = "M"
 
         t = [

--- a/mitmproxy/types.py
+++ b/mitmproxy/types.py
@@ -337,7 +337,7 @@ class _FlowType(_BaseFlowType):
 
     def parse(self, manager: _CommandBase, t: type, s: str) -> flow.Flow:
         try:
-            flows = manager.call_strings("view.resolve", [s])
+            flows = manager.call_strings("view.flows.resolve", [s])
         except exceptions.CommandError as e:
             raise exceptions.TypeError from e
         if len(flows) != 1:
@@ -356,7 +356,7 @@ class _FlowsType(_BaseFlowType):
 
     def parse(self, manager: _CommandBase, t: type, s: str) -> typing.Sequence[flow.Flow]:
         try:
-            return manager.call_strings("view.resolve", [s])
+            return manager.call_strings("view.flows.resolve", [s])
         except exceptions.CommandError as e:
             raise exceptions.TypeError from e
 

--- a/test/mitmproxy/addons/test_view.py
+++ b/test/mitmproxy/addons/test_view.py
@@ -107,13 +107,12 @@ def test_simple():
 
 def test_filter():
     v = view.View()
-    f = flowfilter.parse("~m get")
     v.request(tft(method="get"))
     v.request(tft(method="put"))
     v.request(tft(method="get"))
     v.request(tft(method="put"))
     assert(len(v)) == 4
-    v.set_filter(f)
+    v.set_filter_cmd("~m get")
     assert [i.request.method for i in v] == ["GET", "GET"]
     assert len(v._store) == 4
     v.set_filter(None)
@@ -303,23 +302,24 @@ def test_setgetval():
 
 def test_order():
     v = view.View()
-    with taddons.context(v) as tctx:
-        v.request(tft(method="get", start=1))
-        v.request(tft(method="put", start=2))
-        v.request(tft(method="get", start=3))
-        v.request(tft(method="put", start=4))
-        assert [i.request.timestamp_start for i in v] == [1, 2, 3, 4]
+    v.request(tft(method="get", start=1))
+    v.request(tft(method="put", start=2))
+    v.request(tft(method="get", start=3))
+    v.request(tft(method="put", start=4))
+    assert [i.request.timestamp_start for i in v] == [1, 2, 3, 4]
 
-        tctx.configure(v, view_order="method")
-        assert [i.request.method for i in v] == ["GET", "GET", "PUT", "PUT"]
-        v.set_reversed(True)
-        assert [i.request.method for i in v] == ["PUT", "PUT", "GET", "GET"]
+    v.set_order("method")
+    assert v.get_order() == "method"
+    assert [i.request.method for i in v] == ["GET", "GET", "PUT", "PUT"]
+    v.set_reversed(True)
+    assert [i.request.method for i in v] == ["PUT", "PUT", "GET", "GET"]
 
-        tctx.configure(v, view_order="time")
-        assert [i.request.timestamp_start for i in v] == [4, 3, 2, 1]
+    v.set_order("time")
+    assert v.get_order() == "time"
+    assert [i.request.timestamp_start for i in v] == [4, 3, 2, 1]
 
-        v.set_reversed(False)
-        assert [i.request.timestamp_start for i in v] == [1, 2, 3, 4]
+    v.set_reversed(False)
+    assert [i.request.timestamp_start for i in v] == [1, 2, 3, 4]
 
 
 def test_reversed():
@@ -549,6 +549,17 @@ def test_settings():
     assert v.settings.keys()
     v.clear()
     assert not v.settings.keys()
+
+
+def test_properties():
+    v = view.View()
+    f = tft()
+    v.request(f)
+    assert v.get_length() == 1
+    assert not v.get_marked()
+    v.toggle_marked()
+    assert v.get_length() == 0
+    assert v.get_marked()
 
 
 def test_configure():

--- a/test/mitmproxy/test_command.py
+++ b/test/mitmproxy/test_command.py
@@ -313,7 +313,7 @@ def test_typename():
 
 
 class DummyConsole:
-    @command.command("view.resolve")
+    @command.command("view.flows.resolve")
     def resolve(self, spec: str) -> typing.Sequence[flow.Flow]:
         n = int(spec)
         return [tflow.tflow(resp=True)] * n

--- a/test/mitmproxy/test_types.py
+++ b/test/mitmproxy/test_types.py
@@ -146,7 +146,7 @@ def test_strseq():
 
 
 class DummyConsole:
-    @command.command("view.resolve")
+    @command.command("view.flows.resolve")
     def resolve(self, spec: str) -> typing.Sequence[flow.Flow]:
         if spec == "err":
             raise mitmproxy.exceptions.CommandError()


### PR DESCRIPTION
So, here we start with the refactoring of the View addon. Since the addon is quite complex, and its usage spread to many points in the codebase, this will be an incremental process - as suggested in #3198 .

### The API Structure
The current API is composed of the following sections:

- _Focus_ -> __movements__ of focus in the view.
- _Order_ -> order key manipulation, and querying, of flows in the view.
- _Filter_ -> filter manipulation, and querying, of flows showed in the view.
- _Flows_ -> operation on flows (create, remove, duplicates)
- _Settings_ -> querying and setting of values in the **Settings** object of the View. 

- _Updates_ and _Properties_ -> this is kinda misc. I feel this could go somewhere else for further modularity, but for now I will leave those 'outliers' where they are.

### Content of the PR

Mainly, I have ordered the code, to make it more readable, together with creating some new primitives to clean some points in the codebase. Mind that this is only an initial cleaning process, just to gather some feedback and make the process gradual.

Moreover, I have added tests to make sure that the primitives behave as expected. Every command has been tested in the console, and there are some commands that fail there (like `view.flows.resolve`), due to some bug in the _types.py_ converter that do not correctly show return type. This will go in an issue in a while.

### What's next

- Extension of the type manager, to support, eventually, `typing.Optional` return statements. Other solution, like using `typing.Sequence`, are a Request For Comments here.
- Make every command symmetric between usage in the code and usage in console, as discussed in #3198 . 
- Work on the **Session** addon that implements the same interface of the **View** addon, storing on disk, and test for **interoperability** in the code.
- Improving the **View** addon in the meantime.