### PR TITLE
Fix a failing test on macOS Mojave

### DIFF
--- a/test/mitmproxy/test_proxy.py
+++ b/test/mitmproxy/test_proxy.py
@@ -1,4 +1,5 @@
 import argparse
+import platform
 from unittest import mock
 import pytest
 
@@ -52,8 +53,11 @@ class TestProcessProxyOptions:
 class TestProxyServer:
 
     @skip_windows
+    @pytest.mark.skipif(platform.mac_ver()[0].split('.')[:2] == ['10', '14'],
+                        reason='Skipping due to macOS Mojave')
     def test_err(self):
-        # binding to 0.0.0.0:1 works without special permissions on Windows
+        # binding to 0.0.0.0:1 works without special permissions on Windows and
+        # macOS Mojave
         conf = ProxyConfig(options.Options(listen_port=1))
         with pytest.raises(Exception, match="Error starting proxy server"):
             ProxyServer(conf)


### PR DESCRIPTION
Apparently macOS Mojave allows non-root users to bind ports < 1024. Similar reports:

* https://github.com/nodejs/node/pull/23550/files
* https://news.ycombinator.com/item?id=18302380