### PR TITLE
Fix Headers replace matching.

### DIFF
--- a/mitmproxy/net/http/headers.py
+++ b/mitmproxy/net/http/headers.py
@@ -172,11 +172,12 @@ class Headers(multidict.MultiDict):
                 # There's not much we can do about this, so we just keep the header as-is.
                 pass
             else:
-                replacements += n
                 if flag_count:
-                    count -= n
                     if count == 0:
+                        fields += self.fields[len(fields):]
                         break
+                    count -= n
+                replacements += n
             fields.append((name, value))
         self.fields = tuple(fields)
         return replacements

--- a/test/mitmproxy/net/http/test_headers.py
+++ b/test/mitmproxy/net/http/test_headers.py
@@ -78,6 +78,20 @@ class TestHeaders:
         headers.replace(r"Host: example.com", r"Host: example.de")
         assert headers.get_all("Host") == ["example.de", "example.org"]
 
+    def test_replace_multi_count(self):
+        headers = self._2host()
+        replaced = headers.replace('example', 'testing', count=1)
+
+        assert replaced == 1
+        assert headers.get_all("HOST") == ["testing.com", "example.org"]
+
+    def test_replace_multi_count_all(self):
+        headers = self._2host()
+        replaced = headers.replace('example', 'testing', count=2)
+
+        assert replaced == 2
+        assert headers.get_all("HOST") == ["testing.com", "testing.org"]
+
     def test_replace_remove_spacer(self):
         headers = Headers(Host="example.com")
         replacements = headers.replace(r"Host: ", "X-Host ")


### PR DESCRIPTION
#### Problem
- Headers replace matching fails when counter is passed.

#### Solution
- Refactor Headers replace matching logic to handle counter.
-  Add unit tests to cover replace counter.  

#### Proof
![mitmproxy_headers_proof](https://user-images.githubusercontent.com/26286907/77567967-f3c53380-6ed8-11ea-907c-4bfc71e22079.gif)

#### Tests
- `test/mitmproxy/net/http/test_headers.py::TestHeaders::test_replace_multi_count`
- `test/mitmproxy/net/http/test_headers.py::TestHeaders::test_replace_multi_count_all`

#### Related issues
Resolves #3833 
