### PR TITLE
Add Addon Upgrade Docs for mitmproxy 7

### DIFF
--- a/docs/src/content/addons-api-changelog.md
+++ b/docs/src/content/addons-api-changelog.md
@@ -14,9 +14,18 @@ We try to avoid them, but this page lists breaking changes in the mitmproxy addo
 
 #### Connection Events
 
-We've revised mitmproxy's connection-specific event hooks as part of the new proxy core. See the new 
-[event hook documentation]({{< relref "addons-api#ConnectionEvents" >}}) for details. As the passed objects are slightly
-different now, we've also taken this opportunity to introduce a consistent event names:
+We've revised mitmproxy's connection-specific event hooks as part of the new proxy core. The `.client_conn` and 
+`.server_conn` objects have major API changes across the board. See the new 
+[event hook documentation]({{< relref "addons-api#ConnectionEvents" >}}) for details. 
+
+| Attribute      | Client (v6) | Server (v6)       | mitmproxy v7 |
+|----------------|-------------|-------------------|--------------|
+| Remote IP:Port | `.address`  | `.ip_address`     | `.peername`  |
+| Local IP:Port  | ❌          | `.source_address` | `.sockname`  |
+| Remote Domain  | N/A         | `.address`        | `.address`   |
+
+
+As the passed objects are different now, we've also taken this opportunity to introduce more consistent event names:
 
 | mitmproxy 6        | mitmproxy 7           |
 | ------------------ | --------------------- |
@@ -44,3 +53,12 @@ mitmproxy 6 had a custom WebSocketFlow class, which had
 WebSocketFlow is no more and instead HTTPFlow has a neat 
 [`.websocket` attribute]({{< relref "api/mitmproxy.http.md#HTTPFlow.websocket" >}}). All WebSocket flows are now passed
 the originating `HTTPFlow` with this attribute set. As always, existing dumpfiles are automatically converted on load.
+
+#### Certificates
+
+mitmproxy now uses `cryptography` instead of `pyOpenSSL` to generate certificates. As a consequence, the API of
+`mitmproxy.certs` has changed.
+
+#### HTTP Headers
+
+`mitmproxy.net.http.Headers` -> `mitmproxy.http.Headers` for consistency.

--- a/docs/src/content/addons-api-changelog.md
+++ b/docs/src/content/addons-api-changelog.md
@@ -1,0 +1,46 @@
+---
+title: "API Changelog"
+layout: single
+menu:
+    addons:
+        weight: 9
+---
+
+# API Changelog
+
+We try to avoid them, but this page lists breaking changes in the mitmproxy addon API.
+
+## mitmproxy 7.0
+
+#### Connection Events
+
+We've revised mitmproxy's connection-specific event hooks as part of the new proxy core. See the new 
+[event hook documentation]({{< relref "addons-api#ConnectionEvents" >}}) for details. As the passed objects are slightly
+different now, we've also taken this opportunity to introduce a consistent event names:
+
+| mitmproxy 6 | mitmproxy 7 |
+|--|--|
+| `clientconnect` | `client_connected` |
+| `clientdisconnect` | `client_disconnected` |
+| ❌ | `server_connect` |
+| `serverconnect` | `server_connected` |
+| `serverdisconnect` | `server_disconnected` |
+
+#### Logging
+
+The `log` event has been renamed to `add_log`. This fixes a consistent source of errors where users imported 
+modules with the name "log", which were then inadvertedly picked up.
+
+#### Contentviews
+
+Contentviews now implement `render_priority` instead of `should_render`. This enables additional specialization, for
+example one can now write contentviews that pretty-print only specific JSON responses.
+See the [contentview.py]({{< relref "addons-examples#contentview" >}}) example for details.
+
+#### WebSocket Flows
+
+mitmproxy 6 had a custom WebSocketFlow class, which had 
+[ugly co-dependencies with the related HTTPFlow](https://github.com/mitmproxy/mitmproxy/issues/4425). Long story short,
+WebSocketFlow is no more and instead HTTPFlow has a neat 
+[`.websocket` attribute]({{< relref "api/mitmproxy.http.md#HTTPFlow.websocket" >}}). All WebSocket flows are now passed
+the originating `HTTPFlow` with this attribute set.

--- a/docs/src/content/addons-api-changelog.md
+++ b/docs/src/content/addons-api-changelog.md
@@ -18,12 +18,12 @@ We've revised mitmproxy's connection-specific event hooks as part of the new pro
 [event hook documentation]({{< relref "addons-api#ConnectionEvents" >}}) for details. As the passed objects are slightly
 different now, we've also taken this opportunity to introduce a consistent event names:
 
-| mitmproxy 6 | mitmproxy 7 |
-|--|--|
-| `clientconnect` | `client_connected` |
+| mitmproxy 6        | mitmproxy 7           |
+| ------------------ | --------------------- |
+| `clientconnect`    | `client_connected`    |
 | `clientdisconnect` | `client_disconnected` |
-| ❌ | `server_connect` |
-| `serverconnect` | `server_connected` |
+| ❌                 | `server_connect`      |
+| `serverconnect`    | `server_connected`    |
 | `serverdisconnect` | `server_disconnected` |
 
 #### Logging
@@ -43,4 +43,4 @@ mitmproxy 6 had a custom WebSocketFlow class, which had
 [ugly co-dependencies with the related HTTPFlow](https://github.com/mitmproxy/mitmproxy/issues/4425). Long story short,
 WebSocketFlow is no more and instead HTTPFlow has a neat 
 [`.websocket` attribute]({{< relref "api/mitmproxy.http.md#HTTPFlow.websocket" >}}). All WebSocket flows are now passed
-the originating `HTTPFlow` with this attribute set.
+the originating `HTTPFlow` with this attribute set. As always, existing dumpfiles are automatically converted on load.


### PR DESCRIPTION
This PR includes some initial documentation on how to upgrade existing addons to mitmproxy 7. For most addons, no changes should be necessary. If you encounter any issues not listed here, please leave a comment so that we can address them! 😃 