### PR TITLE
Add option to fall back to checking CN field if SANs are missing

### DIFF
--- a/mitmproxy/addons/tlsconfig.py
+++ b/mitmproxy/addons/tlsconfig.py
@@ -102,6 +102,12 @@ class TlsConfig:
             choices=[x.name for x in net_tls.Version],
             help=f"Set the maximum TLS version for server connections.",
         )
+        loader.add_option(
+            name="tls_allow_cn_fallback",
+            typespec=bool,
+            default=False,
+            help=f"Allow checking an upstream certificate's CN field if SANs are missing",
+        )
 
     def tls_clienthello(self, tls_clienthello: tls.ClientHelloData):
         conn_context = tls_clienthello.context
@@ -217,6 +223,7 @@ class TlsConfig:
             ca_pemfile=ctx.options.ssl_verify_upstream_trusted_ca,
             client_cert=client_cert,
             alpn_protos=server.alpn_offers,
+            allow_cn_fallback=ctx.options.tls_allow_cn_fallback,
         )
 
         tls_start.ssl_conn = SSL.Connection(ssl_ctx)

--- a/test/mitmproxy/net/test_tls.py
+++ b/test/mitmproxy/net/test_tls.py
@@ -41,6 +41,7 @@ def test_sslkeylogfile(tdata, monkeypatch):
         ca_pemfile=None,
         client_cert=None,
         alpn_protos=(),
+        allow_cn_fallback=False,
     )
     sctx = tls.create_client_proxy_context(
         min_version=tls.DEFAULT_MIN_VERSION,


### PR DESCRIPTION
#### Description

This optionally increases compatibility with upstream certificates generated by legacy upstreams which only specify the `CN` field.

https://github.com/mitmproxy/mitmproxy/commit/e768f5ba83dd92d380f3e03da5da6c68edb3f45b (correctly) disabled falling back to checking the `CN` field in the absence of `subjectAltName` extensions to match browsers' behaviour. I deal with upstream TLS servers that generate certificates with no `subjectAltName` extensions. The clients manually handle peer verification and only look at the `CN` field. Not ideal, but I'm not able to change either the client or the server.

To deal with that I'm currently monkeypatching the `X509_VERIFY_PARAM_set_hostflags` function in an addon to mask off the `X509_CHECK_FLAG_NEVER_CHECK_SUBJECT` flag, this is a configurable way to do the same without having to monkeypatch pyOpenSSL internals.

What would be the best way to make a test for this? Changing [`test/mitmproxy/net/data/verificationcerts/generate.py`](https://github.com/mitmproxy/mitmproxy/blob/main/test/mitmproxy/net/data/verificationcerts/generate.py) to also generate a cert with no SAN seems like a good start, but I don't see any existing testcases for upstream cert verification.

#### Checklist

 - [ ] I have updated tests where applicable.
 - [ ] I have added an entry to the CHANGELOG.
