### PR TITLE
Improve Shell Script syntax

### DIFF
--- a/docs/ci.sh
+++ b/docs/ci.sh
@@ -10,7 +10,7 @@ set -o pipefail
 
 # Only upload if we have defined credentials - we only have these defined for
 # trusted commits (i.e. not PRs).
-if [[ ! -z "${AWS_ACCESS_KEY_ID}" && $GITHUB_REF == "refs/heads/master" ]]; then
+if [[ -n "${AWS_ACCESS_KEY_ID}" && $GITHUB_REF == "refs/heads/master" ]]; then
     aws s3 sync --delete --acl public-read ./public s3://docs.mitmproxy.org/master
     aws cloudfront create-invalidation --distribution-id E1TH3USJHFQZ5Q \
         --paths "/master/*"

--- a/docs/upload-archive.sh
+++ b/docs/upload-archive.sh
@@ -16,7 +16,7 @@ SPATH="/archive/$1"
 
 aws configure set preview.cloudfront true
 aws --profile mitmproxy \
-    s3 sync --acl public-read ./public s3://docs.mitmproxy.org$SPATH
+    s3 sync --acl public-read ./public "s3://docs.mitmproxy.org$SPATH"
 aws --profile mitmproxy \
     cloudfront create-invalidation --distribution-id E1TH3USJHFQZ5Q \
     --paths "$SPATH/*"

--- a/mitmproxy/contrib/kaitaistruct/make.sh
+++ b/mitmproxy/contrib/kaitaistruct/make.sh
@@ -10,4 +10,4 @@ wget -N https://raw.githubusercontent.com/kaitai-io/kaitai_struct_formats/master
 wget -N https://raw.githubusercontent.com/kaitai-io/kaitai_struct_formats/master/common/vlq_base128_le.ksy
 wget -N https://raw.githubusercontent.com/kaitai-io/kaitai_struct_formats/master/serialization/google_protobuf.ksy
 
-kaitai-struct-compiler --target python --opaque-types=true *.ksy
+kaitai-struct-compiler --target python --opaque-types=true ./*.ksy


### PR DESCRIPTION
#### Description

- Double quote variable to prevent globbing and word splitting
- Use `./*.ksy` instead of `*.ksy` so names with dashes won't become options
- Use `-n` instead of `! -z` double negative condition for better readability and understanding

I believe there isn't a problem here right now as they're already working for a long time, but a better styling can help prevent problem and help improve the maintainability of the scripts ;)

#### Checklist

 - [ ] I have updated tests where applicable.
 - [ ] I have added an entry to the CHANGELOG.
