### PR TITLE
hugo server -D fails if html file in docs/src/generated are not present

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,9 @@ This directory houses the mitmproxy documentation available at <https://docs.mit
  2. Windows users: Depending on your git settings, you may need to manually create a symlink from 
  /docs/src/examples to /examples.
 
+Make sure mitmproxy python package is installed.
+
+Run `./build-current` script in docs folder. If you skip this step, hugo will fail because files in ./src/generated are missing
 
 Now you can run `hugo server -D` in ./src.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,10 +7,8 @@ This directory houses the mitmproxy documentation available at <https://docs.mit
  1. Install [hugo](https://gohugo.io/).
  2. Windows users: Depending on your git settings, you may need to manually create a symlink from 
  /docs/src/examples to /examples.
-
-Make sure mitmproxy python package is installed.
-
-Run `./build-current` script in docs folder. If you skip this step, hugo will fail because files in ./src/generated are missing
+ 3. Make sure the mitmproxy Python package is installed.
+ 4. Run `./build-current` to generate the documentation source files in `./src/generated`.
 
 Now you can run `hugo server -D` in ./src.
 


### PR DESCRIPTION
Wanted to build docs according to quick start and noticed that you have to run ./build-current script in order to start hugo