### PR TITLE
Python 3.9 Compatibility

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,11 +44,11 @@ jobs:
       matrix:
         include:
           - os: windows-latest
-            py: 3.9.0-rc.2
+            py: 3.9
           - os: macos-latest
-            py: 3.9.0-rc.2
+            py: 3.9
           - os: ubuntu-latest
-            py: 3.9.0-rc.2
+            py: 3.9
           - os: ubuntu-latest
             py: 3.8
           - os: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,11 +44,11 @@ jobs:
       matrix:
         include:
           - os: windows-latest
-            py: 3.9.0-rc.1
+            py: 3.9.0-rc.2
           - os: macos-latest
-            py: 3.9.0-rc.1
+            py: 3.9.0-rc.2
           - os: ubuntu-latest
-            py: 3.9.0-rc.1
+            py: 3.9.0-rc.2
           - os: ubuntu-latest
             py: 3.8
           - os: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,28 +14,28 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: actions/setup-python@v1
+      - uses: actions/setup-python@v2
       - run: pip install tox
       - run: tox -e flake8
   filename-matching:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: actions/setup-python@v1
+      - uses: actions/setup-python@v2
       - run: pip install tox
       - run: tox -e filename_matching
   mypy:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: actions/setup-python@v1
+      - uses: actions/setup-python@v2
       - run: pip install tox
       - run: tox -e mypy
   individual-coverage:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: actions/setup-python@v1
+      - uses: actions/setup-python@v2
       - run: pip install tox
       - run: tox -e individual_coverage
   test:
@@ -44,9 +44,11 @@ jobs:
       matrix:
         include:
           - os: windows-latest
-            py: 3.8
+            py: 3.9.0-rc.1
           - os: macos-latest
-            py: 3.8
+            py: 3.9.0-rc.1
+          - os: ubuntu-latest
+            py: 3.9.0-rc.1
           - os: ubuntu-latest
             py: 3.8
           - os: ubuntu-latest
@@ -57,7 +59,7 @@ jobs:
     steps:
       - run: printenv
       - uses: actions/checkout@v1
-      - uses: actions/setup-python@v1
+      - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.py }}
       - run: pip install tox
@@ -70,7 +72,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: actions/setup-python@v1
+      - uses: actions/setup-python@v2
         with:
           python-version: '3.5'
       - run: pip install tox
@@ -81,7 +83,7 @@ jobs:
       CI_BUILD_WHEEL: 1
     steps:
       - uses: actions/checkout@v1
-      - uses: actions/setup-python@v1
+      - uses: actions/setup-python@v2
         with:
           python-version: '3.8'
       - run: pip install tox
@@ -103,7 +105,7 @@ jobs:
       CI_BUILD_KEY: ${{ secrets.CI_BUILD_KEY }}
     steps:
       - uses: actions/checkout@v1
-      - uses: actions/setup-python@v1
+      - uses: actions/setup-python@v2
         with:
           python-version: '3.7'
       - if: matrix.os == 'windows-latest'
@@ -149,7 +151,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: actions/setup-python@v1
+      - uses: actions/setup-python@v2
         with:
           python-version: '3.8'
       - run: pip install tox
@@ -169,7 +171,7 @@ jobs:
       DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
     steps:
       - uses: actions/checkout@v1
-      - uses: actions/setup-python@v1
+      - uses: actions/setup-python@v2
         with:
           python-version: '3.7'
       - run: pip install tox
@@ -194,7 +196,7 @@ jobs:
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
     steps:
       - uses: actions/checkout@v1
-      - uses: actions/setup-python@v1
+      - uses: actions/setup-python@v2
         with:
           python-version: '3.8'
       - uses: actions/download-artifact@v2

--- a/codecov.yml
+++ b/codecov.yml
@@ -15,4 +15,4 @@ coverage:
           - "web/"
 codecov:
   notify:
-    after_n_builds: 6
+    after_n_builds: 7

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
         "Programming Language :: Python :: 3 :: Only",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: Implementation :: CPython",
         "Topic :: Security",
         "Topic :: Internet :: WWW/HTTP",

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setup(
         "Brotli>=1.0,<1.1",
         "certifi>=2019.9.11",  # no semver here - this should always be on the last release!
         "click>=7.0,<8",
-        "cryptography>=3.0,<3.2",
+        "cryptography>=3.0,<3.1.1",
         "flask>=1.1.1,<1.2",
         "h2>=3.2.0,<4",
         "hyperframe>=5.1.0,<6",


### PR DESCRIPTION
Current Status:

 - [x] Windows: Working. ~fails because of missing cryptography wheels~
 - [x] Linux: fails when importing passlib 1.7.2 (https://foss.heptapod.net/python-libs/passlib/-/issues/126)
 - [x] macOS: Working. ~fails with [`TypeError: Subscripted generics cannot be used with class and instance checks`](https://github.com/mitmproxy/mitmproxy/pull/4174/checks?check_run_id=1033827835) (see #4021)~