### PR TITLE
Allow browser.start to open multiple browsers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,8 @@ If you depend on these features, please raise your voice in
 * Add option `export_preserve_original_ip` to force exported command to connect to IP from original request. Only supports curl at the moment. (@dkasak)
 * Major proxy protocol testing (@r00t-)
 * Switch Docker image release to be based on Debian (@PeterDaveHello)
+* Multiple Browsers: The `browser.start` command may be executed more than once to start additional
+  browser sessions. (@rbdixon)
 * --- TODO: add new PRs above this line ---
 * ... and various other fixes, documentation improvements, dependency version bumps, etc.
 

--- a/test/mitmproxy/addons/test_browser.py
+++ b/test/mitmproxy/addons/test_browser.py
@@ -15,9 +15,8 @@ async def test_browser():
             assert po.called
 
             b.start()
-            b.browser.poll = lambda: None
-            b.start()
-            await tctx.master.await_log("already running")
+            await tctx.master.await_log("Starting additional browser")
+            assert len(b.browser) == 2
             b.done()
             assert not b.browser
 


### PR DESCRIPTION
#### Description

Allow `browser.start` to be executed multiple times to open new browsers.

#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
