### PR TITLE
Suggestion: Update Readme to improve testing 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -107,6 +107,12 @@ For speedier testing, we recommend you run `pytest`_ directly on individual test
 
     cd test/mitmproxy/addons
     pytest --cov mitmproxy.addons.anticache --looponfail test_anticache.py
+    
+To generate terminal report along with missing line numbers of individual test files or folders:
+
+.. code-block:: bash
+
+    pytest --cov-report term-missing --cov mitmproxy.flowfilter --looponfail test_flowfilter.py
 
 As pytest does not check the code style, you probably want to run ``tox -e lint`` before committing your changes.
 

--- a/README.rst
+++ b/README.rst
@@ -106,13 +106,7 @@ For speedier testing, we recommend you run `pytest`_ directly on individual test
 .. code-block:: bash
 
     cd test/mitmproxy/addons
-    pytest --cov mitmproxy.addons.anticache --looponfail test_anticache.py
-    
-To generate terminal report along with missing line numbers of individual test files or folders:
-
-.. code-block:: bash
-
-    pytest --cov-report term-missing --cov mitmproxy.flowfilter --looponfail test_flowfilter.py
+    pytest --cov mitmproxy.addons.anticache --cov-report term-missing --looponfail test_anticache.py
 
 As pytest does not check the code style, you probably want to run ``tox -e lint`` before committing your changes.
 


### PR DESCRIPTION
I think this can be useful for contributors if they want to find out which lines they are missing while testing individual files.
I know we can do this using `tox -- --verbose --cov-report=term`. But for speedier testing this might come in handy.

Any thoughts?