### PR TITLE
Switch Docker release to be based on Debian instead of Alpine

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -149,7 +149,6 @@ jobs:
 
   # Separate from everything else because slow.
   build-and-deploy-docker:
-    if: github.repository == 'mitmproxy/mitmproxy' && github.event_name == 'push'
     needs: [test, test-web-ui, build-wheel]
     runs-on: ubuntu-latest
     env:
@@ -167,7 +166,7 @@ jobs:
           name: wheel
           path: release/dist
       - run: tox -e cibuild -- build
-      - run: tox -e cibuild -- upload
+      #- run: tox -e cibuild -- upload
 
   deploy:
     if: github.repository == 'mitmproxy/mitmproxy' && github.event_name == 'push'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -149,6 +149,7 @@ jobs:
 
   # Separate from everything else because slow.
   build-and-deploy-docker:
+    if: github.repository == 'mitmproxy/mitmproxy' && github.event_name == 'push'
     needs: [test, test-web-ui, build-wheel]
     runs-on: ubuntu-latest
     env:
@@ -166,7 +167,7 @@ jobs:
           name: wheel
           path: release/dist
       - run: tox -e cibuild -- build
-      #- run: tox -e cibuild -- upload
+      - run: tox -e cibuild -- upload
 
   deploy:
     if: github.repository == 'mitmproxy/mitmproxy' && github.event_name == 'push'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,6 @@ If you depend on these features, please raise your voice in
 
 ### Full Changelog
 
-* Switch Docker image release to be based on Debian (@PeterDaveHello)
 * New Proxy Core based on sans-io pattern (@mhils)
 * mitmproxy's command line interface now supports Windows (@mhils)
 * The `clientconnect`, `clientdisconnect`, `serverconnect`, `serverdisconnect`, and `log`
@@ -58,6 +57,7 @@ If you depend on these features, please raise your voice in
 * Fix SNI-related reproducibility issues when exporting to curl/httpie commands. (@dkasak)
 * Add option `export_preserve_original_ip` to force exported command to connect to IP from original request. Only supports curl at the moment. (@dkasak)
 * Major proxy protocol testing (@r00t-)
+* Switch Docker image release to be based on Debian (@PeterDaveHello)
 * --- TODO: add new PRs above this line ---
 * ... and various other fixes, documentation improvements, dependency version bumps, etc.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ If you depend on these features, please raise your voice in
 
 ### Full Changelog
 
+* Switch Docker image release to be based on Debian (@PeterDaveHello)
 * New Proxy Core based on sans-io pattern (@mhils)
 * mitmproxy's command line interface now supports Windows (@mhils)
 * The `clientconnect`, `clientdisconnect`, `serverconnect`, `serverdisconnect`, and `log`

--- a/release/docker/Dockerfile
+++ b/release/docker/Dockerfile
@@ -1,36 +1,17 @@
-FROM alpine:3.12
-
-ENV LANG=en_US.UTF-8
+FROM python:3.9-slim-buster
 
 ARG WHEEL_MITMPROXY
 ARG WHEEL_BASENAME_MITMPROXY
 
+RUN useradd -mU mitmproxy
 COPY $WHEEL_MITMPROXY /home/mitmproxy/
 
-# Add our user first to make sure the ID get assigned consistently,
-# regardless of whatever dependencies get added.
-RUN addgroup -S mitmproxy && adduser -S -G mitmproxy mitmproxy \
-    && apk add --no-cache \
-        su-exec \
-        git \
-        g++ \
-        libffi \
-        libffi-dev \
-        libstdc++ \
-        openssl \
-        openssl-dev \
-        python3 \
-        python3-dev \
-    && python3 -m ensurepip --upgrade \
-    && pip3 install -U pip \
-    && LDFLAGS=-L/lib pip3 install -U /home/mitmproxy/${WHEEL_BASENAME_MITMPROXY} \
-    && apk del --purge \
-        git \
-        g++ \
-        libffi-dev \
-        openssl-dev \
-        python3-dev \
-    && rm -rf ~/.cache/pip /home/mitmproxy/${WHEEL_BASENAME_MITMPROXY}
+RUN pip3 install --no-cache-dir -U /home/mitmproxy/${WHEEL_BASENAME_MITMPROXY} \
+    && rm -rf /home/mitmproxy/${WHEEL_BASENAME_MITMPROXY}
+
+RUN apt-get update \
+    && apt-get install -y gosu \
+    && rm -rf /var/lib/apt/lists/*
 
 VOLUME /home/mitmproxy/.mitmproxy
 

--- a/release/docker/Dockerfile
+++ b/release/docker/Dockerfile
@@ -4,14 +4,13 @@ ARG WHEEL_MITMPROXY
 ARG WHEEL_BASENAME_MITMPROXY
 
 RUN useradd -mU mitmproxy
-COPY $WHEEL_MITMPROXY /home/mitmproxy/
-
-RUN pip3 install --no-cache-dir -U /home/mitmproxy/${WHEEL_BASENAME_MITMPROXY} \
-    && rm -rf /home/mitmproxy/${WHEEL_BASENAME_MITMPROXY}
-
 RUN apt-get update \
     && apt-get install -y gosu \
     && rm -rf /var/lib/apt/lists/*
+    
+COPY $WHEEL_MITMPROXY /home/mitmproxy/
+RUN pip3 install --no-cache-dir -U /home/mitmproxy/${WHEEL_BASENAME_MITMPROXY} \
+    && rm -rf /home/mitmproxy/${WHEEL_BASENAME_MITMPROXY}
 
 VOLUME /home/mitmproxy/.mitmproxy
 

--- a/release/docker/docker-entrypoint.sh
+++ b/release/docker/docker-entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # WARNING: do not change the shebang - the Docker base image might not have what you want!
 
 set -o errexit
@@ -11,7 +11,7 @@ MITMPROXY_PATH="/home/mitmproxy/.mitmproxy"
 if [[ "$1" = "mitmdump" || "$1" = "mitmproxy" || "$1" = "mitmweb" ]]; then
   mkdir -p "$MITMPROXY_PATH"
   chown -R mitmproxy:mitmproxy "$MITMPROXY_PATH"
-  su-exec mitmproxy "$@"
+  gosu mitmproxy "$@"
 else
   exec "$@"
 fi


### PR DESCRIPTION
#### Description

As @mhils invited, help rewrite the Docker image to replace Alpine Linux. The final image size is about 179MB, compared with original 123MB, should be not too big :D

It's a large rewrite and I'm not very familiar with mitmproxy, so please help test its functionality to be as expected, thanks.

fix #3712

#### Checklist

 - [ ] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
