### PR TITLE
Replace asynctest with stdlib mock

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -102,7 +102,6 @@ setup(
             "dataclasses>=0.7",
         ],
         'dev': [
-            "asynctest>=0.12.0",
             "Flask>=1.0,<1.2",
             "hypothesis>=5.8,<6",
             "parver>=0.1,<2.0",


### PR DESCRIPTION
This is an implementation of
https://github.com/mitmproxy/mitmproxy/issues/4020

Tested to work fine here with Python 3.8.6.

#### Description

Replace asynctest with stdlib mock

#### Checklist

 - [x] I have updated tests where applicable.
 - [ ] I have added an entry to the CHANGELOG.
