### PR TITLE
Command history

### DIFF
--- a/mitmproxy/tools/console/commander/commander.py
+++ b/mitmproxy/tools/console/commander/commander.py
@@ -1,5 +1,7 @@
 import abc
+import copy
 import typing
+import collections
 
 import urwid
 from urwid.text_layout import calc_coords
@@ -156,13 +158,52 @@ class CommandBuffer:
         self.completion = None
 
 
+class CommandHistory:
+    def __init__(self, master: mitmproxy.master.Master, size: int=30) -> None:
+        self.history: collections.deque = collections.deque(
+            [CommandBuffer(master, "")],
+            maxlen=size
+        )
+        self.index: int = 0
+
+    @property
+    def last_index(self):
+        return len(self.history) - 1
+
+    def get_next(self) -> typing.Optional[CommandBuffer]:
+        if self.index < self.last_index:
+            self.index = self.index + 1
+            return self.history[self.index]
+        return None
+
+    def get_prev(self) -> typing.Optional[CommandBuffer]:
+        if self.index > 0:
+            self.index = self.index - 1
+            return self.history[self.index]
+        return None
+
+    def add_command(self, command: CommandBuffer, execution: bool=False) -> None:
+        if self.index == self.last_index or execution:
+            last_item_empty = not self.history[-1].text
+            if self.history[-1].text == command.text or (last_item_empty and execution):
+                self.history[-1] = copy.copy(command)
+            else:
+                self.history.append(command)
+                if not execution and self.index < self.last_index:
+                    self.index += 1
+            if execution:
+                self.index = self.last_index
+
+
 class CommandEdit(urwid.WidgetWrap):
     leader = ": "
 
-    def __init__(self, master: mitmproxy.master.Master, text: str) -> None:
+    def __init__(self, master: mitmproxy.master.Master,
+                 text: str, history: CommandHistory) -> None:
         super().__init__(urwid.Text(self.leader))
         self.master = master
         self.cbuf = CommandBuffer(master, text)
+        self.history = history
         self.update()
 
     def keypress(self, size, key):
@@ -172,6 +213,11 @@ class CommandEdit(urwid.WidgetWrap):
             self.cbuf.left()
         elif key == "right":
             self.cbuf.right()
+        elif key == "up":
+            self.history.add_command(self.cbuf)
+            self.cbuf = self.history.get_prev() or self.cbuf
+        elif key == "down":
+            self.cbuf = self.history.get_next() or self.cbuf
         elif key == "tab":
             self.cbuf.cycle_completion()
         elif len(key) == 1:

--- a/mitmproxy/tools/console/commander/commander.py
+++ b/mitmproxy/tools/console/commander/commander.py
@@ -160,7 +160,7 @@ class CommandBuffer:
 
 class CommandHistory:
     def __init__(self, master: mitmproxy.master.Master, size: int=30) -> None:
-        self.history: collections.deque = collections.deque(
+        self.saved_commands: collections.deque = collections.deque(
             [CommandBuffer(master, "")],
             maxlen=size
         )
@@ -168,27 +168,28 @@ class CommandHistory:
 
     @property
     def last_index(self):
-        return len(self.history) - 1
+        return len(self.saved_commands) - 1
 
     def get_next(self) -> typing.Optional[CommandBuffer]:
         if self.index < self.last_index:
             self.index = self.index + 1
-            return self.history[self.index]
+            return self.saved_commands[self.index]
         return None
 
     def get_prev(self) -> typing.Optional[CommandBuffer]:
         if self.index > 0:
             self.index = self.index - 1
-            return self.history[self.index]
+            return self.saved_commands[self.index]
         return None
 
     def add_command(self, command: CommandBuffer, execution: bool=False) -> None:
         if self.index == self.last_index or execution:
-            last_item_empty = not self.history[-1].text
-            if self.history[-1].text == command.text or (last_item_empty and execution):
-                self.history[-1] = copy.copy(command)
+            last_item = self.saved_commands[-1]
+            last_item_empty = not last_item.text
+            if last_item.text == command.text or (last_item_empty and execution):
+                self.saved_commands[-1] = copy.copy(command)
             else:
-                self.history.append(command)
+                self.saved_commands.append(command)
                 if not execution and self.index < self.last_index:
                     self.index += 1
             if execution:

--- a/mitmproxy/tools/console/statusbar.py
+++ b/mitmproxy/tools/console/statusbar.py
@@ -42,6 +42,8 @@ class ActionBar(urwid.WidgetWrap):
         signals.status_prompt_onekey.connect(self.sig_prompt_onekey)
         signals.status_prompt_command.connect(self.sig_prompt_command)
 
+        self.command_history = commander.CommandHistory(master)
+
         self.prompting = None
 
         self.onekey = False
@@ -98,7 +100,7 @@ class ActionBar(urwid.WidgetWrap):
 
     def sig_prompt_command(self, sender, partial=""):
         signals.focus.send(self, section="footer")
-        self._w = commander.CommandEdit(self.master, partial)
+        self._w = commander.CommandEdit(self.master, partial, self.command_history)
         self.prompting = commandexecutor.CommandExecutor(self.master)
 
     def sig_prompt_onekey(self, sender, prompt, keys, callback, args=()):
@@ -125,6 +127,7 @@ class ActionBar(urwid.WidgetWrap):
     def keypress(self, size, k):
         if self.prompting:
             if k == "esc":
+                self.command_history.index = self.command_history.last_index
                 self.prompt_done()
             elif self.onekey:
                 if k == "enter":
@@ -132,6 +135,7 @@ class ActionBar(urwid.WidgetWrap):
                 elif k in self.onekey:
                     self.prompt_execute(k)
             elif k == "enter":
+                self.command_history.add_command(self._w.cbuf, True)
                 self.prompt_execute(self._w.get_edit_text())
             else:
                 if common.is_keypress(k):

--- a/mitmproxy/tools/console/statusbar.py
+++ b/mitmproxy/tools/console/statusbar.py
@@ -100,7 +100,8 @@ class ActionBar(urwid.WidgetWrap):
 
     def sig_prompt_command(self, sender, partial=""):
         signals.focus.send(self, section="footer")
-        self._w = commander.CommandEdit(self.master, partial, self.command_history)
+        self._w = commander.CommandEdit(self.master, partial,
+                                        self.command_history)
         self.prompting = commandexecutor.CommandExecutor(self.master)
 
     def sig_prompt_onekey(self, sender, prompt, keys, callback, args=()):

--- a/test/mitmproxy/tools/console/test_commander.py
+++ b/test/mitmproxy/tools/console/test_commander.py
@@ -41,20 +41,31 @@ class TestCommandHistory:
         commands = ["command1", "command2"]
         history, tctx_master = self.fill_history(commands)
 
-        history_commands = [buf.text for buf in history.history]
-        assert history_commands == [""] + commands
+        saved_commands = [buf.text for buf in history.saved_commands]
+        assert saved_commands == [""] + commands
 
-        # The history size is only 3. So, we forget the first one command,
-        # when adding fourth command
+        # The history size is only 3. So, we forget the first
+        # one command, when adding fourth command
         cbuf = commander.CommandBuffer(tctx_master, "command3")
         history.add_command(cbuf)
-        history_commands = [buf.text for buf in history.history]
-        assert history_commands == commands + ["command3"]
+        saved_commands = [buf.text for buf in history.saved_commands]
+        assert saved_commands == commands + ["command3"]
 
         # Commands with the same text are not repeated in the history one by one
         history.add_command(cbuf)
-        history_commands = [buf.text for buf in history.history]
-        assert history_commands == commands + ["command3"]
+        saved_commands = [buf.text for buf in history.saved_commands]
+        assert saved_commands == commands + ["command3"]
+
+        # adding command in execution mode sets index at the beginning of the history
+        # and replace the last command buffer if it is empty or has the same text
+        cbuf = commander.CommandBuffer(tctx_master, "")
+        history.add_command(cbuf)
+        history.index = 0
+        cbuf = commander.CommandBuffer(tctx_master, "command4")
+        history.add_command(cbuf, True)
+        assert history.index == history.last_index
+        saved_commands = [buf.text for buf in history.saved_commands]
+        assert saved_commands == ["command2", "command3", "command4"]
 
     def test_get_next(self):
         commands = ["command1", "command2"]


### PR DESCRIPTION
This PR implements command history. It tries to work similar to the history in the ubuntu terminal.

### How to use
1. Start mitmproxy.
2. Press `:` and start typing in the status bar.
3. Input a few commands.
4. Press `up` button to see previous command if available. Press `down` button to see next command. 

**A few moments to know.** 
The history contains of `CommandBuffer` objects, not text objects. It was done in order to save cursor position and autocompletion state.
 
When we press `up` button, the command buffer currently typed in the status bar will be saved to the command history. But if the last history buffer has the same text as the current one buffer, the last buffer will be replaced with the current one. We can also add command with `execution` param. It will mean, whenever we decide to execute command. It will be added at the end of the history or will replace either command buffer has the same text or with no text.

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/20267977/42953307-d3adbb20-8b82-11e8-86ce-5a5e35e09922.gif)


