### PR TITLE
#3911 Support keybinding for different contexts with different commands

### DIFF
--- a/mitmproxy/tools/console/keymap.py
+++ b/mitmproxy/tools/console/keymap.py
@@ -202,7 +202,7 @@ class KeymapConfig:
                 user_ctxs = v.get("ctx", ["global"])
                 try:
                     km._check_contexts(user_ctxs)
-                    km.remove(v["key"], Contexts)
+                    km.remove(v["key"], user_ctxs)
                     km.add(
                         key = v["key"],
                         command = v["cmd"],

--- a/test/mitmproxy/tools/console/test_keymap.py
+++ b/test/mitmproxy/tools/console/test_keymap.py
@@ -117,6 +117,21 @@ def test_load_path(tmpdir):
         kmc.load_path(km, dst)
         assert(km.get("chooser", "key1"))
 
+        with open(dst, 'w') as f:
+            f.write(
+                """
+                    -   key: key2
+                        ctx: [flowlist]
+                        cmd: foo
+                    -   key: key2
+                        ctx: [flowview]
+                        cmd: bar
+                """
+            )
+        kmc.load_path(km, dst)
+        assert(km.get("flowlist", "key2"))
+        assert(km.get("flowview", "key2"))
+
         km.add("key123", "str", ["flowlist", "flowview"])
         with open(dst, 'w') as f:
             f.write(
@@ -127,10 +142,9 @@ def test_load_path(tmpdir):
                 """
             )
         kmc.load_path(km, dst)
-        for b in km.bindings:
-            if b.key == "key123":
-                assert b.contexts == ["options"]
-                break
+        assert(km.get("flowlist", "key123"))
+        assert(km.get("flowview", "key123"))
+        assert(km.get("options", "key123"))
 
 
 def test_parse():


### PR DESCRIPTION
When reading `keys.yaml` file for a specific key and context, instead of removing all contexts bound with this key, it will only overwrite the specific context. This change allows user to bind 1 key with different commands for different contexts.