### PR TITLE
Tutorial: How to Install mitmproxy-ca-cert.pem on Wii U

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 [![Latest Version](https://shields.mitmproxy.org/pypi/v/mitmproxy.svg)](https://pypi.python.org/pypi/mitmproxy)
 [![Supported Python versions](https://shields.mitmproxy.org/pypi/pyversions/mitmproxy.svg)](https://pypi.python.org/pypi/mitmproxy)
 
-
 ``mitmproxy`` is an interactive, SSL/TLS-capable intercepting proxy with a console
 interface for HTTP/1, HTTP/2, and WebSockets.
 
@@ -17,6 +16,7 @@ interface for HTTP/1, HTTP/2, and WebSockets.
 
 The installation instructions are [here](https://docs.mitmproxy.org/stable/overview-installation).
 If you want to install from source, see [CONTRIBUTING.md](./CONTRIBUTING.md).
+``wii u instalation docs are avaliable, Homebrewed Wii U Required``
 
 ## Documentation & Help
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ interface for HTTP/1, HTTP/2, and WebSockets.
 
 The installation instructions are [here](https://docs.mitmproxy.org/stable/overview-installation).
 If you want to install from source, see [CONTRIBUTING.md](./CONTRIBUTING.md).
-``wii u instalation docs are avaliable, Homebrewed Wii U Required``
+
+``Wii U instalation docs are avaliable, Homebrewed Wii U Required``
 
 ## Documentation & Help
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ interface for HTTP/1, HTTP/2, and WebSockets.
 The installation instructions are [here](https://docs.mitmproxy.org/stable/overview-installation).
 If you want to install from source, see [CONTRIBUTING.md](./CONTRIBUTING.md).
 
-``Wii U instalation docs are avaliable, Homebrewed Wii U Required``
+If you want to check the tutorial on how to install mitmproxy-ca-cert.pem on Wii U, please check the [pull request](https://github.com/mitmproxy/mitmproxy/pull/4445) for the tutorial.
 
 ## Documentation & Help
 


### PR DESCRIPTION
#### Description

This Tutorial Explains on How to Install mitmproxy-ca-cert.pem on Wii U

#### Tutorial

First you download mitmproxy-ca-cert.pem on your computer
Then you need to homebrew your Wii U: https://wiiu.hacks.guide/#/ 
Then Install FTPiiU and run it on Homebrew Channel
Download /storage_mlc/usr/nsec/sys/wiiu_device_certchain.pem on your Wii U from your FTP Client
Open both mitmproxy-ca-cert.pem and wiiu_device_certchain.pem as notepad
Copy all text of mitmproxy-ca-cert.pem then append it on wiiu_device_certchain.pem and save it
Upload Your Modified wiiu_device_certchain.pem to a directory (/storage_mlc/usr/nsec/sys/) from your FTP Client
Restart Your Wii U and You're done!
Now it's capturing https traffic from your Wii U! 😄

#### Note
The Error Code 102-2160 that points to HTTP_SSL_CACERT will always be appeared while connected to Mitmproxy from your Wii U Console!
 
#### Photos of Proof
![Picture](https://media.discordapp.net/attachments/352944118864805889/810167715771187250/IMG_20210213_121627972.jpg?width=1202&height=676)
![381](https://user-images.githubusercontent.com/59511669/107853836-f4b7ca00-6df6-11eb-99dc-2b83e9f20faa.PNG)
