### PR TITLE
Add Organization field for the generated certificate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,5 +28,3 @@ sslkeylogfile.log
 coverage.xml
 web/coverage/
 .mypy_cache/
-
-# To triggle CI, will be delete later

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ sslkeylogfile.log
 coverage.xml
 web/coverage/
 .mypy_cache/
+
+# To triggle CI, will be delete later

--- a/mitmproxy/proxy/protocol/tls.py
+++ b/mitmproxy/proxy/protocol/tls.py
@@ -502,4 +502,3 @@ class TlsLayer(base.Layer):
         if host:
             sans.add(host)
         return self.config.certstore.get_cert(host, list(sans), o)
-        # To satisfy the CIs

--- a/mitmproxy/proxy/protocol/tls.py
+++ b/mitmproxy/proxy/protocol/tls.py
@@ -502,3 +502,4 @@ class TlsLayer(base.Layer):
         if host:
             sans.add(host)
         return self.config.certstore.get_cert(host, list(sans), o)
+        # To satisfy the CIs

--- a/mitmproxy/proxy/protocol/tls.py
+++ b/mitmproxy/proxy/protocol/tls.py
@@ -469,6 +469,7 @@ class TlsLayer(base.Layer):
         """
         host = None
         sans = set()
+        o = None
 
         # In normal operation, the server address should always be known at this point.
         # However, we may just want to establish TLS so that we can send an error message to the client,
@@ -488,6 +489,8 @@ class TlsLayer(base.Layer):
             if upstream_cert.cn:
                 sans.add(host)
                 host = upstream_cert.cn.decode("utf8").encode("idna")
+            if upstream_cert.o:
+                o = upstream_cert.o
         # Also add SNI values.
         if self._client_hello.sni:
             sans.add(self._client_hello.sni.encode("idna"))
@@ -498,4 +501,4 @@ class TlsLayer(base.Layer):
         # In other words, the Common Name is irrelevant then.
         if host:
             sans.add(host)
-        return self.config.certstore.get_cert(host, list(sans))
+        return self.config.certstore.get_cert(host, list(sans), o)

--- a/test/mitmproxy/test_certs.py
+++ b/test/mitmproxy/test_certs.py
@@ -129,18 +129,22 @@ class TestDummyCert:
             ca.default_privatekey,
             ca.default_ca,
             b"foo.com",
-            [b"one.com", b"two.com", b"*.three.com", b"127.0.0.1"]
+            [b"one.com", b"two.com", b"*.three.com", b"127.0.0.1"],
+            b"Foo Ltd."
         )
         assert r.cn == b"foo.com"
         assert r.altnames == [b'one.com', b'two.com', b'*.three.com']
+        assert r.o == b"Foo Ltd."
 
         r = certs.dummy_cert(
             ca.default_privatekey,
             ca.default_ca,
             None,
-            []
+            [],
+            None
         )
         assert r.cn is None
+        assert r.o is None
         assert r.altnames == []
 
 
@@ -152,6 +156,7 @@ class TestCert:
         c1 = certs.Cert.from_pem(d)
         assert c1.cn == b"google.com"
         assert len(c1.altnames) == 436
+        assert c1.o == b"Google Inc"
 
         with open(tdata.path("mitmproxy/net/data/text_cert_2"), "rb") as f:
             d = f.read()


### PR DESCRIPTION
Some clients (for example, the client below) will check organization fields`(O)` to avoid fake certificate generated by others. So I chang the tls layer and cert store to support the organization field`(O)` in the generated certificate.

So far, the organization field`(O)` will be duplicated from the original certificate from server.

![example](https://user-images.githubusercontent.com/9047404/47998348-f2effe00-e139-11e8-827f-4a8d1929a4b3.PNG)

> Though unbelievable, some clients check their certificate by its Organization field.