### PR TITLE
Support using `wslview` as a browser to open web url

### DIFF
--- a/mitmproxy/tools/web/webaddons.py
+++ b/mitmproxy/tools/web/webaddons.py
@@ -44,7 +44,7 @@ def open_browser(url: str) -> bool:
         False, if no suitable browser has been found.
     """
     browsers = (
-        "windows-default", "macosx",
+        "windows-default", "wslview %s", "macosx",
         "google-chrome", "chrome", "chromium", "chromium-browser",
         "firefox", "opera", "safari",
     )


### PR DESCRIPTION
[`wslview`](http://manpages.ubuntu.com/manpages/eoan/man1/wslview.1.html) is a utility that ships with the newer versions of WSL as a way of opening links in the default web browser on the Windows host.