### PR TITLE
mitmweb: protect against dns rebinding

### DIFF
--- a/mitmproxy/tools/web/app.py
+++ b/mitmproxy/tools/web/app.py
@@ -463,10 +463,20 @@ class SaveOptions(RequestHandler):
         pass
 
 
+class DnsRebind(RequestHandler):
+    def get(self):
+        raise tornado.web.HTTPError(
+            403,
+            reason="To protect against DNS rebinding, mitmweb can only be accessed by IP at the moment. "
+                   "(https://github.com/mitmproxy/mitmproxy/issues/3234)"
+        )
+
+
 class Application(tornado.web.Application):
     def __init__(self, master, debug):
         self.master = master
         super().__init__(
+            default_host="dns-rebind-protection",
             template_path=os.path.join(os.path.dirname(__file__), "templates"),
             static_path=os.path.join(os.path.dirname(__file__), "static"),
             xsrf_cookies=True,
@@ -475,9 +485,10 @@ class Application(tornado.web.Application):
             autoreload=False,
         )
 
+        self.add_handlers("dns-rebind-protection", [(r"/.*", DnsRebind)])
         self.add_handlers(
             # make mitmweb accessible by IP only to prevent DNS rebinding.
-            r'(localhost|\d+\.\d+\.\d+\.\d+)',
+            r'^(localhost|[0-9.:\[\]]+)$',
             [
                 (r"/", IndexHandler),
                 (r"/filter-help(?:\.json)?", FilterHelp),

--- a/mitmproxy/tools/web/app.py
+++ b/mitmproxy/tools/web/app.py
@@ -466,31 +466,7 @@ class SaveOptions(RequestHandler):
 class Application(tornado.web.Application):
     def __init__(self, master, debug):
         self.master = master
-        handlers = [
-            (r"/", IndexHandler),
-            (r"/filter-help(?:\.json)?", FilterHelp),
-            (r"/updates", ClientConnection),
-            (r"/events(?:\.json)?", Events),
-            (r"/flows(?:\.json)?", Flows),
-            (r"/flows/dump", DumpFlows),
-            (r"/flows/resume", ResumeFlows),
-            (r"/flows/kill", KillFlows),
-            (r"/flows/(?P<flow_id>[0-9a-f\-]+)", FlowHandler),
-            (r"/flows/(?P<flow_id>[0-9a-f\-]+)/resume", ResumeFlow),
-            (r"/flows/(?P<flow_id>[0-9a-f\-]+)/kill", KillFlow),
-            (r"/flows/(?P<flow_id>[0-9a-f\-]+)/duplicate", DuplicateFlow),
-            (r"/flows/(?P<flow_id>[0-9a-f\-]+)/replay", ReplayFlow),
-            (r"/flows/(?P<flow_id>[0-9a-f\-]+)/revert", RevertFlow),
-            (r"/flows/(?P<flow_id>[0-9a-f\-]+)/(?P<message>request|response)/content.data", FlowContent),
-            (
-                r"/flows/(?P<flow_id>[0-9a-f\-]+)/(?P<message>request|response)/content/(?P<content_view>[0-9a-zA-Z\-\_]+)(?:\.json)?",
-                FlowContentView),
-            (r"/settings(?:\.json)?", Settings),
-            (r"/clear", ClearAll),
-            (r"/options(?:\.json)?", Options),
-            (r"/options/save", SaveOptions)
-        ]
-        settings = dict(
+        super().__init__(
             template_path=os.path.join(os.path.dirname(__file__), "templates"),
             static_path=os.path.join(os.path.dirname(__file__), "static"),
             xsrf_cookies=True,
@@ -498,4 +474,32 @@ class Application(tornado.web.Application):
             debug=debug,
             autoreload=False,
         )
-        super().__init__(handlers, **settings)
+
+        self.add_handlers(
+            # make mitmweb accessible by IP only to prevent DNS rebinding.
+            r'(localhost|\d+\.\d+\.\d+\.\d+)',
+            [
+                (r"/", IndexHandler),
+                (r"/filter-help(?:\.json)?", FilterHelp),
+                (r"/updates", ClientConnection),
+                (r"/events(?:\.json)?", Events),
+                (r"/flows(?:\.json)?", Flows),
+                (r"/flows/dump", DumpFlows),
+                (r"/flows/resume", ResumeFlows),
+                (r"/flows/kill", KillFlows),
+                (r"/flows/(?P<flow_id>[0-9a-f\-]+)", FlowHandler),
+                (r"/flows/(?P<flow_id>[0-9a-f\-]+)/resume", ResumeFlow),
+                (r"/flows/(?P<flow_id>[0-9a-f\-]+)/kill", KillFlow),
+                (r"/flows/(?P<flow_id>[0-9a-f\-]+)/duplicate", DuplicateFlow),
+                (r"/flows/(?P<flow_id>[0-9a-f\-]+)/replay", ReplayFlow),
+                (r"/flows/(?P<flow_id>[0-9a-f\-]+)/revert", RevertFlow),
+                (r"/flows/(?P<flow_id>[0-9a-f\-]+)/(?P<message>request|response)/content.data", FlowContent),
+                (
+                    r"/flows/(?P<flow_id>[0-9a-f\-]+)/(?P<message>request|response)/content/(?P<content_view>[0-9a-zA-Z\-\_]+)(?:\.json)?",
+                    FlowContentView),
+                (r"/settings(?:\.json)?", Settings),
+                (r"/clear", ClearAll),
+                (r"/options(?:\.json)?", Options),
+                (r"/options/save", SaveOptions)
+            ]
+        )


### PR DESCRIPTION
This PR attempts to guard mitmweb against DNS rebinding attacks. 

See also:
 - https://github.com/mitmproxy/mitmproxy/issues/3234
 - http://www.tornadoweb.org/en/stable/guide/security.html#dns-rebinding

@atx: My understanding is that enforcing the hostname to match `'(localhost|\d+\.\d+\.\d+\.\d+)'` should effectively mitigate this while still enabling users to access mitmweb from other hosts if they so desire. Do you see errors in my thinking?

In the long term we should probably adopt a jupyter-style solution, but it's more important to get this fixed quickly now.