### PR TITLE
Disable Google Analytics for docs

### DIFF
--- a/docs/src/config.toml
+++ b/docs/src/config.toml
@@ -4,7 +4,6 @@ title = "mitmproxy.org docs"
 theme = "mitmproxydocs"
 publishDir = "../public"
 RelativeURLs = true
-googleAnalytics = "UA-4150636-13"
 pygmentsCodefences = true
 
 [indexes]

--- a/docs/src/themes/mitmproxydocs/layouts/partials/footer.html
+++ b/docs/src/themes/mitmproxydocs/layouts/partials/footer.html
@@ -1,3 +1,2 @@
-{{ template "_internal/google_analytics_async.html" . }}
 </body>
 </html>


### PR DESCRIPTION
We already removed this from the main page, let's get rid of it here as well.