### PR TITLE
Make the CA cert live longer

### DIFF
--- a/mitmproxy/certs.py
+++ b/mitmproxy/certs.py
@@ -17,7 +17,7 @@ import OpenSSL
 from mitmproxy.coretypes import serializable
 
 # Default expiry must not be too long: https://github.com/mitmproxy/mitmproxy/issues/815
-CA_EXPIRY = datetime.timedelta(days=3 * 365)
+CA_EXPIRY = datetime.timedelta(days=10 * 365)
 CERT_EXPIRY = datetime.timedelta(days=365)
 
 # Generated with "openssl dhparam". It's too slow to generate this on startup.


### PR DESCRIPTION
We need to restrict `CERT_EXPIRY` because modern browsers only accept a ~ <= 1year period for certs, but re-reading all prior commits and issues as well as the CA/Browser Forum Baseline Requirements on the topic, it looks like we don't actually need to restrict our CA lifetime by that much. Let's try out a longer validity and see if anyone complains.
