### PR TITLE
Record float timestamp for WebSocket messages instead of truncating to int

### DIFF
--- a/mitmproxy/websocket.py
+++ b/mitmproxy/websocket.py
@@ -17,7 +17,7 @@ class WebSocketMessage(serializable.Serializable):
     """
 
     def __init__(
-        self, type: int, from_client: bool, content: bytes, timestamp: Optional[int]=None, killed: bool=False
+        self, type: int, from_client: bool, content: bytes, timestamp: Optional[float]=None, killed: bool=False
     ) -> None:
         self.type = Opcode(type)  # type: ignore
         """indicates either TEXT or BINARY (from wsproto.frame_protocol.Opcode)."""
@@ -25,7 +25,7 @@ class WebSocketMessage(serializable.Serializable):
         """True if this messages was sent by the client."""
         self.content = content
         """A byte-string representing the content of this message."""
-        self.timestamp: int = timestamp or int(time.time())
+        self.timestamp: float = timestamp or time.time()
         """Timestamp of when this message was received or created."""
         self.killed = killed
         """True if this messages was killed and should not be sent to the other endpoint."""


### PR DESCRIPTION
Closes #3986

To test backward compatibility, I did the following:

```shell
# Capture some WebSocket traffic...
# ... with mitmproxy 5.1.1
$ mitmdump -w stable.mitmdump -q
# ... with patched mitmproxy (commit 479d4cda)
$ mitmdump -w patched.mitmdump -q

# Get a representation of the contents; ws.py is based on the example at https://docs.mitmproxy.org/stable/addons-scripting/#scripting-websocket
$ cat ws.py
from mitmproxy import ctx


def websocket_message(flow):
    # get the latest message
    message = flow.messages[-1]
    ctx.log.info(repr(message.get_state()))

    # was the message sent from the client or server?
    if message.from_client:
        ctx.log.info(f'Client sent a message at {message.timestamp}: {message.content}')
    else:
        ctx.log.info(f'Server sent a message at {message.timestamp}: {message.content}')

# ... with mitmproxy 5.1.1
$ mitmdump -nr stable.mitmdump -s ws.py -v >stable.out_stable
$ mitmdump -nr patched.mitmdump -s ws.py -v >patched.out_stable

# ... with patched mitmproxy
$ mitmdump -nr stable.mitmdump -s ws.py -v > stable.out_patched
$ mitmdump -nr patched.mitmdump -s ws.py -v > patched.out_patched

# Compare
$ diff -qs stable.out_*
Files stable.out_patched and stable.out_stable are identical
$ diff -qs patched.out_*
Files patched.out_patched and patched.out_stable are identical
```

5.1.1 and 479d4cda can read each other's output without issues and get the exact same state for each WebSocketMessage (i.e. reading a new file with 5.1.1 will also have float timestamps). This is obviously not a comprehensive test, and ideally there'd be regression testing in the test suite in general (or did I just miss that?), but that's beyond the scope of this issue/PR.