### PR TITLE
fix http2 request replay missing host header

### DIFF
--- a/mitmproxy/addons/clientplayback.py
+++ b/mitmproxy/addons/clientplayback.py
@@ -205,6 +205,7 @@ class ClientPlayback:
             # https://github.com/mitmproxy/mitmproxy/issues/2197
             if hf.request.http_version == "HTTP/2.0":
                 hf.request.http_version = "HTTP/1.1"
+                hf.request.headers.pop(":authority", None)
                 host = hf.request.host
                 if host is not None:
                     hf.request.headers.insert(0, "host", host)

--- a/mitmproxy/addons/clientplayback.py
+++ b/mitmproxy/addons/clientplayback.py
@@ -205,7 +205,7 @@ class ClientPlayback:
             # https://github.com/mitmproxy/mitmproxy/issues/2197
             if hf.request.http_version == "HTTP/2.0":
                 hf.request.http_version = "HTTP/1.1"
-                host = hf.request.headers.pop(":authority", None)
+                host = hf.request.host
                 if host is not None:
                     hf.request.headers.insert(0, "host", host)
             self.q.put(hf)


### PR DESCRIPTION
#### Description

Http2 replay is broeken as per: https://github.com/mitmproxy/mitmproxy/issues/4318 
this patch fixes this.

Tested with 
```
curl --http1.1 https://httpbin.org/get -k -x localhost:8080
# then replay in mitmweb
curl --http2 https://httpbin.org/get -k -x localhost:8080
# then replay in mitmweb
```

#### Checklist

 - [x] I have updated tests where applicable.
 - [ ] I have added an entry to the CHANGELOG.
