### PR TITLE
Fix error message for failure to start editor

### DIFF
--- a/mitmproxy/tools/console/master.py
+++ b/mitmproxy/tools/console/master.py
@@ -128,7 +128,7 @@ class ConsoleMaster(master.Master):
                 subprocess.call(cmd)
             except:
                 signals.status_message.send(
-                    message="Can't start editor: %s" % " ".join(c)
+                    message="Can't start editor: %s" % c
                 )
             else:
                 with open(name, "r" if text else "rb") as f:


### PR DESCRIPTION
Before:

```
Can't start editor: / u s r / b i n / n a n o
```

After:

```
Can't start editor: /usr/bin/nano
```