### PR TITLE
Upon --replace, suggest --modify-body / --modify-headers

### DIFF
--- a/mitmproxy/utils/arg_check.py
+++ b/mitmproxy/utils/arg_check.py
@@ -97,7 +97,7 @@ REPLACEMENTS = {
     "--cert": "--certs",
     "--insecure": "--ssl-insecure",
     "-c": "-C",
-    "--replace": "--replacements",
+    "--replace": ["--modify-body", "--modify-headers"],
     "--replacements": ["--modify-body", "--modify-headers"],
     "-i": "--intercept",
     "-f": "--view-filter",


### PR DESCRIPTION
Else the user sees
```
--replace is deprecated.
Please use `--replacements` instead.
mitmdump: error: unrecognized arguments: --replace
```
and then
```
mitmdump: error: unrecognized arguments: --replacements
--replacements is deprecated.
Please use `--modify-body` or `--modify-headers` instead.
```
and feels silly