### PR TITLE
ssl_insecure added to option_whitelist because it was missing

### DIFF
--- a/mitmproxy/tools/web/app.py
+++ b/mitmproxy/tools/web/app.py
@@ -432,7 +432,7 @@ class Settings(RequestHandler):
     def put(self):
         update = self.json
         option_whitelist = {
-            "intercept", "showhost", "upstream_cert",
+            "intercept", "showhost", "upstream_cert", "ssl_insecure",
             "rawtcp", "http2", "websocket", "anticache", "anticomp",
             "stickycookie", "stickyauth", "stream_large_bodies"
         }


### PR DESCRIPTION
I am using mitmweb and on clicking to "Verify server certificates"
![image](https://user-images.githubusercontent.com/7146902/65752943-29e25000-e10e-11e9-88d8-e3035d81352e.png) gave me an error like this:
![image](https://user-images.githubusercontent.com/7146902/65752972-3c5c8980-e10e-11e9-8f51-97cb93dc5e2a.png) (Unknown setting ssl_insecure)
I investigated the problem and the "ssl_insecure" option was missing from the "option_whitelist".

The same setting could be toggled from the option popup:
![image](https://user-images.githubusercontent.com/7146902/65753129-9cebc680-e10e-11e9-8812-960b85df4b1f.png)

Now it works from both places.

This should fix the following issue: #3625