### PR TITLE
Fix broken link with link to similar addon. This fixes issue #3775.

### DIFF
--- a/docs/src/content/tute-clientreplay.md
+++ b/docs/src/content/tute-clientreplay.md
@@ -31,9 +31,8 @@ mitmdump -w wireless-login
 
 ## 2. Point your browser at the mitmdump instance.
 
-I use a tiny Firefox addon called [Toggle
-Proxy](https://addons.mozilla.org/en-us/firefox/addon/toggle-proxy-51740/) to
-switch quickly to and from mitmproxy. I'm assuming you've already [configured
+There is a Firefox addon called [FoxyProxy](https://addons.mozilla.org/fi/firefox/addon/foxyproxy-standard/) that
+lets you switch quickly to and from mitmproxy. I'm assuming you've already [configured
 your browser with mitmproxy's SSL certificate authority]({{< relref
 "concepts-certificates" >}}).
 


### PR DESCRIPTION
Foxyproxy is a commonly used Firefox addon with more than 180k users. Would this be a good replacement for Toggle Proxy?