### PR TITLE
Fix text truncation for full-width characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
   ([#5217](https://github.com/mitmproxy/mitmproxy/issues/5217), @randomstuff)
 * Improve cut addon to better handle binary contents
   ([#3965](https://github.com/mitmproxy/mitmproxy/issues/3965), @mhils)
+* Fix text truncation for full-width characters 
+  ([#4278](https://github.com/mitmproxy/mitmproxy/issues/4278), @kjy00302)
 
 ## 19 March 2022: mitmproxy 8.0.0
 

--- a/mitmproxy/tools/console/common.py
+++ b/mitmproxy/tools/console/common.py
@@ -191,7 +191,7 @@ class TruncatedText(urwid.Widget):
             text = text[::-1]
             attr = attr[::-1]
 
-        text_len = len(text)  # TODO: unicode?
+        text_len = urwid.util.calc_width(text, 0, len(text))
         if size is not None and len(size) > 0:
             width = size[0]
         else:
@@ -206,8 +206,10 @@ class TruncatedText(urwid.Widget):
                 c_text = text
                 c_attr = attr
         else:
-            visible_len = width - len(SYMBOL_ELLIPSIS)
-            visible_text = text[0:visible_len]
+            trim = urwid.util.calc_trim_text(text, 0, width - 1, 0, width - 1)
+            visible_text = text[0:trim[1]]
+            if trim[3] == 1:
+                visible_text += ' '
             c_text = visible_text + SYMBOL_ELLIPSIS
             c_attr = (urwid.util.rle_subseg(attr, 0, len(visible_text.encode())) +
                       [('focus', len(SYMBOL_ELLIPSIS.encode()))])

--- a/test/mitmproxy/tools/console/test_common.py
+++ b/test/mitmproxy/tools/console/test_common.py
@@ -36,3 +36,10 @@ def test_format_keyvals():
             ("aa", wrapped)
         ]
     )
+
+
+def test_truncated_text():
+    half_width_text = common.TruncatedText("Half-width", [])
+    full_width_text = common.TruncatedText("ＦＵＬＬ－ＷＩＤＴＨ", [])
+    assert half_width_text.render((10,))
+    assert full_width_text.render((10,))


### PR DESCRIPTION
#### Description

This commit fixes crashing when TruncatedText couldn't properly truncate string contains full-width characters.

Fixes #2894

#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
