### PR TITLE
Use original flow host instead of IP when exporting to curl/httpie.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased: mitmproxy next
 
 * Fix SNI-related reproducibility issues when exporting to curl/httpie commands. (@dkasak)
+* Add option `export_preserve_original_ip` to force exported command to connect to IP from original request. Only supports curl at the moment. (@dkasak)
 
 ### New Proxy Core (@mhils)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,6 @@
 
 ## Unreleased: mitmproxy next
 
-* Fix SNI-related reproducibility issues when exporting to curl/httpie commands. (@dkasak)
-* Add option `export_preserve_original_ip` to force exported command to connect to IP from original request. Only supports curl at the moment. (@dkasak)
-
 ### New Proxy Core (@mhils)
 
 Mitmproxy has a completely new proxy core, fixing many longstanding issues:
@@ -56,6 +53,8 @@ If you depend on these features, please raise your voice in
   mitmproxy never phones home, which means we don't know how prominently these options were used. (@mhils)
 * Fix IDNA host 'Bad HTTP request line' error (@grahamrobbins)
 * Pressing `?` now exits console help view (@abitrolly)
+* Fix SNI-related reproducibility issues when exporting to curl/httpie commands. (@dkasak)
+* Add option `export_preserve_original_ip` to force exported command to connect to IP from original request. Only supports curl at the moment. (@dkasak)
 * --- TODO: add new PRs above this line ---
 * ... and various other fixes, documentation improvements, dependency version bumps, etc.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased: mitmproxy next
 
+* Fix SNI-related reproducibility issues when exporting to curl/httpie commands. (@dkasak)
+
 ### New Proxy Core (@mhils)
 
 Mitmproxy has a completely new proxy core, fixing many longstanding issues:

--- a/mitmproxy/addons/export.py
+++ b/mitmproxy/addons/export.py
@@ -60,7 +60,7 @@ def curl_command(f: flow.Flow) -> str:
     request = pop_headers(request)
     args = ["curl"]
 
-    server_addr = f.server_conn.address[0]
+    server_addr = f.server_conn.ip_address[0]
     if request.pretty_host != server_addr:
         resolve = "{}:{}:[{}]".format(request.pretty_host, request.port, server_addr)
         args.append("--resolve")

--- a/mitmproxy/addons/export.py
+++ b/mitmproxy/addons/export.py
@@ -60,8 +60,9 @@ def curl_command(f: flow.Flow, preserve_ip: bool = False) -> str:
     request = pop_headers(request)
     args = ["curl"]
 
-    server_addr = f.server_conn.ip_address[0]
-    if preserve_ip and request.pretty_host != server_addr:
+    server_addr = f.server_conn.peername[0] if f.server_conn.peername else None
+
+    if preserve_ip and server_addr and request.pretty_host != server_addr:
         resolve = "{}:{}:[{}]".format(request.pretty_host, request.port, server_addr)
         args.append("--resolve")
         args.append(resolve)

--- a/test/mitmproxy/addons/test_export.py
+++ b/test/mitmproxy/addons/test_export.py
@@ -104,7 +104,8 @@ class TestExportCurlCommand:
     def test_correct_host_used(self, get_request):
         get_request.request.headers["host"] = "domain:22"
 
-        result = """curl --resolve 'domain:22:[address]' -H 'header: qvalue' -H 'host: domain:22' 'http://domain:22/path?a=foo&a=bar&b=baz'"""
+        result = """curl --resolve 'domain:22:[address]' -H 'header: qvalue' -H 'host: domain:22' """ \
+                 """'http://domain:22/path?a=foo&a=bar&b=baz'"""
         assert export.curl_command(get_request) == result
 
 
@@ -154,7 +155,8 @@ class TestExportHttpieCommand:
     def test_correct_host_used(self, get_request):
         get_request.request.headers["host"] = "domain:22"
 
-        result = """http GET 'http://domain:22/path?a=foo&a=bar&b=baz' 'header: qvalue' 'host: domain:22'"""
+        result = """http GET 'http://domain:22/path?a=foo&a=bar&b=baz' """ \
+                 """'header: qvalue' 'host: domain:22'"""
         assert export.httpie_command(get_request) == result
 
 


### PR DESCRIPTION
#### Description

Unless this is done, the SNI server name will not be sent, often making
the curl/httpie command have different behaviour than the original
request (most often in the form of failing to establish a TLS
connection).

With this change, we always use the original host, fixing this failure.
However, if the original host is a domain, it may sometimes resolve to
a different IP address later on. In curl, we solve this problem by
forcing it to connect to the original IP using `--resolve`. For httpie
there is currently no easy solution (see:
https://github.com/httpie/httpie/issues/414).


#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.

(Note: Ugh, ignore the name change. I sent the initial PR by accident, where I was using the showhost for controlling this, before I decided this has nothing to do with showhost.)