### PR TITLE
Extract port number from authority before IDNA decode 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ If you depend on these features, please raise your voice in
 * Remove the following options: `http2_priority`, `relax_http_form_validation`, `upstream_bind_address`,
   `spoof_source_address`, and `stream_websockets`. If you depended on one of them please let us know. 
   mitmproxy never phones home, which means we don't know how prominently these options were used. (@mhils)
+* Fix IDNA host 'Bad HTTP request line' error (@grahamrobbins)
 * --- TODO: add new PRs above this line ---
 * ... and various other fixes, documentation improvements, dependency version bumps, etc.
 

--- a/mitmproxy/net/http/url.py
+++ b/mitmproxy/net/http/url.py
@@ -160,14 +160,16 @@ def parse_authority(authority: AnyStr, check: bool) -> Tuple[str, Optional[int]]
     """
     try:
         if isinstance(authority, bytes):
-            authority_str = authority.decode("idna")
+            m = _authority_re.match(authority.decode("utf-8"))
+            if not m:
+                raise ValueError
+            host = m["host"].encode("utf-8").decode("idna")
         else:
-            authority_str = authority
-        m = _authority_re.match(authority_str)
-        if not m:
-            raise ValueError
+            m = _authority_re.match(authority)
+            if not m:
+                raise ValueError
+            host = m.group("host")
 
-        host = m.group("host")
         if host.startswith("[") and host.endswith("]"):
             host = host[1:-1]
         if not is_valid_host(host):

--- a/test/mitmproxy/net/http/test_url.py
+++ b/test/mitmproxy/net/http/test_url.py
@@ -166,6 +166,7 @@ def test_default_port():
         ["foo", True, ("foo", None)],
         ["foo..bar", False, ("foo..bar", None)],
         ["foo:bar", False, ("foo:bar", None)],
+        [b"foo:bar", False, ("foo:bar", None)],
         ["foo:999999999", False, ("foo:999999999", None)],
         [b"\xff", False, ('\udcff', None)]
     ]

--- a/test/mitmproxy/net/http/test_url.py
+++ b/test/mitmproxy/net/http/test_url.py
@@ -162,6 +162,7 @@ def test_default_port():
         ["127.0.0.1:443", True, ("127.0.0.1", 443)],
         ["[2001:db8:42::]:443", True, ("2001:db8:42::", 443)],
         [b"xn--aaa-pla.example:80", True, ("äaaa.example", 80)],
+        [b"xn--r8jz45g.xn--zckzah:80", True, ('例え.テスト', 80)],
         ["foo", True, ("foo", None)],
         ["foo..bar", False, ("foo..bar", None)],
         ["foo:bar", False, ("foo:bar", None)],


### PR DESCRIPTION
#### Description

Before calling `.decode("idna")` first extract the port number. Attempt to fix issue #4409

If the port is present it can lead to a UnicodeError exception causing net.http.url.parse_authority to incorrectly return False.

The existing test passes because `.decode("idna")` accepts a port number some of the time:

```
>>> b"xn--aaa-pla.example:80".decode("idna")
'äaaa.example:80'
```

However this results in a UnicodeError exception:

```
>>> b"xn--r8jz45g.xn--zckzah:80".decode("idna")
Traceback (most recent call last):
  File "/usr/lib/python3.6/encodings/punycode.py", line 207, in decode
    res = punycode_decode(input, errors)
  File "/usr/lib/python3.6/encodings/punycode.py", line 194, in punycode_decode
    return insertion_sort(base, extended, errors)
  File "/usr/lib/python3.6/encodings/punycode.py", line 165, in insertion_sort
    bias, errors)
  File "/usr/lib/python3.6/encodings/punycode.py", line 146, in decode_generalized_number
    % extended[extpos])
UnicodeError: Invalid extended code point '8'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/lib/python3.6/encodings/idna.py", line 214, in decode
    result.append(ToUnicode(label))
  File "/usr/lib/python3.6/encodings/idna.py", line 131, in ToUnicode
    result = label1.decode("punycode")
UnicodeError: decoding with 'punycode' codec failed (UnicodeError: Invalid extended code point '8')

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
UnicodeError: decoding with 'idna' codec failed (UnicodeError: decoding with 'punycode' codec failed (UnicodeError: Invalid extended code point '8'))
```

#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
