### PR TITLE
Add DEFAULT_EXP_DUMMY_CERT and set to two years

### DIFF
--- a/mitmproxy/certs.py
+++ b/mitmproxy/certs.py
@@ -15,7 +15,7 @@ from mitmproxy.coretypes import serializable
 
 # Default expiry must not be too long: https://github.com/mitmproxy/mitmproxy/issues/815
 DEFAULT_EXP = 94608000  # = 24 * 60 * 60 * 365 * 3
-DEFAULT_EXP_DUMMY_CERT = 7776000  # = 90 days
+DEFAULT_EXP_DUMMY_CERT = 63072000  # = 2 years
 
 # Generated with "openssl dhparam". It's too slow to generate this on startup.
 DEFAULT_DHPARAM = b"""

--- a/mitmproxy/certs.py
+++ b/mitmproxy/certs.py
@@ -15,6 +15,7 @@ from mitmproxy.coretypes import serializable
 
 # Default expiry must not be too long: https://github.com/mitmproxy/mitmproxy/issues/815
 DEFAULT_EXP = 94608000  # = 24 * 60 * 60 * 365 * 3
+DEFAULT_EXP_DUMMY_CERT = 7776000  # = 90 days
 
 # Generated with "openssl dhparam". It's too slow to generate this on startup.
 DEFAULT_DHPARAM = b"""
@@ -101,7 +102,7 @@ def dummy_cert(privkey, cacert, commonname, sans):
 
     cert = OpenSSL.crypto.X509()
     cert.gmtime_adj_notBefore(-3600 * 48)
-    cert.gmtime_adj_notAfter(DEFAULT_EXP)
+    cert.gmtime_adj_notAfter(DEFAULT_EXP_DUMMY_CERT)
     cert.set_issuer(cacert.get_subject())
     if commonname is not None and len(commonname) < 64:
         cert.get_subject().CN = commonname


### PR DESCRIPTION
Helps with Chrome's "certificates can not be valid longer than 27,5 month"
Fixes #3273