### PR TITLE
[mitmweb] fix 'hide response type menu' bug

### DIFF
--- a/web/src/css/flowdetail.less
+++ b/web/src/css/flowdetail.less
@@ -20,6 +20,8 @@
             padding: 5px 12px 0;
         }
         >footer {
+            position: absolute;
+            bottom: 0;
             box-shadow: 0 0 3px gray;
             padding: 2px;
             margin: 0;


### PR DESCRIPTION
#### Description

When the answer type list is displayed, part of this list will be hidden if the answer is low

Example:

![Screenshot from 2021-06-18 13-22-21](https://user-images.githubusercontent.com/77061285/122539114-7b4a1580-d03c-11eb-9135-4d1108188275.png)

Fixed problem result:

![Screenshot from 2021-06-18 13-24-55](https://user-images.githubusercontent.com/77061285/122539844-4d190580-d03d-11eb-9e97-974b26aaefc5.png)


#### Checklist

 - [ ] I have updated tests where applicable.
 - [ ] I have added an entry to the CHANGELOG.
