### PR TITLE
Add `.dockerignore` to speed up Docker build image process

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+*
+!release/docker/docker-entrypoint.sh
+!**/*.whl


### PR DESCRIPTION
#### Description

This will boost the process of sending build context.

#### Checklist

 - [ ] I have updated tests where applicable.
 - [ ] I have added an entry to the CHANGELOG.
