### PR TITLE
Provide message object for content view addons

### DIFF
--- a/mitmproxy/contentviews/__init__.py
+++ b/mitmproxy/contentviews/__init__.py
@@ -75,7 +75,7 @@ def safe_to_print(lines, encoding="utf8"):
         yield clean_line
 
 
-def get_message_content_view(viewname, message):
+def get_message_content_view(viewname, message, flow=None):
     """
     Like get_content_view, but also handles message encoding.
     """
@@ -99,6 +99,7 @@ def get_message_content_view(viewname, message):
         return "", iter([[("error", "content missing")]]), None
 
     metadata = {}
+    metadata["flow"] = flow
     metadata["message"] = message
     if isinstance(message, http.Request):
         metadata["query"] = message.query

--- a/mitmproxy/contentviews/__init__.py
+++ b/mitmproxy/contentviews/__init__.py
@@ -99,6 +99,7 @@ def get_message_content_view(viewname, message):
         return "", iter([[("error", "content missing")]]), None
 
     metadata = {}
+    metadata["message"] = message
     if isinstance(message, http.Request):
         metadata["query"] = message.query
     if isinstance(message, http.Message):

--- a/mitmproxy/tools/web/app.py
+++ b/mitmproxy/tools/web/app.py
@@ -390,7 +390,7 @@ class FlowContentView(RequestHandler):
         message = getattr(self.flow, message)
 
         description, lines, error = contentviews.get_message_content_view(
-            content_view.replace('_', ' '), message
+            content_view.replace('_', ' '), message, self.flow
         )
         #        if error:
         #           add event log


### PR DESCRIPTION
Sometimes you need to access data from the original request to implement a Content View addon. Right now, such an addon has access only to the request/response headers:

https://github.com/mitmproxy/mitmproxy/blob/9047c4f2a58d6e6b08d8066fb890b2a13de21fb3/mitmproxy/contentviews/__init__.py#L101-L106

So, there is no way to access request headers from response content view.

Also it might be useful to add an additional metadata field to indicate whether it is a request or a response. Something like `metadata["is_request"]`. Or we can do it manually via `isinstance(metadata["message"], http.Request)` or via `if 'query' in metadata`.

closes #3213