### PR TITLE
Pass flow object to stream callable object.

### DIFF
--- a/examples/complex/stream_modify.py
+++ b/examples/complex/stream_modify.py
@@ -8,7 +8,7 @@ Be aware that content replacement isn't trivial:
 """
 
 
-def modify(chunks):
+def modify(chunks, flow=None):
     """
     chunks is a generator that can be used to iterate over all chunks.
     """

--- a/mitmproxy/proxy/protocol/http.py
+++ b/mitmproxy/proxy/protocol/http.py
@@ -338,7 +338,7 @@ class HttpLayer(base.Layer):
                     if f.request.stream:
                         chunks = self.read_request_body(f.request)
                         if callable(f.request.stream):
-                            chunks = f.request.stream(chunks)
+                            chunks = f.request.stream(chunks, flow=f)
                         self.send_request_body(f.request, chunks)
                     else:
                         self.send_request_body(f.request, [f.request.data.content])
@@ -418,7 +418,7 @@ class HttpLayer(base.Layer):
                     f.response
                 )
                 if callable(f.response.stream):
-                    chunks = f.response.stream(chunks)
+                    chunks = f.response.stream(chunks, flow=f)
                 self.send_response_body(f.response, chunks)
                 f.response.timestamp_end = time.time()
 

--- a/test/mitmproxy/data/addonscripts/stream_modify.py
+++ b/test/mitmproxy/data/addonscripts/stream_modify.py
@@ -1,6 +1,6 @@
 from mitmproxy import ctx
 
-def modify(chunks):
+def modify(chunks, flow=None):
     for chunk in chunks:
         yield chunk.replace(b"foo", b"bar")
 


### PR DESCRIPTION
Hi. I was faced with the problem of the lack of any information about the flow inside the stream generator function.

When I ask for example `flow.response.stream = modify` , and at the same time `flow.request.stream = modify`, there is no way inside modify() to determine whether a request or a response is being processed.

This problem can be solved by declaring two modify generators, such as `flow.response.stream = modify_response` and `flow.request.stream = modify_request`.

But there is a case and worse, for example it is necessary to intercept all GET requests of a kind:

- http://127.0.0.1/cat_1.jpg
- http://127.0.0.1/cat_2.jpg
- ....
- http://127.0.0.1/cat_100.jpg

And replace the contents of each file with the contents of another corresponding file, such as:

- dog_1.jpg
- dog_2.jpg
- ....
- dog_100.jpg

Then, you will need to create 100 modify functions and set `flow.response.stream=modify_cat_to_dog_N`, where N - number of file.

But it is not necessary to change 100 cats to 100 dogs to understand that the flow object is needed inside the modify function. There is another example:

When a client requests a large file from the server and the connection is lost, the client re-requests the file from the server, but with the header `'Content-Range'`. If in mitmproxy to do file substitution in the function generator modify, then there is no way to know whether the header `'Content-Range'` or not, also there is no way to do `seek()` on the file to retreat the desired value.

I suggest passing the flow object to the generator function, which is called when streaming the request/response. However, it is worth noting that you cannot change the flow object inside modify (), as part of the request is likely already sent, this should be mentioned in the documentation.
