### PR TITLE
document flow_details 4

### DIFF
--- a/mitmproxy/addons/dumper.py
+++ b/mitmproxy/addons/dumper.py
@@ -42,7 +42,8 @@ class Dumper:
               0: shortened request URL, response status code, WebSocket and TCP message notifications.
               1: full request URL with response status code
               2: 1 + HTTP headers
-              3: 2 + full response content, content of WebSocket and TCP messages.
+              3: 2 + truncated response content, content of WebSocket and TCP messages
+              4: 3 + nothing is truncated
             """
         )
         loader.add_option(


### PR DESCRIPTION
Tests for `4` already exist https://github.com/mitmproxy/mitmproxy/blob/8178f6c77b715cd342f8be161d5ca5da8938645c/test/mitmproxy/addons/test_dumper.py#L59

Not a fan of the `70` magic number here, but this PR references #4476

https://github.com/mitmproxy/mitmproxy/blob/8178f6c77b715cd342f8be161d5ca5da8938645c/mitmproxy/addons/dumper.py#L110-L113

Next: make the 70 configurable. I think merging `3` and `4` is not a good idea, truncating megabytes of responses is usually a good thing. So a new option `dumper_lines_cutoff` could be introduces that only affects `flow_detail = 3`