### PR TITLE
Sans-IO Improvements: Connection Strategy

### DIFF
--- a/mitmproxy/addons/proxyserver.py
+++ b/mitmproxy/addons/proxyserver.py
@@ -83,8 +83,11 @@ class Proxyserver:
 
     def load(self, loader):
         loader.add_option(
-            "connection_strategy", str, "lazy",
-            "Determine when server connections should be established.",
+            "connection_strategy", str, "eager",
+            "Determine when server connections should be established. When set to lazy, mitmproxy "
+            "tries to defer establishing an upstream connection as long as possible. This makes it possible to "
+            "use server replay while being offline. When set to eager, mitmproxy can detect protocols with "
+            "server-side greetings, as well as accurately mirror TLS ALPN negotiation.",
             choices=("eager", "lazy")
         )
         loader.add_option(

--- a/mitmproxy/addons/tlsconfig.py
+++ b/mitmproxy/addons/tlsconfig.py
@@ -34,6 +34,10 @@ def alpn_select_callback(conn: SSL.Connection, options: List[bytes]) -> Any:
     http2 = app_data["http2"]
     if server_alpn and server_alpn in options:
         return server_alpn
+    if server_alpn == b"":
+        # We do have a server connection, but the remote server refused to negotiate a protocol:
+        # We need to mirror this on the client connection.
+        return SSL.NO_OVERLAPPING_PROTOCOLS
     http_alpns = tls.HTTP_ALPNS if http2 else tls.HTTP1_ALPNS
     for alpn in options:  # client sends in order of preference, so we are nice and respect that.
         if alpn in http_alpns:

--- a/mitmproxy/connection.py
+++ b/mitmproxy/connection.py
@@ -43,7 +43,13 @@ class Connection(serializable.Serializable, metaclass=ABCMeta):
     sockname: Optional[Address]
     """Our local `(ip, port)` tuple for this connection."""
     error: Optional[str] = None
-    """A string describing the connection error."""
+    """
+    A string describing a general error with connections to this address.
+
+    The purpose of this property is to signal that new connections to the particular endpoint should not be attempted,
+    for example because it uses an untrusted TLS certificate. Regular (unexpected) disconnects do not set the error
+    property. This property is only reused per client connection.
+    """
 
     tls: bool = False
     """

--- a/mitmproxy/contentviews/query.py
+++ b/mitmproxy/contentviews/query.py
@@ -15,4 +15,7 @@ class ViewQuery(base.View):
             return "Query", base.format_text("")
 
     def render_priority(self, data: bytes, *, http_message: Optional[http.Message] = None, **metadata) -> float:
-        return 0.3 * float(bool(getattr(http_message, "query", False)))
+        return 0.3 * float(bool(
+            getattr(http_message, "query", False)
+            and not data
+        ))

--- a/mitmproxy/proxy/events.py
+++ b/mitmproxy/proxy/events.py
@@ -84,7 +84,7 @@ class CommandCompleted(Event):
         command_reply_subclasses[command_cls] = cls
 
     def __repr__(self):
-        return f"Reply({repr(self.command)})"
+        return f"Reply({repr(self.command)},{repr(self.reply)})"
 
 
 command_reply_subclasses: typing.Dict[commands.Command, typing.Type[CommandCompleted]] = {}

--- a/mitmproxy/proxy/layers/http/_http_h2.py
+++ b/mitmproxy/proxy/layers/http/_http_h2.py
@@ -112,8 +112,15 @@ class BufferedH2Connection(h2.connection.H2Connection):
         The window for a specific stream has updated. Send as much buffered data as possible.
         """
         # If the stream has been reset in the meantime, we just clear the buffer.
-        stream: h2.stream.H2Stream = self.streams[stream_id]
-        if stream.state_machine.state not in (h2.stream.StreamState.OPEN, h2.stream.StreamState.HALF_CLOSED_REMOTE):
+        try:
+            stream: h2.stream.H2Stream = self.streams[stream_id]
+        except KeyError:
+            stream_was_reset = True
+        else:
+            stream_was_reset = (
+                stream.state_machine.state not in (h2.stream.StreamState.OPEN, h2.stream.StreamState.HALF_CLOSED_REMOTE)
+            )
+        if stream_was_reset:
             self.stream_buffers.pop(stream_id, None)
             return False
 

--- a/mitmproxy/proxy/layers/modes.py
+++ b/mitmproxy/proxy/layers/modes.py
@@ -23,7 +23,7 @@ class DestinationKnown(layer.Layer, metaclass=ABCMeta):
     child_layer: layer.Layer
 
     def finish_start(self) -> layer.CommandGenerator[Optional[str]]:
-        if self.context.options.connection_strategy == "eager":
+        if self.context.options.connection_strategy == "eager" and self.context.server.address:
             err = yield commands.OpenConnection(self.context.server)
             if err:
                 self._handle_event = self.done  # type: ignore

--- a/mitmproxy/proxy/layers/tls.py
+++ b/mitmproxy/proxy/layers/tls.py
@@ -254,7 +254,11 @@ class _TLSLayer(tunnel.TunnelLayer):
             yield from super().receive_close()
 
     def send_data(self, data: bytes) -> layer.CommandGenerator[None]:
-        self.tls.sendall(data)
+        try:
+            self.tls.sendall(data)
+        except SSL.ZeroReturnError:
+            # The other peer may still be trying to send data over, which we discard here.
+            pass
         yield from self.tls_interact()
 
     def send_close(self, half_close: bool) -> layer.CommandGenerator[None]:

--- a/mitmproxy/proxy/layers/tls.py
+++ b/mitmproxy/proxy/layers/tls.py
@@ -193,8 +193,9 @@ class _TLSLayer(tunnel.TunnelLayer):
             elif last_err == ('SSL routines', 'ssl3_get_record', 'wrong version number') and data[:4].isascii():
                 err = f"The remote server does not speak TLS."
             else:  # pragma: no cover
-                # TODO: Add test case one we find one.
+                # TODO: Add test case once we find one.
                 err = f"OpenSSL {e!r}"
+            self.conn.error = err
             return False, err
         else:
             # Here we set all attributes that are only known *after* the handshake.

--- a/mitmproxy/proxy/layers/tls.py
+++ b/mitmproxy/proxy/layers/tls.py
@@ -270,14 +270,39 @@ class ServerTLSLayer(_TLSLayer):
     """
     This layer establishes TLS for a single server connection.
     """
-    command_to_reply_to: Optional[commands.OpenConnection] = None
+    wait_for_clienthello: bool = False
 
     def __init__(self, context: context.Context, conn: Optional[connection.Server] = None):
         super().__init__(context, conn or context.server)
 
     def start_handshake(self) -> layer.CommandGenerator[None]:
-        yield from self.start_tls()
-        yield from self.receive_handshake_data(b"")
+        wait_for_clienthello = (
+            # if command_to_reply_to is set, we've been instructed to open the connection from the child layer.
+            # in that case any potential ClientHello is already parsed (by the ClientTLS child layer).
+            not self.command_to_reply_to
+            # if command_to_reply_to is not set, the connection was already open when this layer received its Start
+            # event (eager connection strategy). We now want to establish TLS right away, _unless_ we already know
+            # that there's TLS on the client side as well (we check if our immediate child layer is set to be ClientTLS)
+            # In this case want to wait for ClientHello to be parsed, so that we can incorporate SNI/ALPN from there.
+            and isinstance(self.child_layer, ClientTLSLayer)
+        )
+        if wait_for_clienthello:
+            self.wait_for_clienthello = True
+            self.tunnel_state = tunnel.TunnelState.CLOSED
+        else:
+            yield from self.start_tls()
+            yield from self.receive_handshake_data(b"")
+
+    def event_to_child(self, event: events.Event) -> layer.CommandGenerator[None]:
+        if self.wait_for_clienthello:
+            for command in super().event_to_child(event):
+                if isinstance(command, commands.OpenConnection) and command.connection == self.conn:
+                    self.wait_for_clienthello = False
+                    # swallow OpenConnection here by not re-yielding it.
+                else:
+                    yield command
+        else:
+            yield from super().event_to_child(event)
 
     def on_handshake_error(self, err: str) -> layer.CommandGenerator[None]:
         yield commands.Log(f"Server TLS handshake failed. {err}", level="warn")

--- a/mitmproxy/proxy/tunnel.py
+++ b/mitmproxy/proxy/tunnel.py
@@ -75,7 +75,7 @@ class TunnelLayer(layer.Layer):
                 if self.tunnel_state is TunnelState.OPEN:
                     yield from self.receive_close()
                 elif self.tunnel_state is TunnelState.ESTABLISHING:
-                    err = "connection closed without notice"
+                    err = "connection closed"
                     yield from self.on_handshake_error(err)
                     yield from self._handshake_finished(err)
                 self.tunnel_state = TunnelState.CLOSED

--- a/test/mitmproxy/addons/test_next_layer.py
+++ b/test/mitmproxy/addons/test_next_layer.py
@@ -97,6 +97,10 @@ class TestNextLayer:
 
             tctx.configure(nl, ignore_hosts=[])
             assert isinstance(nl._next_layer(ctx, client_hello_no_extensions, b""), layers.ServerTLSLayer)
+            assert isinstance(ctx.layers[-1], layers.ClientTLSLayer)
+
+            ctx.layers = []
+            assert isinstance(nl._next_layer(ctx, b"", b""), layers.modes.HttpProxy)
             assert isinstance(nl._next_layer(ctx, client_hello_no_extensions, b""), layers.ClientTLSLayer)
 
             ctx.layers = []

--- a/test/mitmproxy/addons/test_tlsconfig.py
+++ b/test/mitmproxy/addons/test_tlsconfig.py
@@ -30,6 +30,10 @@ def test_alpn_select_callback():
     # Test no overlap
     assert tlsconfig.alpn_select_callback(conn, [b"qux", b"quux"]) == SSL.NO_OVERLAPPING_PROTOCOLS
 
+    # Test that we don't select an ALPN if the server refused to select one.
+    conn.set_app_data(tlsconfig.AppData(server_alpn=b"", http2=True))
+    assert tlsconfig.alpn_select_callback(conn, [b"http/1.1"]) == SSL.NO_OVERLAPPING_PROTOCOLS
+
 
 here = Path(__file__).parent
 

--- a/test/mitmproxy/proxy/layers/http/test_http.py
+++ b/test/mitmproxy/proxy/layers/http/test_http.py
@@ -546,6 +546,7 @@ def test_http_proxy_tcp(tctx, mode, close_first):
     """Test TCP over HTTP CONNECT."""
     server = Placeholder(Server)
     f = Placeholder(TCPFlow)
+    tctx.options.connection_strategy = "lazy"
 
     if mode == "upstream":
         tctx.options.mode = "upstream:http://proxy:8080"
@@ -813,6 +814,7 @@ def test_http_server_aborts(tctx, stream):
                                   "response", "error"])
 def test_kill_flow(tctx, when):
     """Test that we properly kill flows if instructed to do so"""
+    tctx.options.connection_strategy = "lazy"
     server = Placeholder(Server)
     connect_flow = Placeholder(HTTPFlow)
     flow = Placeholder(HTTPFlow)

--- a/test/mitmproxy/proxy/layers/test_modes.py
+++ b/test/mitmproxy/proxy/layers/test_modes.py
@@ -119,6 +119,7 @@ def test_reverse_proxy(tctx, keep_host_header):
     """
     server = Placeholder(Server)
     tctx.options.mode = "reverse:http://localhost:8000"
+    tctx.options.connection_strategy = "lazy"
     tctx.options.keep_host_header = keep_host_header
     assert (
         Playbook(modes.ReverseProxy(tctx), hooks=False)
@@ -321,6 +322,7 @@ def test_socks5_success(address: str, packed: bytes, tctx: Context):
 
 
 def test_socks5_trickle(tctx: Context):
+    tctx.options.connection_strategy = "lazy"
     playbook = Playbook(modes.Socks5Proxy(tctx))
     for x in CLIENT_HELLO:
         playbook >> DataReceived(tctx.client, bytes([x]))

--- a/test/mitmproxy/proxy/layers/test_tls.py
+++ b/test/mitmproxy/proxy/layers/test_tls.py
@@ -509,6 +509,6 @@ class TestClientTLS:
                 << commands.SendData(tctx.client, tutils.Placeholder())
                 >> events.ConnectionClosed(tctx.client)
                 << commands.Log("Client TLS handshake failed. The client may not trust the proxy's certificate "
-                                "for wrong.host.mitmproxy.org (connection closed without notice)", "warn")
+                                "for wrong.host.mitmproxy.org (connection closed)", "warn")
                 << commands.CloseConnection(tctx.client)
         )

--- a/test/mitmproxy/proxy/test_layer.py
+++ b/test/mitmproxy/proxy/test_layer.py
@@ -52,7 +52,7 @@ class TestLayer:
                 << commands.Log(" >! DataReceived(client, b'foo')", "debug")
                 >> tutils.reply(None, to=-3)
                 << commands.Log(" >> Reply(OpenConnection({'connection': Server("
-                                "{'id': '…rverid', 'address': None, 'state': <ConnectionState.OPEN: 3>})}))", "debug")
+                                "{'id': '…rverid', 'address': None, 'state': <ConnectionState.OPEN: 3>})}),None)", "debug")
                 << commands.Log(" !> DataReceived(client, b'foo')", "debug")
 
                 << commands.Log("baz", "info")

--- a/test/mitmproxy/proxy/test_tunnel.py
+++ b/test/mitmproxy/proxy/test_tunnel.py
@@ -245,7 +245,7 @@ def test_disconnect_during_handshake_command(tctx: Context, disconnect):
                 >> ConnectionClosed(tctx.client)
                 >> ConnectionClosed(server)  # proxyserver will cancel all other connections as well.
                 << CloseConnection(server)
-                << Log("Opened: err='connection closed without notice'. Server state: CLOSED")
+                << Log("Opened: err='connection closed'. Server state: CLOSED")
                 << Log("Got client close.")
                 << CloseConnection(tctx.client)
         )
@@ -254,7 +254,7 @@ def test_disconnect_during_handshake_command(tctx: Context, disconnect):
                 playbook
                 >> ConnectionClosed(server)
                 << CloseConnection(server)
-                << Log("Opened: err='connection closed without notice'. Server state: CLOSED")
+                << Log("Opened: err='connection closed'. Server state: CLOSED")
         )
 
 


### PR DESCRIPTION
This PR fixes a rather long list of smaller bugs I found during testing. Most importantly, it also sets the `connection_strategy` option to `eager` by default. 

`connection_strategy` is a new sans-io feature that we haven't really talked about much yet, although it controls a fundamental aspect of mitmproxy's proxy logic:

```python
loader.add_option(
    "connection_strategy", str, "eager",
    "Determine when server connections should be established. When set to lazy, mitmproxy "
    "tries to defer establishing an upstream connection as long as possible. This makes it possible to "
    "use server replay while being offline. When set to eager, mitmproxy can detect protocols with "
    "server-side greetings, as well as accurately mirror TLS ALPN negotiation.",
    choices=("eager", "lazy")
)
```

Mitmproxy 6 had a rather handwavy approach to this general question (you could configure some parts using `upstream_cert`), now it's an explicit setting that's well-tested across the board. So far, master has been running on `lazy`, which worked surprisingly well. I say _surprisingly_ because it does have some quirks: For example, mitmproxy will often end up with an HTTP/2 connection to the client and an HTTP/1 connection to the server, transparently translating between the two. This _should_ cause some interoperability issues (e.g., HTTP/2 headers will always be lowercase, a server may (incorrectly) expect a particular casing), but even though we had some extensive testing from @r00t- and others, noone complained about those aspects. However, after thinking about it a bit more I still feel `eager` is a more sensible default:

 - It's generally much nicer if client and server HTTP version agree with each other. Any kind of "doesn't work with mitmproxy, works without" bugs are tricky to debug and terrible.
 - Setting `eager` by default allows us to better support protocols with server-side greetings, see e.g. https://stackoverflow.com/a/66779301/934719
 - While offline server replay is desirable, I think it's fair to say that this isn't necessarily something that one would generally expect to work. But even more importantly, in contrast to the interoperability issues mentioned above, it's easy to diagnose and fix.

@mitmproxy/devs: I don't expect particular feedback on the individual changes below (I guess most changes require tons of context and aren't that debatable anyways), but if you have thoughts on `connection_strategy`, I'd be happy to hear them! 😃 

fixes #4527
fixes #4513