### PR TITLE
Add WebSocket/TCP Message Injection

### DIFF
--- a/examples/addons/websocket-inject-message.py
+++ b/examples/addons/websocket-inject-message.py
@@ -1,0 +1,31 @@
+"""
+Inject a WebSocket message into a running connection.
+
+This example shows how to inject a WebSocket message into a running connection.
+"""
+import asyncio
+
+from mitmproxy import ctx, http
+
+
+# Simple example: Inject a message as a response to an event
+
+def websocket_message(flow):
+    last_message = flow.websocket.messages[-1]
+    if b"secret" in last_message.content:
+        last_message.kill()
+        ctx.master.commands.call("inject", [flow], not last_message.from_client, "ssssssh")
+
+
+# Complex example: Schedule a periodic timer
+
+async def inject_async(flow: http.HTTPFlow):
+    msg = "hello from mitmproxy! "
+    while flow.server_conn.connected:
+        ctx.master.commands.call("inject", [flow], False, msg)
+        await asyncio.sleep(1)
+        msg = msg[1:] + msg[:1]
+
+
+def websocket_start(flow: http.HTTPFlow):
+    asyncio.create_task(inject_async(flow))

--- a/examples/addons/websocket-inject-message.py
+++ b/examples/addons/websocket-inject-message.py
@@ -14,15 +14,16 @@ def websocket_message(flow):
     last_message = flow.websocket.messages[-1]
     if b"secret" in last_message.content:
         last_message.kill()
-        ctx.master.commands.call("inject", [flow], not last_message.from_client, "ssssssh")
+        ctx.master.commands.call("inject.websocket", flow, last_message.from_client, "ssssssh")
 
 
 # Complex example: Schedule a periodic timer
 
 async def inject_async(flow: http.HTTPFlow):
     msg = "hello from mitmproxy! "
+    assert flow.websocket  # make type checker happy
     while flow.websocket.timestamp_end is None:
-        ctx.master.commands.call("inject", [flow], False, msg)
+        ctx.master.commands.call("inject.websocket", flow, True, msg)
         await asyncio.sleep(1)
         msg = msg[1:] + msg[:1]
 

--- a/examples/addons/websocket-inject-message.py
+++ b/examples/addons/websocket-inject-message.py
@@ -21,7 +21,7 @@ def websocket_message(flow):
 
 async def inject_async(flow: http.HTTPFlow):
     msg = "hello from mitmproxy! "
-    while flow.server_conn.connected:
+    while flow.websocket.timestamp_end is None:
         ctx.master.commands.call("inject", [flow], False, msg)
         await asyncio.sleep(1)
         msg = msg[1:] + msg[:1]

--- a/mitmproxy/addons/proxyserver.py
+++ b/mitmproxy/addons/proxyserver.py
@@ -166,7 +166,7 @@ class Proxyserver:
                     continue
             elif isinstance(f, tcp.TCPFlow):
                 event = TcpMessageInjected(f, tcp.TCPMessage(from_client, message_bytes))
-            else:
+            else:  # pragma: no cover
                 ctx.log.warn(f"Cannot inject message into {f.__class__.__name__}, skipping.")
 
             try:

--- a/mitmproxy/addons/proxyserver.py
+++ b/mitmproxy/addons/proxyserver.py
@@ -168,6 +168,7 @@ class Proxyserver:
                 event = TcpMessageInjected(f, tcp.TCPMessage(from_client, message_bytes))
             else:  # pragma: no cover
                 ctx.log.warn(f"Cannot inject message into {f.__class__.__name__}, skipping.")
+                continue
 
             try:
                 self.inject_event(f, event)

--- a/mitmproxy/addons/proxyserver.py
+++ b/mitmproxy/addons/proxyserver.py
@@ -157,7 +157,7 @@ class Proxyserver:
             if isinstance(f, http.HTTPFlow):
                 if f.websocket:
                     event = WebSocketMessageInjected(
-                        f.client_conn if from_client else f.server_conn,
+                        f,
                         websocket.WebSocketMessage(
                             Opcode.TEXT, from_client, message.encode()
                         )

--- a/mitmproxy/io/compat.py
+++ b/mitmproxy/io/compat.py
@@ -291,6 +291,7 @@ def convert_11_12(data):
             "closed_by_client": ws_flow["close_sender"] == "client",
             "close_code": ws_flow["close_code"],
             "close_reason": ws_flow["close_reason"],
+            "timestamp_end": data.get("server_conn", {}).get("timestamp_end", None),
         }
 
     else:

--- a/mitmproxy/proxy/commands.py
+++ b/mitmproxy/proxy/commands.py
@@ -23,6 +23,9 @@ class Command:
     blocking: Union[bool, "mitmproxy.proxy.layer.Layer"] = False
     """
     Determines if the command blocks until it has been completed.
+    For practical purposes, this attribute should be thought of as a boolean value,
+    layers may swap out `True` with a reference to themselves to signal to outer layers
+    that they do not need to block as well.
 
     Example:
 

--- a/mitmproxy/proxy/events.py
+++ b/mitmproxy/proxy/events.py
@@ -8,6 +8,7 @@ import typing
 import warnings
 from dataclasses import dataclass, is_dataclass
 
+from mitmproxy import flow
 from mitmproxy.proxy import commands
 from mitmproxy.connection import Connection
 
@@ -112,8 +113,9 @@ T = typing.TypeVar('T')
 
 
 @dataclass
-class MessageInjected(ConnectionEvent, typing.Generic[T]):
+class MessageInjected(Event, typing.Generic[T]):
     """
     The user has injected a custom WebSocket/TCP/... message.
     """
+    flow: flow.Flow
     message: T

--- a/mitmproxy/proxy/events.py
+++ b/mitmproxy/proxy/events.py
@@ -106,3 +106,14 @@ class HookCompleted(CommandCompleted):
 class GetSocketCompleted(CommandCompleted):
     command: commands.GetSocket
     reply: socket.socket
+
+
+T = typing.TypeVar('T')
+
+
+@dataclass
+class MessageInjected(ConnectionEvent, typing.Generic[T]):
+    """
+    The user has injected a custom WebSocket/TCP/... message.
+    """
+    message: T

--- a/mitmproxy/proxy/layer.py
+++ b/mitmproxy/proxy/layer.py
@@ -91,8 +91,12 @@ class Layer:
     @property
     def stack_pos(self) -> str:
         """repr() for this layer and all its parent layers, only useful for debugging."""
-        idx = self.context.layers.index(self)
-        return " >> ".join(repr(x) for x in self.context.layers[:idx + 1])
+        try:
+            idx = self.context.layers.index(self)
+        except ValueError:
+            return repr(self)
+        else:
+            return " >> ".join(repr(x) for x in self.context.layers[:idx + 1])
 
     @abstractmethod
     def _handle_event(self, event: events.Event) -> CommandGenerator[None]:

--- a/mitmproxy/proxy/layers/http/__init__.py
+++ b/mitmproxy/proxy/layers/http/__init__.py
@@ -589,10 +589,8 @@ class HttpLayer(layer.Layer):
             yield from self.event_to_child(stream, event)
         elif isinstance(event, events.MessageInjected):
             # For injected messages we pass the HTTP stacks entirely and directly address the stream.
-            conn = self.connections[event.connection]
-            if isinstance(conn, Http1Server):
-                stream_id = conn.stream_id
-            elif isinstance(conn, HttpStream):
+            conn = self.connections[event.flow.server_conn]
+            if isinstance(conn, HttpStream):
                 stream_id = conn.stream_id
             else:
                 # We reach to the end of the connection's child stack to get the HTTP/1 client layer,

--- a/mitmproxy/proxy/layers/tcp.py
+++ b/mitmproxy/proxy/layers/tcp.py
@@ -6,6 +6,7 @@ from mitmproxy.proxy import commands, events, layer
 from mitmproxy.proxy.commands import StartHook
 from mitmproxy.connection import ConnectionState, Connection
 from mitmproxy.proxy.context import Context
+from mitmproxy.proxy.events import MessageInjected
 from mitmproxy.proxy.utils import expect
 
 
@@ -45,6 +46,12 @@ class TcpErrorHook(StartHook):
     flow: tcp.TCPFlow
 
 
+class TcpMessageInjected(MessageInjected[tcp.TCPMessage]):
+    """
+    The user has injected a custom TCP message.
+    """
+
+
 class TCPLayer(layer.Layer):
     """
     Simple TCP layer that just relays messages right now.
@@ -76,8 +83,18 @@ class TCPLayer(layer.Layer):
 
     _handle_event = start
 
-    @expect(events.DataReceived, events.ConnectionClosed)
-    def relay_messages(self, event: events.ConnectionEvent) -> layer.CommandGenerator[None]:
+    @expect(events.DataReceived, events.ConnectionClosed, TcpMessageInjected)
+    def relay_messages(self, event: events.Event) -> layer.CommandGenerator[None]:
+
+        if isinstance(event, TcpMessageInjected):
+            # we just spoof that we received data here and then process that regularly.
+            event = events.DataReceived(
+                self.context.client if event.message.from_client else self.context.server,
+                event.message.content,
+            )
+
+        assert isinstance(event, events.ConnectionEvent)
+
         from_client = event.connection == self.context.client
         send_to: Connection
         if from_client:
@@ -110,6 +127,8 @@ class TCPLayer(layer.Layer):
                     yield TcpEndHook(self.flow)
             else:
                 yield commands.CloseConnection(send_to, half_close=True)
+        else:
+            raise AssertionError(f"Unexpected event: {event}")
 
     @expect(events.DataReceived, events.ConnectionClosed)
     def done(self, _) -> layer.CommandGenerator[None]:

--- a/mitmproxy/proxy/layers/tcp.py
+++ b/mitmproxy/proxy/layers/tcp.py
@@ -130,6 +130,6 @@ class TCPLayer(layer.Layer):
         else:
             raise AssertionError(f"Unexpected event: {event}")
 
-    @expect(events.DataReceived, events.ConnectionClosed)
+    @expect(events.DataReceived, events.ConnectionClosed, TcpMessageInjected)
     def done(self, _) -> layer.CommandGenerator[None]:
         yield from ()

--- a/mitmproxy/proxy/layers/websocket.py
+++ b/mitmproxy/proxy/layers/websocket.py
@@ -1,3 +1,4 @@
+import time
 from dataclasses import dataclass
 from typing import Iterator, List
 
@@ -189,6 +190,7 @@ class WebsocketLayer(layer.Layer):
                 )
                 yield dst_ws.send2(ws_event)
             elif isinstance(ws_event, wsproto.events.CloseConnection):
+                self.flow.websocket.timestamp_end = time.time()
                 self.flow.websocket.closed_by_client = from_client
                 self.flow.websocket.close_code = ws_event.code
                 self.flow.websocket.close_reason = ws_event.reason

--- a/mitmproxy/proxy/layers/websocket.py
+++ b/mitmproxy/proxy/layers/websocket.py
@@ -207,7 +207,7 @@ class WebsocketLayer(layer.Layer):
             else:  # pragma: no cover
                 raise AssertionError(f"Unexpected WebSocket event: {ws_event}")
 
-    @expect(events.DataReceived, events.ConnectionClosed)
+    @expect(events.DataReceived, events.ConnectionClosed, WebSocketMessageInjected)
     def done(self, _) -> layer.CommandGenerator[None]:
         yield from ()
 

--- a/mitmproxy/proxy/tunnel.py
+++ b/mitmproxy/proxy/tunnel.py
@@ -79,8 +79,6 @@ class TunnelLayer(layer.Layer):
                     yield from self.on_handshake_error(err)
                     yield from self._handshake_finished(err)
                 self.tunnel_state = TunnelState.CLOSED
-            elif isinstance(event, events.MessageInjected):
-                yield from self.event_to_child(event)
             else:  # pragma: no cover
                 raise AssertionError(f"Unexpected event: {event}")
         else:

--- a/mitmproxy/proxy/tunnel.py
+++ b/mitmproxy/proxy/tunnel.py
@@ -79,6 +79,8 @@ class TunnelLayer(layer.Layer):
                     yield from self.on_handshake_error(err)
                     yield from self._handshake_finished(err)
                 self.tunnel_state = TunnelState.CLOSED
+            elif isinstance(event, events.MessageInjected):
+                yield from self.event_to_child(event)
             else:  # pragma: no cover
                 raise AssertionError(f"Unexpected event: {event}")
         else:

--- a/mitmproxy/websocket.py
+++ b/mitmproxy/websocket.py
@@ -106,11 +106,15 @@ class WebSocketData(stateobject.StateObject):
     close_reason: Optional[str] = None
     """[Close Reason](https://tools.ietf.org/html/rfc6455#section-7.1.6)"""
 
+    timestamp_end: Optional[float] = None
+    """*Timestamp:* WebSocket connection closed."""
+
     _stateobject_attributes = dict(
         messages=List[WebSocketMessage],
         closed_by_client=bool,
         close_code=int,
         close_reason=str,
+        timestamp_end=float,
     )
 
     def __init__(self):

--- a/test/mitmproxy/addons/test_proxyserver.py
+++ b/test/mitmproxy/addons/test_proxyserver.py
@@ -110,9 +110,9 @@ async def test_inject():
 
             writer.write(b"a")
             assert await reader.read(1) == b"A"
-            ps.inject(state.flows, True, "b")
+            ps.inject_tcp(state.flows[0], False, "b")
             assert await reader.read(1) == b"B"
-            ps.inject(state.flows, False, "c")
+            ps.inject_tcp(state.flows[0], True, "c")
             assert await reader.read(1) == b"c"
 
 
@@ -120,16 +120,28 @@ async def test_inject():
 async def test_inject_fail():
     ps = Proxyserver()
     with taddons.context(ps) as tctx:
-        ps.inject(
-            [tflow.tflow()],
-            False,
+        ps.inject_websocket(
+            tflow.tflow(),
+            True,
             "test"
         )
-        await tctx.master.await_log("Cannot inject messages into HTTP connections.", level="warn")
+        await tctx.master.await_log("Cannot inject WebSocket messages into non-WebSocket flows.", level="warn")
+        ps.inject_tcp(
+            tflow.tflow(),
+            True,
+            "test"
+        )
+        await tctx.master.await_log("Cannot inject TCP messages into non-TCP flows.", level="warn")
 
-        ps.inject(
-            [tflow.twebsocketflow()],
-            False,
+        ps.inject_websocket(
+            tflow.twebsocketflow(),
+            True,
+            "test"
+        )
+        await tctx.master.await_log("Flow is not from a live connection.", level="warn")
+        ps.inject_websocket(
+            tflow.ttcpflow(),
+            True,
             "test"
         )
         await tctx.master.await_log("Flow is not from a live connection.", level="warn")

--- a/test/mitmproxy/addons/test_proxyserver.py
+++ b/test/mitmproxy/addons/test_proxyserver.py
@@ -56,10 +56,10 @@ async def test_start_stop():
 
             proxy_addr = ps.server.sockets[0].getsockname()[:2]
             reader, writer = await asyncio.open_connection(*proxy_addr)
-            assert repr(ps) == "ProxyServer(running, 1 active conns)"
             req = f"GET http://{addr[0]}:{addr[1]}/hello HTTP/1.1\r\n\r\n"
             writer.write(req.encode())
             assert await reader.readuntil(b"\r\n\r\n") == b"HTTP/1.1 204 No Content\r\n\r\n"
+            assert repr(ps) == "ProxyServer(running, 1 active conns)"
 
             tctx.configure(ps, server=False)
             await tctx.master.await_log("Stopping server", level="info")

--- a/test/mitmproxy/addons/test_proxyserver.py
+++ b/test/mitmproxy/addons/test_proxyserver.py
@@ -56,6 +56,7 @@ async def test_start_stop():
 
             proxy_addr = ps.server.sockets[0].getsockname()[:2]
             reader, writer = await asyncio.open_connection(*proxy_addr)
+            assert repr(ps) == "ProxyServer(running, 1 active conns)"
             req = f"GET http://{addr[0]}:{addr[1]}/hello HTTP/1.1\r\n\r\n"
             writer.write(req.encode())
             assert await reader.readuntil(b"\r\n\r\n") == b"HTTP/1.1 204 No Content\r\n\r\n"

--- a/test/mitmproxy/proxy/layers/http/test_http.py
+++ b/test/mitmproxy/proxy/layers/http/test_http.py
@@ -9,9 +9,9 @@ from mitmproxy.proxy.commands import CloseConnection, OpenConnection, SendData, 
 from mitmproxy.connection import ConnectionState, Server
 from mitmproxy.proxy.events import ConnectionClosed, DataReceived
 from mitmproxy.proxy.layers import TCPLayer, http, tls
-from mitmproxy.proxy.layers.tcp import TcpStartHook
+from mitmproxy.proxy.layers.tcp import TcpMessageInjected, TcpStartHook
 from mitmproxy.proxy.layers.websocket import WebsocketStartHook
-from mitmproxy.tcp import TCPFlow
+from mitmproxy.tcp import TCPFlow, TCPMessage
 from test.mitmproxy.proxy.tutils import Placeholder, Playbook, reply, reply_next_layer
 
 
@@ -543,6 +543,7 @@ def test_upstream_proxy(tctx, redirect, scheme):
 def test_http_proxy_tcp(tctx, mode, close_first):
     """Test TCP over HTTP CONNECT."""
     server = Placeholder(Server)
+    f = Placeholder(TCPFlow)
 
     if mode == "upstream":
         tctx.options.mode = "upstream:http://proxy:8080"
@@ -558,7 +559,9 @@ def test_http_proxy_tcp(tctx, mode, close_first):
             << SendData(tctx.client, b"HTTP/1.1 200 Connection established\r\n\r\n")
             >> DataReceived(tctx.client, b"this is not http")
             << layer.NextLayerHook(Placeholder())
-            >> reply_next_layer(lambda ctx: TCPLayer(ctx, ignore=True))
+            >> reply_next_layer(lambda ctx: TCPLayer(ctx, ignore=False))
+            << TcpStartHook(f)
+            >> reply()
             << OpenConnection(server)
     )
 
@@ -578,6 +581,12 @@ def test_http_proxy_tcp(tctx, mode, close_first):
         assert server().address == ("example", 443)
     else:
         assert server().address == ("proxy", 8080)
+
+    assert (
+        playbook
+        >> TcpMessageInjected(f, TCPMessage(False, b"fake news from your friendly man-in-the-middle"))
+        << SendData(tctx.client, b"fake news from your friendly man-in-the-middle")
+    )
 
     if close_first == "client":
         a, b = tctx.client, server

--- a/test/mitmproxy/proxy/layers/test_websocket.py
+++ b/test/mitmproxy/proxy/layers/test_websocket.py
@@ -328,7 +328,7 @@ def test_inject_message(ws_testdata):
             playbook
             << websocket.WebsocketStartHook(flow)
             >> reply()
-            >> WebSocketMessageInjected(tctx.server, WebSocketMessage(Opcode.TEXT, False, b"hello"))
+            >> WebSocketMessageInjected(flow, WebSocketMessage(Opcode.TEXT, False, b"hello"))
             << websocket.WebsocketMessageHook(flow)
     )
     assert flow.websocket.messages[-1].content == b"hello"


### PR DESCRIPTION
<s>I still need to fix test coverage for proxyserver.py,</s> but I figured this can already take some review. 😃 

This PR introduces the `inject` command, which can be used to inject messages into running TCP and WebSocket connections. The implementation here is _very_ different from the previous `flow.inject_message` API as we want to keep our sans-io proxy sans-io. 😄 In a nutshell, injected messages are modeled as an external Event, similar to DataReceived/ConnectionClosed. They get passed into the proxy core from the outside (`.server_event`), passed through to the target layer, and then processed there. Most notably, injected messages now also trigger the associated `*_message` hooks.