### PR TITLE
Only emit "serverconnect" after successfully connecting

### DIFF
--- a/mitmproxy/proxy/protocol/base.py
+++ b/mitmproxy/proxy/protocol/base.py
@@ -160,10 +160,10 @@ class ServerConnectionMixin:
         """
         if not self.server_conn.address:
             raise exceptions.ProtocolException("Cannot connect to server, no server address given.")
-        self.log("serverconnect", "debug", [repr(self.server_conn.address)])
-        self.channel.ask("serverconnect", self.server_conn)
         try:
             self.server_conn.connect()
+            self.log("serverconnect", "debug", [repr(self.server_conn.address)])
+            self.channel.ask("serverconnect", self.server_conn)
         except exceptions.TcpException as e:
             raise exceptions.ProtocolException(
                 "Server connection to {} failed: {}".format(


### PR DESCRIPTION
Fixes #3880

It looks like there are no tests for events so far? I'm not familiar with Python especially testing frameworks and stuff. But I guess it makes sense to look into that?