### PR TITLE
Update concepts-protocols.md

### DIFF
--- a/docs/src/content/concepts-protocols.md
+++ b/docs/src/content/concepts-protocols.md
@@ -29,9 +29,6 @@ internal state of HTTP/2 connections and provides an easy-to-use event-based
 API. mitmproxy supports the majority of HTTP/2 feature and tries to
 transparently pass-through as much information as possible.
 
-mitmproxy currently does not support HTTP/2 trailers - but if you want to send
-us a PR, we promise to take look!
-
 mitmproxy currently does not support HTTP/2 Cleartext (h2c) since none of the
 major browser vendors have implemented it.
 


### PR DESCRIPTION
There is support for HTTP/2 trailers since 5.2

I was confused for a moment because there is https://github.com/mitmproxy/mitmproxy/blob/46a0f694852fdb73e8b4c8971b41ee7fa96afe01/examples/addons/http-trailers.py but it looks like this just hasn't been updated after #4042

Also #2474 could be updated or even closed (until "anyone ever requests HTTP/1.0 trailer support.")? Or I guess they're still missing from the mitmproxy ui? Haven't checked.