### PR TITLE
Pipes initial support

### DIFF
--- a/mitmproxy/language/lexer.py
+++ b/mitmproxy/language/lexer.py
@@ -7,6 +7,7 @@ import ply.lex as lex
 class CommandLanguageLexer:
     tokens = (
         "WHITESPACE",
+        "PIPE",
         "LPAREN", "RPAREN",
         "LBRACE", "RBRACE",
         "PLAIN_STR", "QUOTED_STR",
@@ -21,12 +22,13 @@ class CommandLanguageLexer:
 
     # Main(INITIAL) state
     t_ignore_WHITESPACE = r"\s+"
+    t_PIPE = r"\|"
     t_LPAREN = r"\("
     t_RPAREN = r"\)"
     t_LBRACE = r"\["
     t_RBRACE = r"\]"
 
-    special_symbols = re.escape("()[]")
+    special_symbols = re.escape("()[]|")
     plain_str = rf"[^{special_symbols}\s]+"
 
     def t_COMMAND(self, t):

--- a/mitmproxy/language/parser.py
+++ b/mitmproxy/language/parser.py
@@ -39,7 +39,7 @@ class CommandLanguageParser:
            pipes_chain : pipes_chain pipe_expression"""
         p[0] = self._create_list(p)
 
-    def p_pipe_expression_no_parentheses(self, p):
+    def p_pipe_expression(self, p):
         """pipe_expression : PIPE COMMAND argument_list
            pipe_expression : PIPE COMMAND LPAREN argument_list RPAREN"""
         if len(p) == 4:

--- a/mitmproxy/language/parser.py
+++ b/mitmproxy/language/parser.py
@@ -3,6 +3,7 @@ import typing
 import ply.lex as lex
 import ply.yacc as yacc
 
+import mitmproxy.command  # noqa
 from mitmproxy import exceptions
 from mitmproxy.language.lexer import CommandLanguageLexer
 
@@ -11,10 +12,10 @@ class CommandLanguageParser:
     # the list of possible tokens is always required
     tokens = CommandLanguageLexer.tokens
 
-    def __init__(self, command_manager) -> None:
+    def __init__(self,
+                 command_manager: "mitmproxy.command.CommandManager") -> None:
         self.return_value: typing.Any = None
         self._pipe_value: typing.Any = None
-        self._ready_for_pipe: bool = False
         self.command_manager = command_manager
 
     # Grammar rules
@@ -27,10 +28,10 @@ class CommandLanguageParser:
         """starting_expression : PLAIN_STR
                                | quoted_str
                                | array
-                               | command_call"""
+                               | command_call_no_parentheses
+                               | command_call_with_parentheses"""
         p[0] = p[1]
         self._pipe_value = p[0]
-        self._ready_for_pipe = True
 
     def p_pipes_chain(self, p):
         """pipes_chain : empty
@@ -38,23 +39,23 @@ class CommandLanguageParser:
            pipes_chain : pipes_chain pipe_expression"""
         p[0] = self._create_list(p)
 
-    def p_pipe_expression(self, p):
-        """pipe_expression : PIPE command_call"""
-        p[0] = p[2]
+    def p_pipe_expression_no_parentheses(self, p):
+        """pipe_expression : PIPE COMMAND argument_list
+           pipe_expression : PIPE COMMAND LPAREN argument_list RPAREN"""
+        if len(p) == 4:
+            new_args = [self._pipe_value, *p[3]]
+        else:
+            new_args = [self._pipe_value, *p[4]]
+        p[0] = self.command_manager.call_strings(p[2], new_args)
         self._pipe_value = p[0]
 
-    def p_command_call(self, p):
-        """command_call : command_call_no_parentheses
-                        | command_call_with_parentheses"""
-        p[0] = p[1]
-
-    def p_command_call_no_parentheses(self, p):
+    def p_call_command_no_parentheses(self, p):
         """command_call_no_parentheses : COMMAND argument_list"""
-        p[0] = self._command_call(p[1], p[2])
+        p[0] = self.command_manager.call_strings(p[1], p[2])
 
-    def p_command_call_with_parentheses(self, p):
+    def p_call_command_with_parentheses(self, p):
         """command_call_with_parentheses : COMMAND LPAREN argument_list RPAREN"""
-        p[0] = self._command_call(p[1], p[3])
+        p[0] = self.command_manager.call_strings(p[1], p[3])
 
     def p_argument_list(self, p):
         """argument_list : empty
@@ -87,14 +88,6 @@ class CommandLanguageParser:
         else:
             raise exceptions.CommandError(f"Syntax error at '{p.value}'")
 
-    # Supporting methods
-
-    def _command_call(self, command: str, args: list) -> typing.Any:
-        if self._ready_for_pipe:
-            new_first_argument = self._pipe_value
-            args = [new_first_argument, *args]
-        return self.command_manager.call_strings(command, args)
-
     @staticmethod
     def _create_list(p: yacc.YaccProduction) -> typing.List[typing.Any]:
         if len(p) == 2:
@@ -110,11 +103,13 @@ class CommandLanguageParser:
 
     def parse(self, lexer: lex.Lexer, **kwargs) -> typing.Any:
         self.parser.parse(lexer=lexer, **kwargs)
-        self._pipe_value, self._ready_for_pipe = None, False
+        self._pipe_value = None
         return self.return_value
 
 
-def create_parser(command_manager) -> CommandLanguageParser:
+def create_parser(
+        command_manager: "mitmproxy.command.CommandManager"
+) -> CommandLanguageParser:
     command_parser = CommandLanguageParser(command_manager)
     command_parser.build(debug=False, write_tables=False)
     return command_parser

--- a/mitmproxy/language/parser.py
+++ b/mitmproxy/language/parser.py
@@ -12,32 +12,55 @@ class CommandLanguageParser:
     tokens = CommandLanguageLexer.tokens
 
     def __init__(self, command_manager):
-        self.return_value = None
+        self.return_value: typing.Any = None
+        self._pipe_value: typing.Any = None
+        self._inside_pipe: bool = False
         self.command_manager = command_manager
 
+    # Grammar rules
+
     def p_command_line(self, p):
-        """command_line : command_call_no_parentheses
+        """command_line : starting_expression pipes_chain"""
+        self.return_value = self._pipe_value
+
+    def p_starting_expression(self, p):
+        """starting_expression : PLAIN_STR
+                               | quoted_str
+                               | array
+                               | command_call"""
+        p[0] = p[1]
+        self._pipe_value = p[0]
+
+    def p_pipes_chain(self, p):
+        """pipes_chain : empty
+           pipes_chain : pipe_expression
+           pipes_chain : pipes_chain pipe_expression"""
+        p[0] = self._create_list(p)
+
+    def p_pipe_expression(self, p):
+        """pipe_expression : PIPE command_call"""
+        self._inside_pipe = True
+        p[0] = p[2]
+        self._pipe_value = p[0]
+
+    def p_command_call(self, p):
+        """command_call : command_call_no_parentheses
                         | command_call_with_parentheses"""
         p[0] = p[1]
-        self.return_value = p[0]
 
     def p_command_call_no_parentheses(self, p):
         """command_call_no_parentheses : COMMAND argument_list"""
-        p[0] = self.command_manager.call_strings(p[1], p[2])
+        p[0] = self._command_call(p[1], p[2])
 
     def p_command_call_with_parentheses(self, p):
         """command_call_with_parentheses : COMMAND LPAREN argument_list RPAREN"""
-        p[0] = self.command_manager.call_strings(p[1], p[3])
+        p[0] = self._command_call(p[1], p[3])
 
     def p_argument_list(self, p):
         """argument_list : empty
                          | argument
                          | argument_list argument"""
-        if len(p) == 2:
-            p[0] = [] if p[1] is None else [p[1]]
-        else:
-            p[0] = p[1]
-            p[0].append(p[2])
+        p[0] = self._create_list(p)
 
     def p_argument(self, p):
         """argument : PLAIN_STR
@@ -64,14 +87,31 @@ class CommandLanguageParser:
         else:
             raise exceptions.CommandError(f"Syntax error at '{p.value}'")
 
-    def build(self, **kwargs):
+    # Supporting methods
+
+    def _command_call(self, command: str, args: list) -> typing.Any:
+        if self._inside_pipe:
+            new_first_argument = self._pipe_value
+            args = [new_first_argument, *args]
+        return self.command_manager.call_strings(command, args)
+
+    @staticmethod
+    def _create_list(p: yacc.YaccProduction) -> typing.List[typing.Any]:
+        if len(p) == 2:
+            p[0] = [] if p[1] is None else [p[1]]
+        else:
+            p[0] = p[1]
+            p[0].append(p[2])
+        return p[0]
+
+    def build(self, **kwargs) -> None:
         self.parser = yacc.yacc(module=self,
                                 errorlog=yacc.NullLogger(), **kwargs)
 
     def parse(self, lexer: lex.Lexer, **kwargs) -> typing.Any:
         self.parser.parse(lexer=lexer, **kwargs)
-        return_value, self.return_value = self.return_value, None
-        return return_value
+        self._pipe_value = None
+        return self.return_value
 
 
 def create_parser(command_manager) -> CommandLanguageParser:

--- a/test/mitmproxy/test_command.py
+++ b/test/mitmproxy/test_command.py
@@ -33,8 +33,8 @@ class TAddon:
         return choices
 
     @command.command("cmd6")
-    def cmd6(self, pipe_value: str) -> str:
-        return pipe_value
+    def cmd6(self, one: str, two: str) -> str:
+        return f"{one} {two}"
 
     @command.command("subcommand")
     def subcommand(self, cmd: mitmproxy.types.Cmd, *args: mitmproxy.types.Arg) -> str:
@@ -306,7 +306,10 @@ def test_simple():
         assert(c.execute("one.two foo") == "ret foo")
         assert (c.execute("one.two(foo)") == "ret foo")
         assert (c.execute("array.command [1 2 3]") == ["1", "2", "3"])
-        assert (c.execute("foo | pipe.command") == "foo")
+        assert (c.execute("foo | one.two | one.two") == "ret ret foo")
+        assert (c.execute("one | pipe.command(two) |"
+                          " pipe.command(three)") == "one two three")
+
         assert(c.execute("one.two \"foo\"") == "ret foo")
         assert(c.execute("one.two 'foo'") == "ret foo")
         assert(c.call("one.two", "foo") == "ret foo")

--- a/test/mitmproxy/test_command.py
+++ b/test/mitmproxy/test_command.py
@@ -32,6 +32,10 @@ class TAddon:
     def cmd5(self, choices: typing.Sequence[str]) -> typing.Sequence[str]:
         return choices
 
+    @command.command("cmd6")
+    def cmd6(self, pipe_value: str) -> str:
+        return pipe_value
+
     @command.command("subcommand")
     def subcommand(self, cmd: mitmproxy.types.Cmd, *args: mitmproxy.types.Arg) -> str:
         return "ok"
@@ -296,15 +300,20 @@ def test_simple():
         a = TAddon()
         c.add("one.two", a.cmd1)
         c.add("array.command", a.cmd5)
+        c.add("pipe.command", a.cmd6)
+
         assert c.commands["one.two"].help == "cmd1 help"
         assert(c.execute("one.two foo") == "ret foo")
         assert (c.execute("one.two(foo)") == "ret foo")
         assert (c.execute("array.command [1 2 3]") == ["1", "2", "3"])
+        assert (c.execute("foo | pipe.command") == "foo")
         assert(c.execute("one.two \"foo\"") == "ret foo")
         assert(c.execute("one.two 'foo'") == "ret foo")
         assert(c.call("one.two", "foo") == "ret foo")
         with pytest.raises(exceptions.CommandError, match="Syntax error"):
-            c.execute("nonexistent")
+            c.execute("one.two(")
+        with pytest.raises(exceptions.CommandError, match="Syntax error"):
+            c.execute("nonexistent()")
         with pytest.raises(exceptions.CommandError, match="Unknown"):
             c.execute("two.three")
         with pytest.raises(exceptions.CommandError, match="error at EOF"):

--- a/test/mitmproxy/test_types.py
+++ b/test/mitmproxy/test_types.py
@@ -225,7 +225,7 @@ def test_choice():
         ) is False
         assert b.is_valid(
             tctx.master.commands,
-            mitmproxy.types.Choice("nonexistent"),
+            mitmproxy.types.Choice("non.existent"),
             "invalid",
         ) is False
         comp = b.completion(tctx.master.commands, mitmproxy.types.Choice("options"), "")


### PR DESCRIPTION
Hello everyone!
This PR provides basic pipes support.

As we discussed earlier pipes syntax is just a syntactic sugar.
`@focus | replay.client` is the same as `replay.client @focus` or `replay.client(@focus)`
Pipes are just moving the resulting value from the left-hand side  to the right-hand side command as the first argument. One more example:
`console.choose Part [request response] | cut.clip @focus` is the same as 
`cut.clip console.choose(Part [request response]) @focus`

**Implementation details**
Pipe elements are executed one by one from left-hand side to the right-hand side, like in this picture:
![image](https://user-images.githubusercontent.com/20267977/43358582-d9b330ba-929c-11e8-8e0a-47cdb943f79e.png)

As soon as the result of the particular pipe element is given, we save it into `self._pipe_value`. In other words, `self._pipe_value` stores the current pipe element value.
As soon as the next pipe element is executed, we take the value from `self._pipe_value` and put it as the first argument into the element.

**Results:**
![ezgif com-video-to-gif 2](https://user-images.githubusercontent.com/20267977/43358744-1fb5c288-929f-11e8-8145-dc889f8f2ff7.gif)

Now you can also write a plain string into the status bar and no errors will occur:
![ezgif com-video-to-gif 3](https://user-images.githubusercontent.com/20267977/43358767-7f713130-929f-11e8-8f39-d21de68c3d6a.gif)
