### PR TITLE
Memoise command parsing

### DIFF
--- a/mitmproxy/command.py
+++ b/mitmproxy/command.py
@@ -14,11 +14,11 @@ from mitmproxy import exceptions
 import mitmproxy.types
 
 
-@functools.lru_cache(maxsize=200)
+@functools.lru_cache()
 def verify_arg_signature(f: typing.Callable, args: tuple, kwargs: tuple) -> None:
     sig = inspect.signature(f)
     try:
-        sig.bind(*list(args), **dict(kwargs))
+        sig.bind(*args, **dict(kwargs))
     except TypeError as v:
         raise exceptions.CommandError("command argument mismatch: %s" % v.args[0])
 
@@ -32,8 +32,8 @@ def lexer(s):
     return lex
 
 
-@functools.lru_cache(maxsize=200)
-def lex_string(cmdstr):
+@functools.lru_cache()
+def lex_string(cmdstr: str) -> typing.List[str]:
     buf = io.StringIO(cmdstr)
     parts: typing.List[str] = []
     lex = lexer(buf)

--- a/mitmproxy/command.py
+++ b/mitmproxy/command.py
@@ -278,7 +278,7 @@ def command(path):
     def decorator(function):
         @functools.wraps(function)
         def wrapper(*args, **kwargs):
-            verify_arg_signature(function, args, tuple(kwargs.items()))
+            verify_arg_signature(function, tuple(args), tuple(kwargs.items()))
             return function(*args, **kwargs)
         wrapper.__dict__["command_path"] = path
         return wrapper


### PR DESCRIPTION
https://github.com/mitmproxy/mitmproxy/pull/3427#issuecomment-447928549

Refactor `verify_arg_signature` and the code to lex a command string so that they can be memoised using `functools.lru_cache`, then do so.