### PR TITLE
Speculative HTTP/2 fixes, refs #4451

### DIFF
--- a/mitmproxy/proxy/layers/http/__init__.py
+++ b/mitmproxy/proxy/layers/http/__init__.py
@@ -461,7 +461,7 @@ class HttpStream(layer.Layer):
             )
 
         if 200 <= self.flow.response.status_code < 300:
-            yield SendHttp(ResponseHeaders(self.stream_id, self.flow.response), self.context.client)
+            yield SendHttp(ResponseHeaders(self.stream_id, self.flow.response, True), self.context.client)
             yield SendHttp(ResponseEndOfMessage(self.stream_id), self.context.client)
             self.child_layer = self.child_layer or layer.NextLayer(self.context)
             yield from self.child_layer.handle_event(events.Start())

--- a/mitmproxy/proxy/layers/http/_http2.py
+++ b/mitmproxy/proxy/layers/http/_http2.py
@@ -109,6 +109,7 @@ class Http2Connection(HttpConnection):
                     stream: h2.stream.H2Stream = self.h2_conn.streams[event.stream_id]
                     send_error_message = (
                         isinstance(event, ResponseProtocolError)
+                        and self.is_open_for_us(event.stream_id)
                         and not stream.state_machine.headers_sent
                         and event.code != status_codes.NO_RESPONSE
                     )
@@ -291,6 +292,7 @@ class Http2Server(Http2Connection):
                 self.h2_conn.send_headers(
                     event.stream_id,
                     headers,
+                    end_stream=event.end_stream,
                 )
                 yield SendData(self.conn, self.h2_conn.data_to_send())
         else:

--- a/test/mitmproxy/proxy/layers/http/test_http2.py
+++ b/test/mitmproxy/proxy/layers/http/test_http2.py
@@ -282,9 +282,7 @@ def test_no_normalization(tctx):
             >> reply()
             << http.HttpResponseHook(flow)
             >> reply()
-            << SendData(tctx.client,
-                        cff.build_headers_frame(response_headers).serialize() +
-                        cff.build_data_frame(b"", flags=["END_STREAM"]).serialize())
+            << SendData(tctx.client, cff.build_headers_frame(response_headers, flags=["END_STREAM"]).serialize())
     )
     assert flow().request.headers.fields == ((b"Should-Not-Be-Capitalized! ", b" :) "),)
     assert flow().response.headers.fields == ((b"Same", b"Here"),)


### PR DESCRIPTION
@r00t-'s comment in #4451 pointing to Facebook was a useful one - their custom HTTP/2 stack exposed some interesting race conditions in ours, which I believe I fixed all now.

@r00t-: Could you check out this branch and see if that fixes your Facebook POST requests in particular? 🍰 