### PR TITLE
Improve TLS handshake warnings

### DIFF
--- a/test/mitmproxy/proxy/layers/test_tls.py
+++ b/test/mitmproxy/proxy/layers/test_tls.py
@@ -533,7 +533,8 @@ class TestClientTLS:
                 >> reply_tls_start_client()
                 << commands.SendData(tctx.client, tutils.Placeholder())
                 >> events.ConnectionClosed(tctx.client)
-                << commands.Log("Client TLS handshake failed. The client may not trust the proxy's certificate "
-                                "for wrong.host.mitmproxy.org (connection closed)", "warn")
+                << commands.Log("Client TLS handshake failed. The client disconnected during the handshake. "
+                                "If this happens consistently for wrong.host.mitmproxy.org, this may indicate that the "
+                                "client does not trust the proxy's certificate.", "info")
                 << commands.CloseConnection(tctx.client)
         )


### PR DESCRIPTION
This PR brings two improvements when we have TLS handshake failures:

 - If we did not send a ServerHello yet, the root cause is unrelated to the certificate, so we don't emit an "untrusted?" warning in this case anymore.
 - A clearer and less prominent error message if we already sent a ServerHello.