### PR TITLE
http2: send all stream reset types to other connection

### DIFF
--- a/mitmproxy/proxy/protocol/http2.py
+++ b/mitmproxy/proxy/protocol/http2.py
@@ -209,13 +209,12 @@ class Http2Layer(base.Layer):
     def _handle_stream_reset(self, eid, event, is_server, other_conn):
         if eid in self.streams:
             self.streams[eid].kill()
-            if event.error_code == h2.errors.ErrorCodes.CANCEL:
-                if is_server:
-                    other_stream_id = self.streams[eid].client_stream_id
-                else:
-                    other_stream_id = self.streams[eid].server_stream_id
-                if other_stream_id is not None:
-                    self.connections[other_conn].safe_reset_stream(other_stream_id, event.error_code)
+            if is_server:
+                other_stream_id = self.streams[eid].client_stream_id
+            else:
+                other_stream_id = self.streams[eid].server_stream_id
+            if other_stream_id is not None:
+                self.connections[other_conn].safe_reset_stream(other_stream_id, event.error_code)
         return True
 
     def _handle_remote_settings_changed(self, event, other_conn):


### PR DESCRIPTION
I am simulating interrupts during http2 responses for Wget2's test suite, while using mitmproxy to debug some of the tests that are not working. 

RST_STREAM frames were received by mitmproxy from the server, but were not sent to the client from mitmproxy. As this is inconsistent with what happens when the proxy is disabled, I have modified mitmproxy to send all stream resets from server to client (and probably client to server) to correct this.