### PR TITLE
Workaround pyopenssl issue that prevents mitmproxy to be used as a Service

### DIFF
--- a/mitmproxy/net/tcp.py
+++ b/mitmproxy/net/tcp.py
@@ -392,7 +392,7 @@ class TCPClient(_Connection):
             self.sni = sni
             self.connection.set_tlsext_host_name(sni.encode("idna"))
         self.connection.set_connect_state()
-        
+
         count = 0
         while True:
             try:
@@ -400,9 +400,9 @@ class TCPClient(_Connection):
             except SSL.WantReadError:
                 rd, _, _ = select.select([self.connection._socket], [], [], self.connection._socket.gettimeout())
                 if not rd:
-                    raise ssl.SSLError("select timed out of {} seconds".format(self.connection._socket.gettimeout()))
-                if count == 10: # Just to be sure we don't get into an inf loop
-                    raise ssl.SSLError("WantReadError bug related with https://github.com/mitmproxy/mitmproxy/issues/4336")
+                    raise SSL.SSLError("select timed out of {} seconds".format(self.connection._socket.gettimeout()))
+                if count == 10:  # Just to be sure we don't get into an inf loop
+                    raise SSL.SSLError("WantReadError bug related with https://github.com/mitmproxy/mitmproxy/issues/4336")
 
                 count += 1
                 continue
@@ -516,7 +516,7 @@ class BaseHandler(_Connection):
             **sslctx_kwargs)
         self.connection = SSL.Connection(context, self.connection)
         self.connection.set_accept_state()
-        
+
         count = 0
         while True:
             try:
@@ -524,9 +524,9 @@ class BaseHandler(_Connection):
             except SSL.WantReadError:
                 rd, _, _ = select.select([self.connection._socket], [], [], self.connection._socket.gettimeout())
                 if not rd:
-                    raise ssl.SSLError("select timed out of {} seconds".format(self.connection._socket.gettimeout()))
-                if count == 10: # Just to be sure we don't get into an inf loop
-                    raise ssl.SSLError("WantReadError bug related with https://github.com/mitmproxy/mitmproxy/issues/4336")
+                    raise SSL.SSLError("select timed out of {} seconds".format(self.connection._socket.gettimeout()))
+                if count == 10:  # Just to be sure we don't get into an inf loop
+                    raise SSL.SSLError("WantReadError bug related with https://github.com/mitmproxy/mitmproxy/issues/4336")
 
                 count += 1
                 continue
@@ -536,7 +536,7 @@ class BaseHandler(_Connection):
                 else:
                     raise exceptions.TlsException("SSL handshake error: %s" % repr(v))
             break
-        
+
         self.tls_established = True
         cert = self.connection.get_peer_certificate()
         if cert:


### PR DESCRIPTION
#### Description

This a fix for https://github.com/mitmproxy/mitmproxy/issues/4336 that prevents mitmproxy to be used as a service.

#### Checklist

 - [X] I have updated tests where applicable.
 - [ ] I have added an entry to the CHANGELOG.
