### PR TITLE
Fix #3502 by using email.utils.formatdate's usegmt argument.

### DIFF
--- a/mitmproxy/net/http/cookies.py
+++ b/mitmproxy/net/http/cookies.py
@@ -304,7 +304,7 @@ def refresh_set_cookie_header(c: str, delta: int) -> str:
             e = email.utils.parsedate_tz(attrs["expires"])
             if e:
                 f = email.utils.mktime_tz(e) + delta
-                attrs.set_all("expires", [email.utils.formatdate(f)])
+                attrs.set_all("expires", [email.utils.formatdate(f, usegmt=True)])
             else:
                 # This can happen when the expires tag is invalid.
                 # reddit.com sends a an expires tag like this: "Thu, 31 Dec

--- a/mitmproxy/net/http/response.py
+++ b/mitmproxy/net/http/response.py
@@ -186,7 +186,7 @@ class Response(message.Message):
                 d = parsedate_tz(self.headers[i])
                 if d:
                     new = mktime_tz(d) + delta
-                    self.headers[i] = formatdate(new)
+                    self.headers[i] = formatdate(new, usegmt=True)
         c = []
         for set_cookie_header in self.headers.get_all("set-cookie"):
             try:

--- a/test/mitmproxy/net/http/test_response.py
+++ b/test/mitmproxy/net/http/test_response.py
@@ -148,7 +148,7 @@ class TestResponseUtils:
     def test_refresh(self):
         r = tresp()
         n = time.time()
-        r.headers["date"] = email.utils.formatdate(n)
+        r.headers["date"] = email.utils.formatdate(n, usegmt=True)
         pre = r.headers["date"]
         r.refresh(946681202)
         assert pre == r.headers["date"]


### PR DESCRIPTION
This fixes issue #3502 by using the usegmt argument for email.utils.formatdate.  

https://docs.python.org/3/library/email.utils.html#email.utils.formatdate
https://docs.python.org/2/library/email.utils.html#email.utils.formatdate

> Optional usegmt is a flag that when True, outputs a date string with the timezone as an ascii string GMT, rather than a numeric -0000. This is needed for some protocols (such as HTTP). This only applies when localtime is False. The default is False.
