### PR TITLE
Refactor docs clirecording Dockerfile

### DIFF
--- a/docs/scripts/clirecording/Dockerfile
+++ b/docs/scripts/clirecording/Dockerfile
@@ -6,7 +6,7 @@ ENV LANGUAGE en_US.UTF-8
 ENV TERM screen-256color
 
 # install mitmproxy, asciinema, and dependencies
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install --no-install-recommends -y \
     asciinema \
     autoconf \
     automake \
@@ -23,6 +23,7 @@ RUN apt-get update && apt-get install -y \
     pkg-config \
     python3-pip \
     python3 \
+    python3-setuptools \
     wget \
     xterm \
     && locale-gen --purge "en_US.UTF-8" \

--- a/docs/scripts/clirecording/Dockerfile
+++ b/docs/scripts/clirecording/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get update && apt-get install -y \
     xterm \
     && locale-gen --purge "en_US.UTF-8" \
     && update-locale "LANG=en_US.UTF-8" \
-    && pip3 install libtmux curl requests mitmproxy \
+    && pip3 install --no-cache-dir libtmux curl requests mitmproxy \
     && rm -rf /var/lib/apt/lists/*
 
 # install latest tmux (to support popups)

--- a/docs/scripts/clirecording/Dockerfile
+++ b/docs/scripts/clirecording/Dockerfile
@@ -27,7 +27,8 @@ RUN apt-get update && apt-get install -y \
     xterm \
     && locale-gen --purge "en_US.UTF-8" \
     && update-locale "LANG=en_US.UTF-8" \
-    && pip3 install libtmux curl requests mitmproxy
+    && pip3 install libtmux curl requests mitmproxy \
+    && rm -rf /var/lib/apt/lists/*
 
 # install latest tmux (to support popups)
 RUN git clone --depth 1 https://github.com/tmux/tmux.git \


### PR DESCRIPTION
#### Description

Remove unnecessary apt & pip packages temp/cache files, prevent additional & unnecessary apt packages, result in saving more than 300 MB in the image size:

```$ docker images
REPOSITORY                    TAG                 IMAGE ID            CREATED             SIZE
after                         latest              c523c04f38f8        25 minutes ago      437MB
before                        latest              3c427b69e9f8        39 minutes ago      785MB
```

#### Checklist

 - [ ] I have updated tests where applicable.
 - [ ] I have added an entry to the CHANGELOG.
