### PR TITLE
Added option to control console_focus_follow behavior

### DIFF
--- a/mitmproxy/tools/console/eventlog.py
+++ b/mitmproxy/tools/console/eventlog.py
@@ -31,6 +31,10 @@ class EventLog(urwid.ListBox, layoutwidget.LayoutWidget):
             "console_focus_follow", bool, False,
             "Focus follows new flows."
         )
+        loader.add_option(
+            "console_focus_follow_steal", bool, True,
+            "Steal focus when a new flow arrives."
+        )
 
     def set_focus(self, index):
         if 0 <= index < len(self.walker):
@@ -53,7 +57,8 @@ class EventLog(urwid.ListBox, layoutwidget.LayoutWidget):
             e = urwid.Text(txt)
         self.walker.append(e)
         if self.master.options.console_focus_follow:
-            self.walker.set_focus(len(self.walker) - 1)
+            if self.master.options.console_focus_follow_steal or self.walker.focus == len(self.walker) - 2:
+                self.walker.set_focus(len(self.walker) - 1)
 
     def refresh_events(self, *_):
         self.walker.clear()

--- a/test/mitmproxy/addons/test_view.py
+++ b/test/mitmproxy/addons/test_view.py
@@ -498,6 +498,71 @@ def test_focus_follow():
         assert v.focus.flow.request.timestamp_start == 6
 
 
+def test_focus_follow_steal():
+    v = view.View()
+    with taddons.context(v) as tctx:
+        console_addon = consoleaddons.ConsoleAddon(tctx.master)
+        tctx.configure(console_addon)
+        tctx.configure(v, console_focus_follow=True, console_focus_follow_steal=False, view_filter="~m get")
+
+        v.add([tft(start=5)])
+        assert v.focus.index == 0
+
+        v.add([tft(start=7)])
+        assert v.focus.index == 1
+        assert v.focus.flow.request.timestamp_start == 7
+
+        # Move focus to the first view
+        v.focus.index = 0
+
+        mod = tft(method="put", start=8)
+        v.add([mod])
+        # Focus should not change
+        assert v.focus.index == 0
+        assert v.focus.flow.request.timestamp_start == 5
+
+        # Move focus to the last flow
+        v.focus.index = 1
+
+        mod.request.method = "GET"
+        v.update([mod])
+        assert v.focus.index == 2
+        assert v.focus.flow.request.timestamp_start == 8
+
+
+def test_focus_follow_steal_reversed():
+    v = view.View()
+    with taddons.context(v) as tctx:
+        console_addon = consoleaddons.ConsoleAddon(tctx.master)
+        tctx.configure(console_addon)
+        tctx.configure(v, console_focus_follow=True, console_focus_follow_steal=False,
+                       view_order_reversed=True, view_filter="~m get")
+
+        v.add([tft(start=5)])
+        assert v.focus.index == 0
+
+        v.add([tft(start=7)])
+        assert v.focus.index == 0
+        assert v.focus.flow.request.timestamp_start == 7
+
+        # Move focus to the last view
+        v.focus.index = 1
+
+        mod = tft(method="put", start=8)
+        v.add([mod])
+        # Focus should not change
+        assert v.focus.index == 1
+        assert v.focus.flow.request.timestamp_start == 5
+
+        # Move focus to the first flow
+        v.focus.index = 0
+
+        mod.request.method = "GET"
+        v.update([mod])
+        assert v.focus.index == 0
+        assert v.focus.flow.request.timestamp_start == 8
+
+
 def test_focus():
     # Special case - initialising with a view that already contains data
     v = view.View()


### PR DESCRIPTION
#### Description

`console_focus_follow` by default aggressively switches focus to new flows, which sometimes is not helpful.
I think, the expected behavior should be: if the view is focused on the latest flow (bottom or top, depending on view order), it is OK to move to the new flows, but if user focused on some other flow, the focus should not change (especially in flow details view). 

I added a new option `console_focus_follow_steal` (I struggle with naming and consicely describing the option) which controls the behavior.
I wonder if a separate option should be added, preserving the old behavior by default. Maybe it is OK to change the defaults?

#### Checklist

 - [x] I have updated tests where applicable.
 - [ ] I have added an entry to the CHANGELOG.
