### PR TITLE
fix docs generation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -120,7 +120,7 @@ Documentation
 
 The following tools are required to build the mitmproxy docs:
 
-- Hugo_
+- Hugo_ (the extended version `hugo_version` is required)
 - modd_
 
 .. code-block:: bash

--- a/README.rst
+++ b/README.rst
@@ -120,7 +120,7 @@ Documentation
 
 The following tools are required to build the mitmproxy docs:
 
-- Hugo_ (the extended version `hugo_version` is required)
+- Hugo_ (the extended version ``hugo_extended`` is required)
 - modd_
 
 .. code-block:: bash

--- a/docs/modd.conf
+++ b/docs/modd.conf
@@ -1,5 +1,5 @@
 scripts/*.py {
-    prep: build.sh
+    prep: ./build.sh
 }
 
 {


### PR DESCRIPTION
The docs generation fails with 2 errors on Ubuntu 18.04:

```
❯ modd
16:10:34: prep: build.sh
"build.sh": executable file not found in $PATH
exit status 1
16:10:34: daemon: cd src; hugo server -D
>> starting...
Error: Error building site: TOCSS: failed to transform "style.scss" (text/x-scss): resource "scss/style.scss_b95b077eb505d5c0aff805
5eaced30ad" not found in file cache
Building sites … Built in 28 ms
exited: exit status 1
```

The first error from modd is fixed by adding `./`to the path.
The second error is fixed by using the extended version of hugo, see https://discourse.gohugo.io/t/tocss-ressource-not-found-in-file-cache/24858