### PR TITLE
Don't stream bodies when content length is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ If you depend on these features, please raise your voice in
 * Fix SNI-related reproducibility issues when exporting to curl/httpie commands. (@dkasak)
 * Add option `export_preserve_original_ip` to force exported command to connect to IP from original request. Only supports curl at the moment. (@dkasak)
 * Major proxy protocol testing (@r00t-)
+* Never `stream_large_bodies` when the size is unknown due to missing `content-length` (@Prinzhorn)
 * --- TODO: add new PRs above this line ---
 * ... and various other fixes, documentation improvements, dependency version bumps, etc.
 

--- a/mitmproxy/addons/streambodies.py
+++ b/mitmproxy/addons/streambodies.py
@@ -37,7 +37,6 @@ class StreamBodies:
             except ValueError:
                 f.kill()
                 return
-
             if (expected_size > self.max_size) and not r.raw_content:
                 # r.stream may already be a callable, which we want to preserve.
                 r.stream = r.stream or True

--- a/mitmproxy/addons/streambodies.py
+++ b/mitmproxy/addons/streambodies.py
@@ -37,7 +37,8 @@ class StreamBodies:
             except ValueError:
                 f.kill()
                 return
-            if expected_size and not r.raw_content and not (0 <= expected_size <= self.max_size):
+
+            if (expected_size > self.max_size) and not r.raw_content:
                 # r.stream may already be a callable, which we want to preserve.
                 r.stream = r.stream or True
                 ctx.log.info("Streaming {} {}".format("response from" if not is_request else "request to", f.request.host))

--- a/test/mitmproxy/addons/test_streambodies.py
+++ b/test/mitmproxy/addons/test_streambodies.py
@@ -35,6 +35,14 @@ def test_simple():
         sa.responseheaders(f)
         assert not f.response.stream
 
+        # Don't stream chunked
+        f = tflow.tflow(resp=True)
+        f.response.content = b""
+        f.response.headers["Transfer-Encoding"] = "chunked"
+        assert not f.response.stream
+        sa.responseheaders(f)
+        assert not f.response.stream
+
         # Don't stream if a body already exists
         f = tflow.tflow(resp=True)
         f.response.content = b"exists"

--- a/test/mitmproxy/addons/test_streambodies.py
+++ b/test/mitmproxy/addons/test_streambodies.py
@@ -12,6 +12,7 @@ def test_simple():
             tctx.configure(sa, stream_large_bodies = "invalid")
         tctx.configure(sa, stream_large_bodies = "10")
 
+        # Stream request
         f = tflow.tflow()
         f.request.content = b""
         f.request.headers["Content-Length"] = "1024"
@@ -19,12 +20,28 @@ def test_simple():
         sa.requestheaders(f)
         assert f.request.stream
 
+        # Stream response
         f = tflow.tflow(resp=True)
         f.response.content = b""
         f.response.headers["Content-Length"] = "1024"
         assert not f.response.stream
         sa.responseheaders(f)
         assert f.response.stream
+
+        # Don't stream if content-length header is missing
+        f = tflow.tflow(resp=True)
+        f.response.content = b""
+        assert not f.response.stream
+        sa.responseheaders(f)
+        assert not f.response.stream
+
+        # Don't stream if a body already exists
+        f = tflow.tflow(resp=True)
+        f.response.content = b"exists"
+        f.response.headers["Content-Length"] = "6"
+        assert not f.response.stream
+        sa.responseheaders(f)
+        assert not f.response.stream
 
         f = tflow.tflow(resp=True)
         f.response.headers["content-length"] = "invalid"


### PR DESCRIPTION
#### Description

`content-length` is optional and if it's missing `expected_http_body_size` returns `-1` which made the falsy check for `expected_size` true. I've simplified the condition. Not sure for what use-case `raw_content` is checked? There was no test for that case.

I think having some false negatives (buffering a body that is larger than we want) is way better than having some false positives (missing out on bodies that would've been small enough). I guess that larger bodies will also have a content-length more commonly.

#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
