### PR TITLE
add MASQUERADE target for iptables

### DIFF
--- a/docs/src/content/howto-transparent.md
+++ b/docs/src/content/howto-transparent.md
@@ -63,8 +63,10 @@ something like this:
 {{< highlight bash  >}}
 iptables -t nat -A PREROUTING -i eth0 -p tcp --dport 80 -j REDIRECT --to-port 8080
 iptables -t nat -A PREROUTING -i eth0 -p tcp --dport 443 -j REDIRECT --to-port 8080
+iptables -t nat -A POSTROUTING -j MASQUERADE
 ip6tables -t nat -A PREROUTING -i eth0 -p tcp --dport 80 -j REDIRECT --to-port 8080
 ip6tables -t nat -A PREROUTING -i eth0 -p tcp --dport 443 -j REDIRECT --to-port 8080
+ip6tables -t nat -A POSTROUTING -j MASQUERADE
 {{< / highlight >}}
 
 If you want to persist this across reboots, you can use the `iptables-persistent` package (see


### PR DESCRIPTION
A MASQUERADE line is necessary for this to work.  I spent quite a while trying to figure out what was missing from the howto to make it work.  It looks to be safe to not specify any target interfaces or ips, etc, the host running mitmproxy can still be used for local traffic fine.