### PR TITLE
Change variable o to organization for generated certficates.

### DIFF
--- a/mitmproxy/proxy/protocol/tls.py
+++ b/mitmproxy/proxy/protocol/tls.py
@@ -464,12 +464,12 @@ class TlsLayer(base.Layer):
 
     def _find_cert(self):
         """
-        This function determines the Common Name (CN) and Subject Alternative Names (SANs)
+        This function determines the Common Name (CN), Subject Alternative Names (SANs) and Organization Name
         our certificate should have and then fetches a matching cert from the certstore.
         """
         host = None
         sans = set()
-        o = None
+        organization = None
 
         # In normal operation, the server address should always be known at this point.
         # However, we may just want to establish TLS so that we can send an error message to the client,
@@ -489,8 +489,8 @@ class TlsLayer(base.Layer):
             if upstream_cert.cn:
                 sans.add(host)
                 host = upstream_cert.cn.decode("utf8").encode("idna")
-            if upstream_cert.o:
-                o = upstream_cert.o
+            if upstream_cert.organization:
+                organization = upstream_cert.organization
         # Also add SNI values.
         if self._client_hello.sni:
             sans.add(self._client_hello.sni.encode("idna"))
@@ -501,4 +501,4 @@ class TlsLayer(base.Layer):
         # In other words, the Common Name is irrelevant then.
         if host:
             sans.add(host)
-        return self.config.certstore.get_cert(host, list(sans), o)
+        return self.config.certstore.get_cert(host, list(sans), organization)

--- a/test/mitmproxy/test_certs.py
+++ b/test/mitmproxy/test_certs.py
@@ -134,7 +134,7 @@ class TestDummyCert:
         )
         assert r.cn == b"foo.com"
         assert r.altnames == [b'one.com', b'two.com', b'*.three.com']
-        assert r.o == b"Foo Ltd."
+        assert r.organization == b"Foo Ltd."
 
         r = certs.dummy_cert(
             ca.default_privatekey,
@@ -144,7 +144,7 @@ class TestDummyCert:
             None
         )
         assert r.cn is None
-        assert r.o is None
+        assert r.organization is None
         assert r.altnames == []
 
 
@@ -156,7 +156,7 @@ class TestCert:
         c1 = certs.Cert.from_pem(d)
         assert c1.cn == b"google.com"
         assert len(c1.altnames) == 436
-        assert c1.o == b"Google Inc"
+        assert c1.organization == b"Google Inc"
 
         with open(tdata.path("mitmproxy/net/data/text_cert_2"), "rb") as f:
             d = f.read()


### PR DESCRIPTION
Follow up for PR #3376 as per [comment](https://github.com/mitmproxy/mitmproxy/pull/3376/#issuecomment-437286850) , replacing the variable `o` with `organization`.