### PR TITLE
Fix: check pending writes before requesting more from server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ If you depend on these features, please raise your voice in
 
 ### Full Changelog
 
+* Check pending writes to client before requesting more from server (@hazcod)
 * New Proxy Core based on sans-io pattern (@mhils)
 * mitmproxy's command line interface now supports Windows (@mhils)
 * The `clientconnect`, `clientdisconnect`, `serverconnect`, `serverdisconnect`, and `log`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,6 @@ If you depend on these features, please raise your voice in
 
 ### Full Changelog
 
-* Check pending writes to client before requesting more from server (@hazcod)
 * New Proxy Core based on sans-io pattern (@mhils)
 * mitmproxy's command line interface now supports Windows (@mhils)
 * The `clientconnect`, `clientdisconnect`, `serverconnect`, `serverdisconnect`, and `log`
@@ -63,6 +62,7 @@ If you depend on these features, please raise your voice in
   browser sessions. (@rbdixon)
 * Improve readability of SHA256 fingerprint. (@wrekone)
 * Metadata and Replay Flow Filters: Flows may be filtered based on metadata and replay status. (@rbdixon)
+* Flow control: don't read connection data faster than it can be forwarded. (@hazcod)
 * --- TODO: add new PRs above this line ---
 * ... and various other fixes, documentation improvements, dependency version bumps, etc.
 

--- a/mitmproxy/proxy/server.py
+++ b/mitmproxy/proxy/server.py
@@ -227,7 +227,8 @@ class ConnectionHandler(metaclass=abc.ABCMeta):
             else:
                 self.server_event(events.DataReceived(connection, data))
                 for transport in self.transports.values():
-                    await transport.writer.drain()
+                    if transport.writer is not None:
+                        await transport.writer.drain()
 
         if cancelled is None:
             connection.state &= ~ConnectionState.CAN_READ

--- a/mitmproxy/proxy/server.py
+++ b/mitmproxy/proxy/server.py
@@ -226,6 +226,8 @@ class ConnectionHandler(metaclass=abc.ABCMeta):
                 break
             else:
                 self.server_event(events.DataReceived(connection, data))
+                for transport in self.transports.values():
+                    await transport.writer.drain()
 
         if cancelled is None:
             connection.state &= ~ConnectionState.CAN_READ
@@ -289,7 +291,6 @@ class ConnectionHandler(metaclass=abc.ABCMeta):
                     writer = self.transports[command.connection].writer
                     assert writer
                     writer.write(command.data)
-                    await writer.drain()
                 elif isinstance(command, commands.CloseConnection):
                     self.close_connection(command.connection, command.half_close)
                 elif isinstance(command, commands.GetSocket):

--- a/mitmproxy/proxy/server.py
+++ b/mitmproxy/proxy/server.py
@@ -289,6 +289,7 @@ class ConnectionHandler(metaclass=abc.ABCMeta):
                     writer = self.transports[command.connection].writer
                     assert writer
                     writer.write(command.data)
+                    await writer.drain()
                 elif isinstance(command, commands.CloseConnection):
                     self.close_connection(command.connection, command.half_close)
                 elif isinstance(command, commands.GetSocket):


### PR DESCRIPTION
#### Description

Fixes https://github.com/mitmproxy/mitmproxy/issues/4563

This fix ensures that first we write out all pending bytes to the client before requesting more from the server.
Potentially this impacts performance.

#### Checklist

 - [X] I have updated tests where applicable.
 - [X] I have added an entry to the CHANGELOG.

CC @mhils 