### PR TITLE
Fix #3571 to support image/webp in mitmweb to display previews

### DIFF
--- a/web/src/js/components/ContentView/ContentViews.jsx
+++ b/web/src/js/components/ContentView/ContentViews.jsx
@@ -7,7 +7,7 @@ import { MessageUtils } from '../../flow/utils'
 import CodeEditor from './CodeEditor'
 
 
-const isImage = /^image\/(png|jpe?g|gif|vnc.microsoft.icon|x-icon)$/i
+const isImage = /^image\/(png|jpe?g|gif|webp|vnc.microsoft.icon|x-icon)$/i
 ViewImage.matches = msg => isImage.test(MessageUtils.getContentType(msg))
 ViewImage.propTypes = {
     flow: PropTypes.object.isRequired,


### PR DESCRIPTION
[WebP is an image format](https://en.wikipedia.org/wiki/WebP) employing both lossy and lossless compression. As a derivative of the VP8 video format, it is a sister project to the WebM multimedia container format. The canonical Internet media type is `image/webp` and is currently [supported by the major web browsers](https://caniuse.com/#feat=webp).