### PR TITLE
deep-link to create a new GitHub bug report

### DIFF
--- a/mitmproxy/master.py
+++ b/mitmproxy/master.py
@@ -69,7 +69,7 @@ class Master:
             print(exc, file=sys.stderr)
             print("mitmproxy has crashed!", file=sys.stderr)
             print("Please lodge a bug report at:", file=sys.stderr)
-            print("\thttps://github.com/mitmproxy/mitmproxy", file=sys.stderr)
+            print("\thttps://github.com/mitmproxy/mitmproxy/issues", file=sys.stderr)
 
         self.addons.trigger(hooks.DoneHook())
 


### PR DESCRIPTION
If we ever decide to rename the issue template file, then GitHub will simply render a default empty issue form.