### PR TITLE
openbsd: divert-to requires exact listen address

### DIFF
--- a/docs/src/content/howto-transparent.md
+++ b/docs/src/content/howto-transparent.md
@@ -124,7 +124,7 @@ doas pfctl -e
 You probably want a command like this:
 
 {{< highlight bash  >}}
-mitmproxy --mode transparent --showhost
+mitmproxy --mode transparent --listen-host 127.0.0.1 --showhost
 {{< / highlight >}}
 
 The `--mode transparent` option turns on transparent mode, and the `--showhost` argument tells


### PR DESCRIPTION
divert-to does not work with '0.0.0.0' or similar listen address, so we
need to specify listen address that we provided to `pf`.