### PR TITLE
Fix intercept toggeling doc

### DIFF
--- a/mitmproxy/tools/console/defaultkeys.py
+++ b/mitmproxy/tools/console/defaultkeys.py
@@ -26,7 +26,7 @@ def map(km):
     km.add("ctrl f", "console.nav.pagedown", ["global"], "Page down")
     km.add("ctrl b", "console.nav.pageup", ["global"], "Page up")
 
-    km.add("I", "set intercept_active toggle", ["global"], "Toggle intercept")
+    km.add("I", "set intercept_active toggle", ["global"], "Toggle whether the filtering via the intercept option is enabled")
     km.add("i", "console.command.set intercept", ["global"], "Set intercept")
     km.add("W", "console.command.set save_stream_file", ["global"], "Stream to file")
     km.add("A", "flow.resume @all", ["flowlist", "flowview"], "Resume all intercepted flows")


### PR DESCRIPTION
Fixes https://github.com/mitmproxy/mitmproxy/issues/4109

#### Description

I hope this also fixes the docs, because it is the only instance where I've found that string. The [docs](https://github.com/mitmproxy/mitmproxy/tree/master/docs) seem to somehow autogenerate the options tabel/text, so I don't know what else may need editing.
Note you also have no `CONTRIBUTING.md` or so that could explain it to me.

#### Checklist

 - [ ] I have updated tests where applicable. N/A
 - [ ] I have added an entry to the CHANGELOG. N/A (for such a small change IMHO)
