### PR TITLE
Improve certificate fingerprint readability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ If you depend on these features, please raise your voice in
 * Switch Docker image release to be based on Debian (@PeterDaveHello)
 * Multiple Browsers: The `browser.start` command may be executed more than once to start additional
   browser sessions. (@rbdixon)
+* Improve readability of SHA256 fingerprint. (@wrekone)
 * --- TODO: add new PRs above this line ---
 * ... and various other fixes, documentation improvements, dependency version bumps, etc.
 

--- a/mitmproxy/tools/console/flowdetailview.py
+++ b/mitmproxy/tools/console/flowdetailview.py
@@ -60,7 +60,7 @@ def flowdetails(state, flow: mitmproxy.flow.Flow):
             text.append(urwid.Text([("head", "Server Certificate:")]))
             parts = [
                 ("Type", "%s, %s bits" % c.keyinfo),
-                ("SHA256 digest", c.fingerprint().hex()),
+                ("SHA256 digest", c.fingerprint().hex(' ')),
                 ("Valid to", str(c.notafter)),
                 ("Valid from", str(c.notbefore)),
                 ("Serial", str(c.serial)),


### PR DESCRIPTION
#### Description

Addresses https://github.com/mitmproxy/mitmproxy/issues/4549

Delimit SHA256 bytes to make fingerprint easier to read.

#### Checklist

 - [] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
