### PR TITLE
Fix HAR dump

### DIFF
--- a/examples/contrib/har_dump.py
+++ b/examples/contrib/har_dump.py
@@ -20,7 +20,7 @@ from datetime import timezone
 
 import mitmproxy
 
-from mitmproxy import connections  # noqa
+from mitmproxy import connection
 from mitmproxy import version
 from mitmproxy import ctx
 from mitmproxy.utils import strutils
@@ -30,7 +30,7 @@ HAR: typing.Dict = {}
 
 # A list of server seen till now is maintained so we can avoid
 # using 'connect' time for entries that use an existing connection.
-SERVERS_SEEN: typing.Set[connections.ServerConnection] = set()
+SERVERS_SEEN: typing.Set[connection.Server] = set()
 
 
 def load(l):

--- a/examples/contrib/har_dump.py
+++ b/examples/contrib/har_dump.py
@@ -53,7 +53,7 @@ def configure(updated):
     })
 
 
-def response(flow):
+def response(flow: mitmproxy.http.HTTPFlow):
     """
        Called when a server response has been received.
     """
@@ -153,7 +153,7 @@ def response(flow):
             "params": params
         }
 
-    if flow.server_conn.connected():
+    if flow.server_conn.connected:
         entry["serverIPAddress"] = str(flow.server_conn.ip_address[0])
 
     HAR["log"]["entries"].append(entry)

--- a/examples/contrib/test_har_dump.py
+++ b/examples/contrib/test_har_dump.py
@@ -20,8 +20,14 @@ class TestHARDump:
         )
 
     def test_simple(self, tmpdir, tdata):
+        # context is needed to provide ctx.log function that
+        # is invoked if there are exceptions
         with taddons.context() as tctx:
             a = tctx.script(tdata.path("../examples/contrib/har_dump.py"))
+            # check script is read without errors
+            assert tctx.master.logs == []
+            assert a.name_value   # last function in har_dump.py
+
             path = str(tmpdir.join("somefile"))
             tctx.configure(a, hardump=path)
             tctx.invoke(a, "response", self.flow())

--- a/examples/contrib/test_har_dump.py
+++ b/examples/contrib/test_har_dump.py
@@ -30,8 +30,8 @@ class TestHARDump:
 
             path = str(tmpdir.join("somefile"))
             tctx.configure(a, hardump=path)
-            tctx.invoke(a, "response", self.flow())
-            tctx.invoke(a, "done")
+            a.response(self.flow())
+            a.done()
             with open(path) as inp:
                 har = json.load(inp)
             assert len(har["log"]["entries"]) == 1
@@ -42,10 +42,8 @@ class TestHARDump:
             path = str(tmpdir.join("somefile"))
             tctx.configure(a, hardump=path)
 
-            tctx.invoke(
-                a, "response", self.flow(resp_content=b"foo" + b"\xFF" * 10)
-            )
-            tctx.invoke(a, "done")
+            a.response(self.flow(resp_content=b"foo" + b"\xFF" * 10))
+            a.done()
             with open(path) as inp:
                 har = json.load(inp)
             assert har["log"]["entries"][0]["response"]["content"]["encoding"] == "base64"
@@ -82,8 +80,8 @@ class TestHARDump:
             f.response.headers["random-junk"] = bytes(range(256))
             f.response.content = bytes(range(256))
 
-            tctx.invoke(a, "response", f)
-            tctx.invoke(a, "done")
+            a.response(f)
+            a.done()
 
             with open(path) as inp:
                 har = json.load(inp)


### PR DESCRIPTION
The reason was an invalid import of `connections` which is gone in d159897d98d47034827714bd0298268d1b9af6f0, but the loading error was silently ignored (#4438) resulting in a misleading exception at a later stage.

The way to run tests from examples.

    ln -sr test/conftest.py examples
    pytest examples/contrib/test_har_dump.py -k simpl

The way to see the execution flow with silenced exceptions.

    from hunter import trace, Q
    trace(Q(stdlib=False), ~Q(filename_contains='site-packages'))

#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.

### References

Fixes #3377
Fixes #3855