### PR TITLE
First step to fix #848 by adding a relax_http_form_validation option.

### DIFF
--- a/mitmproxy/options.py
+++ b/mitmproxy/options.py
@@ -181,5 +181,11 @@ class Options(optmanager.OptManager):
             TLS key size for certificates and CA.
             """
         )
+        self.add_option(
+            "relax_http_form_validation", bool, False,
+            """
+            Disable HTTP form validation.
+            """
+        )
 
         self.update(**kwargs)

--- a/mitmproxy/proxy/protocol/http.py
+++ b/mitmproxy/proxy/protocol/http.py
@@ -267,10 +267,12 @@ class HttpLayer(base.Layer):
                     self.send_error_response(400, msg)
                     return False
 
-            validate_request_form(self.mode, request)
+            if not self.config.options.relax_http_form_validation:
+                validate_request_form(self.mode, request)
             self.channel.ask("requestheaders", f)
             # Re-validate request form in case the user has changed something.
-            validate_request_form(self.mode, request)
+            if not self.config.options.relax_http_form_validation:
+                validate_request_form(self.mode, request)
 
             if request.headers.get("expect", "").lower() == "100-continue":
                 # TODO: We may have to use send_response_headers for HTTP2


### PR DESCRIPTION
Add an option to bypass the call to `validate_request_form` when activated, as suggested in #848.
It's probably not enough to fix the whole issue, but it was enough to solve my issue and I guess that even though it's incomplete, adding a flag disabled by default is okay.