### PR TITLE
Fix location for contrib har_dump.py in its test

### DIFF
--- a/examples/contrib/test_har_dump.py
+++ b/examples/contrib/test_har_dump.py
@@ -21,7 +21,7 @@ class TestHARDump:
 
     def test_simple(self, tmpdir, tdata):
         with taddons.context() as tctx:
-            a = tctx.script(tdata.path("../examples/complex/har_dump.py"))
+            a = tctx.script(tdata.path("../examples/contrib/har_dump.py"))
             path = str(tmpdir.join("somefile"))
             tctx.configure(a, hardump=path)
             tctx.invoke(a, "response", self.flow())
@@ -32,7 +32,7 @@ class TestHARDump:
 
     def test_base64(self, tmpdir, tdata):
         with taddons.context() as tctx:
-            a = tctx.script(tdata.path("../examples/complex/har_dump.py"))
+            a = tctx.script(tdata.path("../examples/contrib/har_dump.py"))
             path = str(tmpdir.join("somefile"))
             tctx.configure(a, hardump=path)
 
@@ -46,7 +46,7 @@ class TestHARDump:
 
     def test_format_cookies(self, tdata):
         with taddons.context() as tctx:
-            a = tctx.script(tdata.path("../examples/complex/har_dump.py"))
+            a = tctx.script(tdata.path("../examples/contrib/har_dump.py"))
 
             CA = cookies.CookieAttrs
 
@@ -65,7 +65,7 @@ class TestHARDump:
 
     def test_binary(self, tmpdir, tdata):
         with taddons.context() as tctx:
-            a = tctx.script(tdata.path("../examples/complex/har_dump.py"))
+            a = tctx.script(tdata.path("../examples/contrib/har_dump.py"))
             path = str(tmpdir.join("somefile"))
             tctx.configure(a, hardump=path)
 


### PR DESCRIPTION
To run the test, I had to copy `conftest.py` to examples.
```bash
cp test/conftest.py examples
pytest examples/contrib/test_har_dump.py
```
This fixes the `fixture 'tdata' not found` error.

#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
