### PR TITLE
Limit WebSocketFlow messages array to a fixed size

### DIFF
--- a/mitmproxy/proxy/protocol/websocket.py
+++ b/mitmproxy/proxy/protocol/websocket.py
@@ -110,6 +110,7 @@ class WebSocketLayer(base.Layer):
             websocket_message = WebSocketMessage(message_type, not is_server, payload)
             length = len(websocket_message.content)
             self.flow.messages.append(websocket_message)
+            while(len(self.flow.messages)>1000): self.flow.messages.pop(0)
             self.channel.ask("websocket_message", self.flow)
 
             if not self.flow.stream and not websocket_message.killed:


### PR DESCRIPTION
If mitmproxy/mitmdump is used with long-running (or very busy) websocket connections, memory usage grows continuously while a socket connection remains active. One approach could be to limit this array to a fixed size, so that only the last N messages are held in memory. I selected 1000 arbitrarily, but this could be a constant defined elsewhere.

It seems most of the user scripts interact with messages as they come in (vs. accessing the complete websocket message history), so this would likely not break any existing functionality.