### PR TITLE
Fixes #4416

### DIFF
--- a/mitmproxy/net/http/http1/read.py
+++ b/mitmproxy/net/http/http1/read.py
@@ -111,8 +111,8 @@ def _read_request_line(line: bytes) -> Tuple[str, int, bytes, bytes, bytes, byte
                 raise ValueError
         else:
             scheme, rest = target.split(b"://", maxsplit=1)
-            authority, *path_ = rest.split(b"/", maxsplit=1)
-            path_ = path_[0] if path_ else b""
+            authority, *paths_ = rest.split(b"/", maxsplit=1)
+            path_ = paths_[0] if paths_ else b""
             path = b"/" + path_
             host, port = url.parse_authority(authority, check=True)
             port = port or url.default_port(scheme)

--- a/mitmproxy/net/http/http1/read.py
+++ b/mitmproxy/net/http/http1/read.py
@@ -111,7 +111,8 @@ def _read_request_line(line: bytes) -> Tuple[str, int, bytes, bytes, bytes, byte
                 raise ValueError
         else:
             scheme, rest = target.split(b"://", maxsplit=1)
-            authority, path_ = rest.split(b"/", maxsplit=1)
+            authority, *path_ = rest.split(b"/", maxsplit=1)
+            path_ = path_[0] if path_ else b""
             path = b"/" + path_
             host, port = url.parse_authority(authority, check=True)
             port = port or url.default_port(scheme)

--- a/mitmproxy/net/http/http1/read.py
+++ b/mitmproxy/net/http/http1/read.py
@@ -111,8 +111,7 @@ def _read_request_line(line: bytes) -> Tuple[str, int, bytes, bytes, bytes, byte
                 raise ValueError
         else:
             scheme, rest = target.split(b"://", maxsplit=1)
-            authority, *paths_ = rest.split(b"/", maxsplit=1)
-            path_ = paths_[0] if paths_ else b""
+            authority, _, path_ = rest.partition(b"/")
             path = b"/" + path_
             host, port = url.parse_authority(authority, check=True)
             port = port or url.default_port(scheme)

--- a/test/mitmproxy/net/http/http1/test_read.py
+++ b/test/mitmproxy/net/http/http1/test_read.py
@@ -137,6 +137,8 @@ def test_read_request_line():
             ("foo", 42, b"CONNECT", b"", b"foo:42", b"", b"HTTP/1.1"))
     assert (t(b"GET http://foo:42/bar HTTP/1.1") ==
             ("foo", 42, b"GET", b"http", b"foo:42", b"/bar", b"HTTP/1.1"))
+    assert (t(b"GET http://foo:42 HTTP/1.1") ==
+            ("foo", 42, b"GET", b"http", b"foo:42", b"/", b"HTTP/1.1"))
 
     with pytest.raises(ValueError):
         t(b"GET / WTF/1.1")


### PR DESCRIPTION
Fix ValueError when splitting on a request URI without a path part.

Consulted [HTTP 1.1 spec](https://tools.ietf.org/html/rfc2616#section-5.1.2) where it says that proxy should append "/" to URI's path if it already doesn't have one.

#### Checklist

 - [x] I have updated tests where applicable.
 - [ ] I have added an entry to the CHANGELOG.
