### PR TITLE
Add EKU extension for dummy certificates

### DIFF
--- a/mitmproxy/certs.py
+++ b/mitmproxy/certs.py
@@ -115,6 +115,13 @@ def dummy_cert(privkey, cacert, commonname, sans, organization):
         cert.set_version(2)
         cert.add_extensions(
             [OpenSSL.crypto.X509Extension(b"subjectAltName", False, ss)])
+    cert.add_extensions([
+        OpenSSL.crypto.X509Extension(
+            b"extendedKeyUsage",
+            False,
+            b"serverAuth,clientAuth"
+        )
+    ])
     cert.set_pubkey(cacert.get_pubkey())
     cert.sign(privkey, "sha256")
     return Cert(cert)


### PR DESCRIPTION
An attempt to fix https://github.com/mitmproxy/mitmproxy/issues/3649 (I have not been able to test it functionally yet with iOS 13)

From: https://support.apple.com/en-gb/HT210176

> TLS server certificates must contain an ExtendedKeyUsage (EKU) extension containing the id-kp-serverAuth OID.

Relevant information: 

- https://community.letsencrypt.org/t/extendedkeyusage-tls-client-authentication-in-tls-server-certificates/59140
- https://letsencrypt.org/documents/isrg-cps-v2.0/