### PR TITLE
Fix "RuntimeError: dictionary changed size during iteration" in the "expire" function of "mitmproxy/certs.py"

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -18,6 +18,7 @@ Unreleased: mitmproxy next
     * mitmweb: "New -> File" menu option has been renamed to "Clear All" (@yogeshojha)
     * Add new MapRemote addon to rewrite URLs of requests (@mplattner)
     * Add support for HTTP Trailers to the HTTP/2 protocol (@sanlengjingvv and @Kriechi)
+    * Fix certificate runtime error during expire cleanup (@gorogoroumaru)
 
     * --- TODO: add new PRs above this line ---
 

--- a/mitmproxy/certs.py
+++ b/mitmproxy/certs.py
@@ -173,9 +173,7 @@ class CertStore:
         self.expire_queue.append(entry)
         if len(self.expire_queue) > self.STORE_CAP:
             d = self.expire_queue.pop(0)
-            for k, v in list(self.certs.items()):
-                if v == d:
-                    del self.certs[k]
+            self.certs = {k: v for k, v in self.certs.items() if v != d}
 
     @staticmethod
     def load_dhparam(path):


### PR DESCRIPTION
Fix #4057 

I changed iteration to list comprehension in order to prevent "RuntimeError: dictionary changed size during iteration" in the "expire" function of "mitmproxy/certs.py"

