### PR TITLE
Increase max header length

### DIFF
--- a/mitmproxy/tools/console/common.py
+++ b/mitmproxy/tools/console/common.py
@@ -34,7 +34,7 @@ def highlight_key(str, key, textattr="text", keyattr="key"):
     return l
 
 
-KEY_MAX = 30
+KEY_MAX = 50
 
 
 def format_keyvals(


### PR DESCRIPTION
This is a kludge to help with #2936. My knowledge of Urwid is slim but it really doesn't seem to offer any tools for this problem.

Using weight = 1 for the header key/value columns would use the available space more efficiently and get you wrapping for both key and value. The downside would be that the key and value would no longer be adjacent.