### PR TITLE
fixes #3559

### DIFF
--- a/mitmproxy/addons/clientplayback.py
+++ b/mitmproxy/addons/clientplayback.py
@@ -203,8 +203,9 @@ class ClientPlayback:
             # https://github.com/mitmproxy/mitmproxy/issues/2197
             if hf.request.http_version == "HTTP/2.0":
                 hf.request.http_version = "HTTP/1.1"
-                host = hf.request.headers.pop(":authority", hf.request.pretty_host)
-                hf.request.headers.insert(0, "host", host)
+                host = hf.request.headers.pop(":authority", None)
+                if host is not None:
+                    hf.request.headers.insert(0, "host", host)
             self.q.put(hf)
         ctx.master.addons.trigger("update", lst)
 

--- a/mitmproxy/addons/clientplayback.py
+++ b/mitmproxy/addons/clientplayback.py
@@ -203,7 +203,7 @@ class ClientPlayback:
             # https://github.com/mitmproxy/mitmproxy/issues/2197
             if hf.request.http_version == "HTTP/2.0":
                 hf.request.http_version = "HTTP/1.1"
-                host = hf.request.headers.pop(":authority")
+                host = hf.request.headers.pop(":authority", hf.request.pretty_host)
                 hf.request.headers.insert(0, "host", host)
             self.q.put(hf)
         ctx.master.addons.trigger("update", lst)


### PR DESCRIPTION
If the `:authority` header is not found, we can try to guess it from
variable `flow.request.pretty_host` as .pop() accepts a fallback
parameter.