### PR TITLE
Speed up `git clone` in docs Dockerfile

### DIFF
--- a/docs/scripts/clirecording/Dockerfile
+++ b/docs/scripts/clirecording/Dockerfile
@@ -30,7 +30,7 @@ RUN apt-get update && apt-get install -y \
     && pip3 install libtmux curl requests mitmproxy
 
 # install latest tmux (to support popups)
-RUN git clone https://github.com/tmux/tmux.git \
+RUN git clone --depth 1 https://github.com/tmux/tmux.git \
     && cd tmux \
     && sh autogen.sh \
     && ./configure && make && make install


### PR DESCRIPTION
#### Description

Speed up `git clone` in docs Dockerfile by reducing the git repository clone depth for the commit history, which is not useful in this case.

#### Checklist

 - [ ] I have updated tests where applicable.
 - [ ] I have added an entry to the CHANGELOG.
