### PR TITLE
Don't count overage for AssertionErrors

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,8 @@ omit = *contrib*, *tnetstring*, *platform*, *main.py
 show_missing = True
 exclude_lines =
     pragma: no cover
-    raise NotImplementedError()
+    raise NotImplementedError
+    raise AssertionError
     if typing.TYPE_CHECKING:
     if TYPE_CHECKING:
     @overload

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ deps =
 setenv = HOME = {envtmpdir}
 commands =
   mitmdump --version
-  pytest --timeout 60 --cov-report xml \
+  pytest --timeout 60 -v --cov-report xml \
     --cov=mitmproxy --cov=pathod --cov=release \
     --full-cov=mitmproxy/ --full-cov=pathod/ \
     {posargs}


### PR DESCRIPTION
A common pattern in sans-io is to essentially match on all variants of
an enum, and then have a `else: raise AssertionError` in the end.
This increases robustness as we spot incomplete coverage instead of
silently passing. However, it makes no sense to explicitly test these
asserts.