### PR TITLE
c is deprecated

### DIFF
--- a/docs/src/content/tute-clientreplay.md
+++ b/docs/src/content/tute-clientreplay.md
@@ -42,7 +42,7 @@ And that's it\! You now have a serialised version of the login process
 in the file wireless-login, and you can replay it at any time like this:
 
 {{< highlight bash  >}}
-mitmdump -c wireless-login
+mitmdump -C wireless-login
 {{< / highlight >}}
 
 ## Embellishments


### PR DESCRIPTION
In mitmproxy -c file command -c is replace with -C but docs still shows -c