### PR TITLE
Draft: Update ws/tcp injection and add ws.text property

### DIFF
--- a/examples/addons/websocket-inject-message.py
+++ b/examples/addons/websocket-inject-message.py
@@ -5,16 +5,22 @@ This example shows how to inject a WebSocket message into a running connection.
 """
 import asyncio
 
-from mitmproxy import ctx, http
+from mitmproxy import ctx, http, websocket
 
 
 # Simple example: Inject a message as a response to an event
 
-def websocket_message(flow):
-    last_message = flow.websocket.messages[-1]
-    if b"secret" in last_message.content:
-        last_message.kill()
-        ctx.master.commands.call("inject.websocket", flow, last_message.from_client, "ssssssh")
+def websocket_message(flow: http.HTTPFlow):
+    recent_message = flow.websocket.messages[-1]
+    if recent_message.is_text and "secret" in recent_message.text:
+        recent_message.kill()
+        ctx.master.commands.call(
+          "inject.websocket",
+          flow,
+          to_client=recent_message.from_client,
+          is_text=True,
+          content=b"ssssssh"
+        )
 
 
 # Complex example: Schedule a periodic timer
@@ -23,7 +29,7 @@ async def inject_async(flow: http.HTTPFlow):
     msg = "hello from mitmproxy! "
     assert flow.websocket  # make type checker happy
     while flow.websocket.timestamp_end is None:
-        ctx.master.commands.call("inject.websocket", flow, True, msg)
+        ctx.master.commands.call("inject.websocket", flow, to_client=True, is_text=True, content=msg.encode())
         await asyncio.sleep(1)
         msg = msg[1:] + msg[:1]
 

--- a/examples/addons/websocket-inject-message.py
+++ b/examples/addons/websocket-inject-message.py
@@ -5,7 +5,7 @@ This example shows how to inject a WebSocket message into a running connection.
 """
 import asyncio
 
-from mitmproxy import ctx, http, websocket
+from mitmproxy import ctx, http
 
 
 # Simple example: Inject a message as a response to an event
@@ -15,11 +15,11 @@ def websocket_message(flow: http.HTTPFlow):
     if recent_message.is_text and "secret" in recent_message.text:
         recent_message.kill()
         ctx.master.commands.call(
-          "inject.websocket",
-          flow,
-          to_client=recent_message.from_client,
-          is_text=True,
-          content=b"ssssssh"
+            "inject.websocket",
+            flow,
+            to_client=recent_message.from_client,
+            is_text=True,
+            content=b"ssssssh"
         )
 
 

--- a/mitmproxy/addons/dumper.py
+++ b/mitmproxy/addons/dumper.py
@@ -291,7 +291,7 @@ class Dumper:
             direction = "->" if message.from_client else "<-"
             self.echo(
                 f"{human.format_address(f.client_conn.peername)} "
-                f"{direction} WebSocket {message.type.name.lower()} message "
+                f"{direction} WebSocket {'TEXT' if message.is_text else 'BINARY'} message "
                 f"{direction} {human.format_address(f.server_conn.address)}{f.request.path}"
             )
             if ctx.options.flow_detail >= 3:

--- a/mitmproxy/addons/proxyserver.py
+++ b/mitmproxy/addons/proxyserver.py
@@ -8,7 +8,7 @@ from mitmproxy.proxy import commands, events, server_hooks
 from mitmproxy.proxy import server
 from mitmproxy.proxy.layers.tcp import TcpMessageInjected
 from mitmproxy.proxy.layers.websocket import WebSocketMessageInjected
-from mitmproxy.utils import asyncio_utils, human, strutils
+from mitmproxy.utils import asyncio_utils, human
 
 
 class AsyncReply(controller.Reply):

--- a/mitmproxy/addons/proxyserver.py
+++ b/mitmproxy/addons/proxyserver.py
@@ -9,7 +9,6 @@ from mitmproxy.proxy import server
 from mitmproxy.proxy.layers.tcp import TcpMessageInjected
 from mitmproxy.proxy.layers.websocket import WebSocketMessageInjected
 from mitmproxy.utils import asyncio_utils, human, strutils
-from wsproto.frame_protocol import Opcode
 
 
 class AsyncReply(controller.Reply):

--- a/mitmproxy/proxy/layers/websocket.py
+++ b/mitmproxy/proxy/layers/websocket.py
@@ -152,7 +152,7 @@ class WebsocketLayer(layer.Layer):
         elif isinstance(event, events.ConnectionClosed):
             src_ws.receive_data(None)
         elif isinstance(event, WebSocketMessageInjected):
-            fragmentizer = Fragmentizer([], event.message.type == Opcode.TEXT)
+            fragmentizer = Fragmentizer([], event.message.is_text)
             src_ws._events.extend(
                 fragmentizer(event.message.content)
             )
@@ -175,7 +175,7 @@ class WebsocketLayer(layer.Layer):
                     fragmentizer = Fragmentizer(src_ws.frame_buf, is_text)
                     src_ws.frame_buf.clear()
 
-                    message = websocket.WebSocketMessage(typ, from_client, content)
+                    message = websocket.WebSocketMessage(typ == Opcode.TEXT, from_client, content)
                     self.flow.websocket.messages.append(message)
                     yield WebsocketMessageHook(self.flow)
 

--- a/mitmproxy/test/tflow.py
+++ b/mitmproxy/test/tflow.py
@@ -7,7 +7,6 @@ from mitmproxy import http
 from mitmproxy import tcp
 from mitmproxy import websocket
 from mitmproxy.test import tutils
-from wsproto.frame_protocol import Opcode
 
 
 def ttcpflow(client_conn=True, server_conn=True, messages=True, err=None):

--- a/mitmproxy/test/tflow.py
+++ b/mitmproxy/test/tflow.py
@@ -70,9 +70,9 @@ def twebsocketflow(messages=True, err=None) -> http.HTTPFlow:
 
     if messages is True:
         flow.websocket.messages = [
-            websocket.WebSocketMessage(Opcode.BINARY, True, b"hello binary", 946681203),
-            websocket.WebSocketMessage(Opcode.TEXT, True, b"hello text", 946681204),
-            websocket.WebSocketMessage(Opcode.TEXT, False, b"it's me", 946681205),
+            websocket.WebSocketMessage(False, True, b"hello binary", 946681203),
+            websocket.WebSocketMessage(True, True, b"hello text", 946681204),
+            websocket.WebSocketMessage(True, False, b"it's me", 946681205),
         ]
     if err is True:
         flow.error = terr()

--- a/mitmproxy/websocket.py
+++ b/mitmproxy/websocket.py
@@ -6,7 +6,7 @@ as HTTP flows as well. They can be distinguished from regular HTTP requests by h
 This module only defines the classes for individual `WebSocketMessage`s and the `WebSocketData` container.
 """
 import time
-from typing import List, Tuple, Union
+from typing import List, Tuple
 from typing import Optional
 
 from mitmproxy import stateobject

--- a/test/mitmproxy/addons/test_proxyserver.py
+++ b/test/mitmproxy/addons/test_proxyserver.py
@@ -131,7 +131,6 @@ async def test_inject_fail():
         ps.inject_tcp(
             tflow.tflow(),
             True,
-            True,
             b"test"
         )
         await tctx.master.await_log("Cannot inject TCP messages into non-TCP flows.", level="warn")

--- a/test/mitmproxy/addons/test_proxyserver.py
+++ b/test/mitmproxy/addons/test_proxyserver.py
@@ -111,9 +111,9 @@ async def test_inject():
 
             writer.write(b"a")
             assert await reader.read(1) == b"A"
-            ps.inject_tcp(state.flows[0], False, "b")
+            ps.inject_tcp(state.flows[0], False, b"b")
             assert await reader.read(1) == b"B"
-            ps.inject_tcp(state.flows[0], True, "c")
+            ps.inject_tcp(state.flows[0], True, b"c")
             assert await reader.read(1) == b"c"
 
 
@@ -124,26 +124,30 @@ async def test_inject_fail():
         ps.inject_websocket(
             tflow.tflow(),
             True,
-            "test"
+            True,
+            b"test"
         )
         await tctx.master.await_log("Cannot inject WebSocket messages into non-WebSocket flows.", level="warn")
         ps.inject_tcp(
             tflow.tflow(),
             True,
-            "test"
+            True,
+            b"test"
         )
         await tctx.master.await_log("Cannot inject TCP messages into non-TCP flows.", level="warn")
 
         ps.inject_websocket(
             tflow.twebsocketflow(),
             True,
-            "test"
+            True,
+            b"test"
         )
         await tctx.master.await_log("Flow is not from a live connection.", level="warn")
         ps.inject_websocket(
             tflow.ttcpflow(),
             True,
-            "test"
+            True,
+            b"test"
         )
         await tctx.master.await_log("Flow is not from a live connection.", level="warn")
 

--- a/test/mitmproxy/proxy/layers/test_websocket.py
+++ b/test/mitmproxy/proxy/layers/test_websocket.py
@@ -328,7 +328,7 @@ def test_inject_message(ws_testdata):
             playbook
             << websocket.WebsocketStartHook(flow)
             >> reply()
-            >> WebSocketMessageInjected(flow, WebSocketMessage(Opcode.TEXT, False, b"hello"))
+            >> WebSocketMessageInjected(flow, WebSocketMessage(True, False, b"hello"))
             << websocket.WebsocketMessageHook(flow)
     )
     assert flow.websocket.messages[-1].content == b"hello"

--- a/test/mitmproxy/proxy/layers/test_websocket.py
+++ b/test/mitmproxy/proxy/layers/test_websocket.py
@@ -14,7 +14,6 @@ from mitmproxy.proxy.layers import http, websocket
 from mitmproxy.proxy.layers.websocket import WebSocketMessageInjected
 from mitmproxy.websocket import WebSocketData, WebSocketMessage
 from test.mitmproxy.proxy.tutils import Placeholder, Playbook, reply
-from wsproto.frame_protocol import Opcode
 
 
 @dataclass
@@ -99,10 +98,10 @@ def test_upgrade(tctx):
     assert len(flow().websocket.messages) == 2
     assert flow().websocket.messages[0].content == b"hello world"
     assert flow().websocket.messages[0].from_client
-    assert flow().websocket.messages[0].type == Opcode.TEXT
+    assert flow().websocket.messages[0].is_text
     assert flow().websocket.messages[1].content == b"hello back"
     assert flow().websocket.messages[1].from_client is False
-    assert flow().websocket.messages[1].type == Opcode.BINARY
+    assert flow().websocket.messages[1].is_text is False
 
 
 @pytest.fixture()

--- a/test/mitmproxy/test_websocket.py
+++ b/test/mitmproxy/test_websocket.py
@@ -1,7 +1,6 @@
 from mitmproxy import http
 from mitmproxy import websocket
 from mitmproxy.test import tflow
-from wsproto.frame_protocol import Opcode
 
 
 class TestWebSocketData:

--- a/test/mitmproxy/test_websocket.py
+++ b/test/mitmproxy/test_websocket.py
@@ -16,11 +16,11 @@ class TestWebSocketData:
 
 class TestWebSocketMessage:
     def test_basic(self):
-        m = websocket.WebSocketMessage(Opcode.TEXT, True, b"foo")
+        m = websocket.WebSocketMessage(True, True, b"foo")
         m.set_state(m.get_state())
         assert m.content == b"foo"
         assert repr(m) == "'foo'"
-        m.type = Opcode.BINARY
+        m.is_text = False
         assert repr(m) == "b'foo'"
 
         assert not m.killed


### PR DESCRIPTION
#### Description

This is still broken. Just me saying that I'm working on this. Or I'm trying.

1. Fix #4558 by not using `strutils.escaped_str_to_bytes`
2. Added the `text` property to WebSocketMessage. This makes manipulating messages in `websocket_message` nicer, but creating/injecting messages still only allows `content` bytes because we wanted to avoid type problems
3. Removed Opcode and use `is_text`. @mhils originally did this in another PR but I wanted to keep the Opcodes around because we might add ping/pong later. But if we ever do so, then we definitely do not want to mix them with `websocket_message` or `WebSocketMessage` because that's even more confusing. By only having `is_text` add-on authors also don't need to import from `wsproto.frame_protocol`.

The mix of `to_client` and `from_client` bools when injecting is _really_ confusing. This will be a lot nicer with source/target when you can just `target=msg.source` to bounce something back.

Missing:

* Tests (there are currently no inject_websocket tests and I don't know how they work)
* Migrations for the `WebSocketMessageState`? At least I think I've seen something like this in past PRs

#### Checklist

 - [ ] I have updated tests where applicable.
 - [ ] I have added an entry to the CHANGELOG.
