### PR TITLE
Modifications to examples/complex/har_dump.py

### DIFF
--- a/examples/complex/har_dump.py
+++ b/examples/complex/har_dump.py
@@ -181,8 +181,8 @@ def response(flow):
 
     if ctx.options.hardir:
         HAR["log"]["entries"] = [entry]
-        filename = "%s-%s" % (flow.request.timestamp_start,
-                              hashlib.sha1(flow.request.url.encode('utf-8')).hexdigest()[:6])
+        filename = "%.6f-%s" % (flow.request.timestamp_start,
+                                hashlib.sha1(flow.request.url.encode('utf-8')).hexdigest()[:6])
 
         if ctx.options.compress == "bzip2":
             filename = "%s.har.bz2" % filename

--- a/test/examples/test_har_dump.py
+++ b/test/examples/test_har_dump.py
@@ -204,3 +204,15 @@ class TestHARDump:
                     with open(filename, "rb") as inp:
                         har = json.loads(zlib.decompress(inp.read()))
                     assert len(har["log"]["entries"]) == 1
+
+    def test_single_filename_format(self, tmpdir, tdata):
+        with taddons.context() as tctx:
+            a = tctx.script(tdata.path("../examples/complex/har_dump.py"))
+            tctx.configure(a, hardir=str(tmpdir), compress="zlib")
+            tctx.invoke(a, "response", self.flow())
+            files = os.listdir(tmpdir)
+            for file in files:
+                filename = str(tmpdir.join(file))
+                if os.path.isfile(filename):
+                    base = os.path.basename(filename)
+                    assert base.startswith("%s.000000" % self.flow().request.timestamp_start)


### PR DESCRIPTION
Updates the har_dump.py example to allow for the creation of a HAR file per flow.

Also allows for different compression options from within the standard Python library.