### PR TITLE
Exit on SIGTERM instead of prompting

### DIFF
--- a/mitmproxy/tools/_main.py
+++ b/mitmproxy/tools/_main.py
@@ -113,12 +113,12 @@ def run(
             opts.update(**extra(args))
 
         loop = asyncio.get_event_loop()
-        for signame in ('SIGINT', 'SIGTERM'):
-            try:
-                loop.add_signal_handler(getattr(signal, signame), getattr(master, "prompt_for_exit", master.shutdown))
-            except NotImplementedError:
-                # Not supported on Windows
-                pass
+        try:
+            loop.add_signal_handler(signal.SIGINT, getattr(master, "prompt_for_exit", master.shutdown))
+            loop.add_signal_handler(signal.SIGTERM, master.shutdown)
+        except NotImplementedError:
+            # Not supported on Windows
+            pass
 
         # Make sure that we catch KeyboardInterrupts on Windows.
         # https://stackoverflow.com/a/36925722/934719


### PR DESCRIPTION
Catching SIGTERM and prompting for exit instead of just shutting down is pretty annoying.
I have scripts to manage mitmproxy, and this behavior was preventing them from working.