### PR TITLE
Use Brotli instead of brotlipy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ setup(
     # It is not considered best practice to use install_requires to pin dependencies to specific versions.
     install_requires=[
         "blinker>=1.4, <1.5",
-        "brotlipy>=0.7.0,<0.8",
+        "Brotli>=1.0,<1.1",
         "certifi>=2015.11.20.1",  # no semver here - this should always be on the last release!
         "click>=6.2, <7",
         "cryptography>=2.1.4,<2.5",

--- a/tox.ini
+++ b/tox.ini
@@ -44,7 +44,7 @@ commands =
 passenv = TRAVIS_* APPVEYOR_* AWS_* TWINE_* DOCKER_* RTOOL_KEY WHEEL DOCKER PYINSTALLER WININSTALLER
 deps =
   -rrequirements.txt
-  pyinstaller==3.4
+  pyinstaller==3.5
   twine==1.12.1
   awscli
 commands =


### PR DESCRIPTION
brotlipy is stuck at brotli 0.6 and upstream is inactive. Let's switch
to the official binding which is up-to-date and has same interfaces.