### PR TITLE
Recreate certs that have expired

### DIFF
--- a/mitmproxy/certs.py
+++ b/mitmproxy/certs.py
@@ -15,7 +15,7 @@ from mitmproxy.coretypes import serializable
 
 # Default expiry must not be too long: https://github.com/mitmproxy/mitmproxy/issues/815
 DEFAULT_EXP = 94608000  # = 24 * 60 * 60 * 365 * 3
-DEFAULT_EXP_DUMMY_CERT = 63072000  # = 2 years
+DEFAULT_EXP_DUMMY_CERT = 7776000  # = 90 days
 
 # Generated with "openssl dhparam". It's too slow to generate this on startup.
 DEFAULT_DHPARAM = b"""
@@ -311,7 +311,7 @@ class CertStore:
             filter(lambda key: key in self.certs, potential_keys),
             None
         )
-        if name:
+        if name and not self.certs[name].cert.has_expired:
             entry = self.certs[name]
         else:
             entry = CertStoreEntry(

--- a/test/mitmproxy/test_certs.py
+++ b/test/mitmproxy/test_certs.py
@@ -93,6 +93,14 @@ class TestCertStore:
         assert (b"three.com", ()) in ca.certs
         assert (b"four.com", ()) in ca.certs
 
+    def test_expire_certificate(self, tmpdir, monkeypatch):
+        monkeypatch.setattr(certs, 'DEFAULT_EXP_DUMMY_CERT', -1)
+
+        ca = certs.CertStore.from_store(str(tmpdir), "test")
+        c1 = ca.get_cert(b"one.com", [])
+        c2 = ca.get_cert(b"one.com", [])
+        assert c1 != c2
+
     def test_overrides(self, tmpdir):
         ca1 = certs.CertStore.from_store(str(tmpdir.join("ca1")), "test")
         ca2 = certs.CertStore.from_store(str(tmpdir.join("ca2")), "test")


### PR DESCRIPTION
In #3274 we talked about the possibility to replace certs that have expired. This PR sets the lifetime of created certs to 90 days (just like Let's Encrypt) and checks if the certs have expired when calling get_cert().

Things I don't like in this PR and would like to improve before merging:
* the existing test "test_expire", the method "expire" and the "expire_queue" should be renamed. This is more like a "overflow" than an "expire". Maybe even switch to lru_cache?
* the ```raise ValueError('Certificate has expired', name)``` feels kina ugly

Any feedback is greatly appreciated!