### PR TITLE
docs: Add mitm.it link in the certificates docs.

### DIFF
--- a/docs/src/content/concepts-certificates.md
+++ b/docs/src/content/concepts-certificates.md
@@ -16,7 +16,7 @@ certificates have to be installed on the client device.
 By far the easiest way to install the mitmproxy certificates is to use the
 built-in certificate installation app. To do this, just start mitmproxy and
 configure your target device with the correct proxy settings. Now start a
-browser on the device, and visit the magic domain **mitm.it**. You should see
+browser on the device, and visit the magic domain [**mitm.it**](http://mitm.it/). You should see
 something like this:
 
 {{< figure src="/certinstall-webapp.png" class="has-border" >}}

--- a/docs/src/content/concepts-certificates.md
+++ b/docs/src/content/concepts-certificates.md
@@ -16,7 +16,7 @@ certificates have to be installed on the client device.
 By far the easiest way to install the mitmproxy certificates is to use the
 built-in certificate installation app. To do this, just start mitmproxy and
 configure your target device with the correct proxy settings. Now start a
-browser on the device, and visit the magic domain [**mitm.it**](http://mitm.it/). You should see
+browser on the device, and visit the magic domain [mitm.it](http://mitm.it/). You should see
 something like this:
 
 {{< figure src="/certinstall-webapp.png" class="has-border" >}}


### PR DESCRIPTION
In the page https://docs.mitmproxy.org/stable/concepts-certificates/, there is usage of mitm.it and it is not a link which seems odd on reading through the documentation. This PR adds the link to the usage.