### PR TITLE
Allow no-op assignments to Server.address when connection open

### DIFF
--- a/mitmproxy/connection.py
+++ b/mitmproxy/connection.py
@@ -291,8 +291,11 @@ class Server(Connection):
         return f"Server({human.format_address(self.address)}, state={self.state.name.lower()}{tls_state}{local_port})"
 
     def __setattr__(self, name, value):
-        if name == "address" and self.__dict__.get("state", ConnectionState.CLOSED) is ConnectionState.OPEN:
-            raise RuntimeError("Cannot change server address on open connection.")
+        if name == "address":
+            connection_open = self.__dict__.get("state", ConnectionState.CLOSED) is ConnectionState.OPEN
+            address_changed = self.__dict__.get("address") != value
+            if connection_open and address_changed:
+                raise RuntimeError("Cannot change server address on open connection.")
         return super().__setattr__(name, value)
 
     def get_state(self):

--- a/mitmproxy/connection.py
+++ b/mitmproxy/connection.py
@@ -293,6 +293,7 @@ class Server(Connection):
     def __setattr__(self, name, value):
         if name == "address":
             connection_open = self.__dict__.get("state", ConnectionState.CLOSED) is ConnectionState.OPEN
+            # assigning the current value is okay, that may be an artifact of calling .set_state().
             address_changed = self.__dict__.get("address") != value
             if connection_open and address_changed:
                 raise RuntimeError("Cannot change server address on open connection.")

--- a/test/mitmproxy/test_connection.py
+++ b/test/mitmproxy/test_connection.py
@@ -85,3 +85,5 @@ class TestServer:
         s.state = ConnectionState.OPEN
         with pytest.raises(RuntimeError):
             s.address = ("example.com", 80)
+        # No-op assignment, allowed because it might be triggered by a Server.set_state() call.
+        s.address = ("example.com", 443)


### PR DESCRIPTION
First of all, congrats on shipping 7.0! Lots of nice improvements and I'm seeing the benefits of sans-io in making my own mitmproxy integrations more testable :smile:

#### Description

Calling `Flow.set_state(state)` on a flow implicitly calls `Server.set_state()` if there's an existing server connection. In the `response` addon hook the `Flow`'s `server_conn.state == ConnectionState.OPEN`, which causes the `Server.address` mutation check to `raise` if you call `flow.set_state(state)`.

This works around that issue by checking if the `Server.address` attribute's value is actually being changed rather than just checking if it's being set.

#### Checklist

 - [x] I have updated tests where applicable.
 - [ ] I have added an entry to the CHANGELOG.
