### PR TITLE
Improve compatibility of wsgi_flask_app example on OS X

### DIFF
--- a/examples/simple/wsgi_flask_app.py
+++ b/examples/simple/wsgi_flask_app.py
@@ -15,9 +15,9 @@ def hello_world() -> str:
 
 
 addons = [
-    # Host app at the magic domain "proxapp.local" on port 80. Requests to this
+    # Host app at the magic domain "example.com" on port 80. Requests to this
     # domain and port combination will now be routed to the WSGI app instance.
-    wsgiapp.WSGIApp(app, "proxapp.local", 80)
+    wsgiapp.WSGIApp(app, "example.com", 80)
     # SSL works too, but the magic domain needs to be resolvable from the mitmproxy machine due to mitmproxy's design.
     # mitmproxy will connect to said domain and use serve its certificate (unless --no-upstream-cert is set)
     # but won't send any data.


### PR DESCRIPTION
### Problem
`example/simple/wsgi_flask_app.py` uses a magic domain `proxapp.local` which cannot be resolved on OS X hosts. This is because Apple uses `.local` as a reserved domain for device discovery in Bonjour's mDNS. 

Reference: https://support.apple.com/en-us/HT207511

### How to reproduce
  Environment: OS X 10.5.2 + mitmproxy 5.1.1

1.  Directly load `wsgi_flask_app.py` example on a OS X host 
```
> mitmproxy --mode transparent --showhost -s examples/simple/wsgi_flask_app.py
```
2. Visit `http://proxapp.local` in Chrome. An `ERR_NAME_NOT_RESOLVED` error is shown.

    It seems OS X will always route `.local` domain to Bonjour's mDNS before passing it through a mitmproxy (even if it's running in global transparent mode).

3. Open `wsgi_flask_app.py` and change the magic domain to `example.com`

4. Open chrome and visit `example.com`, it shows `Hello world!`

### Fix
Use `example.com` as the default domain. 