### PR TITLE
Save user executed commands to a history file

### DIFF
--- a/mitmproxy/addons/__init__.py
+++ b/mitmproxy/addons/__init__.py
@@ -4,6 +4,7 @@ from mitmproxy.addons import block
 from mitmproxy.addons import browser
 from mitmproxy.addons import check_ca
 from mitmproxy.addons import clientplayback
+from mitmproxy.addons import command_history
 from mitmproxy.addons import core
 from mitmproxy.addons import cut
 from mitmproxy.addons import disable_h2c
@@ -30,6 +31,7 @@ def default_addons():
         anticomp.AntiComp(),
         check_ca.CheckCA(),
         clientplayback.ClientPlayback(),
+        command_history.CommandHistory(),
         cut.Cut(),
         disable_h2c.DisableH2C(),
         export.Export(),

--- a/mitmproxy/addons/command_history.py
+++ b/mitmproxy/addons/command_history.py
@@ -15,7 +15,7 @@ class CommandHistory:
         self.filter_str: str = ''
 
         _command_history_path = os.path.join(os.path.expanduser(ctx.options.confdir), 'command_history')
-        _history_lines = []
+        _history_lines: typing.List[str] = []
         if os.path.exists(_command_history_path):
             _history_lines = open(_command_history_path, 'r').readlines()
 

--- a/mitmproxy/addons/command_history.py
+++ b/mitmproxy/addons/command_history.py
@@ -7,6 +7,7 @@ import mitmproxy.options
 import mitmproxy.types
 
 from mitmproxy import command
+from mitmproxy import ctx
 from mitmproxy.tools.console.commander.commander import CommandBuffer
 
 
@@ -22,8 +23,10 @@ class CommandHistory:
         self.filtered_commands: typing.Deque[str] = collections.deque()
         self.filter_active: bool = True
 
-        _command_history_path = os.path.join(os.path.expanduser(mitmproxy.options.CONF_DIR), 'command_history')
-        _history_lines = open(_command_history_path, 'r').readlines()
+        _command_history_path = os.path.join(os.path.expanduser(ctx.options.confdir), 'command_history')
+        _history_lines = []
+        if os.path.exists(_command_history_path):
+            _history_lines = open(_command_history_path, 'r').readlines()
 
         self.command_history_file = open(_command_history_path, 'w')
 

--- a/mitmproxy/addons/command_history.py
+++ b/mitmproxy/addons/command_history.py
@@ -1,6 +1,7 @@
 import collections
 import os
 import typing
+import atexit
 
 from mitmproxy import command
 from mitmproxy import ctx
@@ -27,6 +28,12 @@ class CommandHistory:
 
         for l in _history_lines:
             self.add_command(l.strip())
+
+        atexit.register(self.cleanup)
+
+    def cleanup(self):
+        if self.command_history_file:
+            self.command_history_file.close()
 
     @property
     def last_filtered_index(self):

--- a/mitmproxy/addons/command_history.py
+++ b/mitmproxy/addons/command_history.py
@@ -1,0 +1,152 @@
+import collections
+import copy
+import os
+import typing
+
+import mitmproxy.options
+import mitmproxy.types
+
+from mitmproxy import command
+from mitmproxy.tools.console.commander.commander import CommandBuffer
+
+
+class CommandHistory:
+    def __init__(self, size: int = 300) -> None:
+        self.saved_commands: typing.Deque[str] = collections.deque(
+            maxlen=size
+        )
+        self.index: int = 0
+
+        self.filter: str = ''
+        self.filtered_index: int = 0
+        self.filtered_commands: typing.Deque[str] = collections.deque()
+        self.filter_active: bool = True
+
+        _command_history_path = os.path.join(os.path.expanduser(mitmproxy.options.CONF_DIR), 'command_history')
+        _history_lines = open(_command_history_path, 'r').readlines()
+
+        self.command_history_file = open(_command_history_path, 'w')
+
+        for l in _history_lines:
+            self.add_command(l.strip(), True)
+
+    @property
+    def last_index(self):
+        return len(self.saved_commands) - 1
+
+    @property
+    def last_filtered_index(self):
+        return len(self.filtered_commands) - 1
+
+    @command.command("command_history.clear")
+    def clear_history(self):
+        self.saved_commands.clear()
+        self.index = 0
+        self.command_history_file.truncate(0)
+        self.command_history_file.seek(0)
+        self.command_history_file.flush()
+        self.filter = ''
+        self.filtered_index = 0
+        self.filtered_commands.clear()
+        self.filter_active = True
+
+    @command.command("command_history.next")
+    def get_next(self) -> str:
+        if self.last_index == -1:
+            return ''
+
+        if self.filter != '':
+            if self.filtered_index < self.last_filtered_index:
+                self.filtered_index = self.filtered_index + 1
+            ret = self.filtered_commands[self.filtered_index]
+        else:
+            if self.index == -1:
+                ret = ''
+            elif self.index < self.last_index:
+                self.index = self.index + 1 
+                ret = self.saved_commands[self.index]
+            else:
+                self.index = -1
+                ret = ''
+
+
+        return ret
+
+    @command.command("command_history.prev")
+    def get_prev(self) -> str:
+        if self.last_index == -1:
+            return ''
+
+        if self.filter != '':
+            if self.filtered_index > 0:
+                self.filtered_index = self.filtered_index - 1
+            ret = self.filtered_commands[self.filtered_index]
+        else:
+            if self.index == -1:
+                self.index = self.last_index
+            elif self.index > 0:
+                self.index = self.index - 1
+
+            ret = self.saved_commands[self.index]
+
+        return ret
+
+    @command.command("command_history.filter")
+    def set_filter(self, command: str) -> None:
+        """
+        This is used when the user starts typing part of a command
+        and then press the "up" arrow. This way, the results returned are
+        only for the command that the user started typing
+        """
+        if command.strip() == '':
+            return
+
+        if self.filter != '':
+            last_filtered_command = self.filtered_commands[-1]
+            if command == last_filtered_command:
+                self.filter = ''
+                self.filtered_commands = []
+                self.filtered_index = 0
+        else:
+            self.filter = command
+            _filtered_commands = [c for c in self.saved_commands if c.startswith(command)] 
+            self.filtered_commands = collections.deque(_filtered_commands)
+
+            if command not in self.filtered_commands:
+                self.filtered_commands.append(command)
+
+            self.filtered_index = self.last_filtered_index
+
+        # No commands found, so act like no filter was added
+        if len(self.filtered_commands) == 1:
+            self.add_command(command)
+            self.filter = ''
+
+    @command.command("command_history.cancel")
+    def restart(self) -> None:
+        self.index = -1
+        self.filter = ''
+        self.filtered_commands = []
+        self.filtered_index = 0
+
+    @command.command("command_history.add")
+    def add_command(self, command: str, execution: bool = False) -> None:
+        if command.strip() == '':
+            return
+
+        if execution:
+            if command in self.saved_commands:
+                self.saved_commands.remove(command)
+
+            self.saved_commands.append(command)
+
+            _history_str = "\n".join(self.saved_commands)
+            self.command_history_file.truncate(0)
+            self.command_history_file.seek(0)
+            self.command_history_file.write(_history_str)
+            self.command_history_file.flush()
+
+            self.restart()
+        else:
+            if command not in self.saved_commands:
+                self.saved_commands.append(command)

--- a/mitmproxy/addons/command_history.py
+++ b/mitmproxy/addons/command_history.py
@@ -33,11 +33,12 @@ class CommandHistory:
         if "command_history" in updated or "confdir" in updated:
             if ctx.options.command_history and self.history_file.is_file():
                 self.history = self.history_file.read_text().splitlines()
+                self.set_filter('')
 
     def done(self):
         if ctx.options.command_history and len(self.history) > self.VACUUM_SIZE:
             # vacuum history so that it doesn't grow indefinitely.
-            history_str = "\n".join(self.history[-self.VACUUM_SIZE/2:]) + "\n"
+            history_str = "\n".join(self.history[-self.VACUUM_SIZE / 2:]) + "\n"
             self.history_file.write_text(history_str)
 
     @command.command("commands.history.add")
@@ -49,6 +50,9 @@ class CommandHistory:
         if ctx.options.command_history:
             with self.history_file.open("a") as f:
                 f.write(f"{command}\n")
+                f.close()
+
+        self.set_filter('')
 
     @command.command("commands.history.get")
     def get_history(self) -> typing.Sequence[str]:
@@ -57,8 +61,10 @@ class CommandHistory:
 
     @command.command("commands.history.clear")
     def clear_history(self):
-        self.history_file.unlink()
+        if self.history_file.exists():
+            self.history_file.unlink()
         self.history = []
+        self.set_filter('')
 
     # Functionality to provide a filtered list that can be iterated through.
 

--- a/mitmproxy/addons/command_history.py
+++ b/mitmproxy/addons/command_history.py
@@ -1,14 +1,9 @@
 import collections
-import copy
 import os
 import typing
 
-import mitmproxy.options
-import mitmproxy.types
-
 from mitmproxy import command
 from mitmproxy import ctx
-from mitmproxy.tools.console.commander.commander import CommandBuffer
 
 
 class CommandHistory:
@@ -66,12 +61,11 @@ class CommandHistory:
             if self.index == -1:
                 ret = ''
             elif self.index < self.last_index:
-                self.index = self.index + 1 
+                self.index = self.index + 1
                 ret = self.saved_commands[self.index]
             else:
                 self.index = -1
                 ret = ''
-
 
         return ret
 
@@ -112,7 +106,7 @@ class CommandHistory:
                 self.filtered_index = 0
         else:
             self.filter = command
-            _filtered_commands = [c for c in self.saved_commands if c.startswith(command)] 
+            _filtered_commands = [c for c in self.saved_commands if c.startswith(command)]
             self.filtered_commands = collections.deque(_filtered_commands)
 
             if command not in self.filtered_commands:

--- a/mitmproxy/addons/command_history.py
+++ b/mitmproxy/addons/command_history.py
@@ -8,15 +8,11 @@ from mitmproxy import ctx
 
 class CommandHistory:
     def __init__(self, size: int = 300) -> None:
-        self.saved_commands: typing.Deque[str] = collections.deque(
-            maxlen=size
-        )
-        self.index: int = 0
+        self.saved_commands: typing.Deque[str] = collections.deque(maxlen=size)
 
-        self.filter: str = ''
-        self.filtered_index: int = 0
         self.filtered_commands: typing.Deque[str] = collections.deque()
-        self.filter_active: bool = True
+        self.current_index: int = -1
+        self.filter_str: str = ''
 
         _command_history_path = os.path.join(os.path.expanduser(ctx.options.confdir), 'command_history')
         _history_lines = []
@@ -26,11 +22,7 @@ class CommandHistory:
         self.command_history_file = open(_command_history_path, 'w')
 
         for l in _history_lines:
-            self.add_command(l.strip(), True)
-
-    @property
-    def last_index(self):
-        return len(self.saved_commands) - 1
+            self.add_command(l.strip())
 
     @property
     def last_filtered_index(self):
@@ -39,111 +31,72 @@ class CommandHistory:
     @command.command("command_history.clear")
     def clear_history(self):
         self.saved_commands.clear()
-        self.index = 0
+        self.filtered_commands.clear()
         self.command_history_file.truncate(0)
         self.command_history_file.seek(0)
         self.command_history_file.flush()
-        self.filter = ''
-        self.filtered_index = 0
-        self.filtered_commands.clear()
-        self.filter_active = True
+        self.restart()
+
+    @command.command("command_history.cancel")
+    def restart(self) -> None:
+        self.filtered_commands = self.saved_commands.copy()
+        self.current_index = -1
 
     @command.command("command_history.next")
     def get_next(self) -> str:
-        if self.last_index == -1:
-            return ''
 
-        if self.filter != '':
-            if self.filtered_index < self.last_filtered_index:
-                self.filtered_index = self.filtered_index + 1
-            ret = self.filtered_commands[self.filtered_index]
-        else:
-            if self.index == -1:
-                ret = ''
-            elif self.index < self.last_index:
-                self.index = self.index + 1
-                ret = self.saved_commands[self.index]
-            else:
-                self.index = -1
-                ret = ''
+        if self.current_index == -1 or self.current_index == self.last_filtered_index:
+            self.current_index = -1
+            return ''
+        elif self.current_index < self.last_filtered_index:
+            self.current_index += 1
+
+        ret = self.filtered_commands[self.current_index]
 
         return ret
 
     @command.command("command_history.prev")
     def get_prev(self) -> str:
-        if self.last_index == -1:
-            return ''
 
-        if self.filter != '':
-            if self.filtered_index > 0:
-                self.filtered_index = self.filtered_index - 1
-            ret = self.filtered_commands[self.filtered_index]
-        else:
-            if self.index == -1:
-                self.index = self.last_index
-            elif self.index > 0:
-                self.index = self.index - 1
+        if self.current_index == -1:
+            if self.last_filtered_index >= 0:
+                self.current_index = self.last_filtered_index
+            else:
+                return ''
 
-            ret = self.saved_commands[self.index]
+        elif self.current_index > 0:
+            self.current_index -= 1
+
+        ret = self.filtered_commands[self.current_index]
 
         return ret
 
     @command.command("command_history.filter")
     def set_filter(self, command: str) -> None:
-        """
-        This is used when the user starts typing part of a command
-        and then press the "up" arrow. This way, the results returned are
-        only for the command that the user started typing
-        """
-        if command.strip() == '':
-            return
+        self.filter_str = command
 
-        if self.filter != '':
-            last_filtered_command = self.filtered_commands[-1]
-            if command == last_filtered_command:
-                self.filter = ''
-                self.filtered_commands = []
-                self.filtered_index = 0
-        else:
-            self.filter = command
-            _filtered_commands = [c for c in self.saved_commands if c.startswith(command)]
-            self.filtered_commands = collections.deque(_filtered_commands)
+        _filtered_commands = [c for c in self.saved_commands if c.startswith(command)]
+        self.filtered_commands = collections.deque(_filtered_commands)
 
-            if command not in self.filtered_commands:
-                self.filtered_commands.append(command)
+        if command and command not in self.filtered_commands:
+            self.filtered_commands.append(command)
 
-            self.filtered_index = self.last_filtered_index
-
-        # No commands found, so act like no filter was added
-        if len(self.filtered_commands) == 1:
-            self.add_command(command)
-            self.filter = ''
-
-    @command.command("command_history.cancel")
-    def restart(self) -> None:
-        self.index = -1
-        self.filter = ''
-        self.filtered_commands = []
-        self.filtered_index = 0
+        self.current_index = -1
 
     @command.command("command_history.add")
-    def add_command(self, command: str, execution: bool = False) -> None:
+    def add_command(self, command: str) -> None:
         if command.strip() == '':
             return
 
-        if execution:
-            if command in self.saved_commands:
-                self.saved_commands.remove(command)
+        if command in self.saved_commands:
+            self.saved_commands.remove(command)
 
-            self.saved_commands.append(command)
+        self.saved_commands.append(command)
 
-            _history_str = "\n".join(self.saved_commands)
-            self.command_history_file.truncate(0)
-            self.command_history_file.seek(0)
-            self.command_history_file.write(_history_str)
-            self.command_history_file.flush()
+        _history_str = "\n".join(self.saved_commands)
+        self.command_history_file.truncate(0)
+        self.command_history_file.seek(0)
+        self.command_history_file.write(_history_str)
+        self.command_history_file.flush()
 
-            self.restart()
-        else:
-            if command not in self.saved_commands:
-                self.saved_commands.append(command)
+        self.restart()

--- a/mitmproxy/addons/command_history.py
+++ b/mitmproxy/addons/command_history.py
@@ -14,7 +14,11 @@ class CommandHistory:
         self.current_index: int = -1
         self.filter_str: str = ''
 
-        _command_history_path = os.path.join(os.path.expanduser(ctx.options.confdir), 'command_history')
+        _command_history_dir = os.path.expanduser(ctx.options.confdir)
+        if not os.path.exists(_command_history_dir):
+            os.makedirs(_command_history_dir)
+
+        _command_history_path = os.path.join(_command_history_dir, 'command_history')
         _history_lines: typing.List[str] = []
         if os.path.exists(_command_history_path):
             _history_lines = open(_command_history_path, 'r').readlines()

--- a/mitmproxy/command.py
+++ b/mitmproxy/command.py
@@ -100,7 +100,7 @@ class Command:
     def prepare_args(self, args: typing.Sequence[str]) -> inspect.BoundArguments:
         try:
             bound_arguments = self.signature.bind(*args)
-        except TypeError as v:
+        except TypeError:
             expected = f'Expected: {str(self.signature.parameters)}'
             received = f'Received: {str(args)}'
             raise exceptions.CommandError(f"Command argument mismatch: \n\t{expected}\n\t{received}")

--- a/mitmproxy/command.py
+++ b/mitmproxy/command.py
@@ -101,7 +101,9 @@ class Command:
         try:
             bound_arguments = self.signature.bind(*args)
         except TypeError as v:
-            raise exceptions.CommandError(f"Command argument mismatch: {v.args[0]}")
+            expected = f'Expected: {str(self.signature.parameters)}'
+            received = f'Received: {str(args)}'
+            raise exceptions.CommandError(f"Command argument mismatch: \n\t{expected}\n\t{received}")
 
         for name, value in bound_arguments.arguments.items():
             convert_to = self.signature.parameters[name].annotation

--- a/mitmproxy/tools/_main.py
+++ b/mitmproxy/tools/_main.py
@@ -69,6 +69,7 @@ def run(
     debug.register_info_dumpers()
 
     opts = options.Options()
+    master = master_cls(opts)
     parser = make_parser(opts)
 
     try:
@@ -77,24 +78,13 @@ def run(
         arg_check.check()
         sys.exit(1)
 
-    try:
-        opts.set(*args.setoptions, defer=True)
-        opts.confdir = os.path.expanduser(opts.confdir)
-        if not os.path.isdir(opts.confdir):
-            os.makedirs(opts.confdir)
-
-    except exceptions.OptionsError as e:
-        print("%s: %s" % (sys.argv[0], e), file=sys.stderr)
-        sys.exit(1)
-
-    master = master_cls(opts)
-
     # To make migration from 2.x to 3.0 bearable.
     if "-R" in sys.argv and sys.argv[sys.argv.index("-R") + 1].startswith("http"):
         print("-R is used for specifying replacements.\n"
               "To use mitmproxy in reverse mode please use --mode reverse:SPEC instead")
 
     try:
+        opts.set(*args.setoptions, defer=True)
         optmanager.load_paths(
             opts,
             os.path.join(opts.confdir, "config.yaml"),

--- a/mitmproxy/tools/_main.py
+++ b/mitmproxy/tools/_main.py
@@ -70,18 +70,19 @@ def run(
 
     opts = options.Options()
     master = master_cls(opts)
+
     parser = make_parser(opts)
+
+    # To make migration from 2.x to 3.0 bearable.
+    if "-R" in sys.argv and sys.argv[sys.argv.index("-R") + 1].startswith("http"):
+        print("-R is used for specifying replacements.\n"
+              "To use mitmproxy in reverse mode please use --mode reverse:SPEC instead")
 
     try:
         args = parser.parse_args(arguments)
     except SystemExit:
         arg_check.check()
         sys.exit(1)
-
-    # To make migration from 2.x to 3.0 bearable.
-    if "-R" in sys.argv and sys.argv[sys.argv.index("-R") + 1].startswith("http"):
-        print("-R is used for specifying replacements.\n"
-              "To use mitmproxy in reverse mode please use --mode reverse:SPEC instead")
 
     try:
         opts.set(*args.setoptions, defer=True)

--- a/mitmproxy/tools/_main.py
+++ b/mitmproxy/tools/_main.py
@@ -69,22 +69,35 @@ def run(
     debug.register_info_dumpers()
 
     opts = options.Options()
-    master = master_cls(opts)
-
     parser = make_parser(opts)
-
-    # To make migration from 2.x to 3.0 bearable.
-    if "-R" in sys.argv and sys.argv[sys.argv.index("-R") + 1].startswith("http"):
-        print("-R is used for specifying replacements.\n"
-              "To use mitmproxy in reverse mode please use --mode reverse:SPEC instead")
 
     try:
         args = parser.parse_args(arguments)
     except SystemExit:
         arg_check.check()
         sys.exit(1)
+
+
     try:
         opts.set(*args.setoptions, defer=True)
+        opts.confdir = os.path.expanduser(opts.confdir)
+        if not os.path.isdir(opts.confdir):
+            os.makedirs(opts.confdir)
+
+    except exceptions.OptionsError as e:
+        print("%s: %s" % (sys.argv[0], e), file=sys.stderr)
+        sys.exit(1)
+
+    master = master_cls(opts)
+
+    # To make migration from 2.x to 3.0 bearable.
+    if "-R" in sys.argv and sys.argv[sys.argv.index("-R") + 1].startswith("http"):
+        print("-R is used for specifying replacements.\n"
+              "To use mitmproxy in reverse mode please use --mode reverse:SPEC instead")
+
+        
+    try:
+
         optmanager.load_paths(
             opts,
             os.path.join(opts.confdir, "config.yaml"),

--- a/mitmproxy/tools/_main.py
+++ b/mitmproxy/tools/_main.py
@@ -77,7 +77,6 @@ def run(
         arg_check.check()
         sys.exit(1)
 
-
     try:
         opts.set(*args.setoptions, defer=True)
         opts.confdir = os.path.expanduser(opts.confdir)
@@ -95,9 +94,7 @@ def run(
         print("-R is used for specifying replacements.\n"
               "To use mitmproxy in reverse mode please use --mode reverse:SPEC instead")
 
-        
     try:
-
         optmanager.load_paths(
             opts,
             os.path.join(opts.confdir, "config.yaml"),

--- a/mitmproxy/tools/console/commander/commander.py
+++ b/mitmproxy/tools/console/commander/commander.py
@@ -12,6 +12,7 @@ import mitmproxy.flow
 import mitmproxy.master
 import mitmproxy.types
 
+from mitmproxy import command_lexer
 
 class Completer:
     @abc.abstractmethod
@@ -148,88 +149,13 @@ class CommandBuffer:
         self.completion = None
 
 
-# TODO: This class should be a Singleton
-class CommandHistory:
-    def __init__(self, master: mitmproxy.master.Master, size: int = 300) -> None:
-        self.saved_commands: collections.deque = collections.deque(
-            [CommandBuffer(master, "")],
-            maxlen=size
-        )
-        self.index: int = 0
-        self.size: int = size
-        self.master: mitmproxy.master.Master = master
-
-        _command_history_path = os.path.join(os.path.expanduser(mitmproxy.options.CONF_DIR), 'command_history')
-        if os.path.exists(_command_history_path):
-            with open(_command_history_path, 'r') as f:
-                for l in f.readlines():
-                    cbuf = CommandBuffer(master, l.strip())
-                    self.add_command(cbuf)
-                f.close()
-
-        self.command_history_file = open(_command_history_path, 'w')
-
-    @property
-    def last_index(self):
-        return len(self.saved_commands) - 1
-
-    def clear_history(self):
-        """
-        Needed for test suite.
-        TODO: Maybe create a command to clear the history?
-        """
-        self.saved_commands: collections.deque = collections.deque(
-            [CommandBuffer(self.master, "")],
-            maxlen=self.size
-        )
-
-        self.index = 0
-        self.command_history_file.truncate(0)
-        self.command_history_file.seek(0)
-        self.command_history_file.flush()
-
-    def get_next(self) -> typing.Optional[CommandBuffer]:
-        if self.index < self.last_index:
-            self.index = self.index + 1
-        return self.saved_commands[self.index]
-
-    def get_prev(self) -> typing.Optional[CommandBuffer]:
-        if self.index > 0:
-            self.index = self.index - 1
-        return self.saved_commands[self.index]
-
-    def add_command(self, command: CommandBuffer, execution: bool = False) -> None:
-        if self.index == self.last_index or execution:
-            last_item = self.saved_commands[-1]
-            last_item_empty = not last_item.text
-            if last_item.text == command.text or (last_item_empty and execution):
-                self.saved_commands[-1] = copy.copy(command)
-            else:
-                self.saved_commands.append(command)
-                if not execution and self.index < self.last_index:
-                    self.index += 1
-            if execution:
-                self.index = self.last_index
-
-            # This prevents the constructor from trying to overwrite the file
-            # that it is currently reading
-            if hasattr(self, 'command_history_file'):
-                _history_str = "\n".join([c.text for c in self.saved_commands])
-                self.command_history_file.truncate(0)
-                self.command_history_file.seek(0)
-                self.command_history_file.write(_history_str)
-                self.command_history_file.flush()
-
-
 class CommandEdit(urwid.WidgetWrap):
     leader = ": "
 
-    def __init__(self, master: mitmproxy.master.Master,
-                 text: str, history: CommandHistory) -> None:
+    def __init__(self, master: mitmproxy.master.Master, text: str) -> None:
         super().__init__(urwid.Text(self.leader))
         self.master = master
         self.cbuf = CommandBuffer(master, text)
-        self.history = history
         self.update()
 
     def keypress(self, size, key) -> None:
@@ -240,10 +166,15 @@ class CommandEdit(urwid.WidgetWrap):
         elif key == "right":
             self.cbuf.right()
         elif key == "up":
-            self.history.add_command(self.cbuf)
-            self.cbuf = self.history.get_prev() or self.cbuf
+            _cmd = command_lexer.quote(self.cbuf.text)
+            self.master.commands.execute("command_history.filter %s" % _cmd)
+            cmd = self.master.commands.execute("command_history.prev")
+            self.cbuf = CommandBuffer(self.master, cmd)
         elif key == "down":
-            self.cbuf = self.history.get_next() or self.cbuf
+            _cmd = command_lexer.quote(self.cbuf.text)
+            self.master.commands.execute("command_history.filter %s" % _cmd)
+            cmd = self.master.commands.execute("command_history.next")
+            self.cbuf = CommandBuffer(self.master, cmd)
         elif key == "shift tab":
             self.cbuf.cycle_completion(False)
         elif key == "tab":

--- a/mitmproxy/tools/console/commander/commander.py
+++ b/mitmproxy/tools/console/commander/commander.py
@@ -1,8 +1,5 @@
 import abc
-import collections
-import copy
 import typing
-import os
 
 import urwid
 from urwid.text_layout import calc_coords
@@ -13,6 +10,7 @@ import mitmproxy.master
 import mitmproxy.types
 
 from mitmproxy import command_lexer
+
 
 class Completer:
     @abc.abstractmethod

--- a/mitmproxy/tools/console/statusbar.py
+++ b/mitmproxy/tools/console/statusbar.py
@@ -4,7 +4,6 @@ from typing import Optional
 import urwid
 
 import mitmproxy.tools.console.master # noqa
-from mitmproxy import command_lexer
 from mitmproxy.tools.console import common
 from mitmproxy.tools.console import signals
 from mitmproxy.tools.console import commandexecutor

--- a/mitmproxy/tools/console/statusbar.py
+++ b/mitmproxy/tools/console/statusbar.py
@@ -141,7 +141,7 @@ class ActionBar(urwid.WidgetWrap):
                     self.prompt_execute(k)
             elif k == "enter":
                 cmd = command_lexer.quote(self._w.cbuf.text)
-                self.master.commands.execute(f"command_history.add {cmd} true")
+                self.master.commands.execute(f"command_history.add {cmd}")
                 self.prompt_execute(self._w.get_edit_text())
             else:
                 if common.is_keypress(k):

--- a/mitmproxy/utils/debug.py
+++ b/mitmproxy/utils/debug.py
@@ -10,6 +10,7 @@ from OpenSSL import SSL
 
 from mitmproxy import version
 
+
 def remote_debug(host='localhost', port=4444):
     import remote_pdb
     remote_pdb.RemotePdb(host, port).set_trace()

--- a/mitmproxy/utils/debug.py
+++ b/mitmproxy/utils/debug.py
@@ -11,11 +11,6 @@ from OpenSSL import SSL
 from mitmproxy import version
 
 
-def remote_debug(host='localhost', port=4444):
-    import remote_pdb
-    remote_pdb.RemotePdb(host, port).set_trace()
-
-
 def dump_system_info():
     mitmproxy_version = version.get_dev_version()
 

--- a/mitmproxy/utils/debug.py
+++ b/mitmproxy/utils/debug.py
@@ -10,6 +10,10 @@ from OpenSSL import SSL
 
 from mitmproxy import version
 
+def remote_debug(host='localhost', port=4444):
+    import remote_pdb
+    remote_pdb.RemotePdb(host, port).set_trace()
+
 
 def dump_system_info():
     mitmproxy_version = version.get_dev_version()

--- a/test/mitmproxy/addons/test_command_history.py
+++ b/test/mitmproxy/addons/test_command_history.py
@@ -77,6 +77,8 @@ class TestCommandHistory:
         saved_commands = [cmd for cmd in history.saved_commands]
         assert saved_commands == ['cmd4', 'cmd3', 'cmd2']
 
+        history.command_history_file.close()
+
     def test_get_next_and_prev(self, tctx):
         history = command_history.CommandHistory(5)
 
@@ -150,6 +152,8 @@ class TestCommandHistory:
         assert history.get_next() == ''
         assert history.get_next() == ''
 
+        history.command_history_file.close()
+
     def test_clear(self, tctx):
         history = command_history.CommandHistory(3)
 
@@ -164,6 +168,8 @@ class TestCommandHistory:
         assert history.get_next() == ''
         assert history.get_prev() == ''
         assert history.get_prev() == ''
+
+        history.command_history_file.close()
 
     def test_filter(self, tctx):
         history = command_history.CommandHistory(3)
@@ -196,3 +202,5 @@ class TestCommandHistory:
         assert history.get_next() == 'abc'
         assert history.get_next() == ''
         assert history.get_next() == ''
+
+        history.command_history_file.close()

--- a/test/mitmproxy/addons/test_command_history.py
+++ b/test/mitmproxy/addons/test_command_history.py
@@ -26,200 +26,210 @@ class TestCommandHistory:
         history.add_command('')
         assert history.history == ['cmd1', 'cmd2']
 
-    def test_get_next_and_prev(self, tctx):
-        history = command_history.CommandHistory(5)
-        history.configure([])
+    def test_get_next_and_prev(self, tmpdir):
+        ch = command_history.CommandHistory()
 
-        history.add_command('cmd1')
+        with taddons.context(ch) as tctx:
+            tctx.options.confdir = str(tmpdir)
 
-        assert history.get_next() == ''
-        assert history.get_next() == ''
-        assert history.get_prev() == 'cmd1'
-        assert history.get_prev() == 'cmd1'
-        assert history.get_prev() == 'cmd1'
-        assert history.get_next() == ''
-        assert history.get_next() == ''
+            ch.add_command('cmd1')
 
-        history.add_command('cmd2')
+            assert ch.get_next() == ''
+            assert ch.get_next() == ''
+            assert ch.get_prev() == 'cmd1'
+            assert ch.get_prev() == 'cmd1'
+            assert ch.get_prev() == 'cmd1'
+            assert ch.get_next() == ''
+            assert ch.get_next() == ''
 
-        assert history.get_next() == ''
-        assert history.get_next() == ''
-        assert history.get_prev() == 'cmd2'
-        assert history.get_prev() == 'cmd1'
-        assert history.get_prev() == 'cmd1'
-        assert history.get_next() == 'cmd2'
-        assert history.get_next() == ''
-        assert history.get_next() == ''
+            ch.add_command('cmd2')
 
-        history.add_command('cmd3')
+            assert ch.get_next() == ''
+            assert ch.get_next() == ''
+            assert ch.get_prev() == 'cmd2'
+            assert ch.get_prev() == 'cmd1'
+            assert ch.get_prev() == 'cmd1'
+            assert ch.get_next() == 'cmd2'
+            assert ch.get_next() == ''
+            assert ch.get_next() == ''
 
-        assert history.get_next() == ''
-        assert history.get_next() == ''
-        assert history.get_prev() == 'cmd3'
-        assert history.get_prev() == 'cmd2'
-        assert history.get_prev() == 'cmd1'
-        assert history.get_prev() == 'cmd1'
-        assert history.get_next() == 'cmd2'
-        assert history.get_next() == 'cmd3'
-        assert history.get_next() == ''
-        assert history.get_next() == ''
-        assert history.get_prev() == 'cmd3'
-        assert history.get_prev() == 'cmd2'
+            ch.add_command('cmd3')
 
-        history.add_command('cmd4')
+            assert ch.get_next() == ''
+            assert ch.get_next() == ''
+            assert ch.get_prev() == 'cmd3'
+            assert ch.get_prev() == 'cmd2'
+            assert ch.get_prev() == 'cmd1'
+            assert ch.get_prev() == 'cmd1'
+            assert ch.get_next() == 'cmd2'
+            assert ch.get_next() == 'cmd3'
+            assert ch.get_next() == ''
+            assert ch.get_next() == ''
+            assert ch.get_prev() == 'cmd3'
+            assert ch.get_prev() == 'cmd2'
 
-        assert history.get_prev() == 'cmd4'
-        assert history.get_prev() == 'cmd3'
-        assert history.get_prev() == 'cmd2'
-        assert history.get_prev() == 'cmd1'
-        assert history.get_prev() == 'cmd1'
-        assert history.get_next() == 'cmd2'
-        assert history.get_next() == 'cmd3'
-        assert history.get_next() == 'cmd4'
-        assert history.get_next() == ''
-        assert history.get_next() == ''
+            ch.add_command('cmd4')
 
-        history.add_command('cmd5')
-        history.add_command('cmd6')
+            assert ch.get_prev() == 'cmd4'
+            assert ch.get_prev() == 'cmd3'
+            assert ch.get_prev() == 'cmd2'
+            assert ch.get_prev() == 'cmd1'
+            assert ch.get_prev() == 'cmd1'
+            assert ch.get_next() == 'cmd2'
+            assert ch.get_next() == 'cmd3'
+            assert ch.get_next() == 'cmd4'
+            assert ch.get_next() == ''
+            assert ch.get_next() == ''
 
-        assert history.get_next() == ''
-        assert history.get_prev() == 'cmd6'
-        assert history.get_prev() == 'cmd5'
-        assert history.get_prev() == 'cmd4'
-        assert history.get_next() == 'cmd5'
-        assert history.get_prev() == 'cmd4'
-        assert history.get_prev() == 'cmd3'
-        assert history.get_prev() == 'cmd2'
-        assert history.get_next() == 'cmd3'
-        assert history.get_prev() == 'cmd2'
-        assert history.get_prev() == 'cmd2'
-        assert history.get_next() == 'cmd3'
-        assert history.get_next() == 'cmd4'
-        assert history.get_next() == 'cmd5'
-        assert history.get_next() == 'cmd6'
-        assert history.get_next() == ''
-        assert history.get_next() == ''
+            ch.add_command('cmd5')
+            ch.add_command('cmd6')
 
-        history.cleanup()
+            assert ch.get_next() == ''
+            assert ch.get_prev() == 'cmd6'
+            assert ch.get_prev() == 'cmd5'
+            assert ch.get_prev() == 'cmd4'
+            assert ch.get_next() == 'cmd5'
+            assert ch.get_prev() == 'cmd4'
+            assert ch.get_prev() == 'cmd3'
+            assert ch.get_prev() == 'cmd2'
+            assert ch.get_next() == 'cmd3'
+            assert ch.get_prev() == 'cmd2'
+            assert ch.get_prev() == 'cmd1'
+            assert ch.get_prev() == 'cmd1'
+            assert ch.get_prev() == 'cmd1'
+            assert ch.get_next() == 'cmd2'
+            assert ch.get_next() == 'cmd3'
+            assert ch.get_next() == 'cmd4'
+            assert ch.get_next() == 'cmd5'
+            assert ch.get_next() == 'cmd6'
+            assert ch.get_next() == ''
+            assert ch.get_next() == ''
 
-    def test_clear(self, tctx):
-        history = command_history.CommandHistory(3)
-        history.configure([])
+            ch.clear_history()
 
-        history.add_command('cmd1')
-        history.add_command('cmd2')
-        history.clear_history()
+    def test_clear(self, tmpdir):
+        ch = command_history.CommandHistory()
 
-        saved_commands = [cmd for cmd in history.history]
-        assert saved_commands == []
+        with taddons.context(ch) as tctx:
+            tctx.options.confdir = str(tmpdir)
+            ch.add_command('cmd1')
+            ch.add_command('cmd2')
+            ch.clear_history()
 
-        assert history.get_next() == ''
-        assert history.get_next() == ''
-        assert history.get_prev() == ''
-        assert history.get_prev() == ''
+            saved_commands = ch.get_history()
+            assert saved_commands == []
 
-        history.cleanup()
+            assert ch.get_next() == ''
+            assert ch.get_next() == ''
+            assert ch.get_prev() == ''
+            assert ch.get_prev() == ''
 
-    def test_filter(self, tctx):
-        history = command_history.CommandHistory(3)
-        history.configure([])
+            ch.clear_history()
 
-        history.add_command('cmd1')
-        history.add_command('cmd2')
-        history.add_command('abc')
-        history.set_filter('c')
+    def test_filter(self, tmpdir):
+        ch = command_history.CommandHistory()
 
-        assert history.get_next() == ''
-        assert history.get_next() == ''
-        assert history.get_prev() == 'c'
-        assert history.get_prev() == 'cmd2'
-        assert history.get_prev() == 'cmd1'
-        assert history.get_prev() == 'cmd1'
-        assert history.get_next() == 'cmd2'
-        assert history.get_next() == 'c'
-        assert history.get_next() == ''
-        assert history.get_next() == ''
+        with taddons.context(ch) as tctx:
+            tctx.options.confdir = str(tmpdir)
 
-        history.set_filter('')
+            ch.add_command('cmd1')
+            ch.add_command('cmd2')
+            ch.add_command('abc')
+            ch.set_filter('c')
 
-        assert history.get_next() == ''
-        assert history.get_next() == ''
-        assert history.get_prev() == 'abc'
-        assert history.get_prev() == 'cmd2'
-        assert history.get_prev() == 'cmd1'
-        assert history.get_prev() == 'cmd1'
-        assert history.get_next() == 'cmd2'
-        assert history.get_next() == 'abc'
-        assert history.get_next() == ''
-        assert history.get_next() == ''
+            assert ch.get_next() == 'c'
+            assert ch.get_next() == 'c'
+            assert ch.get_prev() == 'cmd2'
+            assert ch.get_prev() == 'cmd1'
+            assert ch.get_prev() == 'cmd1'
+            assert ch.get_next() == 'cmd2'
+            assert ch.get_next() == 'c'
+            assert ch.get_next() == 'c'
 
-        history.cleanup()
+            ch.set_filter('')
 
-    def test_multiple_instances(self, tctx):
+            assert ch.get_next() == ''
+            assert ch.get_next() == ''
+            assert ch.get_prev() == 'abc'
+            assert ch.get_prev() == 'cmd2'
+            assert ch.get_prev() == 'cmd1'
+            assert ch.get_prev() == 'cmd1'
+            assert ch.get_next() == 'cmd2'
+            assert ch.get_next() == 'abc'
+            assert ch.get_next() == ''
+            assert ch.get_next() == ''
+
+            ch.clear_history()
+
+    def test_multiple_instances(self, tmpdir):
+        ch = command_history.CommandHistory()
+        with taddons.context(ch) as tctx:
+            tctx.options.confdir = str(tmpdir)
+
         instances = [
-            command_history.CommandHistory(10),
-            command_history.CommandHistory(10),
-            command_history.CommandHistory(10)
+            command_history.CommandHistory(),
+            command_history.CommandHistory(),
+            command_history.CommandHistory()
         ]
 
         for i in instances:
-            i.configure([])
-            saved_commands = [cmd for cmd in i.history]
+            i.configure('command_history')
+            saved_commands = i.get_history()
             assert saved_commands == []
 
         instances[0].add_command('cmd1')
-        saved_commands = [cmd for cmd in instances[0].history]
+        saved_commands = instances[0].get_history()
         assert saved_commands == ['cmd1']
 
         # These instances haven't yet added a new command, so they haven't
         # yet reloaded their commands from the command file.
         # This is expected, because if the user is filtering a command on
         # another window, we don't want to interfere with that
-        saved_commands = [cmd for cmd in instances[1].history]
+        saved_commands = instances[1].get_history()
         assert saved_commands == []
-        saved_commands = [cmd for cmd in instances[2].history]
+        saved_commands = instances[2].get_history()
         assert saved_commands == []
 
         # Since the second instanced added a new command, its list of
         # saved commands has been updated to have the commands from the
         # first instance + its own commands
         instances[1].add_command('cmd2')
-        saved_commands = [cmd for cmd in instances[1].history]
-        assert saved_commands == ['cmd1', 'cmd2']
+        saved_commands = instances[1].get_history()
+        assert saved_commands == ['cmd2']
 
-        saved_commands = [cmd for cmd in instances[0].history]
+        saved_commands = instances[0].get_history()
         assert saved_commands == ['cmd1']
 
         # Third instance is still empty as it has not yet ran any command
-        saved_commands = [cmd for cmd in instances[2].history]
+        saved_commands = instances[2].get_history()
         assert saved_commands == []
 
         instances[2].add_command('cmd3')
-        saved_commands = [cmd for cmd in instances[2].history]
-        assert saved_commands == ['cmd1', 'cmd2', 'cmd3']
+        saved_commands = instances[2].get_history()
+        assert saved_commands == ['cmd3']
 
         instances[0].add_command('cmd4')
-        saved_commands = [cmd for cmd in instances[0].history]
-        assert saved_commands == ['cmd1', 'cmd2', 'cmd3', 'cmd4']
+        saved_commands = instances[0].get_history()
+        assert saved_commands == ['cmd1', 'cmd4']
 
-        instances.append(command_history.CommandHistory(10))
-        instances[3].configure([])
-        saved_commands = [cmd for cmd in instances[3].history]
+        instances.append(command_history.CommandHistory())
+        instances[3].configure('command_history')
+        saved_commands = instances[3].get_history()
         assert saved_commands == ['cmd1', 'cmd2', 'cmd3', 'cmd4']
 
         instances[0].add_command('cmd_before_close')
-        instances.pop(0)
+        instances.pop(0).done()
 
-        saved_commands = [cmd for cmd in instances[0].history]
-        assert saved_commands == ['cmd1', 'cmd2']
+        saved_commands = instances[0].get_history()
+        assert saved_commands == ['cmd2']
 
         instances[0].add_command('new_cmd')
-        saved_commands = [cmd for cmd in instances[0].history]
-        assert saved_commands == ['cmd1', 'cmd2', 'cmd3', 'cmd4', 'cmd_before_close', 'new_cmd']
+        saved_commands = instances[0].get_history()
+        assert saved_commands == ['cmd2', 'new_cmd']
 
-        instances.pop(0)
-        instances.pop(0)
-        instances.pop(0)
+        instances.pop(0).done()
+        instances.pop(0).done()
+        instances.pop(0).done()
 
         _path = os.path.join(tctx.options.confdir, 'command_history')
         lines = open(_path, 'r').readlines()
@@ -227,14 +237,14 @@ class TestCommandHistory:
         assert saved_commands == ['cmd1', 'cmd2', 'cmd3', 'cmd4', 'cmd_before_close', 'new_cmd']
 
         instances = [
-            command_history.CommandHistory(10),
-            command_history.CommandHistory(10)
+            command_history.CommandHistory(),
+            command_history.CommandHistory()
         ]
 
         for i in instances:
-            i.configure([])
+            i.configure('command_history')
             i.clear_history()
-            saved_commands = [cmd for cmd in i.history]
+            saved_commands = i.get_history()
             assert saved_commands == []
 
         instances[0].add_command('cmd1')
@@ -243,11 +253,11 @@ class TestCommandHistory:
         instances[1].add_command('cmd4')
         instances[1].add_command('cmd5')
 
-        saved_commands = [cmd for cmd in instances[1].history]
-        assert saved_commands == ['cmd1', 'cmd2', 'cmd3', 'cmd4', 'cmd5']
+        saved_commands = instances[1].get_history()
+        assert saved_commands == ['cmd3', 'cmd4', 'cmd5']
 
-        instances.pop()
-        instances.pop()
+        instances.pop().done()
+        instances.pop().done()
 
         _path = os.path.join(tctx.options.confdir, 'command_history')
         lines = open(_path, 'r').readlines()

--- a/test/mitmproxy/addons/test_command_history.py
+++ b/test/mitmproxy/addons/test_command_history.py
@@ -42,6 +42,8 @@ class TestCommandHistory:
         saved_commands = [cmd for cmd in history.saved_commands]
         assert saved_commands == ['cmd1', 'cmd2', 'cmd3']
 
+        history.command_history_file.close()
+
     def test_add_command(self, tctx):
         history = command_history.CommandHistory(3)
 

--- a/test/mitmproxy/addons/test_command_history.py
+++ b/test/mitmproxy/addons/test_command_history.py
@@ -25,7 +25,7 @@ def tctx():
     yield tctx
 
     # This runs after each test
-    ch.command_history_file.close()  # Makes windows happy
+    ch.cleanup()
     shutil.rmtree(confdir)
 
 
@@ -42,7 +42,7 @@ class TestCommandHistory:
         saved_commands = [cmd for cmd in history.saved_commands]
         assert saved_commands == ['cmd1', 'cmd2', 'cmd3']
 
-        history.command_history_file.close()
+        history.cleanup()
 
     def test_add_command(self, tctx):
         history = command_history.CommandHistory(3)
@@ -77,7 +77,7 @@ class TestCommandHistory:
         saved_commands = [cmd for cmd in history.saved_commands]
         assert saved_commands == ['cmd4', 'cmd3', 'cmd2']
 
-        history.command_history_file.close()
+        history.cleanup()
 
     def test_get_next_and_prev(self, tctx):
         history = command_history.CommandHistory(5)
@@ -152,7 +152,7 @@ class TestCommandHistory:
         assert history.get_next() == ''
         assert history.get_next() == ''
 
-        history.command_history_file.close()
+        history.cleanup()
 
     def test_clear(self, tctx):
         history = command_history.CommandHistory(3)
@@ -169,7 +169,7 @@ class TestCommandHistory:
         assert history.get_prev() == ''
         assert history.get_prev() == ''
 
-        history.command_history_file.close()
+        history.cleanup()
 
     def test_filter(self, tctx):
         history = command_history.CommandHistory(3)
@@ -203,4 +203,74 @@ class TestCommandHistory:
         assert history.get_next() == ''
         assert history.get_next() == ''
 
-        history.command_history_file.close()
+        history.cleanup()
+
+    def test_multiple_instances(self, tctx):
+
+        instances = [
+            command_history.CommandHistory(10),
+            command_history.CommandHistory(10),
+            command_history.CommandHistory(10)
+        ]
+
+        for i in instances:
+            saved_commands = [cmd for cmd in i.saved_commands]
+            assert saved_commands == []
+
+        instances[0].add_command('cmd1')
+        saved_commands = [cmd for cmd in instances[0].saved_commands]
+        assert saved_commands == ['cmd1']
+
+        # These instances haven't yet added a new command, so they haven't
+        # yet reloaded their commands from the command file.
+        # This is expected, because if the user is filtering a command on
+        # another window, we don't want to interfere with that
+        saved_commands = [cmd for cmd in instances[1].saved_commands]
+        assert saved_commands == []
+        saved_commands = [cmd for cmd in instances[2].saved_commands]
+        assert saved_commands == []
+
+        # Since the second instanced added a new command, its list of
+        # saved commands has been updated to have the commands from the
+        # first instance + its own commands
+        instances[1].add_command('cmd2')
+        saved_commands = [cmd for cmd in instances[1].saved_commands]
+        assert saved_commands == ['cmd1', 'cmd2']
+
+        saved_commands = [cmd for cmd in instances[0].saved_commands]
+        assert saved_commands == ['cmd1']
+
+        # Third instance is still empty as it has not yet ran any command
+        saved_commands = [cmd for cmd in instances[2].saved_commands]
+        assert saved_commands == []
+
+        instances[2].add_command('cmd3')
+        saved_commands = [cmd for cmd in instances[2].saved_commands]
+        assert saved_commands == ['cmd1', 'cmd2', 'cmd3']
+
+        instances[0].add_command('cmd4')
+        saved_commands = [cmd for cmd in instances[0].saved_commands]
+        assert saved_commands == ['cmd1', 'cmd2', 'cmd3', 'cmd4']
+
+        instances.append(command_history.CommandHistory(10))
+        saved_commands = [cmd for cmd in instances[3].saved_commands]
+        assert saved_commands == ['cmd1', 'cmd2', 'cmd3', 'cmd4']
+
+        instances[0].add_command('cmd_before_close')
+        instances.pop(0)
+
+        saved_commands = [cmd for cmd in instances[0].saved_commands]
+        assert saved_commands == ['cmd1', 'cmd2']
+
+        instances[0].add_command('new_cmd')
+        saved_commands = [cmd for cmd in instances[0].saved_commands]
+        assert saved_commands == ['cmd1', 'cmd2', 'cmd3', 'cmd4', 'cmd_before_close', 'new_cmd']
+
+        instances.pop(0)
+        instances.pop(0)
+        instances.pop(0)
+
+        _path = os.path.join(tctx.options.confdir, 'command_history')
+        lines = open(_path, 'r').readlines()
+        saved_commands = [cmd.strip() for cmd in lines]
+        assert saved_commands == ['cmd1', 'cmd2', 'cmd3', 'cmd4', 'cmd_before_close', 'new_cmd']

--- a/test/mitmproxy/addons/test_command_history.py
+++ b/test/mitmproxy/addons/test_command_history.py
@@ -1,0 +1,196 @@
+import os
+import pytest
+import shutil
+import uuid
+
+from mitmproxy import options
+from mitmproxy.addons import command_history
+from mitmproxy.test import taddons
+
+
+@pytest.fixture(autouse=True)
+def tctx():
+    # This runs before each test
+    dir_id = str(uuid.uuid4())
+    confdir = os.path.expanduser(f"~/.mitmproxy-test-suite-{dir_id}")
+    if not os.path.exists(confdir):
+        os.makedirs(confdir)
+
+    opts = options.Options()
+    opts.set(*[f"confdir={confdir}"])
+    tctx = taddons.context(options=opts)
+    ch = command_history.CommandHistory()
+    tctx.master.addons.add(ch)
+
+    yield tctx
+
+    # This runs after each test
+    ch.command_history_file.close()  # Makes windows happy
+    shutil.rmtree(confdir)
+
+
+class TestCommandHistory:
+    def test_existing_command_history(self, tctx):
+        commands = ['cmd1', 'cmd2', 'cmd3']
+        confdir = tctx.options.confdir
+        f = open(os.path.join(confdir, 'command_history'), 'w')
+        f.write("\n".join(commands))
+        f.close()
+
+        history = command_history.CommandHistory()
+
+        saved_commands = [cmd for cmd in history.saved_commands]
+        assert saved_commands == ['cmd1', 'cmd2', 'cmd3']
+
+    def test_add_command(self, tctx):
+        history = command_history.CommandHistory(3)
+
+        history.add_command('cmd1')
+        history.add_command('cmd2')
+
+        saved_commands = [cmd for cmd in history.saved_commands]
+        assert saved_commands == ['cmd1', 'cmd2']
+
+        history.add_command('')
+        saved_commands = [cmd for cmd in history.saved_commands]
+        assert saved_commands == ['cmd1', 'cmd2']
+
+        # The history size is only 3. So, we forget the first
+        # one command, when adding fourth command
+        history.add_command('cmd3')
+        history.add_command('cmd4')
+        saved_commands = [cmd for cmd in history.saved_commands]
+        assert saved_commands == ['cmd2', 'cmd3', 'cmd4']
+
+        history.add_command('')
+        saved_commands = [cmd for cmd in history.saved_commands]
+        assert saved_commands == ['cmd2', 'cmd3', 'cmd4']
+
+        # Commands with the same text are not repeated in the history one by one
+        history.add_command('cmd3')
+        saved_commands = [cmd for cmd in history.saved_commands]
+        assert saved_commands == ['cmd2', 'cmd4', 'cmd3']
+
+        history.add_command('cmd2')
+        saved_commands = [cmd for cmd in history.saved_commands]
+        assert saved_commands == ['cmd4', 'cmd3', 'cmd2']
+
+    def test_get_next_and_prev(self, tctx):
+        history = command_history.CommandHistory(5)
+
+        history.add_command('cmd1')
+
+        assert history.get_next() == ''
+        assert history.get_next() == ''
+        assert history.get_prev() == 'cmd1'
+        assert history.get_prev() == 'cmd1'
+        assert history.get_prev() == 'cmd1'
+        assert history.get_next() == ''
+        assert history.get_next() == ''
+
+        history.add_command('cmd2')
+
+        assert history.get_next() == ''
+        assert history.get_next() == ''
+        assert history.get_prev() == 'cmd2'
+        assert history.get_prev() == 'cmd1'
+        assert history.get_prev() == 'cmd1'
+        assert history.get_next() == 'cmd2'
+        assert history.get_next() == ''
+        assert history.get_next() == ''
+
+        history.add_command('cmd3')
+
+        assert history.get_next() == ''
+        assert history.get_next() == ''
+        assert history.get_prev() == 'cmd3'
+        assert history.get_prev() == 'cmd2'
+        assert history.get_prev() == 'cmd1'
+        assert history.get_prev() == 'cmd1'
+        assert history.get_next() == 'cmd2'
+        assert history.get_next() == 'cmd3'
+        assert history.get_next() == ''
+        assert history.get_next() == ''
+        assert history.get_prev() == 'cmd3'
+        assert history.get_prev() == 'cmd2'
+
+        history.add_command('cmd4')
+
+        assert history.get_prev() == 'cmd4'
+        assert history.get_prev() == 'cmd3'
+        assert history.get_prev() == 'cmd2'
+        assert history.get_prev() == 'cmd1'
+        assert history.get_prev() == 'cmd1'
+        assert history.get_next() == 'cmd2'
+        assert history.get_next() == 'cmd3'
+        assert history.get_next() == 'cmd4'
+        assert history.get_next() == ''
+        assert history.get_next() == ''
+
+        history.add_command('cmd5')
+        history.add_command('cmd6')
+
+        assert history.get_next() == ''
+        assert history.get_prev() == 'cmd6'
+        assert history.get_prev() == 'cmd5'
+        assert history.get_prev() == 'cmd4'
+        assert history.get_next() == 'cmd5'
+        assert history.get_prev() == 'cmd4'
+        assert history.get_prev() == 'cmd3'
+        assert history.get_prev() == 'cmd2'
+        assert history.get_next() == 'cmd3'
+        assert history.get_prev() == 'cmd2'
+        assert history.get_prev() == 'cmd2'
+        assert history.get_next() == 'cmd3'
+        assert history.get_next() == 'cmd4'
+        assert history.get_next() == 'cmd5'
+        assert history.get_next() == 'cmd6'
+        assert history.get_next() == ''
+        assert history.get_next() == ''
+
+    def test_clear(self, tctx):
+        history = command_history.CommandHistory(3)
+
+        history.add_command('cmd1')
+        history.add_command('cmd2')
+        history.clear_history()
+
+        saved_commands = [cmd for cmd in history.saved_commands]
+        assert saved_commands == []
+
+        assert history.get_next() == ''
+        assert history.get_next() == ''
+        assert history.get_prev() == ''
+        assert history.get_prev() == ''
+
+    def test_filter(self, tctx):
+        history = command_history.CommandHistory(3)
+
+        history.add_command('cmd1')
+        history.add_command('cmd2')
+        history.add_command('abc')
+        history.set_filter('c')
+
+        assert history.get_next() == ''
+        assert history.get_next() == ''
+        assert history.get_prev() == 'c'
+        assert history.get_prev() == 'cmd2'
+        assert history.get_prev() == 'cmd1'
+        assert history.get_prev() == 'cmd1'
+        assert history.get_next() == 'cmd2'
+        assert history.get_next() == 'c'
+        assert history.get_next() == ''
+        assert history.get_next() == ''
+
+        history.set_filter('')
+
+        assert history.get_next() == ''
+        assert history.get_next() == ''
+        assert history.get_prev() == 'abc'
+        assert history.get_prev() == 'cmd2'
+        assert history.get_prev() == 'cmd1'
+        assert history.get_prev() == 'cmd1'
+        assert history.get_next() == 'cmd2'
+        assert history.get_next() == 'abc'
+        assert history.get_next() == ''
+        assert history.get_next() == ''

--- a/test/mitmproxy/tools/console/test_commander.py
+++ b/test/mitmproxy/tools/console/test_commander.py
@@ -97,6 +97,7 @@ class TestCommandEdit:
     def test_up_and_down(self):
         with taddons.context() as tctx:
             history = commander.CommandHistory(tctx.master, size=3)
+            history.clear_history()
             edit = commander.CommandEdit(tctx.master, '', history)
 
             buf = commander.CommandBuffer(tctx.master, 'cmd1')
@@ -112,6 +113,7 @@ class TestCommandEdit:
             assert edit.get_edit_text() == 'cmd1'
 
             history = commander.CommandHistory(tctx.master, size=5)
+            history.clear_history()
             edit = commander.CommandEdit(tctx.master, '', history)
             edit.keypress(1, 'a')
             edit.keypress(1, 'b')
@@ -139,6 +141,7 @@ class TestCommandHistory:
     def fill_history(self, commands):
         with taddons.context() as tctx:
             history = commander.CommandHistory(tctx.master, size=3)
+            history.clear_history()
             for c in commands:
                 cbuf = commander.CommandBuffer(tctx.master, c)
                 history.add_command(cbuf)
@@ -183,7 +186,7 @@ class TestCommandHistory:
         for i in range(3):
             assert history.get_next().text == expected_items[i]
         # We are at the last item of the history
-        assert history.get_next() is None
+        assert history.get_next().text == expected_items[-1]
 
     def test_get_prev(self):
         commands = ["command1", "command2"]
@@ -194,7 +197,7 @@ class TestCommandHistory:
         for i in range(3):
             assert history.get_prev().text == expected_items[i]
         # We are at the first item of the history
-        assert history.get_prev() is None
+        assert history.get_prev().text == expected_items[-1]
 
 
 class TestCommandBuffer:

--- a/test/mitmproxy/tools/console/test_commander.py
+++ b/test/mitmproxy/tools/console/test_commander.py
@@ -1,7 +1,4 @@
-import os
 import pytest
-import shutil
-import uuid
 
 from mitmproxy import options
 from mitmproxy.addons import command_history
@@ -10,24 +7,22 @@ from mitmproxy.tools.console.commander import commander
 
 
 @pytest.fixture(autouse=True)
-def tctx():
+def tctx(tmpdir):
     # This runs before each test
-    dir_id = str(uuid.uuid4())
-    confdir = os.path.expanduser(f"~/.mitmproxy-test-suite-{dir_id}")
-    if not os.path.exists(confdir):
-        os.makedirs(confdir)
+    dir_name = tmpdir.mkdir('mitmproxy').dirname
+    confdir = dir_name
 
     opts = options.Options()
     opts.set(*[f"confdir={confdir}"])
     tctx = taddons.context(options=opts)
     ch = command_history.CommandHistory()
     tctx.master.addons.add(ch)
+    ch.configure([])
 
     yield tctx
 
     # This runs after each test
-    ch.command_history_file.close()
-    shutil.rmtree(confdir)
+    ch.cleanup()
 
 
 class TestListCompleter:

--- a/test/mitmproxy/tools/console/test_commander.py
+++ b/test/mitmproxy/tools/console/test_commander.py
@@ -17,12 +17,12 @@ def tctx(tmpdir):
     tctx = taddons.context(options=opts)
     ch = command_history.CommandHistory()
     tctx.master.addons.add(ch)
-    ch.configure([])
+    ch.configure('command_history')
 
     yield tctx
 
     # This runs after each test
-    ch.cleanup()
+    ch.clear_history()
 
 
 class TestListCompleter:

--- a/test/mitmproxy/tools/console/test_commander.py
+++ b/test/mitmproxy/tools/console/test_commander.py
@@ -26,6 +26,7 @@ def tctx():
     yield tctx
 
     # This runs after each test
+    ch.command_history_file.close()
     shutil.rmtree(confdir)
 
 


### PR DESCRIPTION
This is the implementation of a feature that saves all user executed commands (`:` prompt) to a file so that the next time they open mitmproxy those commands are already in their command history.

This has been pretty useful for me when testing issues that would cause mitmproxy to crash (so I didn't have to re-type a bunch of commands again). It has also been pretty useful for the cases when I have to close mitmproxy for any reason during my workflow and reopen it and continue where I left of.