### PR TITLE
Add a space after prefilled console command string

### DIFF
--- a/mitmproxy/tools/console/consoleaddons.py
+++ b/mitmproxy/tools/console/consoleaddons.py
@@ -292,6 +292,8 @@ class ConsoleAddon:
         Prompt the user to edit a command with a (possibly empty) starting value.
         """
         quoted = " ".join(command_lexer.quote(x) for x in command_str)
+        if quoted:
+            quoted = quoted + " "
         signals.status_prompt_command.send(partial=quoted)
 
     @command.command("console.command.set")

--- a/mitmproxy/tools/console/consoleaddons.py
+++ b/mitmproxy/tools/console/consoleaddons.py
@@ -293,7 +293,7 @@ class ConsoleAddon:
         """
         quoted = " ".join(command_lexer.quote(x) for x in command_str)
         if quoted:
-            quoted = quoted + " "
+            quoted += " "
         signals.status_prompt_command.send(partial=quoted)
 
     @command.command("console.command.set")


### PR DESCRIPTION
When opening command console by tapping a shortcut, there is no space after prefilled command string, the user has to type a `space` first then user input. For example:

- Type `w` in mitmproxy flow view, see console:

```
: save.file @shown█
```
(█ is current cursor position)

To enter the path `~/test`, user has to enter a `space` first:

```
: save.file @shown ~/test█
```
It's a bit inconvenient every time to type the additional `space`...

After this commit, a `space` is inserted after command string and the initial cursor position is:

```
: save.file @shown █
```