### PR TITLE
[Quick Help Wanted] mitmweb: use native_web_app to open browser

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,7 @@ Unreleased: mitmproxy next
     * Fix links to anticache docs in mitmweb and use HTTPS for links to documentation (@rugk)
     * Updated typing for WebsocketMessage.content (@prinzhorn)
     * Prevent transparent mode from connecting to itself in the basic cases (@prinzhorn)
+    * Make mitmweb feel more like a native app, hide browser controls (@mhils)
 
     * --- TODO: add new PRs above this line ---
 

--- a/mitmproxy/tools/web/webaddons.py
+++ b/mitmproxy/tools/web/webaddons.py
@@ -1,5 +1,4 @@
-import webbrowser
-
+import native_web_app
 from mitmproxy import ctx
 
 
@@ -25,37 +24,9 @@ class WebAddon:
     def running(self):
         if hasattr(ctx.options, "web_open_browser") and ctx.options.web_open_browser:
             web_url = "http://{}:{}/".format(ctx.options.web_host, ctx.options.web_port)
-            success = open_browser(web_url)
-            if not success:
+            try:
+                native_web_app.open(web_url)
+            except Exception:
                 ctx.log.info(
                     "No web browser found. Please open a browser and point it to {}".format(web_url),
                 )
-
-
-def open_browser(url: str) -> bool:
-    """
-    Open a URL in a browser window.
-    In contrast to webbrowser.open, we limit the list of suitable browsers.
-    This gracefully degrades to a no-op on headless servers, where webbrowser.open
-    would otherwise open lynx.
-
-    Returns:
-        True, if a browser has been opened
-        False, if no suitable browser has been found.
-    """
-    browsers = (
-        "windows-default", "macosx",
-        "wslview %s",
-        "x-www-browser %s", "gnome-open %s",
-        "google-chrome", "chrome", "chromium", "chromium-browser",
-        "firefox", "opera", "safari",
-    )
-    for browser in browsers:
-        try:
-            b = webbrowser.get(browser)
-        except webbrowser.Error:
-            pass
-        else:
-            if b.open(url):
-                return True
-    return False

--- a/setup.py
+++ b/setup.py
@@ -72,6 +72,7 @@ setup(
         "kaitaistruct>=0.7,<0.9",
         "ldap3>=2.6.1,<2.8",
         "msgpack>=1.0.0, <1.1.0",
+        "native-web-app>=1.0.0, <1.1.0",
         "passlib>=1.6.5, <1.8",
         "protobuf>=3.6.0, <3.12",
         "pyasn1>=0.3.1,<0.5",


### PR DESCRIPTION
### TL;DR: How you (yes you, you reading this!) can help

1. Download the snapshots for your platform: https://snapshots.mitmproxy.org/branches/native-web-app/.
2. Run the mitmweb binary.
3. Post a comment here with your OS, browser version, and mitmweb screenshot.


#### Detailed Description

I have a new weekend project that makes it possible to build Electron-style apps without shipping the behemoth that is Electron: https://pypi.org/project/native-web-app/. This makes mitmweb look much more like a proper app on my system:

<p align="center">
<img width="500" src="https://user-images.githubusercontent.com/1019198/89948554-9d0d8b80-dc26-11ea-837b-825ef63e7b26.png">
</p>

Now that makes me very excited, but correctness highly depends on platform/browser version and we need more testing before we can confidently ship this. If you read this, please follow the instructions at the top! 😃 


#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
