### PR TITLE
Added `wsreplay` as a temporary fix of mitmproxy not being able to replay websockets

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "examples/contrib/wsreplay.py"]
+	path = examples/contrib/wsreplay
+	url = https://github.com/KOLANICH-tools/wsreplay.py
+	branch = master


### PR DESCRIPTION
#### Description

Added a standalone mitigation to mitmproxy not being able to replay websockets

#### Checklist

 - [x] I have updated tests where applicable. - not applicable, `contrib` goes without tests
 - [ ] I have added an entry to the CHANGELOG. - not sure if it should be done
