### PR TITLE
Remove the confdir argument

### DIFF
--- a/mitmproxy/tools/_main.py
+++ b/mitmproxy/tools/_main.py
@@ -87,7 +87,7 @@ def run(
         arg_check.check()
         sys.exit(1)
     try:
-        opts.confdir = args.confdir
+        opts.set(*args.setoptions, defer=True)
         optmanager.load_paths(
             opts,
             os.path.join(opts.confdir, OPTIONS_FILE_NAME),
@@ -110,7 +110,6 @@ def run(
         if args.commands:
             master.commands.dump()
             sys.exit(0)
-        opts.set(*args.setoptions, defer=True)
         if extra:
             opts.update(**extra(args))
 

--- a/mitmproxy/tools/cmdline.py
+++ b/mitmproxy/tools/cmdline.py
@@ -21,12 +21,6 @@ def common_options(parser, opts):
         help="Show all commands and their signatures",
     )
     parser.add_argument(
-        "--confdir",
-        type=str, dest="confdir", default=core.CONF_DIR,
-        metavar="PATH",
-        help="Path to the mitmproxy config directory"
-    )
-    parser.add_argument(
         "--set",
         type=str, dest="setoptions", default=[],
         action="append",


### PR DESCRIPTION
This removes the deprecated `--confdir` argument from the `--help` output, and no longer accepts the value even if specified.