### PR TITLE
Inform user when underscore-formatted options are used.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ Unreleased: mitmproxy next
 * Deprecation of pathod and pathoc tools and modules. Future releases might not contain them! (@Kriechi)
 * Addon to suppress unwanted error messages sent by mitmproxy. (@anneborcherding)
 * Updated imports and styles for web scanner helper addons. (@anneborcherding)
+* Inform when underscore-formatted options are used in client arg. (@jrblixt)
 
 * --- TODO: add new PRs above this line ---
 

--- a/mitmproxy/utils/arg_check.py
+++ b/mitmproxy/utils/arg_check.py
@@ -1,4 +1,5 @@
 import sys
+import re
 
 DEPRECATED = """
 --confdir
@@ -152,4 +153,13 @@ def check():
                     option,
                     REPLACEMENTS.get(option, None) or option.lstrip("-").replace("-", "_")
                 )
+            )
+
+    # Check for underscores in the options. Options always follow '--'.
+    for argument in args:
+        underscoreParam = re.search('[-]{2}((.*?_)(.*?(\s|$)))+', argument)
+        if underscoreParam is not None:
+            print("{} uses underscores, please use hyphens {}".format(
+                argument,
+                argument.replace('_', '-'))
             )

--- a/test/mitmproxy/utils/test_arg_check.py
+++ b/test/mitmproxy/utils/test_arg_check.py
@@ -26,7 +26,8 @@ from mitmproxy.utils import arg_check
                          '"ldap[s]:url_server_ldap:dn_auth:password:dn_subtree" '
                          'for LDAP authentication.'),
     (["--replacements"], "--replacements is deprecated.\n"
-                         "Please use `--modify-body` or `--modify-headers` instead.")
+                         "Please use `--modify-body` or `--modify-headers` instead."),
+    (["--underscore_option"], "--underscore_option uses underscores, please use hyphens --underscore-option")
 ])
 def test_check_args(arg, output):
     f = io.StringIO()


### PR DESCRIPTION
#### Description

Informs the user when an underscore-formatted option is used. Currently, only an error is thrown. Replaces the underscore option and gives the correct format.

#### Checklist

 - [*] I have updated tests where applicable.
 - [*] I have added an entry to the CHANGELOG.
