### PR TITLE
Fixes #3072

### DIFF
--- a/mitmproxy/contentviews/base.py
+++ b/mitmproxy/contentviews/base.py
@@ -1,5 +1,6 @@
 # Default view cutoff *in lines*
 import typing
+from mitmproxy.coretypes import multidict
 
 VIEW_CUTOFF = 512
 
@@ -51,7 +52,13 @@ def format_dict(
 
     max_key_len = max((len(k) for k in d.keys()), default=0)
     max_key_len = min((max_key_len, KEY_MAX), default=0)
-    for key, value in d.items():
+
+    if isinstance(d, multidict.MultiDictView):
+        items = d.items(multi=True)
+    else:
+        items = d.items()
+
+    for key, value in items:
         if isinstance(key, bytes):
             key += b":"
         else:

--- a/test/mitmproxy/contentviews/test_query.py
+++ b/test/mitmproxy/contentviews/test_query.py
@@ -6,8 +6,8 @@ from . import full_eval
 def test_view_query():
     d = ""
     v = full_eval(query.ViewQuery())
-    f = v(d, query=multidict.MultiDict([("foo", "bar")]))
+    f = v(d, query=multidict.MultiDictView(lambda: [("foo", "bar"), ("foo", "baz")], lambda: None))
     assert f[0] == "Query"
-    assert f[1] == [[("header", "foo: "), ("text", "bar")]]
+    assert f[1] == [[("header", "foo: "), ("text", "bar")], [("header", "foo: "), ("text", "baz")]]
 
     assert v(d) == ("Query", [])


### PR DESCRIPTION
Query is a MultiDict so `d.items()` in `base.format_dict` didn't return all of it's values.
https://github.com/mitmproxy/mitmproxy/blob/ec092fdc120273644c79ae65ae0328dc9f31ee80/mitmproxy/contentviews/base.py#L54