### PR TITLE
Make content view lines limit configurable

### DIFF
--- a/mitmproxy/contentviews/__init__.py
+++ b/mitmproxy/contentviews/__init__.py
@@ -24,7 +24,7 @@ from . import (
     auto, raw, hex, json, xml_html, wbxml, javascript, css,
     urlencoded, multipart, image, query, protobuf
 )
-from .base import View, VIEW_CUTOFF, KEY_MAX, format_text, format_dict, TViewResult
+from .base import View, KEY_MAX, format_text, format_dict, TViewResult
 
 views: List[View] = []
 content_types_map: Dict[str, List[View]] = {}
@@ -160,6 +160,6 @@ add(query.ViewQuery())
 add(protobuf.ViewProtobuf())
 
 __all__ = [
-    "View", "VIEW_CUTOFF", "KEY_MAX", "format_text", "format_dict", "TViewResult",
+    "View", "KEY_MAX", "format_text", "format_dict", "TViewResult",
     "get", "add", "remove", "get_content_view", "get_message_content_view",
 ]

--- a/mitmproxy/contentviews/base.py
+++ b/mitmproxy/contentviews/base.py
@@ -1,8 +1,6 @@
 # Default view cutoff *in lines*
 import typing
 
-VIEW_CUTOFF = 512
-
 KEY_MAX = 30
 
 TTextType = typing.Union[str, bytes]  # FIXME: This should be either bytes or str ultimately.

--- a/mitmproxy/options.py
+++ b/mitmproxy/options.py
@@ -6,6 +6,7 @@ from mitmproxy.net import tls
 
 CONF_DIR = "~/.mitmproxy"
 LISTEN_PORT = 8080
+CONTENT_VIEW_LINES_CUTOFF = 512
 
 
 class Options(optmanager.OptManager):
@@ -159,6 +160,13 @@ class Options(optmanager.OptManager):
             Generic TCP SSL proxy mode for all hosts that match the pattern.
             Similar to --ignore, but SSL connections are intercepted. The
             communication contents are printed to the log in verbose mode.
+            """
+        )
+        self.add_option(
+            "content_view_lines_cutoff", int, CONTENT_VIEW_LINES_CUTOFF,
+            """
+            Flow content view lines limit. Limit is enabled by default to
+            speedup flows browsing.
             """
         )
 

--- a/mitmproxy/tools/console/flowview.py
+++ b/mitmproxy/tools/console/flowview.py
@@ -6,6 +6,7 @@ from typing import Optional, Union  # noqa
 import urwid
 
 from mitmproxy import contentviews
+from mitmproxy import ctx
 from mitmproxy import http
 from mitmproxy.tools.console import common
 from mitmproxy.tools.console import layoutwidget
@@ -102,7 +103,7 @@ class FlowDetails(tabs.Tabs):
             if full == "true":
                 limit = sys.maxsize
             else:
-                limit = contentviews.VIEW_CUTOFF
+                limit = ctx.options.content_view_lines_cutoff
 
             flow_modify_cache_invalidation = hash((
                 message.raw_content,


### PR DESCRIPTION
Currently mitmproxy by default limits a flow content to 512 lines. This PR makes that cutoff configurable.