### PR TITLE
addons/browser: fallback to google-chrome-unstable as last try

### DIFF
--- a/mitmproxy/addons/browser.py
+++ b/mitmproxy/addons/browser.py
@@ -19,6 +19,7 @@ def get_chrome_executable() -> typing.Optional[str]:
             "chrome",
             "chromium",
             "chromium-browser",
+            "google-chrome-unstable",
     ):
         if shutil.which(browser):
             return browser


### PR DESCRIPTION
On archlinux, if you install `google-chrome-dev` from AUR, the chrome binary is called `google-chrome-unstable`. It shouldn't hurt to try if everything else fails.