### PR TITLE
Fix: Two error responses on bad HTTP request

### DIFF
--- a/mitmproxy/proxy/protocol/http.py
+++ b/mitmproxy/proxy/protocol/http.py
@@ -289,9 +289,12 @@ class HttpLayer(base.Layer):
             f.request = None
             f.error = flow.Error(str(e))
             self.channel.ask("error", f)
-            raise exceptions.ProtocolException(
-                "HTTP protocol error in client request: {}".format(e)
-            ) from e
+            if not isinstance(e, exceptions.HttpSyntaxException):
+                raise exceptions.ProtocolException(
+                    "HTTP protocol error in client request: {}".format(e)
+                ) from e
+            
+            return False
 
         self.log("request", "debug", [repr(request)])
 

--- a/mitmproxy/proxy/protocol/http.py
+++ b/mitmproxy/proxy/protocol/http.py
@@ -293,7 +293,7 @@ class HttpLayer(base.Layer):
                 raise exceptions.ProtocolException(
                     "HTTP protocol error in client request: {}".format(e)
                 ) from e
-            
+
             return False
 
         self.log("request", "debug", [repr(request)])


### PR DESCRIPTION
Fixed issue #3354

When the request is not sintactically correct, there is already an exception raised(HttpSyntaxException), so there is no need to raise a further ProtocolException. 
So this fix added a check to verify that, before raise a ProtocolException, it has not already been raised an HttpSyntaxException.
