### PR TITLE
docker: clean up tmux dir in clirecording Dockerfile

### DIFF
--- a/docs/scripts/clirecording/Dockerfile
+++ b/docs/scripts/clirecording/Dockerfile
@@ -35,7 +35,9 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 RUN git clone --depth 1 https://github.com/tmux/tmux.git \
     && cd tmux \
     && sh autogen.sh \
-    && ./configure && make && make install
+    && ./configure && make && make install \
+    && cd ../ \
+    && rm -rf tmux
 
 WORKDIR /root/clidirector
 


### PR DESCRIPTION
#### Description

clean up tmux dir in clirecording Dockerfile, will save the image size a little bit.

#### Checklist

 - [ ] I have updated tests where applicable.
 - [ ] I have added an entry to the CHANGELOG.
