### PR TITLE
List was not cycled right for tab auto-completion

### DIFF
--- a/mitmproxy/tools/console/commander/commander.py
+++ b/mitmproxy/tools/console/commander/commander.py
@@ -28,15 +28,17 @@ class ListCompleter(Completer):
             if o.startswith(start):
                 self.options.append(o)
         self.options.sort()
-        self.offset = 0
+        self.pos = None
 
     def cycle(self, forward: bool = True) -> str:
         if not self.options:
             return self.start
-        ret = self.options[self.offset]
-        delta = 1 if forward else -1
-        self.offset = (self.offset + delta) % len(self.options)
-        return ret
+        if self.pos is None:
+            self.pos = 0 if forward else len(self.options) - 1
+        else:
+            delta = 1 if forward else -1
+            self.pos = (self.pos + delta) % len(self.options)
+        return self.options[self.pos]
 
 
 class CompletionState(typing.NamedTuple):

--- a/mitmproxy/tools/console/commander/commander.py
+++ b/mitmproxy/tools/console/commander/commander.py
@@ -1,4 +1,3 @@
-import sys
 import abc
 import typing
 
@@ -29,12 +28,12 @@ class ListCompleter(Completer):
             if o.startswith(start):
                 self.options.append(o)
         self.options.sort()
-        self.pos = sys.maxsize
+        self.pos = -1
 
     def cycle(self, forward: bool = True) -> str:
         if not self.options:
             return self.start
-        if self.pos == sys.maxsize:
+        if self.pos == -1:
             self.pos = 0 if forward else len(self.options) - 1
         else:
             delta = 1 if forward else -1

--- a/mitmproxy/tools/console/commander/commander.py
+++ b/mitmproxy/tools/console/commander/commander.py
@@ -1,3 +1,4 @@
+import sys
 import abc
 import typing
 
@@ -28,12 +29,12 @@ class ListCompleter(Completer):
             if o.startswith(start):
                 self.options.append(o)
         self.options.sort()
-        self.pos = None
+        self.pos = sys.maxsize
 
     def cycle(self, forward: bool = True) -> str:
         if not self.options:
             return self.start
-        if self.pos is None:
+        if self.pos == sys.maxsize:
             self.pos = 0 if forward else len(self.options) - 1
         else:
             delta = 1 if forward else -1

--- a/test/mitmproxy/tools/console/test_commander.py
+++ b/test/mitmproxy/tools/console/test_commander.py
@@ -31,23 +31,35 @@ class TestListCompleter:
             [
                 "",
                 ["a", "b", "c"],
-                ["a", "b", "c", "a"]
+                ["a", "b", "c", "a"],
+                ["c", "b", "a", "c"],
+                ["a", "c", "a", "c"]
             ],
             [
                 "xxx",
                 ["a", "b", "c"],
+                ["xxx", "xxx", "xxx"],
+                ["xxx", "xxx", "xxx"],
                 ["xxx", "xxx", "xxx"]
             ],
             [
                 "b",
                 ["a", "b", "ba", "bb", "c"],
-                ["b", "ba", "bb", "b"]
+                ["b", "ba", "bb", "b"],
+                ["bb", "ba", "b", "bb"],
+                ["b", "bb", "b", "bb"]
             ],
         ]
-        for start, opts, cycle in tests:
+        for start, opts, cycle, cycle_reverse, cycle_mix in tests:
             c = commander.ListCompleter(start, opts)
             for expected in cycle:
                 assert c.cycle() == expected
+            for expected in cycle_reverse:
+                assert c.cycle(False) == expected
+            forward = True
+            for expected in cycle_mix:
+                assert c.cycle(forward) == expected
+                forward = not forward
 
 
 class TestCommandEdit:


### PR DESCRIPTION
#### Description

Options was not cycled right for tab auto-completion. Using tabs and shift-tabs mixed up when you are in cut.clip for instance. You would see the options just don't go back right when you press shift-tab, and it wouldn't go forward right for some occasion caused by the same bug. 

The code before did not even care if tab or shift tab was pressed and set the previously calculated position as the new position of the options, then calculate the next position after it. 

So fix was fairly simple. Check if tab or shift tab was pressed and calculate the new position according to it. A little difficult part was how to deal with the first time the tab or shift tab was pressed, but it could be handled by setting sys.maxsize as the initial value for the position.

Probably the code itself would explain you better :) 

#### Checklist

 - [x] I have updated tests where applicable.
 - [ ] I have added an entry to the CHANGELOG.
