### PR TITLE
Display TCP flows at flow list!

### DIFF
--- a/mitmproxy/tcp.py
+++ b/mitmproxy/tcp.py
@@ -39,6 +39,7 @@ class TCPFlow(flow.Flow):
     def __init__(self, client_conn, server_conn, live=None):
         super().__init__("tcp", client_conn, server_conn, live)
         self.messages: List[TCPMessage] = []
+        self.timestamp_start: float = time.time()
 
     _stateobject_attributes = flow.Flow._stateobject_attributes.copy()
     _stateobject_attributes["messages"] = List[TCPMessage]


### PR DESCRIPTION
Hi @mhils,

In this pull request I've implemented part of the 1st step of https://github.com/mitmproxy/mitmproxy/issues/1020#issuecomment-609906840. Right now it's not so fancy nor sexy but does the job:

 <img width="1440" alt="Screenshot 2020-04-10 at 20 57 09" src="https://user-images.githubusercontent.com/18281368/79012871-0c3b7c00-7b70-11ea-91c2-351eeb9e6a08.png">

There is no detail view yet. I'm planning to add it with another commit.