### PR TITLE
Remove upstreamed pyinstaller hooks

### DIFF
--- a/release/hooks/hook-passlib.py
+++ b/release/hooks/hook-passlib.py
@@ -1,3 +1,0 @@
-# https://github.com/pyinstaller/pyinstaller-hooks-contrib/pull/39
-
-hiddenimports = ["configparser"]

--- a/release/hooks/hook-publicsuffix2.py
+++ b/release/hooks/hook-publicsuffix2.py
@@ -1,3 +1,0 @@
-from PyInstaller.utils.hooks import collect_data_files
-
-datas = collect_data_files('publicsuffix2')

--- a/release/hooks/hook-pydivert.py
+++ b/release/hooks/hook-pydivert.py
@@ -1,3 +1,0 @@
-from PyInstaller.utils.hooks import collect_data_files
-
-datas = collect_data_files('pydivert.windivert_dll')


### PR DESCRIPTION
These parts have been upstreamed:
 - https://github.com/pyinstaller/pyinstaller-hooks-contrib/pull/39
 - https://github.com/pyinstaller/pyinstaller-hooks-contrib/pull/40
 - https://github.com/pyinstaller/pyinstaller-hooks-contrib/pull/41

🤸 