### PR TITLE
docs(docs-readme): clarify documentation readme

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -7,7 +7,7 @@ This directory houses the mitmproxy documentation available at <https://docs.mit
  1. Install [hugo](https://gohugo.io/).
  2. Windows users: Depending on your git settings, you may need to manually create a symlink from
  /docs/src/examples to /examples.
- 3. Make sure the mitmproxy Python package is installed. [See Development Setup for details](https://github.com/mitmproxy/mitmproxy/blob/main/CONTRIBUTING.md#development-setup)
+ 3. Make sure the mitmproxy Python package is installed. See [CONTRIBUTING.md](../CONTRIBUTING.md#development-setup) for details.
  4. Run `./build.py` to generate additional documentation source files.
 
 Now you can run `hugo server -D` in ./src.

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,8 +7,8 @@ This directory houses the mitmproxy documentation available at <https://docs.mit
  1. Install [hugo](https://gohugo.io/).
  2. Windows users: Depending on your git settings, you may need to manually create a symlink from
  /docs/src/examples to /examples.
- 3. Make sure the mitmproxy Python package is installed.
- 4. Run `./build.sh` to generate additional documentation source files.
+ 3. Make sure the mitmproxy Python package is installed. [See Development Setup for details](https://github.com/mitmproxy/mitmproxy/blob/main/CONTRIBUTING.md#development-setup)
+ 4. Run `./build.py` to generate additional documentation source files.
 
 Now you can run `hugo server -D` in ./src.
 


### PR DESCRIPTION
#### Description

I was confused what `mitmproxy Python package` meant. At first I did `pipx install mitmproxy`, but that didn't work. Then I realized I needed it as a library/module, not cli.

Changed `build.sh` to `build.py` since it was deleted on commit a7d1f32c89f3ea8b989a2d63fac13a44bc34f946

#### Checklist

 - [ ] I have updated tests where applicable.
 - [ ] I have added an entry to the CHANGELOG.
