### PR TITLE
Reduce leaf certificate lifetime to one year

### DIFF
--- a/mitmproxy/certs.py
+++ b/mitmproxy/certs.py
@@ -15,8 +15,8 @@ import OpenSSL
 from mitmproxy.coretypes import serializable
 
 # Default expiry must not be too long: https://github.com/mitmproxy/mitmproxy/issues/815
-DEFAULT_EXP = 94608000  # = 24 * 60 * 60 * 365 * 3
-DEFAULT_EXP_DUMMY_CERT = 63072000  # = 2 years
+DEFAULT_EXP = 94608000  # = 60 * 60 * 24 * 365 * 3 = 3 years
+DEFAULT_EXP_DUMMY_CERT = 31536000  # = 60 * 60 * 24 * 365 = 1 year
 
 # Generated with "openssl dhparam". It's too slow to generate this on startup.
 DEFAULT_DHPARAM = b"""


### PR DESCRIPTION
Safari will, later this year, no longer accept new HTTPS certificates that expire more than 13 months from their creation date.

#3748 was a helpful reminder that we need to do this.