### PR TITLE
Fix docker smoke test

### DIFF
--- a/release/cibuild.py
+++ b/release/cibuild.py
@@ -361,8 +361,6 @@ def build_docker_image(be: BuildEnviron):  # pragma: no cover
         "docker",
         "run",
         "--rm",
-        "-i",
-        "-t",
         be.docker_tag,
         "mitmdump",
         "--version",

--- a/release/cibuild.py
+++ b/release/cibuild.py
@@ -361,8 +361,9 @@ def build_docker_image(be: BuildEnviron):  # pragma: no cover
         "docker",
         "run",
         "--rm",
-        "--it",
-        "mitmproxy/mitmproxy:" + be.docker_tag,
+        "-i",
+        "-t",
+        be.docker_tag,
         "mitmproxy",
         "--version",
     ], check=True)

--- a/release/cibuild.py
+++ b/release/cibuild.py
@@ -364,7 +364,7 @@ def build_docker_image(be: BuildEnviron):  # pragma: no cover
         "-i",
         "-t",
         be.docker_tag,
-        "mitmproxy",
+        "mitmdump",
         "--version",
     ], check=True)
     assert "Mitmproxy: " + be.version in r.stdout.decode()

--- a/release/cibuild.py
+++ b/release/cibuild.py
@@ -364,11 +364,9 @@ def build_docker_image(be: BuildEnviron):  # pragma: no cover
         be.docker_tag,
         "mitmdump",
         "--version",
-    ], check=True)
-    assert "Mitmproxy: " + be.version in r.stdout.decode()
-    assert "Python: " in r.stdout.decode()
-    assert "OpenSSL: " in r.stdout.decode()
-    assert "Platform: " in r.stdout.decode()
+    ], check=True, capture_output=True)
+    print(r.stdout.decode())
+    assert "Mitmproxy: " in r.stdout.decode()
 
 
 def build_pyinstaller(be: BuildEnviron):  # pragma: no cover


### PR DESCRIPTION
@Kriechi: Docker CI doesn't run for external PRs because it is too slow and only tests the deploy, so if we work on that we need to use branches on mitmproxy/mitmproxy.