### PR TITLE
docs: fix simple typo, viewier -> viewer

### DIFF
--- a/mitmproxy/tools/console/consoleaddons.py
+++ b/mitmproxy/tools/console/consoleaddons.py
@@ -364,7 +364,7 @@ class ConsoleAddon:
         """
             Spawn an external viewer for a flow request or response body based
             on the detected MIME type. We use the mailcap system to find the
-            correct viewier, and fall back to the programs in $PAGER or $EDITOR
+            correct viewer, and fall back to the programs in $PAGER or $EDITOR
             if necessary.
         """
         fpart = getattr(flow, part, None)


### PR DESCRIPTION
There is a small typo in mitmproxy/tools/console/consoleaddons.py.

Should read `viewer` rather than `viewier`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md