### PR TITLE
Async commands support

### DIFF
--- a/mitmproxy/command.py
+++ b/mitmproxy/command.py
@@ -221,7 +221,7 @@ class CommandManager(mitmproxy.types._CommandBase):
         """
             Parse a possibly partial command. Return a sequence of ParseResults and a sequence of remainder type help items.
         """
-        parts: typing.List[str] = [t.value for t in lexer.get_tokens(cmdstr)]
+        parts: typing.List[str] = lexer.get_tokens(cmdstr)
         if not parts:
             parts = [""]
         elif parts[-1].isspace():
@@ -305,7 +305,6 @@ class CommandManager(mitmproxy.types._CommandBase):
             Execute a command string. May raise CommandError.
         """
         lex = lexer.create_lexer(cmdstr, self.oneword_commands)
-        self.command_parser.async_exec = False
         parsed_cmd = self.command_parser.parse(lexer=lex)
         return parsed_cmd
 

--- a/mitmproxy/exceptions.py
+++ b/mitmproxy/exceptions.py
@@ -97,6 +97,10 @@ class CommandError(Exception):
     pass
 
 
+class ExecutionError(CommandError):
+    pass
+
+
 class OptionsError(MitmproxyException):
     pass
 

--- a/mitmproxy/language/lexer.py
+++ b/mitmproxy/language/lexer.py
@@ -8,6 +8,7 @@ class CommandLanguageLexer:
     tokens = (
         "WHITESPACE",
         "PIPE",
+        "EQUAL_SIGN",
         "LPAREN", "RPAREN",
         "LBRACE", "RBRACE",
         "PLAIN_STR", "QUOTED_STR",
@@ -23,12 +24,13 @@ class CommandLanguageLexer:
     # Main(INITIAL) state
     t_ignore_WHITESPACE = r"\s+"
     t_PIPE = r"\|"
+    t_EQUAL_SIGN = r"\="
     t_LPAREN = r"\("
     t_RPAREN = r"\)"
     t_LBRACE = r"\["
     t_RBRACE = r"\]"
 
-    special_symbols = re.escape("()[]|")
+    special_symbols = re.escape("()[]|=")
     plain_str = rf"[^{special_symbols}\s]+"
 
     def t_COMMAND(self, t):

--- a/mitmproxy/language/lexer.py
+++ b/mitmproxy/language/lexer.py
@@ -62,8 +62,11 @@ def create_lexer(cmdstr: str, oneword_commands: typing.Sequence[str]) -> lex.Lex
     return command_lexer.lexer
 
 
-def get_tokens(cmdstr: str, state="interactive") -> typing.List[str]:
-    lexer = create_lexer(cmdstr, [])
+def get_tokens(cmdstr: str, state="interactive",
+               oneword_commands=None) -> typing.List[lex.LexToken]:
+    if oneword_commands is None:
+        oneword_commands = []
+    lexer = create_lexer(cmdstr, oneword_commands)
     # Switching to the other state
     lexer.begin(state)
-    return [token.value for token in lexer]
+    return list(lexer)

--- a/mitmproxy/language/lexer.py
+++ b/mitmproxy/language/lexer.py
@@ -62,11 +62,8 @@ def create_lexer(cmdstr: str, oneword_commands: typing.Sequence[str]) -> lex.Lex
     return command_lexer.lexer
 
 
-def get_tokens(cmdstr: str, state="interactive",
-               oneword_commands=None) -> typing.List[lex.LexToken]:
-    if oneword_commands is None:
-        oneword_commands = []
-    lexer = create_lexer(cmdstr, oneword_commands)
+def get_tokens(cmdstr: str, state="interactive") -> typing.List[lex.LexToken]:
+    lexer = create_lexer(cmdstr, [])
     # Switching to the other state
     lexer.begin(state)
     return list(lexer)

--- a/mitmproxy/language/lexer.py
+++ b/mitmproxy/language/lexer.py
@@ -66,4 +66,4 @@ def get_tokens(cmdstr: str, state="interactive") -> typing.List[lex.LexToken]:
     lexer = create_lexer(cmdstr, [])
     # Switching to the other state
     lexer.begin(state)
-    return list(lexer)
+    return [token.value for token in lexer]

--- a/mitmproxy/language/parser.py
+++ b/mitmproxy/language/parser.py
@@ -136,7 +136,7 @@ class CommandLanguageParser:
                                 errorlog=yacc.NullLogger(), **kwargs)
 
     def parse(self, lexer: lex.Lexer,
-              async_exec=False, **kwargs) -> typing.Any:
+              async_exec: bool=False, **kwargs) -> typing.Any:
         self.async_exec = async_exec
         self.parser.parse(lexer=lexer, **kwargs)
         self._reset_internals()

--- a/mitmproxy/language/traversal.py
+++ b/mitmproxy/language/traversal.py
@@ -1,5 +1,4 @@
 import typing
-import asyncio
 
 import mitmproxy.command  # noqa
 from mitmproxy.language.parser import ParsedCommand, ParsedEntity
@@ -18,13 +17,12 @@ async def traverse_entity(command: typing.Optional["mitmproxy.command.Command"],
         if isinstance(arg, ParsedCommand):
             args[i] = await traverse_entity(arg.command, arg.args)
         elif isinstance(arg, list):
-            args[i] = await traverse_entity(args=arg, command=command)
+            args[i] = await traverse_entity(command=None, args=arg)
 
     if command is not None:
-        ret = command.call(args)
-        if asyncio.iscoroutine(ret):
-            return await ret
+        if command.asyncf:
+            return await command.async_call(args)
         else:
-            return ret
+            return command.call(args)
     else:
         return args

--- a/mitmproxy/language/traversal.py
+++ b/mitmproxy/language/traversal.py
@@ -1,0 +1,30 @@
+import typing
+import asyncio
+
+import mitmproxy.command  # noqa
+from mitmproxy.language.parser import ParsedCommand, ParsedEntity
+
+
+async def execute_parsed_line(line: ParsedEntity):
+    if isinstance(line, ParsedCommand):
+        return await traverse_entity(line.command, line.args)
+    else:
+        return line
+
+
+async def traverse_entity(command: typing.Optional["mitmproxy.command.Command"],
+                          args: typing.List[ParsedEntity]):
+    for i, arg in enumerate(args):
+        if isinstance(arg, ParsedCommand):
+            args[i] = await traverse_entity(arg.command, arg.args)
+        elif isinstance(arg, list):
+            args[i] = await traverse_entity(args=arg, command=command)
+
+    if command is not None:
+        ret = command.call(args)
+        if asyncio.iscoroutine(ret):
+            return await ret
+        else:
+            return ret
+    else:
+        return args

--- a/mitmproxy/optmanager.py
+++ b/mitmproxy/optmanager.py
@@ -234,8 +234,8 @@ class OptManager:
         if attr not in self._options:
             raise KeyError("No such option: %s" % attr)
 
-        def setter(x):
-            setattr(self, attr, x)
+        def setter(future_x):
+            setattr(self, attr, future_x.result())
         return setter
 
     def toggler(self, attr):

--- a/mitmproxy/tools/console/commands.py
+++ b/mitmproxy/tools/console/commands.py
@@ -18,6 +18,7 @@ class CommandItem(urwid.WidgetWrap):
     def get_widget(self):
         parts = [
             ("focus", ">> " if self.focused else "   "),
+            ("text", "async " if self.cmd.asyncf else "      "),
             ("title", self.cmd.path),
             ("text", " "),
             ("text", " ".join(self.cmd.paramnames())),

--- a/mitmproxy/tools/console/consoleaddons.py
+++ b/mitmproxy/tools/console/consoleaddons.py
@@ -574,15 +574,19 @@ class ConsoleAddon:
     @command.command("console.key.edit.focus")
     def key_edit_focus(self) -> None:
         """
-            Execute the currently focused key binding.
+            Edit the currently focused key binding.
         """
         b = self._keyfocus()
-        self.console_command(
-            "console.key.bind",
-            ",".join(b.contexts),
-            b.key,
-            b.command,
-        )
+        print(f"""console.command [ console.key.bind 
+                                    [{" ".join(b.contexts)}]
+                                    {b.key}
+                                    "{b.command}" ]""")
+        # self.console_command(
+        #     "console.key.bind",
+        #     ",".join(b.contexts),
+        #     b.key,
+        #     b.command,
+        # )
 
     def running(self):
         self.started = True

--- a/mitmproxy/tools/console/consoleaddons.py
+++ b/mitmproxy/tools/console/consoleaddons.py
@@ -1,5 +1,4 @@
 import csv
-import shlex
 import typing
 
 from mitmproxy import ctx
@@ -147,7 +146,7 @@ class ConsoleAddon:
         fv = self.master.window.current("options")
         if not fv:
             raise exceptions.CommandError("Not viewing options.")
-        self.master.commands.execute("options.reset.one %s" % fv.current_name())
+        self.master.commands.execute(f"options.reset.one {fv.current_name()}")
 
     @command.command("console.nav.start")
     def nav_start(self) -> None:
@@ -220,65 +219,25 @@ class ConsoleAddon:
         self.master.inject_key("right")
 
     @command.command("console.choose")
-    def console_choose(
+    async def console_choose(
         self,
         prompt: str,
-        choices: typing.Sequence[str],
-        cmd: mitmproxy.types.Cmd,
-        *args: mitmproxy.types.Arg
-    ) -> None:
+        choices: typing.Sequence[str]
+    ) -> str:
         """
-            Prompt the user to choose from a specified list of strings, then
-            invoke another command with all occurrences of {choice} replaced by
-            the choice the user made.
+            Prompt the user to choose from a list of strings.
+            Wait until user makes choice. Returns it.
         """
-        def callback(opt):
-            # We're now outside of the call context...
-            repl = cmd + " " + " ".join(args)
-            repl = repl.replace("{choice}", opt)
-            try:
-                self.master.commands.execute(repl)
-            except exceptions.CommandError as e:
-                signals.status_message.send(message=str(e))
-
-        self.master.overlay(
-            overlay.Chooser(self.master, prompt, choices, "", callback)
-        )
-
-    @command.command("console.choose.cmd")
-    def console_choose_cmd(
-        self,
-        prompt: str,
-        choicecmd: mitmproxy.types.Cmd,
-        subcmd: mitmproxy.types.Cmd,
-        *args: mitmproxy.types.Arg
-    ) -> None:
-        """
-            Prompt the user to choose from a list of strings returned by a
-            command, then invoke another command with all occurrences of {choice}
-            replaced by the choice the user made.
-        """
-        choices = ctx.master.commands.call_strings(choicecmd, [])
-
-        def callback(opt):
-            # We're now outside of the call context...
-            repl = shlex.quote(" ".join(args))
-            repl = repl.replace("{choice}", opt)
-            try:
-                self.master.commands.execute(subcmd + " " + repl)
-            except exceptions.CommandError as e:
-                signals.status_message.send(message=str(e))
-
-        self.master.overlay(
-            overlay.Chooser(self.master, prompt, choices, "", callback)
-        )
+        chooser = overlay.Chooser(self.master, prompt, choices, "")
+        self.master.overlay(chooser)
+        return await chooser.get_choice()
 
     @command.command("console.command")
-    def console_command(self, *partial: str) -> None:
+    def console_command(self, command_parts: typing.Sequence[str]) -> None:
         """
         Prompt the user to edit a command with a (possibly empty) starting value.
         """
-        signals.status_prompt_command.send(partial=" ".join(partial))  # type: ignore
+        signals.status_prompt_command.send(partial=" ".join(command_parts))  # type: ignore
 
     @command.command("console.command.set")
     def console_command_set(self, option: str) -> None:
@@ -288,7 +247,7 @@ class ConsoleAddon:
         option_value = getattr(self.master.options, option, None)
         current_value = option_value if option_value else ""
         self.master.commands.execute(
-            "console.command set %s=%s" % (option, current_value)
+            f"console.command [set {option}={current_value}]"
         )
 
     @command.command("console.view.keybindings")
@@ -430,7 +389,7 @@ class ConsoleAddon:
             self.master.switch_view("edit_focus_setcookies")
         elif part in ["url", "method", "status_code", "reason"]:
             self.master.commands.execute(
-                "console.command flow.set @focus %s " % part
+                f"console.command [flow.set @focus {part}]"
             )
 
     def _grideditor(self):
@@ -516,7 +475,7 @@ class ConsoleAddon:
         try:
             self.master.commands.call_strings(
                 "view.setval",
-                ["@focus", "flowview_mode_%s" % idx, mode]
+                ["@focus", f"flowview_mode_{idx}", mode]
             )
         except exceptions.CommandError as e:
             signals.status_message.send(message=str(e))
@@ -541,7 +500,7 @@ class ConsoleAddon:
             "view.getval",
             [
                 "@focus",
-                "flowview_mode_%s" % idx,
+                f"flowview_mode_{idx}",
                 self.master.options.console_default_contentview,
             ]
         )

--- a/mitmproxy/tools/console/consoleaddons.py
+++ b/mitmproxy/tools/console/consoleaddons.py
@@ -577,16 +577,12 @@ class ConsoleAddon:
             Edit the currently focused key binding.
         """
         b = self._keyfocus()
-        print(f"""console.command [ console.key.bind 
-                                    [{" ".join(b.contexts)}]
-                                    {b.key}
-                                    "{b.command}" ]""")
-        # self.console_command(
-        #     "console.key.bind",
-        #     ",".join(b.contexts),
-        #     b.key,
-        #     b.command,
-        # )
+        self.console_command(
+            "console.key.bind",
+            ",".join(b.contexts),
+            b.key,
+            b.command,
+        )
 
     def running(self):
         self.started = True

--- a/mitmproxy/tools/console/defaultkeys.py
+++ b/mitmproxy/tools/console/defaultkeys.py
@@ -1,6 +1,6 @@
 
 def map(km):
-    km.add(":", "console.command ", ["global"], "Command prompt")
+    km.add(":", "console.command []", ["global"], "Command prompt")
     km.add("?", "console.view.help", ["global"], "View help")
     km.add("B", "browser.start", ["global"], "Start an attached browser")
     km.add("C", "console.view.commands", ["global"], "View commands")
@@ -32,7 +32,7 @@ def map(km):
     km.add("A", "flow.resume @all", ["flowlist", "flowview"], "Resume all intercepted flows")
     km.add("a", "flow.resume @focus", ["flowlist", "flowview"], "Resume this intercepted flow")
     km.add(
-        "b", "console.command cut.save @focus response.content ",
+        "b", "console.command [cut.save @focus response.content]",
         ["flowlist", "flowview"],
         "Save response body to file"
     )
@@ -41,8 +41,10 @@ def map(km):
     km.add(
         "e",
         """
-        console.choose.cmd Format export.formats
-        console.command export.file {choice} @focus
+        console.command [
+            export.file
+            console.choose(Format export.formats()) @focus
+        ]
         """,
         ["flowlist", "flowview"],
         "Export this flow to file"
@@ -51,40 +53,37 @@ def map(km):
     km.add("F", "set console_focus_follow=toggle", ["flowlist"], "Set focus follow")
     km.add(
         "ctrl l",
-        "console.command cut.clip ",
+        "console.command [cut.clip]",
         ["flowlist", "flowview"],
         "Send cuts to clipboard"
     )
-    km.add("L", "console.command view.load ", ["flowlist"], "Load flows from file")
+    km.add("L", "console.command [view.load]", ["flowlist"], "Load flows from file")
     km.add("m", "flow.mark.toggle @focus", ["flowlist"], "Toggle mark on this flow")
     km.add("M", "view.marked.toggle", ["flowlist"], "Toggle viewing marked flows")
     km.add(
         "n",
-        "console.command view.create get https://example.com/",
+        "console.command [view.create get https://example.com/]",
         ["flowlist"],
         "Create a new flow"
     )
     km.add(
         "o",
-        """
-        console.choose.cmd Order view.order.options
-        set view_order={choice}
-        """,
+        "set view_order=console.choose(Order view.order.options())",
         ["flowlist"],
         "Set flow list order"
     )
     km.add("r", "replay.client @focus", ["flowlist", "flowview"], "Replay this flow")
-    km.add("S", "console.command replay.server ", ["flowlist"], "Start server replay")
+    km.add("S", "console.command [replay.server]", ["flowlist"], "Start server replay")
     km.add("v", "set view_order_reversed=toggle", ["flowlist"], "Reverse flow list order")
     km.add("U", "flow.mark @all false", ["flowlist"], "Un-set all marks")
-    km.add("w", "console.command save.file @shown ", ["flowlist"], "Save listed flows to file")
+    km.add("w", "console.command [save.file @shown]", ["flowlist"], "Save listed flows to file")
     km.add("V", "flow.revert @focus", ["flowlist", "flowview"], "Revert changes to this flow")
     km.add("X", "flow.kill @focus", ["flowlist"], "Kill this flow")
     km.add("z", "view.remove @all", ["flowlist"], "Clear flow list")
     km.add("Z", "view.remove @hidden", ["flowlist"], "Purge all flows not showing")
     km.add(
         "|",
-        "console.command script.run @focus ",
+        "console.command [script.run @focus]",
         ["flowlist", "flowview"],
         "Run a script on this flow"
     )
@@ -92,8 +91,8 @@ def map(km):
     km.add(
         "e",
         """
-        console.choose.cmd Part console.edit.focus.options
-        console.edit.focus {choice}
+        console.edit.focus
+        console.choose(Part console.edit.focus.options())
         """,
         ["flowview"],
         "Edit a flow component"
@@ -104,14 +103,14 @@ def map(km):
         ["flowview"],
         "Toggle viewing full contents on this flow",
     )
-    km.add("w", "console.command save.file @focus ", ["flowview"], "Save flow to file")
+    km.add("w", "console.command [save.file @focus]", ["flowview"], "Save flow to file")
     km.add("space", "view.focus.next", ["flowview"], "Go to next flow")
 
     km.add(
         "v",
         """
-        console.choose "View Part" request,response
-        console.bodyview @focus {choice}
+        @focus |
+        console.bodyview console.choose("View Part" [request response])
         """,
         ["flowview"],
         "View flow body in an external viewer"
@@ -120,8 +119,8 @@ def map(km):
     km.add(
         "m",
         """
-        console.choose.cmd Mode console.flowview.mode.options
-        console.flowview.mode.set {choice}
+        console.flowview.mode.set
+        console.choose(Mode console.flowview.mode.options())
         """,
         ["flowview"],
         "Set flow view mode"
@@ -129,15 +128,15 @@ def map(km):
     km.add(
         "z",
         """
-        console.choose "Part" request,response
-        flow.encode.toggle @focus {choice}
+        @focus |
+        flow.encode.toggle console.choose(Part [request response])
         """,
         ["flowview"],
         "Encode/decode flow body"
     )
 
-    km.add("L", "console.command options.load ", ["options"], "Load from file")
-    km.add("S", "console.command options.save ", ["options"], "Save to file")
+    km.add("L", "console.command [options.load]", ["options"], "Load from file")
+    km.add("S", "console.command [options.save]", ["options"], "Save to file")
     km.add("D", "options.reset", ["options"], "Reset all options")
     km.add("d", "console.options.reset.focus", ["options"], "Reset this option")
 
@@ -146,20 +145,20 @@ def map(km):
     km.add("d", "console.grideditor.delete", ["grideditor"], "Delete this row")
     km.add(
         "r",
-        "console.command console.grideditor.load",
+        "console.command [console.grideditor.load]",
         ["grideditor"],
         "Read unescaped data into the current cell from file"
     )
     km.add(
         "R",
-        "console.command console.grideditor.load_escaped",
+        "console.command [console.grideditor.load_escaped]",
         ["grideditor"],
         "Load a Python-style escaped string into the current cell from file"
     )
     km.add("e", "console.grideditor.editor", ["grideditor"], "Edit in external editor")
     km.add(
         "w",
-        "console.command console.grideditor.save ",
+        "console.command [console.grideditor.save]",
         ["grideditor"],
         "Save data to file as CSV"
     )
@@ -169,8 +168,10 @@ def map(km):
     km.add(
         "a",
         """
-        console.choose.cmd "Context" console.key.contexts
-        console.command console.key.bind {choice}
+        console.command [
+            console.key.bind
+            console.choose(Context console.key.contexts())
+        ]
         """,
         ["keybindings"],
         "Add a key binding"

--- a/mitmproxy/tools/console/keymap.py
+++ b/mitmproxy/tools/console/keymap.py
@@ -155,11 +155,6 @@ class Keymap:
             return self.executor(b.command)
         return key
 
-    def _get_braced_command(self, command):
-        tokens = lexer.get_tokens(command, self.oneword_commands)
-
-
-
 
 keyAttrs = {
     "key": lambda x: isinstance(x, str),

--- a/mitmproxy/tools/console/keymap.py
+++ b/mitmproxy/tools/console/keymap.py
@@ -4,6 +4,7 @@ import os
 import ruamel.yaml
 
 from mitmproxy import command
+from mitmproxy.language import lexer
 from mitmproxy.tools.console import commandexecutor
 from mitmproxy.tools.console import signals
 from mitmproxy import ctx
@@ -55,6 +56,7 @@ class Binding:
 
 class Keymap:
     def __init__(self, master):
+        self.oneword_commands = master.commands.oneword_commands
         self.executor = commandexecutor.CommandExecutor(master)
         self.keys = {}
         for c in Contexts:
@@ -152,6 +154,11 @@ class Keymap:
         if b:
             return self.executor(b.command)
         return key
+
+    def _get_braced_command(self, command):
+        tokens = lexer.get_tokens(command, self.oneword_commands)
+
+
 
 
 keyAttrs = {

--- a/mitmproxy/tools/console/keymap.py
+++ b/mitmproxy/tools/console/keymap.py
@@ -4,7 +4,6 @@ import os
 import ruamel.yaml
 
 from mitmproxy import command
-from mitmproxy.language import lexer
 from mitmproxy.tools.console import commandexecutor
 from mitmproxy.tools.console import signals
 from mitmproxy import ctx
@@ -56,7 +55,6 @@ class Binding:
 
 class Keymap:
     def __init__(self, master):
-        self.oneword_commands = master.commands.oneword_commands
         self.executor = commandexecutor.CommandExecutor(master)
         self.keys = {}
         for c in Contexts:

--- a/mitmproxy/tools/console/overlay.py
+++ b/mitmproxy/tools/console/overlay.py
@@ -108,7 +108,7 @@ class Chooser(urwid.WidgetWrap, layoutwidget.LayoutWidget):
     def __init__(self, master, title, choices, current, callback=None):
         self.master = master
         self.choices = choices
-        self._future_choice = asyncio.get_event_loop().create_future()
+        self._future_choice = asyncio.Future()
         if callback:
             self._future_choice.add_done_callback(callback)
         choicewidth = max([len(i) for i in choices])
@@ -146,6 +146,7 @@ class Chooser(urwid.WidgetWrap, layoutwidget.LayoutWidget):
             signals.pop_view_state.send(self)
             return
         elif key in ["q", "esc"]:
+            self._future_choice.cancel()
             signals.pop_view_state.send(self)
             return
 

--- a/test/mitmproxy/language/test_traversal.py
+++ b/test/mitmproxy/language/test_traversal.py
@@ -1,0 +1,46 @@
+import typing
+import asyncio
+
+from mitmproxy import command
+from mitmproxy.test import taddons
+from mitmproxy.language import lexer, parser, traversal
+
+import pytest
+
+
+class TAddon:
+    @command.command("cmd1")
+    def cmd1(self, foo: typing.Sequence[str]) -> str:
+        return " ".join(foo)
+
+    @command.command("cmd2")
+    def cmd2(self, foo: str) -> str:
+        return foo
+
+    @command.command("cmd3")
+    async def cmd3(self, foo: str) -> str:
+        await asyncio.sleep(0.01)
+        return foo
+
+
+@pytest.mark.asyncio
+async def test_execute_parsed_line():
+    test_commands = ["""join.cmd1 [str.cmd2(abc)
+                        str.cmd2(strasync.cmd3("def"))]""",
+                     "[1 2 3]", "str.cmd2 abc | strasync.cmd3()"]
+    results = ["abc def", ['1', '2', '3'], "abc"]
+
+    with taddons.context() as tctx:
+        cm = command.CommandManager(tctx.master)
+        a = TAddon()
+        cm.add("join.cmd1", a.cmd1)
+        cm.add("str.cmd2", a.cmd2)
+        cm.add("strasync.cmd3", a.cmd3)
+
+        command_parser = parser.create_parser(cm)
+        for cmd, exp_res in zip(test_commands, results):
+            lxr = lexer.create_lexer(cmd, cm.oneword_commands)
+            parsed = command_parser.parse(lxr, async_exec=True)
+
+            result = await traversal.execute_parsed_line(parsed)
+            assert result == exp_res

--- a/test/mitmproxy/test_command.py
+++ b/test/mitmproxy/test_command.py
@@ -33,8 +33,8 @@ class TAddon:
         return choices
 
     @command.command("cmd6")
-    def cmd6(self, one: str, two: str) -> str:
-        return f"{one} {two}"
+    def cmd6(self, pipe_value: str) -> str:
+        return pipe_value
 
     @command.command("subcommand")
     def subcommand(self, cmd: mitmproxy.types.Cmd, *args: mitmproxy.types.Arg) -> str:
@@ -306,10 +306,7 @@ def test_simple():
         assert(c.execute("one.two foo") == "ret foo")
         assert (c.execute("one.two(foo)") == "ret foo")
         assert (c.execute("array.command [1 2 3]") == ["1", "2", "3"])
-        assert (c.execute("foo | one.two | one.two") == "ret ret foo")
-        assert (c.execute("one | pipe.command(two) |"
-                          " pipe.command(three)") == "one two three")
-
+        assert (c.execute("foo | pipe.command") == "foo")
         assert(c.execute("one.two \"foo\"") == "ret foo")
         assert(c.execute("one.two 'foo'") == "ret foo")
         assert(c.call("one.two", "foo") == "ret foo")

--- a/test/mitmproxy/test_optmanager.py
+++ b/test/mitmproxy/test_optmanager.py
@@ -1,6 +1,7 @@
 import copy
 import pytest
 import typing
+import asyncio
 import argparse
 
 from mitmproxy import options
@@ -114,7 +115,9 @@ def test_options():
 def test_setter():
     o = TO()
     f = o.setter("two")
-    f(99)
+    opt_future = asyncio.Future()
+    opt_future.set_result(99)
+    f(opt_future)
     assert o.two == 99
     with pytest.raises(Exception, match="No such option"):
         o.setter("nonexistent")


### PR DESCRIPTION
Hi there! This PR makes initial steps porting the current command system to asyncio. Some parts don't work correctly yet (like `console.key.bind`). And yes, I understand, that copying the same code in two different places is the last thing we want to do :) But after reading some documentation and stackoverflow answers, I understood, that dealing with sync and async code in one function isn't a good idea. So sometimes you can see two functions/methods, which do the same thing: one does synchronously, the other - asynchronously. 

As you remember, my last PR provided pipes support. Now the main features of the language are more or less in the workable state, but the thing is our commands and types checking implementations aren't adapted to the ideas of these features. I will give you an example. Now we have such command
```
  console.choose.cmd Format export.formats
  console.command export.file {choice} @focus
```

Since we have new language features, we need to rewrite it like
```
console.command [
        export.file 
        console.choose(Format export.formats()) @focus
]
```

And here 2 issues come:
1. `console.choose` must wait until a user makes a choice or closes an overlay. The previous version of this function used a callback for this, but the current version needs new approach. How to do that?
2. We want to call the command. We are calling `call` method from Command object and pass `str` arguments to it. String arguments will be checked for compilance, parsed and converted to some Python objects. The function corresponding to the command will be called with converted `str` arguments.
The thing is commands can be chained now `console.choose(Format export.formats())` and any enclosing command returns some value as is (not necessary `str`) -> https://github.com/mitmproxy/mitmproxy/blob/master/mitmproxy/command.py#L105-L115 and outer command should do something with it. So, we have the situation, when `console.choose` is being called like `console.choose(Format ['curl', 'httpie', 'raw'])`. The return of `export.formats` is a Python list, Format is a string. Type checking system will try to parse these arguments and convert them to some Python objects, but fail, because arguments must be strings to be parsed.

After long discussions there are two solutions for these two issues:
1. Let mitmproxy execute async commands. 
Now you can define async command like:
```
@command.command("myaddon.acommand")
async acommand(self, arg1: SomeType) -> SomeType:
    ...
```
There are 2 ways to execute commands now: `command_manager.execute` and `command_manager.async_execute`. 
`command_manager.execute` is needed for sync commands.
`command_manager.async_execute` is needed for async commands.
If we try to run async command using sync executor `command_manager.execute`, we will get `ExecutionError` exception. We also have `AsyncExecutionManager`, which tracks running commands.
`AsyncExecutionManager` will probably become a separate addon and get new commands for convenient running commands management.

When you call async command or the command, which has enclosing async command, recursive `ParsedEntity` object is created and traversed then.

2. Simplified check for the return value of enclosing command.

Briefly speaking, what this PR brings:
- All default key bindings are rewritten according to the new language features;
- basic async commands support;
- simple async execution manager is provided;
- minor changes like f-strings support.
