### PR TITLE
Fix deadlock caused by the "replay.client.stop" command

### DIFF
--- a/mitmproxy/addons/clientplayback.py
+++ b/mitmproxy/addons/clientplayback.py
@@ -180,7 +180,7 @@ class ClientPlayback:
             self.q.queue.clear()
             for f in lst:
                 f.revert()
-            ctx.master.addons.trigger("update", lst)
+        ctx.master.addons.trigger("update", lst)
         ctx.log.alert("Client replay queue cleared.")
 
     @command.command("replay.client")


### PR DESCRIPTION
Fix #4037 

When we execute the command "replay.client.stop", this function is called.
```@command.command("replay.client.stop")
def stop_replay(self) -> None:
    with self.q.mutex:
        lst = list(self.q.queue)
        self.q.queue.clear()
        for f in lst:
            f.revert()
        ctx.master.addons.trigger("update", lst) 
    ctx.log.alert("Client replay queue cleared.")
```

In this function, "ctx.master.addons.trigger("update", lst)" is called inside "with self.q.mutex".
This causes a deadlock.
So, I moved "ctx.master.addons.trigger("update", lst)" outside of "with self.q.mutex"


