### PR TITLE
fixes copying on macos

### DIFF
--- a/web/src/js/ducks/ui/keyboard.js
+++ b/web/src/js/ducks/ui/keyboard.js
@@ -6,7 +6,7 @@ import * as modalActions from "./modal"
 
 export function onKeyDown(e) {
     //console.debug("onKeyDown", e)
-    if (e.ctrlKey) {
+    if (e.ctrlKey || e.metaKey) {
         return () => {
         }
     }


### PR DESCRIPTION
I tested `e.metaKey` and it returns `true` when the command key is pressed.

resolves #2910 
