### PR TITLE
Query array fix

### DIFF
--- a/mitmproxy/contentviews/base.py
+++ b/mitmproxy/contentviews/base.py
@@ -35,6 +35,35 @@ class View:
         raise NotImplementedError()  # pragma: no cover
 
 
+def format_pair(item: TViewLine) -> typing.Iterator[TViewLine]:
+
+    """
+    Helper function that accepts a list of (k,v) pairs into a list of
+    [
+        ("key", key    )
+        ("value", value)
+    ]
+    where key is padded to a uniform width
+    """
+
+    max_key_len = max((len(k[0]) for k in item), default=0)
+    max_key_len = min((max_key_len, KEY_MAX), default=0)
+
+    for k in item:
+        if isinstance(k[0], bytes):
+
+            temp = b"k[0]" + b":"
+        else:
+            temp = k[0] + ":"
+
+        key = temp.ljust(max_key_len + 2)
+
+        yield [
+            ("header", key),
+            ("text", k[1])
+        ]
+
+
 def format_dict(
         d: typing.Mapping[TTextType, TTextType]
 ) -> typing.Iterator[TViewLine]:
@@ -47,18 +76,7 @@ def format_dict(
     entries, where key is padded to a uniform width.
     """
 
-    max_key_len = max((len(k) for k in d.keys()), default=0)
-    max_key_len = min((max_key_len, KEY_MAX), default=0)
-    for key, value in d.items():
-        if isinstance(key, bytes):
-            key += b":"
-        else:
-            key += ":"
-        key = key.ljust(max_key_len + 2)
-        yield [
-            ("header", key),
-            ("text", value)
-        ]
+    return format_pair(list(d.items()))
 
 
 def format_text(text: TTextType) -> typing.Iterator[TViewLine]:

--- a/mitmproxy/contentviews/base.py
+++ b/mitmproxy/contentviews/base.py
@@ -35,7 +35,9 @@ class View:
         raise NotImplementedError()  # pragma: no cover
 
 
-def format_pair(item: TViewLine) -> typing.Iterator[TViewLine]:
+def format_pairs(
+        items: typing.Iterable[typing.Tuple[TTextType, TTextType]]
+)-> typing.Iterator[TViewLine]:
 
     """
     Helper function that accepts a list of (k,v) pairs into a list of
@@ -46,21 +48,21 @@ def format_pair(item: TViewLine) -> typing.Iterator[TViewLine]:
     where key is padded to a uniform width
     """
 
-    max_key_len = max((len(k[0]) for k in item), default=0)
+    max_key_len = max((len(k[0]) for k in items), default=0)
     max_key_len = min((max_key_len, KEY_MAX), default=0)
 
-    for k in item:
-        if isinstance(k[0], bytes):
+    for key, value in items:
+        if isinstance(key, bytes):
 
-            temp = b"k[0]" + b":"
+            key += b":"
         else:
-            temp = k[0] + ":"
+            key += ":"
 
-        key = temp.ljust(max_key_len + 2)
+        key = key.ljust(max_key_len + 2)
 
         yield [
             ("header", key),
-            ("text", k[1])
+            ("text", value)
         ]
 
 
@@ -76,7 +78,7 @@ def format_dict(
     entries, where key is padded to a uniform width.
     """
 
-    return format_pair(list(d.items()))
+    return format_pairs(d.items())
 
 
 def format_text(text: TTextType) -> typing.Iterator[TViewLine]:

--- a/mitmproxy/contentviews/query.py
+++ b/mitmproxy/contentviews/query.py
@@ -9,6 +9,6 @@ class ViewQuery(base.View):
     def __call__(self, data, **metadata):
         query = metadata.get("query")
         if query:
-            return "Query", base.format_dict(query)
+            return "Query", base.format_pair(query.items(multi=True))
         else:
             return "Query", base.format_text("")

--- a/mitmproxy/contentviews/query.py
+++ b/mitmproxy/contentviews/query.py
@@ -9,6 +9,6 @@ class ViewQuery(base.View):
     def __call__(self, data, **metadata):
         query = metadata.get("query")
         if query:
-            return "Query", base.format_pair(query.items(multi=True))
+            return "Query", base.format_pairs(query.items(multi=True))
         else:
             return "Query", base.format_text("")

--- a/mitmproxy/contentviews/urlencoded.py
+++ b/mitmproxy/contentviews/urlencoded.py
@@ -1,5 +1,4 @@
 from mitmproxy.net.http import url
-from mitmproxy.coretypes import multidict
 from . import base
 
 
@@ -13,4 +12,4 @@ class ViewURLEncoded(base.View):
         except ValueError:
             return None
         d = url.decode(data)
-        return "URLEncoded form", base.format_dict(multidict.MultiDict(d))
+        return "URLEncoded form", base.format_pair(d)

--- a/mitmproxy/contentviews/urlencoded.py
+++ b/mitmproxy/contentviews/urlencoded.py
@@ -12,4 +12,4 @@ class ViewURLEncoded(base.View):
         except ValueError:
             return None
         d = url.decode(data)
-        return "URLEncoded form", base.format_pair(d)
+        return "URLEncoded form", base.format_pairs(d)

--- a/test/mitmproxy/contentviews/test_base.py
+++ b/test/mitmproxy/contentviews/test_base.py
@@ -15,3 +15,18 @@ def test_format_dict():
     f_d = base.format_dict(d)
     with pytest.raises(StopIteration):
         next(f_d)
+
+
+def test_format_pair():
+    d = [("a", "c"), ("b", "d")]
+    f_d = base.format_pair(d)
+    assert next(f_d)
+
+    d = [("abc", "")]
+    f_d = base.format_pair(d)
+    assert next(f_d)
+
+    d = []
+    f_d = base.format_pair(d)
+    with pytest.raises(StopIteration):
+        next(f_d)

--- a/test/mitmproxy/contentviews/test_base.py
+++ b/test/mitmproxy/contentviews/test_base.py
@@ -17,16 +17,16 @@ def test_format_dict():
         next(f_d)
 
 
-def test_format_pair():
+def test_format_pairs():
     d = [("a", "c"), ("b", "d")]
-    f_d = base.format_pair(d)
+    f_d = base.format_pairs(d)
     assert next(f_d)
 
     d = [("abc", "")]
-    f_d = base.format_pair(d)
+    f_d = base.format_pairs(d)
     assert next(f_d)
 
     d = []
-    f_d = base.format_pair(d)
+    f_d = base.format_pairs(d)
     with pytest.raises(StopIteration):
         next(f_d)

--- a/test/mitmproxy/contentviews/test_query.py
+++ b/test/mitmproxy/contentviews/test_query.py
@@ -6,8 +6,8 @@ from . import full_eval
 def test_view_query():
     d = ""
     v = full_eval(query.ViewQuery())
-    f = v(d, query=multidict.MultiDict([("foo", "bar")]))
+    f = v(d, query=multidict.MultiDict([("foo", "bar"), ("foo", "baz")]))
     assert f[0] == "Query"
-    assert f[1] == [[("header", "foo: "), ("text", "bar")]]
+    assert f[1] == [[("header", "foo: "), ("text", "bar")], [("header", "foo: "), ("text", "baz")]]
 
     assert v(d) == ("Query", [])


### PR DESCRIPTION
Fix for #3072 and #3254 

Added `format_pair` function and changed the implementation of `format_dict`.
Did relevant changes in urlencoded.py