### PR TITLE
Fix link to anticache docs in mitmweb

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@ Unreleased: mitmproxy next
 ** Full Changelog **
 
     * Add MsgPack content viewer (@tasn)
+    * Fix links to anticache docs in mitmweb and use HTTPS for links to documentation (@rugk)
 
     * --- TODO: add new PRs above this line ---
 

--- a/web/src/js/__tests__/components/Header/__snapshots__/OptionMenuSpec.js.snap
+++ b/web/src/js/__tests__/components/Header/__snapshots__/OptionMenuSpec.js.snap
@@ -46,7 +46,7 @@ exports[`OptionMenu Component should render correctly 1`] = `
           />
           Strip cache headers 
           <a
-            href="http://docs.mitmproxy.org/en/stable/features/anticache.html"
+            href="https://docs.mitmproxy.org/stable/overview-features/#anticache"
             target="_blank"
           >
             <i

--- a/web/src/js/__tests__/components/common/__snapshots__/DocsLinkSpec.js.snap
+++ b/web/src/js/__tests__/components/common/__snapshots__/DocsLinkSpec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`DocsLink Component should be able to be rendered with children nodes 1`] = `
 <a
-  href="http://docs.mitmproxy.org/en/stable/bar"
+  href="https://docs.mitmproxy.org/en/stable/bar"
   target="_blank"
 >
   foo
@@ -11,7 +11,7 @@ exports[`DocsLink Component should be able to be rendered with children nodes 1`
 
 exports[`DocsLink Component should be able to be rendered without children nodes 1`] = `
 <a
-  href="http://docs.mitmproxy.org/en/stable/bar"
+  href="https://docs.mitmproxy.org/en/stable/bar"
   target="_blank"
 >
   <i

--- a/web/src/js/__tests__/components/common/__snapshots__/DocsLinkSpec.js.snap
+++ b/web/src/js/__tests__/components/common/__snapshots__/DocsLinkSpec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`DocsLink Component should be able to be rendered with children nodes 1`] = `
 <a
-  href="https://docs.mitmproxy.org/en/stable/bar"
+  href="https://docs.mitmproxy.org/stable/bar"
   target="_blank"
 >
   foo
@@ -11,7 +11,7 @@ exports[`DocsLink Component should be able to be rendered with children nodes 1`
 
 exports[`DocsLink Component should be able to be rendered without children nodes 1`] = `
 <a
-  href="https://docs.mitmproxy.org/en/stable/bar"
+  href="https://docs.mitmproxy.org/stable/bar"
   target="_blank"
 >
   <i

--- a/web/src/js/components/Header/OptionMenu.jsx
+++ b/web/src/js/components/Header/OptionMenu.jsx
@@ -25,7 +25,7 @@ function OptionMenu({ openOptions }) {
                 <div className="menu-group">
                     <div className="menu-content">
                         <SettingsToggle setting="anticache">
-                            Strip cache headers <DocsLink resource="features/anticache.html"/>
+                            Strip cache headers <DocsLink resource="overview-features/#anticache"/>
                         </SettingsToggle>
                         <SettingsToggle setting="showhost">
                             Use host header for display

--- a/web/src/js/components/common/DocsLink.jsx
+++ b/web/src/js/components/common/DocsLink.jsx
@@ -6,7 +6,7 @@ DocsLink.propTypes = {
 }
 
 export default function DocsLink({ children, resource }) {
-    let url = `https://docs.mitmproxy.org/en/stable/${resource}`
+    let url = `https://docs.mitmproxy.org/stable/${resource}`
     return (
         <a target="_blank" href={url}>
             {children || <i className="fa fa-question-circle"></i>}

--- a/web/src/js/components/common/DocsLink.jsx
+++ b/web/src/js/components/common/DocsLink.jsx
@@ -6,7 +6,7 @@ DocsLink.propTypes = {
 }
 
 export default function DocsLink({ children, resource }) {
-    let url = `http://docs.mitmproxy.org/en/stable/${resource}`
+    let url = `https://docs.mitmproxy.org/en/stable/${resource}`
     return (
         <a target="_blank" href={url}>
             {children || <i className="fa fa-question-circle"></i>}


### PR DESCRIPTION
#### Description
Mitmweb has a bug that it links to http://docs.mitmproxy.org/en/stable/features/anticache.html, which just redirects to the home page of the docs of mitmweb.

This changes two things:
* fixes that link to point to the current version at https://docs.mitmproxy.org/stable/overview-features/#anticache
* also changes all doc link to use HTTPS, as there is no reason not to do this :shrug: :smiley: 

#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
