### PR TITLE
Prevent transparent mode from connecting to itself in the basic cases, references #4128

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@ Unreleased: mitmproxy next
 
     * Add MsgPack content viewer (@tasn)
     * Fix links to anticache docs in mitmweb and use HTTPS for links to documentation (@rugk)
+    * Prevent transparent mode from connecting to itself in the basic cases (@prinzhorn)
 
     * --- TODO: add new PRs above this line ---
 

--- a/mitmproxy/proxy/modes/transparent_proxy.py
+++ b/mitmproxy/proxy/modes/transparent_proxy.py
@@ -10,7 +10,7 @@ class TransparentProxy(protocol.Layer, protocol.ServerConnectionMixin):
 
     def __call__(self):
         try:
-            self.server_conn.address = platform.original_addr(self.client_conn.connection)
+            self.set_server(platform.original_addr(self.client_conn.connection))
         except Exception as e:
             raise exceptions.ProtocolException("Transparent mode failure: %s" % repr(e))
 

--- a/mitmproxy/proxy/protocol/base.py
+++ b/mitmproxy/proxy/protocol/base.py
@@ -107,9 +107,14 @@ class ServerConnectionMixin:
         """
         address = self.server_conn.address
         if address:
+            forbidden_hosts = ["localhost", "127.0.0.1", "::1"]
+
+            if self.config.options.listen_host:
+                forbidden_hosts.append(self.config.options.listen_host)
+
             self_connect = (
                 address[1] == self.config.options.listen_port and
-                address[0] in ("localhost", "127.0.0.1", "::1")
+                address[0] in forbidden_hosts
             )
             if self_connect:
                 raise exceptions.ProtocolException(


### PR DESCRIPTION
#### Description

This is obviously not a security feature, it just prevents the most obvious shoot-yourself-in-the-foot type of thing. For example if I don't specify listen_host and then connect to the proxy via it's local IP (192.168.0.6 right now) it cannot detect that this is actually it's own. We might be able to extend this later tho if DoS is a relevant concern. Right now a single `curl` command will drain all resources and for example result in "OSError: [Errno 24] Too many open files". You can even exit the curl process and mitmproxy will keep doing it's endless loop.

Are there integration tests for this kind of thing? Might be worth setting up using Docker containers (maybe using compose) to test different network combinations. I don't really feel comfortable modifying these core things and don't know if it actually still works as before.

#### Checklist

 - [ ] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
