### PR TITLE
Add a new "verbose" log level for per-connection messages.

### DIFF
--- a/mitmproxy/log.py
+++ b/mitmproxy/log.py
@@ -65,10 +65,11 @@ LogTierOrder = [
     "error",
     "warn",
     "info",
+    "verbose",
     "alert",
     "debug",
 ]
 
 
 def log_tier(level):
-    return dict(error=0, warn=1, info=2, alert=2, debug=3).get(level)
+    return dict(error=0, warn=1, info=2, verbose=3, alert=4, debug=5).get(level)

--- a/mitmproxy/proxy2/server.py
+++ b/mitmproxy/proxy2/server.py
@@ -97,10 +97,10 @@ class ConnectionHandler(metaclass=abc.ABCMeta):
         if not watch:
             return  # this should not be needed, see asyncio_utils.create_task
 
-        self.log("client connect")
+        self.log("client connect", level="verbose")
         await self.handle_hook(server_hooks.ClientConnectedHook(self.client))
         if self.client.error:
-            self.log("client kill connection")
+            self.log("client kill connection", level="verbose")
             writer = self.transports.pop(self.client).writer
             assert writer
             writer.close()
@@ -118,7 +118,7 @@ class ConnectionHandler(metaclass=abc.ABCMeta):
 
         watch.cancel()
 
-        self.log("client disconnect")
+        self.log("client disconnect", level="verbose")
         self.client.timestamp_end = time.time()
         await self.handle_hook(server_hooks.ClientClosedHook(self.client))
 
@@ -175,7 +175,7 @@ class ConnectionHandler(metaclass=abc.ABCMeta):
                     addr = f"{command.connection.address[0]} ({human.format_address(command.connection.peername)})"
                 else:
                     addr = human.format_address(command.connection.address)
-                self.log(f"server connect {addr}")
+                self.log(f"server connect {addr}", level="verbose")
                 connected_hook = asyncio_utils.create_task(
                     self.handle_hook(server_hooks.ServerConnectedHook(hook_data)),
                     name=f"handle_hook(server_connected) {addr}",
@@ -199,7 +199,7 @@ class ConnectionHandler(metaclass=abc.ABCMeta):
                 self.transports[command.connection].handler = new_handler
                 await asyncio.wait([new_handler])
 
-                self.log(f"server disconnect {addr}")
+                self.log(f"server disconnect {addr}", level="verbose")
                 command.connection.timestamp_end = time.time()
                 await connected_hook  # wait here for this so that closed always comes after connected.
                 await self.handle_hook(server_hooks.ServerClosedHook(hook_data))


### PR DESCRIPTION
#### Description

I'm writing plugins more frequently now for various hacks. The per-connection client/server connect and disconnect messages fill up the event log and make it hard to monitor what my plugins are doing.

One solution, in the PR, is to add a new "verbose" log level so that these messages are hidden but can be revealed to aid troubleshooting.

Another solution would be to add a new bit of UI just for scripts to use. Maybe that would be a "script log" or something. There are probably other good ideas... I'm open to suggestions that help solve the usability problem I have now.

oh... and if this is just a "bad idea" or not right for the project that's ok, too.

#### Checklist

 - [ ] I have updated tests where applicable.
 - [ ] I have added an entry to the CHANGELOG.
