### PR TITLE
Edit URLs in external editor

### DIFF
--- a/mitmproxy/tools/console/consoleaddons.py
+++ b/mitmproxy/tools/console/consoleaddons.py
@@ -428,7 +428,12 @@ class ConsoleAddon:
             message.content = c.rstrip(b"\n")
         elif part == "set-cookies":
             self.master.switch_view("edit_focus_setcookies")
-        elif part in ["url", "method", "status_code", "reason"]:
+        elif part == "url":
+            url = flow.request.url.encode()
+            edited_url = self.master.spawn_editor(url)
+            url = edited_url.rstrip(b"\n")
+            flow.request.url = url.decode()
+        elif part in ["method", "status_code", "reason"]:
             self.master.commands.execute(
                 "console.command flow.set @focus %s " % part
             )


### PR DESCRIPTION
Fixes: #3288 

Since URLs can be long and unwieldy they should be edited in an external editor instead of in the action bar. 