### PR TITLE
UTF 8 dependency

### DIFF
--- a/docs/src/content/overview-installation.md
+++ b/docs/src/content/overview-installation.md
@@ -32,6 +32,7 @@ OpenSUSE, etc.). We are not involved in the maintenance of downstream packaging
 efforts, and they often lag behind the current mitmproxy release. Please contact
 the repository maintainers directly for issues with native packages.
 
+
 ## Windows
 
 
@@ -93,3 +94,5 @@ If you use our binary packages, please make sure you update regularly to ensure
 that everything remains current.
 
 As a general principle, mitmproxy does not "phone home" and consequently will not do any update checks.
+
+Note: mitmproxy requires UTF encoding - en_US, en_IN, or anything else to run.The user has to configure the terminal & environment properly for the same.

--- a/docs/src/content/overview-installation.md
+++ b/docs/src/content/overview-installation.md
@@ -51,6 +51,13 @@ command line.
 ## Note: 
 mitmproxy requires UTF encoding - en_US, en_IN, or anything else to run.The user has to configure the terminal & environment properly for the same.
 
+The followinng instructions can be followed to set UTF environment in linux :
+
+$ sudo update-locale LANG=LANG=en_IN.UTF-8 LANGUAGE
+OR
+$ sudo localectl set-locale LANG=en_IN.UTF-8
+
+
 
 # Advanced Installation
 

--- a/docs/src/content/overview-installation.md
+++ b/docs/src/content/overview-installation.md
@@ -48,6 +48,9 @@ After installation, you'll find shortcuts for mitmweb and mitmdump in the start
 menu. Both executables are added to your PATH and can be invoked from the
 command line.
 
+## Note: 
+mitmproxy requires UTF encoding - en_US, en_IN, or anything else to run.The user has to configure the terminal & environment properly for the same.
+
 
 # Advanced Installation
 
@@ -95,4 +98,3 @@ that everything remains current.
 
 As a general principle, mitmproxy does not "phone home" and consequently will not do any update checks.
 
-Note: mitmproxy requires UTF encoding - en_US, en_IN, or anything else to run.The user has to configure the terminal & environment properly for the same.


### PR DESCRIPTION
I would be really helpful for newbies if docs had a clear "we need UTF encoding " in the installation section