### PR TITLE
Document what a websocket_error is

### DIFF
--- a/mitmproxy/proxy/layers/websocket.py
+++ b/mitmproxy/proxy/layers/websocket.py
@@ -47,7 +47,7 @@ class WebsocketEndHook(StartHook):
 @dataclass
 class WebsocketErrorHook(StartHook):
     """
-    A WebSocket connection has had an error.
+    A WebSocket connection has had an error (a close code other than 1000, 1001 or 1005).
 
     Every WebSocket flow will receive either a websocket_error or a websocket_end event, but not both.
     """


### PR DESCRIPTION
Honestly I don't know how I feel about `websocket_error`. Before digging into the code I was expecting this to be an actual error (e.g. the TCP connection dropped unexpectedly or there was a malformed packet).

Why 1000, 1001 or 1005 in particular? Do you have a source why these three are considered success? The entire 4000 - 4999 range is "Available for use by applications" but considered an error by mitmproxy.

Maybe I'm also misunderstanding the use of `WebsocketErrorHook` in websocket.py vs eventsequence.py

Right now this is literally my addon code

```py
  def websocket_error(self, flow: mitmproxy.http.HTTPFlow):
    self.websocket_end(flow)
```

#### Description

<!-- describe your changes here -->

#### Checklist

 - [ ] I have updated tests where applicable.
 - [ ] I have added an entry to the CHANGELOG.
