### PR TITLE
Update changelog and add PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,8 @@
-This PR fixes #<issue-numer>.
+#### Description
 
-This PR introduces a new feature to ...
+<!-- describe your changes here -->
 
-**Please add a new entry for the changes in this PR to the CHANGELOG in the unreleased section at the top!**
+#### Checklist
 
-**Please make sure all automated tests and checks pass - we will not consider your PR for merging with failing checks!**
+ - [ ] I have updated tests where applicable.
+ - [ ] I have added an entry to the CHANGELOG.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,7 @@
+This PR fixes #<issue-numer>.
+
+This PR introduces a new feature to ...
+
+**Please add a new entry for the changes in this PR to the CHANGELOG in the unreleased section at the top!**
+
+**Please make sure all automated tests and checks pass - we will not consider your PR for merging with failing checks!**

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,28 @@
+Unreleased: mitmproxy next
+
+  ** Full Changelog **
+    * Add Filter message to mitmdump (@sarthak212)
+    * Display TCP flows at flow list (@Jessonsotoventura, @nikitastupin, @mhils)
+    * Colorize JSON Contentview (@sarthak212)
+    * Fix console crash when entering regex escape character in half-open string (@sarthak212)
+    * Integrate contentviews to TCP flow details (@nikitastupin)
+    * Added add-ons that enhance the performance of web application scanners (@anneborcherding)
+    * Increase WebSocket message timestamp precision (@JustAnotherArchivist)
+    * Fix HTTP reason value on HTTP/2 reponses (@rbdixon)
+    * mitmweb: support wslview to open a web browser (@G-Rath)
+    * Fix dev version detection with parent git repo (@JustAnotherArchivist)
+    * Restructure examples and supported addons (@mhils)
+    * Certificate generation: mark SAN as critical if no CN is set (@mhils)
+    * Simplify Replacements with new ModifyBody addon (@mplattner)
+    * Rename SetHeaders addon to ModifyHeaders (@mplattner)
+    * mitmweb: "New -> File" menu option has been renamed to "Clear All" (@yogeshojha)
+
+    * --- TODO: add new PRs above this line ---
+
+    * ... and various other fixes, documentation improvements, dependency version bumps, etc.
+
 13 April 2020: mitmproxy 5.1.1
+
     * Fixed Docker images not starting due to missing shell
 
 13 April 2020: mitmproxy 5.1


### PR DESCRIPTION
as discussed with @mhils, we should keep the changelog up2date at all times to avoid this daunting task before cutting a release.

This PR adds all recent PRs since the last release to the changelog.
This PR adds a PR template to instruct users to add new changelog entries directly into their newly sent PRs.