### PR TITLE
docs: requirements for custom mitmproxy-ca.pem

### DIFF
--- a/docs/src/content/concepts-certificates.md
+++ b/docs/src/content/concepts-certificates.md
@@ -151,6 +151,27 @@ mitmproxy. Mitmproxy will then look for `mitmproxy-ca.pem` in the
 specified directory. If no such file exists, it will be generated
 automatically.
 
+The `mitmproxy-ca.pem` certificate file has to look roughly like this:
+
+    -----BEGIN PRIVATE KEY-----
+    <private key>
+    -----END PRIVATE KEY-----
+    -----BEGIN CERTIFICATE-----
+    <cert>
+    -----END CERTIFICATE-----
+
+When looking at the certificate with 
+`openssl x509 -noout -text -in ~/.mitmproxy/mitmproxy-ca.pem`
+it should have the at least the following X509v3 extensions, mitmproxy can 
+use it to generate certificates:
+
+    X509v3 extensions:
+        X509v3 Key Usage: critical
+            Certificate Sign
+        X509v3 Basic Constraints: critical
+            CA:TRUE
+
+
 ## Using a client side certificate
 
 You can use a client certificate by passing the `--set client_certs=DIRECTORY|FILE`

--- a/docs/src/content/concepts-certificates.md
+++ b/docs/src/content/concepts-certificates.md
@@ -162,7 +162,7 @@ The `mitmproxy-ca.pem` certificate file has to look roughly like this:
 
 When looking at the certificate with 
 `openssl x509 -noout -text -in ~/.mitmproxy/mitmproxy-ca.pem`
-it should have the at least the following X509v3 extensions, mitmproxy can 
+it should have at least the following X509v3 extensions so mitmproxy can 
 use it to generate certificates:
 
     X509v3 extensions:


### PR DESCRIPTION
#### Description

Extend documentation on what format the `mitmproxy-ca.pem` needs to
conform with so it can be used as a CA.

Fixes #4598

#### Checklist

 - [ ] I have updated tests where applicable.
 - [ ] I have added an entry to the CHANGELOG.
