### PR TITLE
docs(concepts-modes): add explanation about socks5

### DIFF
--- a/docs/src/content/concepts-modes.md
+++ b/docs/src/content/concepts-modes.md
@@ -209,4 +209,8 @@ tests).
 
 ## SOCKS Proxy
 
-In this mode, mitmproxy acts as a SOCKS5 proxy.
+In this mode, mitmproxy acts as a [SOCKS5 proxy](https://en.wikipedia.org/wiki/SOCKS).[^1]
+
+### Footnotes
+
+[^1]: SOCKS (which stands for secure sockets) is a type of proxy connection protocol that’s used for general needs. With SOCKS5, it cooperates with different authentication methodologies which permit improved security options when making a connection, and for the data stream. [See difference between socks proxy and http proxy](https://bitrebels.com/technology/difference-between-socks-proxy-http-proxy/)


### PR DESCRIPTION
#### Description

Add link to wikipedia page and brief explanation about SOCKS5.

While reading the mitm proxy documentation, I got curious by the mention of SOCKS5 proxy. I only briefly touched upon it when using ssh tunnel to forward all ports. I find it hard to understand the various explanations about what SOCKS or SOCKS5 proxy is.

#### Checklist

 - [ ] I have updated tests where applicable.
 - [ ] I have added an entry to the CHANGELOG.
