### PR TITLE
Add typechecking of Any values for state object

### DIFF
--- a/test/mitmproxy/test_stateobject.py
+++ b/test/mitmproxy/test_stateobject.py
@@ -125,7 +125,7 @@ def test_any():
     assert a.x == b.x
 
     a = TAny(object())
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError):
         a.get_state()
 
 


### PR DESCRIPTION
An ugly solution for an ugly little problem. This patch uses JSON's type
checker to validate Any values in stateobject, in order to avoid a circular
import of tnetstrings.

This is a temporary solution - stateobject is going to go away entirely once the new serialization is in place. 

Fixes #3180