### PR TITLE
CI Improvements

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,30 +42,33 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-latest]
+        include:
+          - os: windows-latest
+            py: 3.8
+          - os: macos-latest
+            py: 3.8
+          - os: ubuntu-latest
+            py: 3.8
+          - os: ubuntu-latest
+            py: 3.7
+          - os: ubuntu-latest
+            py: 3.6
+          - os: ubuntu-latest
+            py: 3.5
     runs-on: ${{ matrix.os }}
     steps:
       - run: printenv
       - uses: actions/checkout@v1
       - uses: actions/setup-python@v1
         with:
-          python-version: '3.8'
+          python-version: ${{ matrix.py }}
       - run: pip install tox
-      - run: tox -e py38
+      - run: tox -e py
       - uses: codecov/codecov-action@v1
         with:
           file: ./coverage.xml
           name: ${{ matrix.os }}
           fail_ci_if_error: false
-  test-py35:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-python@v1
-        with:
-          python-version: '3.5'
-      - run: pip install tox
-      - run: tox -e py35
   build-wheel:
     runs-on: ubuntu-latest
     env:
@@ -86,7 +89,7 @@ jobs:
       fail-fast: false
       matrix:
         # Old Ubuntu version for old glibc
-        os: [macos-latest, windows-latest, ubuntu-16.04]
+        os: [macos-10.15, windows-2019, ubuntu-16.04]
     runs-on: ${{ matrix.os }}
     env:
       CI_BUILD_PYINSTALLER: 1
@@ -196,11 +199,11 @@ jobs:
           path: release/dist
       - uses: actions/download-artifact@master
         with:
-          name: binaries.windows-latest
+          name: binaries.windows-2019
           path: release/dist
       - uses: actions/download-artifact@master
         with:
-          name: binaries.macos-latest
+          name: binaries.macos-10.15
           path: release/dist
       - uses: actions/download-artifact@master
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,8 +53,6 @@ jobs:
             py: 3.7
           - os: ubuntu-latest
             py: 3.6
-          - os: ubuntu-latest
-            py: 3.5
     runs-on: ${{ matrix.os }}
     steps:
       - run: printenv
@@ -69,6 +67,15 @@ jobs:
           file: ./coverage.xml
           name: ${{ matrix.os }}
           fail_ci_if_error: false
+  test-unsupported-python-version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-python@v1
+        with:
+          python-version: '3.5'
+      - run: pip install tox
+      - run: tox -e py35
   build-wheel:
     runs-on: ubuntu-latest
     env:
@@ -192,7 +199,7 @@ jobs:
       - uses: actions/setup-python@v1
         with:
           python-version: '3.8'
-      - uses: actions/download-artifact@master
+      - uses: actions/download-artifact@v2
         with:
           path: release/dist
       - run: ls release/dist

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,7 +80,7 @@ jobs:
           python-version: '3.8'
       - run: pip install tox
       - run: tox -e cibuild -- build
-      - uses: actions/upload-artifact@master
+      - uses: actions/upload-artifact@v2
         with:
           name: wheel
           path: release/dist
@@ -108,7 +108,7 @@ jobs:
       - run: pip install tox
       - run: tox -e cibuild -- build
       # artifacts must have different names, see https://github.com/actions/upload-artifact/issues/24
-      - uses: actions/upload-artifact@master
+      - uses: actions/upload-artifact@v2
         with:
           name: binaries.${{ matrix.os }}
           path: release/dist
@@ -168,7 +168,7 @@ jobs:
         with:
           python-version: '3.7'
       - run: pip install tox
-      - uses: actions/download-artifact@master
+      - uses: actions/download-artifact@v2
         with:
           name: wheel
           path: release/dist
@@ -192,22 +192,8 @@ jobs:
       - uses: actions/setup-python@v1
         with:
           python-version: '3.8'
-      # artifacts must be downloaded individually, see https://github.com/actions/download-artifact/issues/6
       - uses: actions/download-artifact@master
         with:
-          name: wheel
-          path: release/dist
-      - uses: actions/download-artifact@master
-        with:
-          name: binaries.windows-2019
-          path: release/dist
-      - uses: actions/download-artifact@master
-        with:
-          name: binaries.macos-10.15
-          path: release/dist
-      - uses: actions/download-artifact@master
-        with:
-          name: binaries.ubuntu-16.04
           path: release/dist
       - run: ls release/dist
       - run: pip install tox

--- a/setup.py
+++ b/setup.py
@@ -90,6 +90,9 @@ setup(
         ':sys_platform == "win32"': [
             "pydivert>=2.0.3,<2.2",
         ],
+        ':python_version == "3.6"': [
+            "dataclasses>=0.7",
+        ],
         'dev': [
             "asynctest>=0.12.0",
             "Flask>=1.0,<1.2",


### PR DESCRIPTION
- Pin binary-generating CI jobs to to lowest available macOS and Windows versions (see https://github.com/mitmproxy/mitmproxy/issues/3728). Those were unavailable when we set up CI.
- Add jobs for Python 3.6 and 3.7. We're deliberately not running the full matrix (Windows/macOS) because that takes too much time.
- Fix compatibility with Python 3.6 (incompatibilities were introduced in #4088, after 5.2)
- Simplify CI script with recent GitHub changes.