### PR TITLE
Support content type suffixes (rfc6839)

### DIFF
--- a/examples/simple/custom_contentview.py
+++ b/examples/simple/custom_contentview.py
@@ -7,7 +7,7 @@ from mitmproxy import contentviews
 
 class ViewSwapCase(contentviews.View):
     name = "swapcase"
-    content_types = ["text/plain"]
+    media_types = ["text/plain"]
 
     def __call__(self, data, **metadata) -> contentviews.TViewResult:
         return "case-swapped text", contentviews.format_text(data.swapcase())

--- a/mitmproxy/contentviews/__init__.py
+++ b/mitmproxy/contentviews/__init__.py
@@ -27,7 +27,8 @@ from . import (
 from .base import View, VIEW_CUTOFF, KEY_MAX, format_text, format_dict, TViewResult
 
 views: List[View] = []
-content_types_map: Dict[str, List[View]] = {}
+media_types_map: Dict[str, List[View]] = {}
+suffixes_map: Dict[str, List[View]] = {}
 
 
 def get(name: str) -> Optional[View]:
@@ -45,18 +46,29 @@ def add(view: View) -> None:
 
     views.append(view)
 
-    for ct in view.content_types:
-        l = content_types_map.setdefault(ct, [])
+    for mt in view.media_types:
+        l = media_types_map.setdefault(mt, [])
+        l.append(view)
+
+    for suffix in view.suffixes:
+        l = suffixes_map.setdefault(suffix, [])
         l.append(view)
 
 
 def remove(view: View) -> None:
-    for ct in view.content_types:
-        l = content_types_map.setdefault(ct, [])
+    for mt in view.media_types:
+        l = media_types_map.setdefault(mt, [])
         l.remove(view)
 
         if not len(l):
-            del content_types_map[ct]
+            del media_types_map[mt]
+
+    for suffix in view.suffixes:
+        l = suffixes_map.setdefault(suffix, [])
+        l.remove(view)
+
+        if not len(l):
+            del suffixes_map[suffix]
 
     views.remove(view)
 

--- a/mitmproxy/contentviews/auto.py
+++ b/mitmproxy/contentviews/auto.py
@@ -12,12 +12,15 @@ class ViewAuto(base.View):
         ctype = headers.get("content-type")
         if data and ctype:
             ct = http.parse_content_type(ctype) if ctype else None
-            ct = "%s/%s" % (ct[0], ct[1])
-            if ct in contentviews.content_types_map:
-                return contentviews.content_types_map[ct][0](data, **metadata)
+            suffix = ct[2]
+            mt = "%s/%s" % (ct[0], ct[1])
+            if suffix in contentviews.suffixes_map:
+                return contentviews.suffixes_map[suffix][0](data, **metadata)
+            elif mt in contentviews.media_types_map:
+                return contentviews.media_types_map[mt][0](data, **metadata)
             elif strutils.is_xml(data):
                 return contentviews.get("XML/HTML")(data, **metadata)
-            elif ct.startswith("image/"):
+            elif mt.startswith("image/"):
                 return contentviews.get("Image")(data, **metadata)
         if metadata.get("query"):
             return contentviews.get("Query")(data, **metadata)

--- a/mitmproxy/contentviews/base.py
+++ b/mitmproxy/contentviews/base.py
@@ -12,7 +12,8 @@ TViewResult = typing.Tuple[str, typing.Iterator[TViewLine]]
 
 class View:
     name: str = None
-    content_types: typing.List[str] = []
+    media_types: typing.List[str] = []
+    suffixes: typing.List[str] = [] # rfc6839
 
     def __call__(self, data: bytes, **metadata) -> TViewResult:
         """

--- a/mitmproxy/contentviews/base.py
+++ b/mitmproxy/contentviews/base.py
@@ -13,7 +13,7 @@ TViewResult = typing.Tuple[str, typing.Iterator[TViewLine]]
 class View:
     name: str = None
     media_types: typing.List[str] = []
-    suffixes: typing.List[str] = [] # rfc6839
+    suffixes: typing.List[str] = []  # rfc6839
 
     def __call__(self, data: bytes, **metadata) -> TViewResult:
         """

--- a/mitmproxy/contentviews/css.py
+++ b/mitmproxy/contentviews/css.py
@@ -50,7 +50,7 @@ def beautify(data: str, indent: str = "    "):
 
 class ViewCSS(base.View):
     name = "CSS"
-    content_types = [
+    media_types = [
         "text/css"
     ]
 

--- a/mitmproxy/contentviews/image/view.py
+++ b/mitmproxy/contentviews/image/view.py
@@ -17,7 +17,7 @@ class ViewImage(base.View):
     name = "Image"
 
     # there is also a fallback in the auto view for image/*.
-    content_types = [
+    media_types = [
         "image/png",
         "image/jpeg",
         "image/gif",

--- a/mitmproxy/contentviews/javascript.py
+++ b/mitmproxy/contentviews/javascript.py
@@ -46,7 +46,7 @@ def beautify(data):
 
 class ViewJavaScript(base.View):
     name = "JavaScript"
-    content_types = [
+    media_types = [
         "application/x-javascript",
         "application/javascript",
         "text/javascript"

--- a/mitmproxy/contentviews/json.py
+++ b/mitmproxy/contentviews/json.py
@@ -15,11 +15,11 @@ def pretty_json(s: bytes) -> Optional[bytes]:
 
 class ViewJSON(base.View):
     name = "JSON"
-    content_types = [
+    media_types = [
         "application/json",
-        "application/json-rpc",
-        "application/vnd.api+json"
+        "application/json-rpc"
     ]
+    suffixes = ["json"]
 
     def __call__(self, data, **metadata):
         pj = pretty_json(data)

--- a/mitmproxy/contentviews/multipart.py
+++ b/mitmproxy/contentviews/multipart.py
@@ -5,7 +5,7 @@ from . import base
 
 class ViewMultipart(base.View):
     name = "Multipart Form"
-    content_types = ["multipart/form-data"]
+    media_types = ["multipart/form-data"]
 
     @staticmethod
     def _format(v):

--- a/mitmproxy/contentviews/protobuf.py
+++ b/mitmproxy/contentviews/protobuf.py
@@ -66,7 +66,7 @@ class ViewProtobuf(base.View):
     """
 
     name = "Protocol Buffer"
-    content_types = [
+    media_types = [
         "application/x-protobuf",
         "application/x-protobuffer",
     ]

--- a/mitmproxy/contentviews/urlencoded.py
+++ b/mitmproxy/contentviews/urlencoded.py
@@ -5,7 +5,7 @@ from . import base
 
 class ViewURLEncoded(base.View):
     name = "URL-encoded"
-    content_types = ["application/x-www-form-urlencoded"]
+    media_types = ["application/x-www-form-urlencoded"]
 
     def __call__(self, data, **metadata):
         try:

--- a/mitmproxy/contentviews/wbxml.py
+++ b/mitmproxy/contentviews/wbxml.py
@@ -4,10 +4,11 @@ from . import base
 
 class ViewWBXML(base.View):
     name = "WBXML"
-    content_types = [
+    media_types = [
         "application/vnd.wap.wbxml",
         "application/vnd.ms-sync.wbxml"
     ]
+    suffixes = ["wbxml"]
 
     def __call__(self, data, **metadata):
         try:

--- a/mitmproxy/contentviews/xml_html.py
+++ b/mitmproxy/contentviews/xml_html.py
@@ -214,7 +214,8 @@ def format_xml(tokens: Iterable[Token]) -> str:
 
 class ViewXmlHtml(base.View):
     name = "XML/HTML"
-    content_types = ["text/xml", "text/html"]
+    media_types = ["text/xml", "text/html"]
+    suffixes = ["xml"]
 
     def __call__(self, data, **metadata):
         # TODO:

--- a/mitmproxy/net/http/message.py
+++ b/mitmproxy/net/http/message.py
@@ -162,7 +162,7 @@ class Message(serializable.Serializable):
     def _get_content_type_charset(self) -> Optional[str]:
         ct = headers.parse_content_type(self.headers.get("content-type", ""))
         if ct:
-            return ct[2].get("charset")
+            return ct[3].get("charset")
         return None
 
     def _guess_encoding(self) -> str:
@@ -209,8 +209,8 @@ class Message(serializable.Serializable):
             self.content = encoding.encode(text, enc)
         except ValueError:
             # Fall back to UTF-8 and update the content-type header.
-            ct = headers.parse_content_type(self.headers.get("content-type", "")) or ("text", "plain", {})
-            ct[2]["charset"] = "utf-8"
+            ct = headers.parse_content_type(self.headers.get("content-type", "")) or ("text", "plain", None, {})
+            ct[3]["charset"] = "utf-8"
             self.headers["content-type"] = headers.assemble_content_type(*ct)
             enc = "utf8"
             self.content = text.encode(enc, "surrogateescape")

--- a/mitmproxy/net/http/multipart.py
+++ b/mitmproxy/net/http/multipart.py
@@ -13,7 +13,7 @@ def decode(hdrs, content):
         if not v:
             return []
         try:
-            boundary = v[2]["boundary"].encode("ascii")
+            boundary = v[3]["boundary"].encode("ascii")
         except (KeyError, UnicodeError):
             return []
 

--- a/test/mitmproxy/contentviews/test_api.py
+++ b/test/mitmproxy/contentviews/test_api.py
@@ -9,7 +9,7 @@ from mitmproxy.test import tutils
 
 class TestContentView(contentviews.View):
     name = "test"
-    content_types = ["test/123"]
+    media_types = ["test/123"]
 
 
 def test_add_remove():

--- a/test/mitmproxy/contentviews/test_auto.py
+++ b/test/mitmproxy/contentviews/test_auto.py
@@ -37,6 +37,18 @@ def test_view_auto():
     assert f[0].startswith("XML")
 
     f = v(
+        b"{\"foo\":\"bar\"}",
+        headers=http.Headers(content_type="application/vnd.acme+json")
+    )
+    assert f[0] == "JSON"
+
+    f = v(
+        b"\x03\x01\x6A\x00",
+        headers=http.Headers(content_type="application/vnd.acme+wbxml")
+    )
+    assert f[0] == "WBXML"
+
+    f = v(
         b"verybinary",
         headers=http.Headers(content_type="image/new-magic-image-format")
     )

--- a/test/mitmproxy/net/http/test_headers.py
+++ b/test/mitmproxy/net/http/test_headers.py
@@ -106,5 +106,9 @@ def test_assemble_content_type():
     p = assemble_content_type
     assert p("text", "html", None, {}) == "text/html"
     assert p("text", "html", None, {"charset": "utf8"}) == "text/html; charset=utf8"
-    assert p("text", "html", None, collections.OrderedDict([("charset", "utf8"), ("foo", "bar")])) == "text/html; charset=utf8; foo=bar"
-    assert p("application", "vnd.acme", "json", collections.OrderedDict([("charset", "utf8"), ("foo", "bar")])) == "application/vnd.acme+json; charset=utf8; foo=bar"
+
+    v = p("text", "html", None, collections.OrderedDict([("charset", "utf8"), ("foo", "bar")]))
+    assert v == "text/html; charset=utf8; foo=bar"
+
+    v = p("application", "vnd.acme", "json", collections.OrderedDict([("charset", "utf8"), ("foo", "bar")]))
+    assert v == "application/vnd.acme+json; charset=utf8; foo=bar"

--- a/test/mitmproxy/net/http/test_headers.py
+++ b/test/mitmproxy/net/http/test_headers.py
@@ -92,15 +92,19 @@ class TestHeaders:
 
 def test_parse_content_type():
     p = parse_content_type
-    assert p("text/html") == ("text", "html", {})
+    assert p("text/html") == ("text", "html", None, {})
     assert p("text") is None
 
     v = p("text/html; charset=UTF-8")
-    assert v == ('text', 'html', {'charset': 'UTF-8'})
+    assert v == ('text', 'html', None, {'charset': 'UTF-8'})
+
+    v = p("application/vnd.acme+json; charset=UTF-8")
+    assert v == ('application', 'vnd.acme', "json", {'charset': 'UTF-8'})
 
 
 def test_assemble_content_type():
     p = assemble_content_type
-    assert p("text", "html", {}) == "text/html"
-    assert p("text", "html", {"charset": "utf8"}) == "text/html; charset=utf8"
-    assert p("text", "html", collections.OrderedDict([("charset", "utf8"), ("foo", "bar")])) == "text/html; charset=utf8; foo=bar"
+    assert p("text", "html", None, {}) == "text/html"
+    assert p("text", "html", None, {"charset": "utf8"}) == "text/html; charset=utf8"
+    assert p("text", "html", None, collections.OrderedDict([("charset", "utf8"), ("foo", "bar")])) == "text/html; charset=utf8; foo=bar"
+    assert p("application", "vnd.acme", "json", collections.OrderedDict([("charset", "utf8"), ("foo", "bar")])) == "application/vnd.acme+json; charset=utf8; foo=bar"


### PR DESCRIPTION
Currently mitmproxy only recognizes json when request/response content type is `application/json`. Mitmproxy uses default raw view mode, when content mode has vendor-specific media-type with json suffix: `application/vnd.my.company+json`. User has to change view mode to json each time he/she opens the flow.

Mitmproxy only recognises media-types and parameters in content type.
`type/subtype; parameter=value`

This PR introduces suffix support (suffixes are described in [rfc6839](https://tools.ietf.org/html/rfc6839)).
`type/subtype+suffix; parameter=value`

This PR introduces support for the most common suffixes:
- `json`,
- `xml`,
- `wbxml`.