### PR TITLE
[web] Fixes #3228:API endpoint error

### DIFF
--- a/web/src/js/__tests__/ducks/flowsSpec.js
+++ b/web/src/js/__tests__/ducks/flowsSpec.js
@@ -159,7 +159,7 @@ describe('flows actions', () => {
         store.dispatch(flowActions.uploadContent(tflow, 'foo', 'foo'))
         // window.Blob's lastModified is always the current time,
         // which causes flaky tests on comparison.
-        expect(fetchApi).toBeCalledWith('/flows/1/foo/content', { method: 'POST', body: expect.anything()})
+        expect(fetchApi).toBeCalledWith('/flows/1/foo/content.data', { method: 'POST', body: expect.anything()})
     })
 
     it('should handle clear action', () => {

--- a/web/src/js/ducks/flows.js
+++ b/web/src/js/ducks/flows.js
@@ -209,7 +209,7 @@ export function uploadContent(flow, file, type) {
     const body = new FormData()
     file       = new window.Blob([file], { type: 'plain/text' })
     body.append('file', file)
-    return dispatch => fetchApi(`/flows/${flow.id}/${type}/content`, { method: 'POST', body })
+    return dispatch => fetchApi(`/flows/${flow.id}/${type}/content.data`, { method: 'POST', body })
 }
 
 


### PR DESCRIPTION
Correct the outdated API for `uploadContent`.