### PR TITLE
Autoformat for json-rpc calls

### DIFF
--- a/mitmproxy/contentviews/json.py
+++ b/mitmproxy/contentviews/json.py
@@ -17,6 +17,7 @@ class ViewJSON(base.View):
     name = "JSON"
     content_types = [
         "application/json",
+        "application/json-rpc",
         "application/vnd.api+json"
     ]
 


### PR DESCRIPTION
For json-rpc responses the program won't recognise the response as JSON.

I have added the missing line to make it happen.

> https://www.jsonrpc.org/historical/json-rpc-over-http.html#http-header

> Content-Type SHOULD be 'application/json-rpc'