### PR TITLE
Handle "deflateRaw" Content-Encoding as "deflate".

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -16,6 +16,7 @@ Unreleased: mitmproxy next
     * Fix file unlinking before external viewer finishes loading (@wchasekelley)
     * Add --cert-passphrase command line argument (@mirosyn)
     * Add interactive tutorials to the documentation (@mplattner)
+    * Support `deflateRaw` `Content-Encoding`s (@kjoconnor)
 
     * --- TODO: add new PRs above this line ---
 

--- a/mitmproxy/net/http/encoding.py
+++ b/mitmproxy/net/http/encoding.py
@@ -216,6 +216,7 @@ custom_decode = {
     "identity": identity,
     "gzip": decode_gzip,
     "deflate": decode_deflate,
+    "deflateRaw": decode_deflate,
     "br": decode_brotli,
     "zstd": decode_zstd,
 }
@@ -224,6 +225,7 @@ custom_encode = {
     "identity": identity,
     "gzip": encode_gzip,
     "deflate": encode_deflate,
+    "deflateRaw": encode_deflate,
     "br": encode_brotli,
     "zstd": encode_zstd,
 }


### PR DESCRIPTION
#### Description

I've come across an application that makes requests with a `Content-Type` of `application/json` and a `Content-Encoding` of `deflateRaw`. Without this change, the parser attempts to parse it as JSON due to a matching `Content-Type` and a non-matching `Content-Encoding`, which then fails since it's compressed binary data.

With this change, mitmproxy correctly decodes the data with the hack described [here](https://github.com/mitmproxy/mitmproxy/blob/46fbba639dd3581fa427db6d26fa4775a991da59/mitmproxy/net/http/encoding.py#L191-L198), and then successfully passes it off to the JSON view.

I don't know how widespread it is to have a `Content-Encoding` of `deflateRaw`, so up for debate whether this is worth adding in this special case, but seems like it's pretty safe hopefully!

#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
