### PR TITLE
fix #4630

### DIFF
--- a/mitmproxy/addons/tlsconfig.py
+++ b/mitmproxy/addons/tlsconfig.py
@@ -169,18 +169,19 @@ class TlsConfig:
         if not server.alpn_offers:
             if client.alpn_offers:
                 if ctx.options.http2:
+                    # We would perfectly support HTTP/1 -> HTTP/2, but we want to keep things on the same protocol
+                    # version. There are some edge cases where we want to mirror the regular server's behavior
+                    # accurately, for example header capitalization.
                     server.alpn_offers = tuple(client.alpn_offers)
                 else:
                     server.alpn_offers = tuple(x for x in client.alpn_offers if x != b"h2")
-            elif client.tls:
-                # We would perfectly support HTTP/1 -> HTTP/2, but we want to keep things on the same protocol version.
-                # There are some edge cases where we want to mirror the regular server's behavior accurately,
-                # for example header capitalization.
-                server.alpn_offers = []
-            elif ctx.options.http2:
-                server.alpn_offers = tls.HTTP_ALPNS
             else:
-                server.alpn_offers = tls.HTTP1_ALPNS
+                # We either have no client TLS or a client without ALPN.
+                # - If the client does use TLS but did not send an ALPN extension, we want to mirror that upstream.
+                # - If the client does not use TLS, there's no clear-cut answer. As a pragmatic approach, we also do
+                #   not send any ALPN extension in this case, which defaults to whatever protocol we are speaking
+                #   or falls back to HTTP.
+                server.alpn_offers = []
 
         if not server.cipher_list and ctx.options.ciphers_server:
             server.cipher_list = ctx.options.ciphers_server.split(":")

--- a/mitmproxy/addons/tlsconfig.py
+++ b/mitmproxy/addons/tlsconfig.py
@@ -172,7 +172,7 @@ class TlsConfig:
                     server.alpn_offers = tuple(client.alpn_offers)
                 else:
                     server.alpn_offers = tuple(x for x in client.alpn_offers if x != b"h2")
-            elif client.tls_established:
+            elif client.tls:
                 # We would perfectly support HTTP/1 -> HTTP/2, but we want to keep things on the same protocol version.
                 # There are some edge cases where we want to mirror the regular server's behavior accurately,
                 # for example header capitalization.

--- a/test/helper_tools/loggrep.py
+++ b/test/helper_tools/loggrep.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import fileinput
 import sys
+import re
 
 if __name__ == "__main__":
     if len(sys.argv) < 3:
@@ -10,7 +11,7 @@ if __name__ == "__main__":
     port = sys.argv[1]
     matches = False
     for line in fileinput.input(sys.argv[2:]):
-        if line.startswith("["):
+        if re.match(r"^\[|(\d+\.){3}", line):
             matches = port in line
         if matches:
             print(line, end="")

--- a/test/mitmproxy/addons/test_tlsconfig.py
+++ b/test/mitmproxy/addons/test_tlsconfig.py
@@ -190,8 +190,8 @@ class TestTlsConfig:
 
             assert_alpn(True, tls.HTTP_ALPNS + (b"foo",), tls.HTTP_ALPNS + (b"foo",))
             assert_alpn(False, tls.HTTP_ALPNS + (b"foo",), tls.HTTP1_ALPNS + (b"foo",))
-            assert_alpn(True, [], tls.HTTP_ALPNS)
-            assert_alpn(False, [], tls.HTTP1_ALPNS)
+            assert_alpn(True, [], [])
+            assert_alpn(False, [], [])
             ctx.client.timestamp_tls_setup = time.time()
             # make sure that we don't upgrade h1 to h2,
             # see comment in tlsconfig.py


### PR DESCRIPTION
This PR fixes #4630. Thanks again for the helpful log, @Nerixyz!

This actually was a really fascinating bug. In short, the following things happened:

1. We have a client that is not sending a TLS ALPN extension.
2. During the client's TLS handshake, we establish a server connection to fetch the server cert (with connection_strategy=lazy, we would just guess what needs to be in the cert and not connect here yet). We know that we eventually want client TLS (`client.tls` is already true), but at this point `client.tls_established` is still false as we haven't finished the handshake yet.
3. In `tlsconfig.py#L175`, we mistakenly believe that there is no client TLS, so we decide to send HTTP ALPNs upstream.
4. We successfully negotiate HTTP/2 upstream. The Facebook server immediately sends its HTTP/2 settings frame.
5. We try to detect the application-level protocol in `addons/next_layer.py`: https://github.com/mitmproxy/mitmproxy/blob/de0951462d5919c6d37bed5f8f3b80d8f810b833/mitmproxy/addons/next_layer.py#L152-L157
6. At this point we haven't received the request from the client yet, but we already have the server's HTTP/2 settings in `client_data`. Mitmproxy concludes that this is a non-HTTP protocol with a server-side greeting.
7. The HTTP/1 client tries to talk to the HTTP/2 server over plain TCP. Everything explodes. 💣 