### PR TITLE
Add small delay before unlinking file in external viewer fixes #4152

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,6 +12,7 @@ Unreleased: mitmproxy next
     * Revamp onboarding app (@mhils)
     * Add ASGI support for embedded apps (@mhils)
     * Updated raw exports to not remove headers (@wchasekelley)
+    * Fix file unlinking before external viewer finishes loading (@wchasekelley)
 
     * --- TODO: add new PRs above this line ---
 

--- a/mitmproxy/tools/console/master.py
+++ b/mitmproxy/tools/console/master.py
@@ -11,6 +11,7 @@ import sys
 import tempfile
 import typing  # noqa
 import contextlib
+import threading
 
 import urwid
 
@@ -171,7 +172,9 @@ class ConsoleMaster(master.Master):
                 signals.status_message.send(
                     message="Can't start external viewer: %s" % " ".join(c)
                 )
-        os.unlink(name)
+        # small delay before removing the file
+        t = threading.Timer(1.0, os.unlink, args=[name])
+        t.start()
 
     def set_palette(self, opts, updated):
         self.ui.register_palette(

--- a/mitmproxy/tools/console/master.py
+++ b/mitmproxy/tools/console/master.py
@@ -172,7 +172,7 @@ class ConsoleMaster(master.Master):
                 signals.status_message.send(
                     message="Can't start external viewer: %s" % " ".join(c)
                 )
-        # small delay before removing the file
+        # add a small delay before deletion so that the file is not removed before being loaded by the viewer
         t = threading.Timer(1.0, os.unlink, args=[name])
         t.start()
 


### PR DESCRIPTION
In some cases, such as with firefox, the file is removed before the viewer is
finished loading.

#### Description

1 second delay in another thread and then unlink

#### Checklist

 - [-] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
