### PR TITLE
Integrate contentviews to TCP flow details

### DIFF
--- a/mitmproxy/contentviews/__init__.py
+++ b/mitmproxy/contentviews/__init__.py
@@ -121,6 +121,9 @@ def get_tcp_content_view(viewname: str, data: bytes):
     if not viewmode:
         viewmode = get("auto")
 
+    # https://github.com/mitmproxy/mitmproxy/pull/3970#issuecomment-623024447
+    assert viewmode
+
     description, lines, error = get_content_view(viewmode, data)
 
     return description, lines, error

--- a/mitmproxy/contentviews/__init__.py
+++ b/mitmproxy/contentviews/__init__.py
@@ -116,6 +116,16 @@ def get_message_content_view(viewname, message, flow):
     return description, lines, error
 
 
+def get_tcp_content_view(viewname: str, data: bytes):
+    viewmode = get(viewname)
+    if not viewmode:
+        viewmode = get("auto")
+
+    description, lines, error = get_content_view(viewmode, data)
+
+    return description, lines, error
+
+
 def get_content_view(viewmode: View, data: bytes, **metadata):
     """
         Args:

--- a/mitmproxy/tools/console/common.py
+++ b/mitmproxy/tools/console/common.py
@@ -104,6 +104,8 @@ if urwid.util.detected_encoding:
     SYMBOL_UP = u"\u21E7"
     SYMBOL_DOWN = u"\u21E9"
     SYMBOL_ELLIPSIS = u"\u2026"
+    SYMBOL_FROM_CLIENT = u"\u21d2"
+    SYMBOL_TO_CLIENT = u"\u21d0"
 else:
     SYMBOL_REPLAY = u"[r]"
     SYMBOL_RETURN = u"<-"
@@ -111,6 +113,8 @@ else:
     SYMBOL_UP = "^"
     SYMBOL_DOWN = " "
     SYMBOL_ELLIPSIS = "~"
+    SYMBOL_FROM_CLIENT = u"->"
+    SYMBOL_TO_CLIENT = u"<-"
 
 SCHEME_STYLES = {
     'http': 'scheme_http',

--- a/mitmproxy/tools/console/flowview.py
+++ b/mitmproxy/tools/console/flowview.py
@@ -115,26 +115,21 @@ class FlowDetails(tabs.Tabs):
         if not flow.messages:
             return searchable.Searchable([urwid.Text(("highlight", "No messages."))])
 
-        from_client = None
-        messages = []
-        for message in flow.messages:
-            if message.from_client is not from_client:
-                messages.append(message.content)
-                from_client = message.from_client
-            else:
-                messages[-1] += message.content
+        viewmode = self.master.commands.call("console.flowview.mode")
 
-        from_client = flow.messages[0].from_client
         parts = []
-        for message in messages:
-            parts.append(
-                (
-                    "head" if from_client else "key",
-                    message
-                )
-            )
-            from_client = not from_client
-        return searchable.Searchable([urwid.Text(parts)])
+        for message in flow.messages:
+            _, lines, _ = contentviews.get_tcp_content_view(viewmode, message.content)
+
+            for line in lines:
+                if message.from_client:
+                    line.insert(0, "--> ")
+                else:
+                    line.insert(0, "<-- ")
+
+                parts.append(urwid.Text(line))
+
+        return searchable.Searchable(parts)
 
     def view_details(self):
         return flowdetailview.flowdetails(self.view, self.flow)

--- a/mitmproxy/tools/console/flowview.py
+++ b/mitmproxy/tools/console/flowview.py
@@ -157,7 +157,6 @@ class FlowDetails(tabs.Tabs):
                     "from_client": message.from_client,
                 })
 
-
         widget_lines = []
 
         widget_lines.append(self._contentview_status_bar(viewmode.capitalize(), viewmode))

--- a/mitmproxy/tools/console/flowview.py
+++ b/mitmproxy/tools/console/flowview.py
@@ -144,9 +144,9 @@ class FlowDetails(tabs.Tabs):
 
             for line in lines:
                 if message["from_client"]:
-                    line.insert(0, "--> ")
+                    line.insert(0, f"{common.SYMBOL_FROM_CLIENT} ")
                 else:
-                    line.insert(0, "<-- ")
+                    line.insert(0, f"{common.SYMBOL_TO_CLIENT} ")
 
                 widget_lines.append(urwid.Text(line))
 

--- a/mitmproxy/tools/console/flowview.py
+++ b/mitmproxy/tools/console/flowview.py
@@ -144,9 +144,9 @@ class FlowDetails(tabs.Tabs):
 
             for line in lines:
                 if message["from_client"]:
-                    line.insert(0, f"{common.SYMBOL_FROM_CLIENT} ")
+                    line.insert(0, ("from_client", f"{common.SYMBOL_FROM_CLIENT} "))
                 else:
-                    line.insert(0, f"{common.SYMBOL_TO_CLIENT} ")
+                    line.insert(0, ("to_client", f"{common.SYMBOL_TO_CLIENT} "))
 
                 widget_lines.append(urwid.Text(line))
 

--- a/mitmproxy/tools/console/flowview.py
+++ b/mitmproxy/tools/console/flowview.py
@@ -108,6 +108,26 @@ class FlowDetails(tabs.Tabs):
         assert isinstance(flow, http.HTTPFlow)
         return self.conn_text(flow.response)
 
+    def _contentview_status_bar(self, description: str, viewmode: str):
+        cols = [
+            urwid.Text(
+                [
+                    ("heading", description),
+                ]
+            ),
+            urwid.Text(
+                [
+                    " ",
+                    ('heading', "["),
+                    ('heading_key', "m"),
+                    ('heading', (":%s]" % viewmode)),
+                ],
+                align="right"
+            )
+        ]
+        contentview_status_bar = urwid.AttrWrap(urwid.Columns(cols), "heading")
+        return contentview_status_bar
+
     def view_tcp_stream(self) -> urwid.Widget:
         flow = self.flow
         assert isinstance(flow, tcp.TCPFlow)
@@ -139,6 +159,9 @@ class FlowDetails(tabs.Tabs):
 
 
         widget_lines = []
+
+        widget_lines.append(self._contentview_status_bar(viewmode.capitalize(), viewmode))
+
         for message in merged_messages:
             _, lines, _ = contentviews.get_tcp_content_view(viewmode, message["content"])
 

--- a/mitmproxy/tools/console/palettes.py
+++ b/mitmproxy/tools/console/palettes.py
@@ -37,6 +37,9 @@ class Palette:
         # JSON view
         'json_string', 'json_number', 'json_boolean',
 
+        # TCP flow details
+        'from_client', 'to_client',
+
         # Grid Editor
         'focusfield', 'focusfield_error', 'field_error', 'editfield',
 
@@ -177,6 +180,10 @@ class LowDark(Palette):
         json_number = ('light magenta', 'default'),
         json_boolean = ('dark magenta', 'default'),
 
+        # TCP flow details
+        from_client = ('light blue', 'default'),
+        to_client = ('light red', 'default'),
+
         # Grid Editor
         focusfield = ('black', 'light gray'),
         focusfield_error = ('dark red', 'light gray'),
@@ -281,6 +288,10 @@ class LowLight(Palette):
         json_string = ('dark blue', 'default'),
         json_number = ('light magenta', 'default'),
         json_boolean = ('dark magenta', 'default'),
+
+        # TCP flow details
+        from_client = ('dark blue', 'default'),
+        to_client = ('dark red', 'default'),
 
         # Grid Editor
         focusfield = ('black', 'light gray'),
@@ -397,6 +408,10 @@ class SolarizedLight(LowLight):
         json_number = (sol_blue, 'default'),
         json_boolean = (sol_magenta, 'default'),
 
+        # TCP flow details
+        from_client = (sol_blue, 'default'),
+        to_client = (sol_red, 'default'),
+
         # Grid Editor
         focusfield = (sol_base00, sol_base2),
         focusfield_error = (sol_red, sol_base2),
@@ -474,6 +489,10 @@ class SolarizedDark(LowDark):
         json_string = (sol_cyan, 'default'),
         json_number = (sol_blue, 'default'),
         json_boolean = (sol_magenta, 'default'),
+
+        # TCP flow details
+        from_client = (sol_blue, 'default'),
+        to_client = (sol_red, 'default'),
 
         # Grid Editor
         focusfield = (sol_base0, sol_base02),


### PR DESCRIPTION
Hey! Just did Step 2 of https://github.com/mitmproxy/mitmproxy/issues/1020#issuecomment-609906840. Here is how it looks like on a real MQTT connection.

Raw contentview:

<img width="1440" alt="Screenshot 2020-05-01 at 20 55 33" src="https://user-images.githubusercontent.com/18281368/80828942-d88fc700-8bee-11ea-847b-93c1a1ce1dc9.png">

Hex contentview:

<img width="1440" alt="Screenshot 2020-05-01 at 20 55 43" src="https://user-images.githubusercontent.com/18281368/80828952-de85a800-8bee-11ea-8277-c5e53d75bdd9.png">
