### PR TITLE
Add wild card support for --scripts option

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,6 +10,7 @@ Unreleased: mitmproxy next
 
 18 July 2020: mitmproxy 5.2
 
+    * Add wild card support for --scripts option
     * Add Filter message to mitmdump (@sarthak212)
     * Display TCP flows at flow list (@Jessonsotoventura, @nikitastupin, @mhils)
     * Colorize JSON Contentview (@sarthak212)

--- a/mitmproxy/addons/script.py
+++ b/mitmproxy/addons/script.py
@@ -122,10 +122,10 @@ class Script:
             try:
                 mtime = os.stat(self.fullpath).st_mtime
             except FileNotFoundError:
-                ctx.log.info("Removing script %s" % self.path)
                 scripts = list(chain.from_iterable([glob(re) for re in ctx.options.scripts]))
                 scripts.remove(self.path)
                 ctx.options.update(scripts=scripts)
+                ctx.log.info("Removed script %s" % self.path)
                 return
             if mtime > last_mtime:
                 self.loadscript()

--- a/mitmproxy/addons/script.py
+++ b/mitmproxy/addons/script.py
@@ -150,8 +150,7 @@ class ScriptLoader:
             "scripts", typing.Sequence[str], [],
             """
                 Execute a script. The script name may include wild card. If you include wild card,
-                don't forget to enclose the script name in single or double quotes. 
-                Example: mitmproxy -s "some/folder/*.py"
+                don't forget to enclose the script name in single or double quotes. Example: mitmproxy -s "some/folder/*.py".
             """
         )
 

--- a/mitmproxy/addons/script.py
+++ b/mitmproxy/addons/script.py
@@ -7,7 +7,6 @@ import types
 import typing
 import traceback
 from glob import glob
-from itertools import chain
 
 from mitmproxy import addonmanager
 from mitmproxy import exceptions
@@ -152,7 +151,7 @@ class ScriptLoader:
         loader.add_option(
             "scripts", typing.Sequence[str], [],
             """
-                Execute a script. 
+                Execute a script.
                 Experimental: If the script name includes a wild card, all matching scripts are executed.
                 Addons created after startup are not picked up.
                 Example: mitmproxy -s "some/folder/*.py".

--- a/mitmproxy/addons/script.py
+++ b/mitmproxy/addons/script.py
@@ -70,7 +70,6 @@ class Script:
     """
 
     def __init__(self, path: str, reload: bool) -> None:
-        ctx.log.info("loading "+path)
         self.name = "scriptmanager:" + path
         self.path = path
         self.fullpath = os.path.expanduser(

--- a/mitmproxy/addons/script.py
+++ b/mitmproxy/addons/script.py
@@ -17,9 +17,11 @@ from mitmproxy import eventsequence
 from mitmproxy import ctx
 import mitmproxy.types as mtypes
 
+
 def get_scripts():
     scripts = list(chain.from_iterable([glob(re) for re in ctx.options.scripts]))
     return scripts
+
 
 def load_script(path: str) -> typing.Optional[types.ModuleType]:
     fullname = "__mitmproxy_script__.{}".format(
@@ -147,9 +149,9 @@ class ScriptLoader:
         loader.add_option(
             "scripts", typing.Sequence[str], [],
             """
-            Execute a script. The script name may include wild card. If you include wild card,
-            don't forget to enclose the script name in single or double quotes. 
-            Example: mitmproxy -s "some/folder/*.py"
+                Execute a script. The script name may include wild card. If you include wild card,
+                don't forget to enclose the script name in single or double quotes. 
+                Example: mitmproxy -s "some/folder/*.py"
             """
         )
 

--- a/mitmproxy/tools/console/statusbar.py
+++ b/mitmproxy/tools/console/statusbar.py
@@ -1,7 +1,5 @@
 import os.path
 from typing import Optional
-from itertools import chain
-from glob import glob
 
 import urwid
 
@@ -10,7 +8,6 @@ from mitmproxy.tools.console import commandexecutor
 from mitmproxy.tools.console import common
 from mitmproxy.tools.console import signals
 from mitmproxy.tools.console.commander import commander
-from mitmproxy.addons import script
 
 
 class PromptPath:

--- a/mitmproxy/tools/console/statusbar.py
+++ b/mitmproxy/tools/console/statusbar.py
@@ -208,6 +208,7 @@ class StatusBar(urwid.WidgetWrap):
 
         sreplay = self.master.commands.call("replay.server.count")
         creplay = self.master.commands.call("replay.client.count")
+        script_length = self.master.commands.call("script.length")
 
         if len(self.master.options.modify_headers):
             r.append("[")
@@ -283,9 +284,8 @@ class StatusBar(urwid.WidgetWrap):
 
         if self.master.options.mode != "regular":
             r.append("[%s]" % self.master.options.mode)
-        if self.master.options.scripts:
-            scripts = script.get_scripts()
-            r.append("[scripts:%s]" % len(scripts))
+        if script_length:
+            r.append("[scripts:%s]" % script_length)
 
         if self.master.options.save_stream_file:
             r.append("[W:%s]" % self.master.options.save_stream_file)

--- a/mitmproxy/tools/console/statusbar.py
+++ b/mitmproxy/tools/console/statusbar.py
@@ -1,5 +1,7 @@
 import os.path
 from typing import Optional
+from itertools import chain
+from glob import glob
 
 import urwid
 
@@ -281,7 +283,8 @@ class StatusBar(urwid.WidgetWrap):
         if self.master.options.mode != "regular":
             r.append("[%s]" % self.master.options.mode)
         if self.master.options.scripts:
-            r.append("[scripts:%s]" % len(self.master.options.scripts))
+            scripts = list(chain.from_iterable([glob(re) for re in self.master.options.scripts]))
+            r.append("[scripts:%s]" % len(scripts))
 
         if self.master.options.save_stream_file:
             r.append("[W:%s]" % self.master.options.save_stream_file)

--- a/mitmproxy/tools/console/statusbar.py
+++ b/mitmproxy/tools/console/statusbar.py
@@ -10,6 +10,7 @@ from mitmproxy.tools.console import commandexecutor
 from mitmproxy.tools.console import common
 from mitmproxy.tools.console import signals
 from mitmproxy.tools.console.commander import commander
+from mitmproxy.addons import script
 
 
 class PromptPath:
@@ -283,7 +284,7 @@ class StatusBar(urwid.WidgetWrap):
         if self.master.options.mode != "regular":
             r.append("[%s]" % self.master.options.mode)
         if self.master.options.scripts:
-            scripts = list(chain.from_iterable([glob(re) for re in self.master.options.scripts]))
+            scripts = script.get_scripts()
             r.append("[scripts:%s]" % len(scripts))
 
         if self.master.options.save_stream_file:

--- a/test/mitmproxy/addons/test_script.py
+++ b/test/mitmproxy/addons/test_script.py
@@ -224,6 +224,8 @@ class TestScriptLoader:
 
     def test_dupes(self):
         sc = script.ScriptLoader()
+        if not os.path.exists('one'):
+            os.open("one", O_CREAT)
         with taddons.context(sc) as tctx:
             with pytest.raises(exceptions.OptionsError):
                 tctx.configure(
@@ -245,7 +247,7 @@ class TestScriptLoader:
 
             os.remove(tdata.path("mitmproxy/data/addonscripts/dummy.py"))
 
-            await tctx.master.await_log("Removing")
+            await tctx.master.await_log("Removed")
             assert not tctx.options.scripts
             assert not sl.addons
 

--- a/test/mitmproxy/addons/test_script.py
+++ b/test/mitmproxy/addons/test_script.py
@@ -226,7 +226,7 @@ class TestScriptLoader:
         sc = script.ScriptLoader()
         with open("one", 'w') as f:
             f.write("foo")
-            
+
         with taddons.context(sc) as tctx:
             with pytest.raises(exceptions.OptionsError):
                 tctx.configure(

--- a/test/mitmproxy/addons/test_script.py
+++ b/test/mitmproxy/addons/test_script.py
@@ -225,7 +225,7 @@ class TestScriptLoader:
     def test_dupes(self):
         sc = script.ScriptLoader()
         if not os.path.exists('one'):
-            os.open("one", O_CREAT)
+            os.open("one", os.O_CREAT)
         with taddons.context(sc) as tctx:
             with pytest.raises(exceptions.OptionsError):
                 tctx.configure(

--- a/test/mitmproxy/addons/test_script.py
+++ b/test/mitmproxy/addons/test_script.py
@@ -224,8 +224,9 @@ class TestScriptLoader:
 
     def test_dupes(self):
         sc = script.ScriptLoader()
-        if not os.path.exists('one'):
-            os.open("one", os.O_CREAT)
+        with open("one", 'w') as f:
+            f.write("foo")
+            
         with taddons.context(sc) as tctx:
             with pytest.raises(exceptions.OptionsError):
                 tctx.configure(
@@ -247,7 +248,7 @@ class TestScriptLoader:
 
             os.remove(tdata.path("mitmproxy/data/addonscripts/dummy.py"))
 
-            await tctx.master.await_log("Removed")
+            await tctx.master.await_log("Removing")
             assert not tctx.options.scripts
             assert not sl.addons
 


### PR DESCRIPTION
#### Description

issue #4112 

When we execute scripts, we have to specify scripts one by one with "--scripts" option.
I added wild card support for --scripts  option ,so that we can specify scripts all at once.


