### PR TITLE
Fix typespec_to_str funcion to process typing.Optional[int]

### DIFF
--- a/mitmproxy/utils/typecheck.py
+++ b/mitmproxy/utils/typecheck.py
@@ -81,6 +81,8 @@ def typespec_to_str(typespec: typing.Any) -> str:
         t = 'optional str'
     elif typespec == typing.Sequence[str]:
         t = 'sequence of str'
+    elif typespec == typing.Optional[int]:
+        t = 'optional int'
     else:
         raise NotImplementedError
     return t

--- a/test/examples/test_examples.py
+++ b/test/examples/test_examples.py
@@ -3,6 +3,7 @@ from mitmproxy.test import tflow
 from mitmproxy.test import tutils
 from mitmproxy.test import taddons
 from mitmproxy.net.http import Headers
+from mitmproxy.utils import typecheck
 
 from ..mitmproxy import tservers
 

--- a/test/examples/test_examples.py
+++ b/test/examples/test_examples.py
@@ -3,7 +3,6 @@ from mitmproxy.test import tflow
 from mitmproxy.test import tutils
 from mitmproxy.test import taddons
 from mitmproxy.net.http import Headers
-from mitmproxy.utils import typecheck
 
 from ..mitmproxy import tservers
 

--- a/test/mitmproxy/utils/test_typecheck.py
+++ b/test/mitmproxy/utils/test_typecheck.py
@@ -72,6 +72,7 @@ def test_typesec_to_str():
     assert(typecheck.typespec_to_str(str)) == "str"
     assert(typecheck.typespec_to_str(typing.Sequence[str])) == "sequence of str"
     assert(typecheck.typespec_to_str(typing.Optional[str])) == "optional str"
+    assert(typecheck.typespec_to_str(typing.Optional[int])) == "optional int"
     with pytest.raises(NotImplementedError):
         typecheck.typespec_to_str(dict)
 


### PR DESCRIPTION
Fix #4059 

The file examples/addons/options-configure.py uses typespec "typing.Optional[int]"  which was not implemented in typespec_to_str function.
So, I implemented it.