### PR TITLE
docker: avoid additional apt packages by `--no-install-recommends`

### DIFF
--- a/release/docker/Dockerfile
+++ b/release/docker/Dockerfile
@@ -4,7 +4,7 @@ ARG MITMPROXY_WHEEL
 
 RUN useradd -mU mitmproxy
 RUN apt-get update \
-    && apt-get install -y gosu \
+    && apt-get install -y --no-install-recommends gosu \
     && rm -rf /var/lib/apt/lists/*
     
 COPY $MITMPROXY_WHEEL /home/mitmproxy/


### PR DESCRIPTION
#### Description

This will help we keep the image not too heavy that caused by those
additional, suggestion apt packages.

Only install the packages we explicitly want.

#### Checklist

 - [ ] I have updated tests where applicable.
 - [ ] I have added an entry to the CHANGELOG.
