### PR TITLE
Don't force host header on outgoing requests

### DIFF
--- a/mitmproxy/net/http/http1/assemble.py
+++ b/mitmproxy/net/http/http1/assemble.py
@@ -1,4 +1,3 @@
-import mitmproxy.net.http.url
 from mitmproxy import exceptions
 
 
@@ -78,15 +77,7 @@ def _assemble_request_headers(request_data):
     Args:
         request_data (mitmproxy.net.http.request.RequestData)
     """
-    headers = request_data.headers
-    if "host" not in headers and request_data.scheme and request_data.host and request_data.port:
-        headers = headers.copy()
-        headers["host"] = mitmproxy.net.http.url.hostport(
-            request_data.scheme,
-            request_data.host,
-            request_data.port
-        )
-    return bytes(headers)
+    return bytes(request_data.headers)
 
 
 def _assemble_response_line(response_data):

--- a/test/mitmproxy/net/http/http1/test_assemble.py
+++ b/test/mitmproxy/net/http/http1/test_assemble.py
@@ -15,7 +15,6 @@ def test_assemble_request():
         b"GET /path HTTP/1.1\r\n"
         b"header: qvalue\r\n"
         b"content-length: 7\r\n"
-        b"host: address:22\r\n"
         b"\r\n"
         b"content"
     )
@@ -82,17 +81,6 @@ def test_assemble_request_headers():
     r.headers["Transfer-Encoding"] = "chunked"
     c = _assemble_request_headers(r.data)
     assert b"Transfer-Encoding" in c
-
-
-def test_assemble_request_headers_host_header():
-    r = treq()
-    r.headers = Headers()
-    c = _assemble_request_headers(r.data)
-    assert b"host" in c
-
-    r.host = None
-    c = _assemble_request_headers(r.data)
-    assert b"host" not in c
 
 
 def test_assemble_response_headers():


### PR DESCRIPTION
It is not really clear why we did this, so we stop doing this and see who complains.