### PR TITLE
Fix #3975 by enabling inline HTML in Markdown docs

### DIFF
--- a/docs/src/config.toml
+++ b/docs/src/config.toml
@@ -9,3 +9,8 @@ pygmentsCodefences = true
 
 [indexes]
   tag = "tags"
+
+[markup]
+  [markup.goldmark]
+    [markup.goldmark.renderer]
+      unsafe = true


### PR DESCRIPTION
Setting `unsafe=true` as suggested.