### PR TITLE
Replaced reference to deprecated --ignore option with --ignore-hosts.

### DIFF
--- a/mitmproxy/options.py
+++ b/mitmproxy/options.py
@@ -164,8 +164,8 @@ class Options(optmanager.OptManager):
             "tcp_hosts", Sequence[str], [],
             """
             Generic TCP SSL proxy mode for all hosts that match the pattern.
-            Similar to --ignore, but SSL connections are intercepted. The
-            communication contents are printed to the log in verbose mode.
+            Similar to --ignore-hosts, but SSL connections are intercepted.
+            The communication contents are printed to the log in verbose mode.
             """
         )
         self.add_option(


### PR DESCRIPTION
#### Description

Just an options help-text change to replace deprecated `--ignore` reference with ``ignore-hosts`.

#### Checklist

 - [ ] I have updated tests where applicable.
 - [ ] I have added an entry to the CHANGELOG.
