### PR TITLE
Update howto-transparent-vms.md for newer versions

### DIFF
--- a/docs/src/content/howto-transparent-vms.md
+++ b/docs/src/content/howto-transparent-vms.md
@@ -14,9 +14,13 @@ Internal Network* setup can be applied to other setups.
 
 ## 1. Configure Proxy VM
 
-On the proxy machine, **eth0** or **enp0s3** (Ubuntu 15.10 and newer) is connected to the internet. **eth1**  or **enp0s8** (Ubuntu 15.10 and newer) is
-connected to the internal network that will be proxified and configured
-to use a static ip (192.168.3.1).
+First, we have to find out under which name Ubuntu has mapped our network interfaces. You can find this information with:
+
+{{< highlight bash  >}}
+ip link
+{{< / highlight >}}
+
+Usually with Ubuntu and Virtualbox, **eth0** or **enp0s3** (Ubuntu 15.10 and newer) is connected to the internet and **eth1**  or **enp0s8** (Ubuntu 15.10 and newer) is connected to the internal network that will be proxified and configured to use a static ip (192.168.3.1). If the names differ, use the ones you got from the *ip link* command.
 
 ### VirtualBox configuration
 

--- a/docs/src/content/howto-transparent-vms.md
+++ b/docs/src/content/howto-transparent-vms.md
@@ -98,7 +98,7 @@ To redirect traffic to mitmproxy, we need to enable IP forwarding and add two ip
 rules:
 
 {{< highlight bash  >}}
-sysctl -w net.ipv4.ip_forward=1
+sudo sysctl -w net.ipv4.ip_forward=1
 sudo iptables -t nat -A PREROUTING -i eth1 -p tcp --dport 80 -j REDIRECT --to-port 8080
 sudo iptables -t nat -A PREROUTING -i eth1 -p tcp --dport 443 -j REDIRECT --to-port 8080
 {{< / highlight >}}

--- a/docs/src/content/howto-transparent-vms.md
+++ b/docs/src/content/howto-transparent-vms.md
@@ -14,7 +14,7 @@ Internal Network* setup can be applied to other setups.
 
 ## 1. Configure Proxy VM
 
-On the proxy machine, **eth0** is connected to the internet. **eth1** is
+On the proxy machine, **eth0** or **enp0s3** (Ubuntu 15.10 and newer) is connected to the internet. **eth1**  or **enp0s8** (Ubuntu 15.10 and newer) is
 connected to the internal network that will be proxified and configured
 to use a static ip (192.168.3.1).
 
@@ -65,6 +65,7 @@ Replace **/etc/dnsmasq.conf** with the following configuration:
 {{< highlight none  >}}
 # Listen for DNS requests on the internal network
 interface=eth1
+bind-interfaces
 # Act as a DHCP server, assign IP addresses to clients
 dhcp-range=192.168.3.10,192.168.3.100,96h
 # Broadcast gateway and dns server information
@@ -93,10 +94,11 @@ IP address via DHCP:
 
 ## 3. Redirect traffic to mitmproxy
 
-To redirect traffic to mitmproxy, we need to add two iptables
+To redirect traffic to mitmproxy, we need to enable IP forwarding and add two iptables
 rules:
 
 {{< highlight bash  >}}
+sysctl -w net.ipv4.ip_forward=1
 sudo iptables -t nat -A PREROUTING -i eth1 -p tcp --dport 80 -j REDIRECT --to-port 8080
 sudo iptables -t nat -A PREROUTING -i eth1 -p tcp --dport 443 -j REDIRECT --to-port 8080
 {{< / highlight >}}


### PR DESCRIPTION
Newer versions of Ubuntu have more dependencies on systemd. The names of the interfaces changed and systemd-resolved provides a stub DNS provider that interferes with dnsmasq. This commit/PR makes some adjustments in order to provide instructions for newer Ubuntu versions.