### PR TITLE
Add 'tzdata' package to Docker image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ If you depend on these features, please raise your voice in
 * `--modify-headers` now works correctly when modifying a header that is also part of the filter expression (@Prinzhorn)
 * Fix SNI-related reproducibility issues when exporting to curl/httpie commands. (@dkasak)
 * Add option `export_preserve_original_ip` to force exported command to connect to IP from original request. Only supports curl at the moment. (@dkasak)
+* Add `tzdata` package to Docker image  (@AltoNyan)
 * --- TODO: add new PRs above this line ---
 * ... and various other fixes, documentation improvements, dependency version bumps, etc.
 

--- a/release/docker/Dockerfile
+++ b/release/docker/Dockerfile
@@ -21,6 +21,7 @@ RUN addgroup -S mitmproxy && adduser -S -G mitmproxy mitmproxy \
         openssl-dev \
         python3 \
         python3-dev \
+        tzdata \
     && python3 -m ensurepip --upgrade \
     && pip3 install -U pip \
     && LDFLAGS=-L/lib pip3 install -U /home/mitmproxy/${WHEEL_BASENAME_MITMPROXY} \


### PR DESCRIPTION
#### Description

Add `tzdata` package to Docker image by appending `tzdata` to Dockerfile's `apk add ...` section.



#### Checklist

 - [ ] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
