### PR TITLE
Add Kubernetes HOWTO to docs

### DIFF
--- a/docs/src/content/howto-kubernetes.md
+++ b/docs/src/content/howto-kubernetes.md
@@ -1,0 +1,13 @@
+---
+title: "Kubernetes Services"
+menu:
+    howto:
+        weight: 1
+---
+
+# Kubernetes Services
+
+The [github.com/soluble-ai/kubetap](https://github.com/soluble-ai/kubetap) project
+provides a kubectl plugin for easily deploying mitmproxy to proxy Kubernetes Services.
+
+For usage and documentation, please refer to the [kubetap project site](https://soluble-ai.github.io/kubetap/).


### PR DESCRIPTION
This references a project I recently released which automates proxying Kubernetes Services using mitmproxy: https://github.com/soluble-ai/kubetap

Thanks for all your hard work, without which Kubetap wouldn't exist!

Feel free to amend the weight.