### PR TITLE
Add minimal TCP interception and modification!

### DIFF
--- a/mitmproxy/addons/intercept.py
+++ b/mitmproxy/addons/intercept.py
@@ -51,4 +51,5 @@ class Intercept:
         self.process_flow(f)
 
     def tcp_message(self, f):
-        f.intercept()
+        if self.filt:
+            f.intercept()

--- a/mitmproxy/addons/intercept.py
+++ b/mitmproxy/addons/intercept.py
@@ -49,3 +49,6 @@ class Intercept:
 
     def response(self, f):
         self.process_flow(f)
+
+    def tcp_message(self, f):
+        f.intercept()

--- a/mitmproxy/addons/intercept.py
+++ b/mitmproxy/addons/intercept.py
@@ -51,5 +51,5 @@ class Intercept:
         self.process_flow(f)
 
     def tcp_message(self, f):
-        if self.filt:
+        if self.filt and ctx.options.intercept_active:
             f.intercept()

--- a/mitmproxy/tools/console/consoleaddons.py
+++ b/mitmproxy/tools/console/consoleaddons.py
@@ -398,6 +398,7 @@ class ConsoleAddon:
             "status_code",
             "set-cookies",
             "url",
+            "tcp-message"
         ]
 
     @command.command("console.edit.focus")
@@ -458,6 +459,10 @@ class ConsoleAddon:
                 "console.command",
                 ["flow.set", "@focus", flow_part]
             )
+        elif flow_part == "tcp-message":
+            message = flow.messages[-1]
+            c = self.master.spawn_editor(message.content or b"")
+            message.content = c.rstrip(b"\n")
 
     def _grideditor(self):
         gewidget = self.master.window.current("grideditor")

--- a/mitmproxy/tools/console/consoleaddons.py
+++ b/mitmproxy/tools/console/consoleaddons.py
@@ -383,23 +383,30 @@ class ConsoleAddon:
         """
             Possible components for console.edit.focus.
         """
-        return [
-            "cookies",
-            "urlencoded form",
-            "multipart form",
-            "path",
-            "method",
-            "query",
-            "reason",
-            "request-headers",
-            "response-headers",
-            "request-body",
-            "response-body",
-            "status_code",
-            "set-cookies",
-            "url",
-            "tcp-message"
-        ]
+        flow = self.master.view.focus.flow
+        focus_options = []
+
+        if type(flow) == tcp.TCPFlow:
+            focus_options = ["tcp-message"]
+        elif type(flow) == http.HTTPFlow:
+            focus_options = [
+                "cookies",
+                "urlencoded form",
+                "multipart form",
+                "path",
+                "method",
+                "query",
+                "reason",
+                "request-headers",
+                "response-headers",
+                "request-body",
+                "response-body",
+                "status_code",
+                "set-cookies",
+                "url",
+            ]
+
+        return focus_options
 
     @command.command("console.edit.focus")
     @command.argument("flow_part", type=mitmproxy.types.Choice("console.edit.focus.options"))

--- a/mitmproxy/tools/console/flowview.py
+++ b/mitmproxy/tools/console/flowview.py
@@ -164,6 +164,10 @@ class FlowDetails(tabs.Tabs):
 
             from_client = not from_client
 
+        if flow.intercepted:
+            markup = widget_lines[-1].get_text()[0]
+            widget_lines[-1].set_text(("intercept", markup))
+
         widget_lines.insert(0, self._contentview_status_bar(viewmode.capitalize(), viewmode))
 
         return searchable.Searchable(widget_lines)

--- a/test/mitmproxy/addons/test_intercept.py
+++ b/test/mitmproxy/addons/test_intercept.py
@@ -42,3 +42,13 @@ def test_simple():
         f = tflow.tflow(resp=True)
         tctx.cycle(r, f)
         assert f.intercepted
+
+        tctx.configure(r, intercept_active=False)
+        f = tflow.ttcpflow()
+        tctx.cycle(r, f)
+        assert not f.intercepted
+
+        tctx.configure(r, intercept_active=True)
+        f = tflow.ttcpflow()
+        tctx.cycle(r, f)
+        assert f.intercepted


### PR DESCRIPTION
Hi team, 

In this pull request I've implemented MVP for Step 3 of https://github.com/mitmproxy/mitmproxy/issues/1020#issuecomment-609906840. Right now it allows to intercept and modify TCP messages. However I suppose that we need to add several cosmetic features to this pull request which will greatly increase usability:

- [x] Highlight intercepted TCP messages which are waiting for acceptance with `a`.
- [ ] Highlight modified TCP messages.
- [x] Remove unrelated list items from `e` menu (`cookies`, `url`, etc) for TCP flow details.
- [ ] Highlight currently selected TCP message.
- [ ] Show *all* intercepted TCP messages, not only one that is going to be accepted. Also user should be able to skip some intercepted messages and don't ever accept them.

@mhils , any additional features from your side? Feedback on above list of features will be helpful too.

P.S. Slowly but surely #1020 moves to an end 😃