### PR TITLE
separate tls_start hooks for client and server, fixes #4665, refs #4547

### DIFF
--- a/docs/scripts/api-events.py
+++ b/docs/scripts/api-events.py
@@ -122,7 +122,8 @@ with outfile.open("w") as f, contextlib.redirect_stdout(f):
         "",
         [
             tls.TlsClienthelloHook,
-            tls.TlsStartHook,
+            tls.TlsStartClientHook,
+            tls.TlsStartServerHook,
         ]
     )
 

--- a/mitmproxy/addons/tlsconfig.py
+++ b/mitmproxy/addons/tlsconfig.py
@@ -118,11 +118,11 @@ class TlsConfig:
                 )
         )
 
-    def tls_start(self, tls_start: tls.TlsStartData):
-        if tls_start.conn == tls_start.context.client:
-            self.create_client_proxy_ssl_conn(tls_start)
-        else:
-            self.create_proxy_server_ssl_conn(tls_start)
+    def tls_start_client(self, tls_start: tls.TlsStartData):
+        self.create_client_proxy_ssl_conn(tls_start)
+
+    def tls_start_server(self, tls_start: tls.TlsStartData):
+        self.create_proxy_server_ssl_conn(tls_start)
 
     def create_client_proxy_ssl_conn(self, tls_start: tls.TlsStartData) -> None:
         client: connection.Client = tls_start.context.client

--- a/test/mitmproxy/addons/test_tlsconfig.py
+++ b/test/mitmproxy/addons/test_tlsconfig.py
@@ -126,7 +126,7 @@ class TestTlsConfig:
             ctx = context.Context(connection.Client(("client", 1234), ("127.0.0.1", 8080), 1605699329), tctx.options)
 
             tls_start = tls.TlsStartData(ctx.client, context=ctx)
-            ta.tls_start(tls_start)
+            ta.tls_start_client(tls_start)
             tssl_server = tls_start.ssl_conn
             tssl_client = test_tls.SSLTest()
             assert self.do_handshake(tssl_client, tssl_server)
@@ -141,7 +141,7 @@ class TestTlsConfig:
             ctx.server.address = ("example.mitmproxy.org", 443)
 
             tls_start = tls.TlsStartData(ctx.server, context=ctx)
-            ta.tls_start(tls_start)
+            ta.tls_start_server(tls_start)
             tssl_client = tls_start.ssl_conn
             tssl_server = test_tls.SSLTest(server_side=True)
             with pytest.raises(SSL.Error, match="certificate verify failed"):
@@ -156,7 +156,7 @@ class TestTlsConfig:
                 "mitmproxy/net/data/verificationcerts/trusted-root.crt"))
 
             tls_start = tls.TlsStartData(ctx.server, context=ctx)
-            ta.tls_start(tls_start)
+            ta.tls_start_server(tls_start)
             tssl_client = tls_start.ssl_conn
             tssl_server = test_tls.SSLTest(server_side=True)
             assert self.do_handshake(tssl_client, tssl_server)
@@ -175,7 +175,7 @@ class TestTlsConfig:
                 ciphers_server="ALL"
             )
             tls_start = tls.TlsStartData(ctx.server, context=ctx)
-            ta.tls_start(tls_start)
+            ta.tls_start_server(tls_start)
             tssl_client = tls_start.ssl_conn
             tssl_server = test_tls.SSLTest(server_side=True)
             assert self.do_handshake(tssl_client, tssl_server)
@@ -191,7 +191,7 @@ class TestTlsConfig:
                 tctx.configure(ta, http2=http2)
                 ctx.client.alpn_offers = client_offers
                 ctx.server.alpn_offers = None
-                ta.tls_start(tls_start)
+                ta.tls_start_server(tls_start)
                 assert ctx.server.alpn_offers == expected
 
             assert_alpn(True, tls.HTTP_ALPNS + (b"foo",), tls.HTTP_ALPNS + (b"foo",))
@@ -222,7 +222,7 @@ class TestTlsConfig:
             )
 
             tls_start = tls.TlsStartData(ctx.server, context=ctx)
-            ta.tls_start(tls_start)
+            ta.tls_start_server(tls_start)
             tssl_client = tls_start.ssl_conn
             tssl_server = test_tls.SSLTest(server_side=True)
 


### PR DESCRIPTION
#### Description

Tests pass and I did a smoke test with one website.

I think this also made the internal code cleaner, there were multiple if/else blocks for these two cases.

There's one open question that only you can decide: does it make sense that `TlsStartData` is used for both hooks? Or is something about that superfluous?

#### Checklist

 - [x] I have updated tests where applicable.
 - [ ] ~I have added an entry to the CHANGELOG.~ Basically "New Proxy Core (@mhils)"

I'll accept :cake: or :broccoli: 