### PR TITLE
the link of wsproto was not displayed right.

### DIFF
--- a/docs/src/content/concepts-protocols.md
+++ b/docs/src/content/concepts-protocols.md
@@ -55,8 +55,7 @@ can enable it with: `http2_priority=true`.
 
 [RFC7692: Compression Extensions for WebSocket](http://tools.ietf.org/html/rfc7692)
 
-WebSocket support in mitmproxy is based on [wsproto]
-(https://github.com/python-hyper/wsproto) project. It fully encapsulates
+WebSocket support in mitmproxy is based on [wsproto](https://github.com/python-hyper/wsproto) project. It fully encapsulates
 WebSocket frames/messages/connections and provides an easy-to-use event-based
 API.
 


### PR DESCRIPTION
I just fixed the link attached to wsproto.

![image](https://user-images.githubusercontent.com/29271244/85231471-3e037580-b432-11ea-8ebf-6210d234ebe1.png)
