### PR TITLE
Improve flow list performance

### DIFF
--- a/mitmproxy/tools/console/common.py
+++ b/mitmproxy/tools/console/common.py
@@ -106,7 +106,7 @@ else:
 
 
 @lru_cache(maxsize=800)
-def raw_format_flow(f, flow):
+def raw_format_flow(f):
     f = dict(f)
     pile = []
     req = []
@@ -126,8 +126,7 @@ def raw_format_flow(f, flow):
     if f["req_is_replay"]:
         req.append(fcol(SYMBOL_REPLAY, "replay"))
 
-    pushed = ' PUSH_PROMISE' if 'h2-pushed-stream' in flow.metadata else ''
-    req.append(fcol(f["req_method"] + pushed, "method"))
+    req.append(fcol(f["req_method"], "method"))
 
     preamble = sum(i[1] for i in req) + len(req) - 1
 
@@ -198,6 +197,7 @@ def format_flow(f, focus, extended=False, hostheader=False, max_url_len=False):
     acked = False
     if f.reply and f.reply.state == "committed":
         acked = True
+    pushed = ' PUSH_PROMISE' if 'h2-pushed-stream' in f.metadata else ''
     d = dict(
         focus=focus,
         extended=extended,
@@ -206,7 +206,7 @@ def format_flow(f, focus, extended=False, hostheader=False, max_url_len=False):
         acked=acked,
         req_timestamp=f.request.timestamp_start,
         req_is_replay=f.request.is_replay,
-        req_method=f.request.method,
+        req_method=f.request.method + pushed,
         req_url=f.request.pretty_url if hostheader else f.request.url,
         req_http_version=f.request.http_version,
         err_msg=f.error.msg if f.error else None,
@@ -238,4 +238,4 @@ def format_flow(f, focus, extended=False, hostheader=False, max_url_len=False):
         else:
             d["resp_ctype"] = ""
 
-    return raw_format_flow(tuple(sorted(d.items())), f)
+    return raw_format_flow(tuple(sorted(d.items())))

--- a/mitmproxy/tools/console/flowlist.py
+++ b/mitmproxy/tools/console/flowlist.py
@@ -43,7 +43,7 @@ class FlowListWalker(urwid.ListWalker):
     def positions(self, reverse=False):
         # The stub implementation of positions can go once this issue is resolved:
         # https://github.com/urwid/urwid/issues/294
-        ret = range(self.master.commands.execute("view.properties.length"))
+        ret = range(self.master.view.get_length())
         if reverse:
             return reversed(ret)
         return ret
@@ -59,12 +59,12 @@ class FlowListWalker(urwid.ListWalker):
         return f, self.master.view.focus.index
 
     def set_focus(self, index):
-        if self.master.commands.execute("view.properties.inbounds %d" % index):
+        if self.master.view.inbounds(index):
             self.master.view.focus.index = index
 
     @lru_cache(maxsize=None)
     def __get(self, pos):
-        if not self.master.commands.execute("view.properties.inbounds %d" % pos):
+        if not self.master.view.inbounds(pos):
             return None, None
         f = FlowItem(self.master, self.master.view[pos])
         return f, pos


### PR DESCRIPTION
mitmproxy's flow list is very slow: holding the down arrow to move the cursor causes it to visibly lag on my machine. The lag affects not just the UI, but the entire application - requests are slowed down as well.

Profiling (using `cProfile`) identified the bottlenecks as:

- For every redraw, `FlowListWalker` was creating several instances of `FlowList` *per flow* for every redraw. This is because `urwid.ListBox` needs to iterate over the list more than once per redraw.

- `FlowListWalker` uses `commands.execute` instead of calling `View` methods directly. The formatting and parsing of commands adds an additional performance cost. (This is a recent performance regression only in git, introduced by @madt1m in commit 773c9535146991af38f954cb4d3b0ead9d7485c5.)

- `raw_format_flow` incorrectly had the entire `Flow` object added to its argument list. This caused needless work for `@lru_cache`, as it was hashing the entire `Flow` object as part of the cache key, and probably causing unnecessary cache misses as `Flow` properties changed without affecting the displayed content. (This is a performance regression, introduced by @Kriechi in commit d86cb76e5ba38c51b7d6017fb151e4946e3fb916.)

Profiling result:

![](https://raw.githubusercontent.com/BkPHcgQL3V/mitmproxy/files/profile.svg?sanitize=true)

The changes in this pull request rectify these problems, thus improving performance somewhat.