### PR TITLE
Document default listen port is 8080

### DIFF
--- a/docs/src/content/concepts-modes.md
+++ b/docs/src/content/concepts-modes.md
@@ -24,7 +24,7 @@ Mitmproxy's regular mode is the simplest and the easiest to set up.
 
 1. Start mitmproxy.
 2. Configure your client to use mitmproxy by explicitly setting an HTTP
-    proxy.
+    proxy. By default, mitmproxy listens on port 8080.
 3. Quick Check: You should already be able to visit an unencrypted HTTP
     site through the proxy.
 4. Open the magic domain **mitm.it** and install the certificate for your


### PR DESCRIPTION
I couldn't find anywhere in the docs that said what port mitmproxy runs on, or how to find out which port it runs on, so I think it would be good to add it to this page.