### PR TITLE
Add py.typed stub as per PEP-561

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(
         "Topic :: Internet :: Proxy Servers",
         "Topic :: System :: Networking :: Monitoring",
         "Topic :: Software Development :: Testing",
+        "Typing :: Typed",
     ],
     packages=find_packages(include=[
         "mitmproxy", "mitmproxy.*",


### PR DESCRIPTION
This marks the package as annotated to allow it's types to be inferred by [mypy][1] when used as a library some another application. More details about this in [PEP-561][2].

Without this, running mypy on some code that uses mitmproxy returns these errors:
```python
test_stubs.py:1: error: Cannot find implementation or library stub for module named 'mitmproxy'
test_stubs.py:2: error: Cannot find implementation or library stub for module named 'mitmproxy.net.http'
test_stubs.py:3: error: Cannot find implementation or library stub for module named 'mitmproxy.utils'
```

Once I added this to the package and installed the latest dev version, the errors are removed. Unfortunately, in some other modules I see these errors:

```python
/Users/pavel.savchenko/.virtualenvs/stub_test/lib/python3.6/site-packages/mitmproxy/optmanager.py:11: error: Cannot find implementation or library stub for module named 'ruamel'
```

This seems to be an issue with ruamel's namespace structure (I'm not sure what is the issue, but I tried to file a ruamel.yaml ticked [here][3])

[1]: https://mypy.readthedocs.io/en/latest/installed_packages.html#making-pep-561-compatible-packages
[2]: https://www.python.org/dev/peps/pep-0561/
[3]: https://bitbucket.org/ruamel/yaml/issues/328/mypy-complains-that-ruamel-is-missing-type