### PR TITLE
Don't raise an exception when script is not found

### DIFF
--- a/mitmproxy/addons/script.py
+++ b/mitmproxy/addons/script.py
@@ -76,7 +76,8 @@ class Script:
         self.ns = None
 
         if not os.path.isfile(self.fullpath):
-            raise exceptions.OptionsError('No such script')
+            ctx.log.error('No such script: %s' % path)
+            return
 
         self.reloadtask = None
         if reload:

--- a/test/mitmproxy/addons/test_script.py
+++ b/test/mitmproxy/addons/test_script.py
@@ -61,10 +61,11 @@ def test_load_fullname(tdata):
 
 
 class TestScript:
-    def test_notfound(self):
-        with taddons.context():
-            with pytest.raises(exceptions.OptionsError):
-                script.Script("nonexistent", False)
+    @pytest.mark.asyncio
+    async def test_notfound(self):
+        with taddons.context() as tctx:
+            script.Script("nonexistent", False)
+            assert await tctx.master.await_log("No such script")
 
     def test_quotes_around_filename(self, tdata):
         """


### PR DESCRIPTION
Is really helpful when you have scripts in your `config.yaml` and don't want to edit the file each time one gets deleted or moved.