### PR TITLE
Fix console command quotes issues

### DIFF
--- a/mitmproxy/command.py
+++ b/mitmproxy/command.py
@@ -103,7 +103,7 @@ class Command:
         except TypeError:
             expected = f'Expected: {str(self.signature.parameters)}'
             received = f'Received: {str(args)}'
-            raise exceptions.CommandError(f"Command argument mismatch: \n\t{expected}\n\t{received}")
+            raise exceptions.CommandError(f"Command argument mismatch: \n    {expected}\n    {received}")
 
         for name, value in bound_arguments.arguments.items():
             convert_to = self.signature.parameters[name].annotation

--- a/mitmproxy/command.py
+++ b/mitmproxy/command.py
@@ -284,7 +284,7 @@ def parsearg(manager: CommandManager, spec: str, argtype: type) -> typing.Any:
     try:
         return t.parse(manager, argtype, spec)
     except exceptions.TypeError as e:
-        raise exceptions.CommandError from e
+        raise exceptions.CommandError(str(e)) from e
 
 
 def command(name: typing.Optional[str] = None):

--- a/mitmproxy/command.py
+++ b/mitmproxy/command.py
@@ -241,7 +241,7 @@ class CommandManager:
             raise exceptions.CommandError("Unknown command: %s" % command_name)
         return self.commands[command_name].func(*args)
 
-    def _call_strings(self, command_name: str, args: typing.Sequence[str]) -> typing.Any:
+    def call_strings(self, command_name: str, args: typing.Sequence[str]) -> typing.Any:
         """
         Call a command using a list of string arguments. May raise CommandError.
         """
@@ -262,7 +262,7 @@ class CommandManager:
             for part in parts
             if part.type != mitmproxy.types.Space
         ]
-        return self._call_strings(command_name, args)
+        return self.call_strings(command_name, args)
 
     def dump(self, out=sys.stdout) -> None:
         cmds = list(self.commands.values())

--- a/mitmproxy/tools/console/commandexecutor.py
+++ b/mitmproxy/tools/console/commandexecutor.py
@@ -2,6 +2,7 @@ import typing
 
 from mitmproxy import exceptions
 from mitmproxy import flow
+from mitmproxy import ctx
 
 from mitmproxy.tools.console import overlay
 from mitmproxy.tools.console import signals
@@ -15,8 +16,10 @@ class CommandExecutor:
         if cmd.strip():
             try:
                 ret = self.master.commands.execute(cmd)
-            except exceptions.CommandError as v:
-                signals.status_message.send(message=str(v))
+            except exceptions.CommandError as e:
+                msg = str(e)
+                ctx.log.error(msg)
+                signals.status_message.send(message=msg)
             else:
                 if ret:
                     if type(ret) == typing.Sequence[flow.Flow]:

--- a/mitmproxy/tools/console/commandexecutor.py
+++ b/mitmproxy/tools/console/commandexecutor.py
@@ -17,9 +17,7 @@ class CommandExecutor:
             try:
                 ret = self.master.commands.execute(cmd)
             except exceptions.CommandError as e:
-                msg = str(e)
-                ctx.log.error(msg)
-                signals.status_message.send(message=msg)
+                ctx.log.error(str(e))
             else:
                 if ret:
                     if type(ret) == typing.Sequence[flow.Flow]:

--- a/mitmproxy/tools/console/consoleaddons.py
+++ b/mitmproxy/tools/console/consoleaddons.py
@@ -160,7 +160,7 @@ class ConsoleAddon:
         fv = self.master.window.current("options")
         if not fv:
             raise exceptions.CommandError("Not viewing options.")
-        self.master.commands.execute("options.reset.one %s" % fv.current_name())
+        self.master.commands.execute("options.reset.one %s" % command_lexer.quote(fv.current_name()))
 
     @command.command("console.nav.start")
     def nav_start(self) -> None:
@@ -280,8 +280,9 @@ class ConsoleAddon:
             try:
                 self.master.commands.execute(subcmd + " " + repl)
             except exceptions.CommandError as e:
-                ctx.log.error(str(e))
-                signals.status_message.send(message=str(e))
+                msg = str(e)
+                ctx.log.error(msg)
+                signals.status_message.send(message=msg)
 
         self.master.overlay(
             overlay.Chooser(self.master, prompt, choices, "", callback)
@@ -455,7 +456,7 @@ class ConsoleAddon:
             flow.request.url = url.decode()
         elif flow_part in ["method", "status_code", "reason"]:
             self.master.commands.execute(
-                "console.command flow.set @focus %s " % flow_part
+                "console.command flow.set @focus %s " % command_lexer.quote(flow_part)
             )
 
     def _grideditor(self):
@@ -542,8 +543,9 @@ class ConsoleAddon:
             cmd = 'view.settings.setval @focus flowview_mode_%s %s' % (idx, command_lexer.quote(mode))
             self.master.commands.execute(cmd)
         except exceptions.CommandError as e:
-            ctx.log.error(e)
-            signals.status_message.send(message=str(e))
+            msg = str(e)
+            ctx.log.error(msg)
+            signals.status_message.send(message=msg)
 
     @command.command("console.flowview.mode.options")
     def flowview_mode_options(self) -> typing.Sequence[str]:
@@ -562,7 +564,7 @@ class ConsoleAddon:
             raise exceptions.CommandError("Not viewing a flow.")
         idx = fv.body.tab_offset
 
-        cmd = 'view.settings.getval @focus flowview_mode_%s %s' % (idx, self.master.options.console_default_contentview)
+        cmd = 'view.settings.getval @focus flowview_mode_%s %s' % (idx, command_lexer.quote(self.master.options.console_default_contentview))
         return self.master.commands.execute(cmd)
 
     @command.command("console.key.contexts")

--- a/mitmproxy/tools/console/consoleaddons.py
+++ b/mitmproxy/tools/console/consoleaddons.py
@@ -252,9 +252,7 @@ class ConsoleAddon:
             try:
                 self.master.commands.call_strings(cmd, repl)
             except exceptions.CommandError as e:
-                msg = str(e)
-                ctx.log.error(msg)
-                signals.status_message.send(message=msg)
+                ctx.log.error(str(e))
 
         self.master.overlay(
             overlay.Chooser(self.master, prompt, choices, "", callback)
@@ -281,9 +279,7 @@ class ConsoleAddon:
             try:
                 self.master.commands.call_strings(subcmd, repl)
             except exceptions.CommandError as e:
-                msg = str(e)
-                ctx.log.error(msg)
-                signals.status_message.send(message=msg)
+                ctx.log.error(str(e))
 
         self.master.overlay(
             overlay.Chooser(self.master, prompt, choices, "", callback)
@@ -547,9 +543,7 @@ class ConsoleAddon:
                 ["@focus", "flowview_mode_%s" % (idx,), mode]
             )
         except exceptions.CommandError as e:
-            msg = str(e)
-            ctx.log.error(msg)
-            signals.status_message.send(message=msg)
+            ctx.log.error(str(e))
 
     @command.command("console.flowview.mode.options")
     def flowview_mode_options(self) -> typing.Sequence[str]:

--- a/mitmproxy/tools/console/consoleaddons.py
+++ b/mitmproxy/tools/console/consoleaddons.py
@@ -276,11 +276,11 @@ class ConsoleAddon:
 
         def callback(opt):
             # We're now outside of the call context...
-            repl = " ".join(command_lexer.quote(x) for x in args)
-            repl = repl.replace("{choice}", opt)
+            repl = " ".join(command_lexer.quote(x.replace("{choice}", opt)) for x in args)
             try:
                 self.master.commands.execute(subcmd + " " + repl)
             except exceptions.CommandError as e:
+                ctx.log.error(str(e))
                 signals.status_message.send(message=str(e))
 
         self.master.overlay(
@@ -539,9 +539,10 @@ class ConsoleAddon:
             raise exceptions.CommandError("Invalid flowview mode.")
 
         try:
-            cmd = 'view.settings.setval @focus flowview_mode_%s %s' % (idx, mode)
+            cmd = 'view.settings.setval @focus flowview_mode_%s %s' % (idx, command_lexer.quote(mode))
             self.master.commands.execute(cmd)
         except exceptions.CommandError as e:
+            ctx.log.error(e)
             signals.status_message.send(message=str(e))
 
     @command.command("console.flowview.mode.options")

--- a/mitmproxy/tools/console/consoleaddons.py
+++ b/mitmproxy/tools/console/consoleaddons.py
@@ -160,7 +160,7 @@ class ConsoleAddon:
         fv = self.master.window.current("options")
         if not fv:
             raise exceptions.CommandError("Not viewing options.")
-        self.master.commands.execute("options.reset.one %s" % command_lexer.quote(fv.current_name()))
+        self.master.commands.call_strings("options.reset.one", [fv.current_name()])
 
     @command.command("console.nav.start")
     def nav_start(self) -> None:
@@ -248,12 +248,13 @@ class ConsoleAddon:
 
         def callback(opt):
             # We're now outside of the call context...
-            repl = cmd + " " + " ".join(args)
-            repl = repl.replace("{choice}", opt)
+            repl = [arg.replace("{choice}", opt) for arg in args]
             try:
-                self.master.commands.execute(repl)
+                self.master.commands.call_strings(cmd, repl)
             except exceptions.CommandError as e:
-                signals.status_message.send(message=str(e))
+                msg = str(e)
+                ctx.log.error(msg)
+                signals.status_message.send(message=msg)
 
         self.master.overlay(
             overlay.Chooser(self.master, prompt, choices, "", callback)
@@ -276,9 +277,9 @@ class ConsoleAddon:
 
         def callback(opt):
             # We're now outside of the call context...
-            repl = " ".join(command_lexer.quote(x.replace("{choice}", opt)) for x in args)
+            repl = [arg.replace("{choice}", opt) for arg in args]
             try:
-                self.master.commands.execute(subcmd + " " + repl)
+                self.master.commands.call_strings(subcmd, repl)
             except exceptions.CommandError as e:
                 msg = str(e)
                 ctx.log.error(msg)
@@ -455,8 +456,9 @@ class ConsoleAddon:
             url = edited_url.rstrip(b"\n")
             flow.request.url = url.decode()
         elif flow_part in ["method", "status_code", "reason"]:
-            self.master.commands.execute(
-                "console.command flow.set @focus %s " % command_lexer.quote(flow_part)
+            self.master.commands.call_strings(
+                "console.command",
+                ["flow.set", "@focus", flow_part]
             )
 
     def _grideditor(self):
@@ -540,8 +542,10 @@ class ConsoleAddon:
             raise exceptions.CommandError("Invalid flowview mode.")
 
         try:
-            cmd = 'view.settings.setval @focus flowview_mode_%s %s' % (idx, command_lexer.quote(mode))
-            self.master.commands.execute(cmd)
+            self.master.commands.call_strings(
+                "view.settings.setval",
+                ["@focus", "flowview_mode_%s" % (idx,), mode]
+            )
         except exceptions.CommandError as e:
             msg = str(e)
             ctx.log.error(msg)
@@ -564,8 +568,10 @@ class ConsoleAddon:
             raise exceptions.CommandError("Not viewing a flow.")
         idx = fv.body.tab_offset
 
-        cmd = 'view.settings.getval @focus flowview_mode_%s %s' % (idx, command_lexer.quote(self.master.options.console_default_contentview))
-        return self.master.commands.execute(cmd)
+        return self.master.commands.call_strings(
+            "view.settings.getval",
+            ["@focus", "flowview_mode_%s" % (idx,), self.master.options.console_default_contentview]
+        )
 
     @command.command("console.key.contexts")
     def key_contexts(self) -> typing.Sequence[str]:

--- a/mitmproxy/types.py
+++ b/mitmproxy/types.py
@@ -134,7 +134,7 @@ class _IntType(_BaseType):
         try:
             return int(s)
         except ValueError as e:
-            raise exceptions.TypeError from e
+            raise exceptions.TypeError(str(e)) from e
 
     def is_valid(self, manager: "CommandManager", typ: typing.Any, val: typing.Any) -> bool:
         return isinstance(val, int)
@@ -328,7 +328,7 @@ class _FlowType(_BaseFlowType):
         try:
             flows = manager.execute("view.flows.resolve %s" % (s))
         except exceptions.CommandError as e:
-            raise exceptions.TypeError from e
+            raise exceptions.TypeError(str(e)) from e
         if len(flows) != 1:
             raise exceptions.TypeError(
                 "Command requires one flow, specification matched %s." % len(flows)
@@ -347,7 +347,7 @@ class _FlowsType(_BaseFlowType):
         try:
             return manager.execute("view.flows.resolve %s" % (s))
         except exceptions.CommandError as e:
-            raise exceptions.TypeError from e
+            raise exceptions.TypeError(str(e)) from e
 
     def is_valid(self, manager: "CommandManager", typ: typing.Any, val: typing.Any) -> bool:
         try:


### PR DESCRIPTION
This PR fixes several issues I've encountered while using mitmproxy in console mode:
1. Trying to manually change to "multipart form" contentview failed because ViewMultipart.name has a space in it. This also affected my custom contentview, so I had to choose a name without spaces.
2. Said error was not visible in the event log, just in the status bar (where it wasn't even informative because it just said "(more in eventlog)"...)
3. When I did manage to show the full exception in the event log, tabs ('\t') were displayed as '?'.
4. A re-raised error (when I run a command with an "invalid choice") would display an empty error string because it was raised like this: `raise exceptions.CommandError from e`

I solved (1) by exposing CommandManager.call_strings and calling it directly, because it seems far more reliable than formatting a full command string with `%s`, quote/unquote operations and so on. I also did this for any command call which involves a `%s` or `{choice}`.

I solved (2) by replacing `signals.status_message.send` with `ctx.log.error`.