### PR TITLE
Don't fail on covecov errors

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,7 +56,7 @@ jobs:
         with:
           file: ./coverage.xml
           name: ${{ matrix.os }}
-          fail_ci_if_error: true
+          fail_ci_if_error: false
   test-py35:
     runs-on: ubuntu-latest
     steps:
@@ -132,7 +132,7 @@ jobs:
         with:
           file: ./web/coverage/coverage-final.json
           name: web
-          fail_ci_if_error: true
+          fail_ci_if_error: false
 
   docs:
     env:


### PR DESCRIPTION
This happens quite a bit, so let's stop failing tests for that.