### PR TITLE
docs: add more precise instructions on docs setup

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,7 +5,6 @@ This directory houses the mitmproxy documentation available at <https://docs.mit
 ## Quick Start
 
  1. Install [hugo "extended"](https://gohugo.io/getting-started/installing/). 
-     - When using snap you can install it using `snap install hugo --channel=extended`
  2. Windows users: Depending on your git settings, you may need to manually create a symlink from
  /docs/src/examples to /examples.
  3. Make sure the mitmproxy Python package is installed and the virtual python environment was activated. See [CONTRIBUTING.md](../CONTRIBUTING.md#development-setup) for details.

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,10 +4,11 @@ This directory houses the mitmproxy documentation available at <https://docs.mit
 
 ## Quick Start
 
- 1. Install [hugo](https://gohugo.io/).
+ 1. Install [hugo "extended"](https://gohugo.io/getting-started/installing/). 
+     - When using snap you can install it using `snap install hugo --channel=extended`
  2. Windows users: Depending on your git settings, you may need to manually create a symlink from
  /docs/src/examples to /examples.
- 3. Make sure the mitmproxy Python package is installed. See [CONTRIBUTING.md](../CONTRIBUTING.md#development-setup) for details.
+ 3. Make sure the mitmproxy Python package is installed and the virtual python environment was activated. See [CONTRIBUTING.md](../CONTRIBUTING.md#development-setup) for details.
  4. Run `./build.py` to generate additional documentation source files.
 
 Now you can run `hugo server -D` in ./src.


### PR DESCRIPTION
#### Description

After only installing the "normal" version of hugo the ./build.py script failed because of some SCSS errors. After installing the extended version using snap, everything worked fine.
I also didn't know that the venv had to be activated manually, so I put a small comment, pointing that out.

#### Checklist

 - [ ] I have updated tests where applicable.
 - [ ] I have added an entry to the CHANGELOG.
