### PR TITLE
match HTTP-WebSocket handshake flow for ~websocket filter

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -20,6 +20,7 @@ Unreleased: mitmproxy next
     * Add support for HTTP Trailers to the HTTP/2 protocol (@sanlengjingvv and @Kriechi)
     * Fix certificate runtime error during expire cleanup (@gorogoroumaru)
     * Fixed the DNS Rebind Protection for secure support of IPv6 addresses (@tunnelpr0)
+    * WebSockets: match the HTTP-WebSocket flow for the ~websocket filter (@Kriechi)
 
     * --- TODO: add new PRs above this line ---
 

--- a/mitmproxy/master.py
+++ b/mitmproxy/master.py
@@ -152,10 +152,15 @@ class Master:
                 self.waiting_flows.append(f)
 
         if isinstance(f, websocket.WebSocketFlow):
-            hf = [hf for hf in self.waiting_flows if hf.id == f.metadata['websocket_handshake']][0]
-            f.handshake_flow = hf
-            self.waiting_flows.remove(hf)
-            self._change_reverse_host(f.handshake_flow)
+            hfs = [hf for hf in self.waiting_flows if hf.id == f.metadata['websocket_handshake']]
+            if hfs:
+                hf = hfs[0]
+                f.handshake_flow = hf
+                self.waiting_flows.remove(hf)
+                self._change_reverse_host(f.handshake_flow)
+            else:
+                # this will fail - but at least it will load the remaining flows
+                f.handshake_flow = http.HTTPFlow(None, None)
 
         f.reply = controller.DummyReply()
         for e, o in eventsequence.iterate(f):

--- a/test/mitmproxy/test_flowfilter.py
+++ b/test/mitmproxy/test_flowfilter.py
@@ -439,6 +439,17 @@ class TestMatchingWebSocketFlow:
         assert not self.q("~tcp", f)
         assert not self.q("~http", f)
 
+    def test_handshake(self):
+        f = self.flow().handshake_flow
+        assert self.q("~websocket", f)
+        assert not self.q("~tcp", f)
+        assert self.q("~http", f)
+
+        f = tflow.tflow()
+        assert not self.q("~websocket", f)
+        f = tflow.tflow(resp=True)
+        assert not self.q("~websocket", f)
+
     def test_ferr(self):
         e = self.err()
         assert self.q("~e", e)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35, py36, py37, flake8, filename_matching, mypy, individual_coverage, docs
+envlist = py35, py36, py37, py38, flake8, filename_matching, mypy, individual_coverage, docs
 skipsdist = True
 toxworkdir={env:TOX_WORK_DIR:.tox}
 


### PR DESCRIPTION
#### Description

fixes #3990 by also matching HTTP-WebSocket handshake flow with `~websocket`.

Also add py38 to the default tox env list.

#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
