### PR TITLE
Improve SetHeaders addon

### DIFF
--- a/docs/src/content/overview-features.md
+++ b/docs/src/content/overview-features.md
@@ -131,11 +131,11 @@ then the respective recorded responses are simply replayed by mitmproxy.
 Otherwise, the unmatched requests is forwarded to the upstream server. If
 forwarding is not desired, you can use the --kill (-k) switch to prevent that.
 
-## Set Headers
+## Modify Headers
 
-The `setheaders` option lets you specify a set of headers to be modified.
+The `modify_headers` option lets you specify a set of headers to be modified.
 New headers can be added, and existing headers can be overwritten or removed.
-A `setheaders` expression looks like this:
+A `modify_headers` expression looks like this:
 
 {{< highlight none  >}}
 /name/value[/filter-expression]

--- a/docs/src/content/overview-features.md
+++ b/docs/src/content/overview-features.md
@@ -133,17 +133,22 @@ forwarding is not desired, you can use the --kill (-k) switch to prevent that.
 
 ## Set Headers
 
-The `setheaders` option lets you specify a set of headers to be added to
-requests or responses, based on a filter pattern. A `setheaders` expression
-looks like this:
+The `setheaders` option lets you specify a set of headers to be modified.
+New headers can be added, and existing headers can be overwritten or removed.
+A `setheaders` expression looks like this:
 
 {{< highlight none  >}}
-/patt/name/value
+/name/value[/filter-expression]
 {{< / highlight >}}
 
-Here, **patt** is a mitmproxy filter expression that defines which flows to set
-headers on, and **name** and **value** are the header name and the value to set
-respectively.
+Here, **name** and **value** are the header name and the value to set respectively,
+e.g., ``/Host/example.org``. An empty **value** removes existing headers with
+**name**, e.g., ``/Host/``. The optional **filter-expression** is a mitmproxy
+[filter expression]({{< relref "concepts-filters">}}) that defines
+which flows to modify headers on, e.g., only on responses using ``~s``.
+Existing headers are overwritten by default.
+This can be changed using filter-expressions, e.g., ``!~h Host:`` to ignore
+requests and responses with an existing ``Host`` header.
 
 ## Sticky auth
 

--- a/mitmproxy/addons/__init__.py
+++ b/mitmproxy/addons/__init__.py
@@ -14,7 +14,7 @@ from mitmproxy.addons import proxyauth
 from mitmproxy.addons import replace
 from mitmproxy.addons import script
 from mitmproxy.addons import serverplayback
-from mitmproxy.addons import setheaders
+from mitmproxy.addons import modifyheaders
 from mitmproxy.addons import stickyauth
 from mitmproxy.addons import stickycookie
 from mitmproxy.addons import streambodies
@@ -40,7 +40,7 @@ def default_addons():
         replace.Replace(),
         script.ScriptLoader(),
         serverplayback.ServerPlayback(),
-        setheaders.SetHeaders(),
+        modifyheaders.ModifyHeaders(),
         stickyauth.StickyAuth(),
         stickycookie.StickyCookie(),
         streambodies.StreamBodies(),

--- a/mitmproxy/addons/modifyheaders.py
+++ b/mitmproxy/addons/modifyheaders.py
@@ -5,11 +5,11 @@ from mitmproxy import flowfilter
 from mitmproxy import ctx
 
 
-def parse_setheader(s):
+def parse_modify_headers(s):
     """
         Returns a (header_name, header_value, flow_filter) tuple.
 
-        The general form for a setheader hook is as follows:
+        The general form for a modify_headers hook is as follows:
 
             /header_name/header_value/flow_filter
 
@@ -42,29 +42,29 @@ def parse_setheader(s):
     return header_name, header_value, flow_filter
 
 
-class SetHeaders:
+class ModifyHeaders:
     def __init__(self):
         self.lst = []
 
     def load(self, loader):
         loader.add_option(
-            "setheaders", typing.Sequence[str], [],
+            "modify_headers", typing.Sequence[str], [],
             """
-            Header set pattern of the form "/header-name/header-value[/flow-filter]", where the
+            Header modify pattern of the form "/header-name/header-value[/flow-filter]", where the
             separator can be any character. An empty header-value removes existing header-name headers.
             """
         )
 
     def configure(self, updated):
-        if "setheaders" in updated:
+        if "modify_headers" in updated:
             self.lst = []
-            for shead in ctx.options.setheaders:
-                header, value, flow_pattern = parse_setheader(shead)
+            for shead in ctx.options.modify_headers:
+                header, value, flow_pattern = parse_modify_headers(shead)
 
                 flow_filter = flowfilter.parse(flow_pattern)
                 if not flow_filter:
                     raise exceptions.OptionsError(
-                        "Invalid setheader filter pattern %s" % flow_pattern
+                        "Invalid modify_headers flow filter %s" % flow_pattern
                     )
                 self.lst.append((header, value, flow_pattern, flow_filter))
 

--- a/mitmproxy/addons/setheaders.py
+++ b/mitmproxy/addons/setheaders.py
@@ -50,7 +50,7 @@ class SetHeaders:
             "setheaders", typing.Sequence[str], [],
             """
             Header set pattern of the form "/header-name/header-value[/flow-filter]", where the
-            separator can be any character.
+            separator can be any character. An empty header-value removes existing header-name headers.
             """
         )
 
@@ -72,7 +72,7 @@ class SetHeaders:
             if flow_filter(f):
                 hdrs.pop(header, None)
         for header, value, _, flow_filter in self.lst:
-            if flow_filter(f):
+            if flow_filter(f) and value:
                 hdrs.add(header, value)
 
     def request(self, flow):

--- a/mitmproxy/addons/setheaders.py
+++ b/mitmproxy/addons/setheaders.py
@@ -16,7 +16,7 @@ def parse_setheader(s):
         The first character specifies the separator. Example:
 
             :foo:bar:~q
-        
+
         If only two clauses are specified, the pattern is set to match
         universally (i.e. ".*"). Example:
 

--- a/mitmproxy/addons/setheaders.py
+++ b/mitmproxy/addons/setheaders.py
@@ -7,22 +7,23 @@ from mitmproxy import ctx
 
 def parse_setheader(s):
     """
-        Returns a (header_name, header_value, flow_pattern) tuple.
+        Returns a (header_name, header_value, flow_filter) tuple.
 
         The general form for a setheader hook is as follows:
 
-            /header_name/header_value/flow_pattern
+            /header_name/header_value/flow_filter
 
         The first character specifies the separator. Example:
 
             :foo:bar:~q
+        
         If only two clauses are specified, the pattern is set to match
         universally (i.e. ".*"). Example:
 
             /foo/bar/
 
         Clauses are parsed from left to right. Extra separators are taken to be
-        part of the final clause. For instance, the flow-pattern clause below is
+        part of the final clause. For instance, the flow filter below is
         "foo/bar/":
 
             /one/two/foo/bar/
@@ -30,15 +31,15 @@ def parse_setheader(s):
     sep, rem = s[0], s[1:]
     parts = rem.split(sep, 2)
     if len(parts) == 2:
-        flow_pattern = ".*"
+        flow_filter = ".*"
         header_name, header_value = parts
     elif len(parts) == 3:
-        header_name, header_value, flow_pattern = parts
+        header_name, header_value, flow_filter = parts
     else:
         raise exceptions.OptionsError(
             "Invalid replacement specifier: %s" % s
         )
-    return header_name, header_value, flow_pattern
+    return header_name, header_value, flow_filter
 
 
 class SetHeaders:

--- a/mitmproxy/tools/cmdline.py
+++ b/mitmproxy/tools/cmdline.py
@@ -85,9 +85,9 @@ def common_options(parser, opts):
     group = parser.add_argument_group("Replacements")
     opts.make_parser(group, "replacements", metavar="PATTERN", short="R")
 
-    # Set headers
-    group = parser.add_argument_group("Set Headers")
-    opts.make_parser(group, "setheaders", metavar="PATTERN", short="H")
+    # Modify headers
+    group = parser.add_argument_group("Modify Headers")
+    opts.make_parser(group, "modify_headers", metavar="PATTERN", short="H")
 
 
 def mitmproxy(opts):

--- a/mitmproxy/tools/console/statusbar.py
+++ b/mitmproxy/tools/console/statusbar.py
@@ -206,7 +206,7 @@ class StatusBar(urwid.WidgetWrap):
         sreplay = self.master.commands.call("replay.server.count")
         creplay = self.master.commands.call("replay.client.count")
 
-        if len(self.master.options.setheaders):
+        if len(self.master.options.modify_headers):
             r.append("[")
             r.append(("heading_key", "H"))
             r.append("eaders]")

--- a/test/mitmproxy/addons/test_modifyheaders.py
+++ b/test/mitmproxy/addons/test_modifyheaders.py
@@ -3,33 +3,33 @@ import pytest
 from mitmproxy.test import tflow
 from mitmproxy.test import taddons
 
-from mitmproxy.addons import setheaders
+from mitmproxy.addons import modifyheaders
 
 
-class TestSetHeaders:
-    def test_parse_setheaders(self):
-        x = setheaders.parse_setheader("/foo/bar/voing")
+class TestModifyHeaders:
+    def test_parse_modifyheaders(self):
+        x = modifyheaders.parse_modify_headers("/foo/bar/voing")
         assert x == ("foo", "bar", "voing")
-        x = setheaders.parse_setheader("/foo/bar/vo/ing/")
+        x = modifyheaders.parse_modify_headers("/foo/bar/vo/ing/")
         assert x == ("foo", "bar", "vo/ing/")
-        x = setheaders.parse_setheader("/bar/voing")
+        x = modifyheaders.parse_modify_headers("/bar/voing")
         assert x == ("bar", "voing", ".*")
         with pytest.raises(Exception, match="Invalid replacement"):
-            setheaders.parse_setheader("/")
+            modifyheaders.parse_modify_headers("/")
 
     def test_configure(self):
-        sh = setheaders.SetHeaders()
+        sh = modifyheaders.ModifyHeaders()
         with taddons.context(sh) as tctx:
-            with pytest.raises(Exception, match="Invalid setheader filter pattern"):
-                tctx.configure(sh, setheaders = ["/one/two/~b"])
-            tctx.configure(sh, setheaders = ["/foo/bar/voing"])
+            with pytest.raises(Exception, match="Invalid modify_headers flow filter"):
+                tctx.configure(sh, modify_headers = ["/one/two/~b"])
+            tctx.configure(sh, modify_headers = ["/foo/bar/voing"])
 
-    def test_setheaders(self):
-        sh = setheaders.SetHeaders()
+    def test_modify_headers(self):
+        sh = modifyheaders.ModifyHeaders()
         with taddons.context(sh) as tctx:
             tctx.configure(
                 sh,
-                setheaders = [
+                modify_headers = [
                     "/one/two/~q",
                     "/one/three/~s"
                 ]
@@ -46,7 +46,7 @@ class TestSetHeaders:
 
             tctx.configure(
                 sh,
-                setheaders = [
+                modify_headers = [
                     "/one/two/~s",
                     "/one/three/~s"
                 ]
@@ -59,7 +59,7 @@ class TestSetHeaders:
 
             tctx.configure(
                 sh,
-                setheaders = [
+                modify_headers = [
                     "/one/two/~q",
                     "/one/three/~q"
                 ]
@@ -69,10 +69,10 @@ class TestSetHeaders:
             sh.request(f)
             assert f.request.headers.get_all("one") == ["two", "three"]
 
-            # test removal of existing header
+            # test removal of existing headers
             tctx.configure(
                 sh,
-                setheaders = [
+                modify_headers = [
                     "/one//~q",
                     "/one//~s"
                 ]
@@ -89,7 +89,7 @@ class TestSetHeaders:
 
             tctx.configure(
                 sh,
-                setheaders = [
+                modify_headers = [
                     "/one/"
                 ]
             )

--- a/test/mitmproxy/addons/test_setheaders.py
+++ b/test/mitmproxy/addons/test_setheaders.py
@@ -13,7 +13,7 @@ class TestSetHeaders:
         x = setheaders.parse_setheader("/foo/bar/vo/ing/")
         assert x == ("foo", "bar", "vo/ing/")
         x = setheaders.parse_setheader("/bar/voing")
-        assert x == (".*", "bar", "voing")
+        assert x == ("bar", "voing", ".*")
         with pytest.raises(Exception, match="Invalid replacement"):
             setheaders.parse_setheader("/")
 
@@ -21,7 +21,7 @@ class TestSetHeaders:
         sh = setheaders.SetHeaders()
         with taddons.context(sh) as tctx:
             with pytest.raises(Exception, match="Invalid setheader filter pattern"):
-                tctx.configure(sh, setheaders = ["/~b/one/two"])
+                tctx.configure(sh, setheaders = ["/one/two/~b"])
             tctx.configure(sh, setheaders = ["/foo/bar/voing"])
 
     def test_setheaders(self):
@@ -30,8 +30,8 @@ class TestSetHeaders:
             tctx.configure(
                 sh,
                 setheaders = [
-                    "/~q/one/two",
-                    "/~s/one/three"
+                    "/one/two/~q",
+                    "/one/three/~s"
                 ]
             )
             f = tflow.tflow()
@@ -47,8 +47,8 @@ class TestSetHeaders:
             tctx.configure(
                 sh,
                 setheaders = [
-                    "/~s/one/two",
-                    "/~s/one/three"
+                    "/one/two/~s",
+                    "/one/three/~s"
                 ]
             )
             f = tflow.tflow(resp=True)
@@ -60,8 +60,8 @@ class TestSetHeaders:
             tctx.configure(
                 sh,
                 setheaders = [
-                    "/~q/one/two",
-                    "/~q/one/three"
+                    "/one/two/~q",
+                    "/one/three/~q"
                 ]
             )
             f = tflow.tflow()

--- a/test/mitmproxy/addons/test_setheaders.py
+++ b/test/mitmproxy/addons/test_setheaders.py
@@ -68,3 +68,37 @@ class TestSetHeaders:
             f.request.headers["one"] = "xxx"
             sh.request(f)
             assert f.request.headers.get_all("one") == ["two", "three"]
+
+            # test removal of existing header
+            tctx.configure(
+                sh,
+                setheaders = [
+                    "/one//~q",
+                    "/one//~s"
+                ]
+            )
+            f = tflow.tflow()
+            f.request.headers["one"] = "xxx"
+            sh.request(f)
+            assert "one" not in f.request.headers
+
+            f = tflow.tflow(resp=True)
+            f.response.headers["one"] = "xxx"
+            sh.response(f)
+            assert "one" not in f.response.headers
+
+            tctx.configure(
+                sh,
+                setheaders = [
+                    "/one/"
+                ]
+            )
+            f = tflow.tflow()
+            f.request.headers["one"] = "xxx"
+            sh.request(f)
+            assert "one" not in f.request.headers
+
+            f = tflow.tflow(resp=True)
+            f.response.headers["one"] = "xxx"
+            sh.response(f)
+            assert "one" not in f.response.headers

--- a/test/mitmproxy/tools/console/test_statusbar.py
+++ b/test/mitmproxy/tools/console/test_statusbar.py
@@ -8,7 +8,7 @@ def test_statusbar(monkeypatch):
     o = options.Options()
     m = master.ConsoleMaster(o)
     m.options.update(
-        setheaders=[":~q:foo:bar"],
+        modify_headers=[":~q:foo:bar"],
         replacements=[":~q:foo:bar"],
         ignore_hosts=["example.com", "example.org"],
         tcp_hosts=["example.tcp"],


### PR DESCRIPTION
This PR improves the `SetHeaders` addon with 3 changes:

1) The flow-filter is now the last parameter in the configuration pattern, as it is optional.
2) The user can now remove existing headers by specifying an empty `header-value`.
3) Updated docs to reflect changes.

refs #3948 