### PR TITLE
Imporove document, pip install -e .[dev] error in mac zsh

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ python3 -m venv --help
 git clone https://github.com/mitmproxy/mitmproxy.git
 cd mitmproxy
 python3 -m venv venv
-venv/bin/pip install -e .[dev]
+venv/bin/pip install -e ".[dev]"
 ```
 
 ##### Windows


### PR DESCRIPTION
#### Description

run `venv/bin/pip install -e .[dev]`  failed in mac zsh:
> zsh: no matches found: .[dev]

`venv/bin/pip install -e ".[dev]"` works well in both mac bash, mac zsh and debian

#### Checklist

 - [ ] I have updated tests where applicable.
 - [ ] I have added an entry to the CHANGELOG.
