### PR TITLE
Added default timeout value

### DIFF
--- a/mitmproxy/net/tcp.py
+++ b/mitmproxy/net/tcp.py
@@ -125,7 +125,9 @@ class Reader(_FileLike):
                 # underlying BIO could not satisfy the needs of SSL_read() to continue the
                 # operation. In this case a call to SSL_get_error with the return value of
                 # SSL_read() will yield SSL_ERROR_WANT_READ or SSL_ERROR_WANT_WRITE.
-                if (time.time() - start) < self.o.gettimeout():
+                # 300 is OpenSSL default timeout
+                self.timeout = self.o.gettimeout() or 300
+                if (time.time() - start) < self.timeout:
                     time.sleep(0.1)
                     continue
                 else:

--- a/mitmproxy/net/tcp.py
+++ b/mitmproxy/net/tcp.py
@@ -126,8 +126,8 @@ class Reader(_FileLike):
                 # operation. In this case a call to SSL_get_error with the return value of
                 # SSL_read() will yield SSL_ERROR_WANT_READ or SSL_ERROR_WANT_WRITE.
                 # 300 is OpenSSL default timeout
-                self.timeout = self.o.gettimeout() or 300
-                if (time.time() - start) < self.timeout:
+                timeout = self.o.gettimeout() or 300
+                if (time.time() - start) < timeout:
                     time.sleep(0.1)
                     continue
                 else:


### PR DESCRIPTION
Fix #4028 

The socket.gettimeout function returns None when timeout value isn't set by the socket.settimeout function.
I added a default timeout value for the situation that socket.gettimeout function returned None.
