### PR TITLE
Feature: add ARM64 docker platform variants

### DIFF
--- a/release/cibuild.py
+++ b/release/cibuild.py
@@ -280,7 +280,9 @@ def build_docker_image(be: BuildEnviron) -> None:  # pragma: no cover
     shutil.copy(whl, docker_build_dir / whl.name)
     subprocess.check_call([
         "docker",
+        "buildx"
         "build",
+        "--platform linux/amd64,linux/arm64,darwin/amd64,darwin/arm64",
         "--tag", be.docker_tag,
         "--build-arg", f"MITMPROXY_WHEEL={whl.name}",
         "."


### PR DESCRIPTION
#### Description

A very fresh proposal to also build arm64 docker images using buildx from docker.

#### Checklist

 - [X] I have updated tests where applicable.
 - [ ] I have added an entry to the CHANGELOG.
