### PR TITLE
HTTP2 response reason is None, render as '' in property.

### DIFF
--- a/mitmproxy/net/http/response.py
+++ b/mitmproxy/net/http/response.py
@@ -122,10 +122,14 @@ class Response(message.Message):
     def reason(self):
         """
         HTTP Reason Phrase, e.g. "Not Found".
-        This is always :py:obj:`None` for HTTP2 requests, because HTTP2 responses do not contain a reason phrase.
+        HTTP2 responses do not contain a reason phrase and self.data.reason will be :py:obj:`None`.
+        When :py:obj:`None` return an empty reason phrase so that functions expecting a string work properly.
         """
         # Encoding: http://stackoverflow.com/a/16674906/934719
-        return self.data.reason.decode("ISO-8859-1", "surrogateescape")
+        if self.data.reason is not None:
+            return self.data.reason.decode("ISO-8859-1", "surrogateescape")
+        else:
+            return ""
 
     @reason.setter
     def reason(self, reason):

--- a/test/mitmproxy/net/http/test_response.py
+++ b/test/mitmproxy/net/http/test_response.py
@@ -77,6 +77,12 @@ class TestResponseCore:
         resp.data.reason = b'cr\xe9e'
         assert resp.reason == "crée"
 
+        # HTTP2 responses do not contain a reason phrase and self.data.reason will be None.
+        # This should render to an empty reason phrase so that functions
+        # expecting a string work properly.
+        resp.data.reason = None
+        assert resp.reason == ""
+
 
 class TestResponseUtils:
     """


### PR DESCRIPTION
Fixes an error triggered when displaying an HTTP2 response loaded from a file.

Using this script saved as `reason_none.py`:

```
from mitmproxy.io import protobuf

def response(flow):
    repr(protobuf.loads(protobuf.dumps(flow)))
```

Run:

```
$ mitmdump --save-stream-file google.flow
<in another terminal>
$ curl -k --http2 --proxy localhost:8080 https://google.com
```

Crashes:

```
$ mitmdump --rfile google.flow --script reason_none.py 
Loading script reason_none.py
Proxy server listening at http://*:8080
[::1]:51048: GET https://google.com/ HTTP/2.0
          << 301  220b
Addon error: Traceback (most recent call last):
  File "reason_none.py", line 4, in response
    repr(protobuf.loads(protobuf.dumps(flow)))
  File "/Users/rbdixon/src/mitmproxy/mitmproxy/http.py", line 174, in __repr__
    return s.format(flow=self)
  File "/Users/rbdixon/src/mitmproxy/mitmproxy/net/http/response.py", line 66, in __repr__
    reason=self.reason,
  File "/Users/rbdixon/src/mitmproxy/mitmproxy/net/http/response.py", line 128, in reason
    return self.data.reason.decode("ISO-8859-1", "surrogateescape")
AttributeError: 'NoneType' object has no attribute 'decode'
```