### PR TITLE
Updated har_dump,py timings dictionary function

### DIFF
--- a/examples/complex/har_dump.py
+++ b/examples/complex/har_dump.py
@@ -87,7 +87,10 @@ def response(flow):
     }
 
     # HAR timings are integers in ms, so we re-encode the raw timings to that format.
-    timings = dict([(k, -1 if v is -1 else int(1000 * v)) for k, v in timings_raw.items()])
+    timings = {
+        k: int(1000 * v) if v != -1 else -1 
+        for k, v in timings_raw.items()
+    }
 
     # full_time is the sum of all timings.
     # Timings set to -1 will be ignored as per spec.

--- a/examples/complex/har_dump.py
+++ b/examples/complex/har_dump.py
@@ -87,7 +87,7 @@ def response(flow):
     }
 
     # HAR timings are integers in ms, so we re-encode the raw timings to that format.
-    timings = dict([(k, int(1000 * v)) for k, v in timings_raw.items()])
+    timings = dict([(k, -1 if v is -1 else int(1000 * v)) for k, v in timings_raw.items()])
 
     # full_time is the sum of all timings.
     # Timings set to -1 will be ignored as per spec.


### PR DESCRIPTION
the HAR file spec (http://www.softwareishard.com/blog/har-12-spec/#timings) states that timings that do not apply for a certain requests should be set to -1, this example may set -1000 as a timings value for certain requests.
This ends up producing invalid HAR files in many cases.

My proposed fix is to assign -1 into the dic and only multiply by 1000 for other values