### PR TITLE
Add WebSocketMessage.injected flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## Unreleased: mitmproxy next
+
+* Allow no-op assignments to `Server.address` when connection open (@SaladDais)
+* Added `WebSocketMessage.injected` flag (@Prinzhorn)
+* --- TODO: add new PRs above this line ---
+
 ## 16 July 2021: mitmproxy 7.0
 
 ### New Proxy Core (@mhils, [blog post](https://www.mitmproxy.org/posts/releases/mitmproxy7/))

--- a/mitmproxy/addons/proxyserver.py
+++ b/mitmproxy/addons/proxyserver.py
@@ -197,7 +197,8 @@ class Proxyserver:
         msg = websocket.WebSocketMessage(
             Opcode.TEXT if is_text else Opcode.BINARY,
             not to_client,
-            message
+            message,
+            injected=True
         )
         event = WebSocketMessageInjected(flow, msg)
         try:

--- a/mitmproxy/proxy/layers/websocket.py
+++ b/mitmproxy/proxy/layers/websocket.py
@@ -125,8 +125,10 @@ class WebsocketLayer(layer.Layer):
 
         if isinstance(event, events.ConnectionEvent):
             from_client = event.connection == self.context.client
+            injected = False
         elif isinstance(event, WebSocketMessageInjected):
             from_client = event.message.from_client
+            injected = True
         else:
             raise AssertionError(f"Unexpected event: {event}")
 
@@ -166,7 +168,7 @@ class WebsocketLayer(layer.Layer):
                     fragmentizer = Fragmentizer(src_ws.frame_buf, is_text)
                     src_ws.frame_buf.clear()
 
-                    message = websocket.WebSocketMessage(typ, from_client, content)
+                    message = websocket.WebSocketMessage(typ, from_client, content, injected=injected)
                     self.flow.websocket.messages.append(message)
                     yield WebsocketMessageHook(self.flow)
 

--- a/mitmproxy/websocket.py
+++ b/mitmproxy/websocket.py
@@ -14,7 +14,7 @@ from mitmproxy import stateobject
 from mitmproxy.coretypes import serializable
 from wsproto.frame_protocol import Opcode
 
-WebSocketMessageState = Tuple[int, bool, bytes, float, bool]
+WebSocketMessageState = Tuple[int, bool, bytes, float, bool, bool]
 
 
 class WebSocketMessage(serializable.Serializable):
@@ -47,6 +47,8 @@ class WebSocketMessage(serializable.Serializable):
     """Timestamp of when this message was received or created."""
     dropped: bool
     """True if the message has not been forwarded by mitmproxy, False otherwise."""
+    injected: bool
+    """True if the message was injected and did not originate from a client/server, False otherwise"""
 
     def __init__(
         self,
@@ -54,23 +56,25 @@ class WebSocketMessage(serializable.Serializable):
         from_client: bool,
         content: bytes,
         timestamp: Optional[float] = None,
-        killed: bool = False,
+        dropped: bool = False,
+        injected: bool = False,
     ) -> None:
         self.from_client = from_client
         self.type = Opcode(type)
         self.content = content
         self.timestamp: float = timestamp or time.time()
-        self.dropped = killed
+        self.dropped = dropped
+        self.injected = injected
 
     @classmethod
     def from_state(cls, state: WebSocketMessageState):
         return cls(*state)
 
     def get_state(self) -> WebSocketMessageState:
-        return int(self.type), self.from_client, self.content, self.timestamp, self.dropped
+        return int(self.type), self.from_client, self.content, self.timestamp, self.dropped, self.injected
 
     def set_state(self, state: WebSocketMessageState) -> None:
-        typ, self.from_client, self.content, self.timestamp, self.dropped = state
+        typ, self.from_client, self.content, self.timestamp, self.dropped, self.injected = state
         self.type = Opcode(typ)
 
     def __repr__(self):


### PR DESCRIPTION
#### Description

I don't think we're going to migrate away from flags anytime soon, so let's add the `injected` flag. These changes wor as expected for me. However:

1. There are currently no tests for `inject.websocket`, I might need some assistance
2. I think this needs a migration for the flow format, right? Because WebSocketMessage serializable changed? Not even sure where to look for them, but I wanted to have this work now :smile: 
3. I was confused for a minute why my injected flag was overridden. Couldn't `relay_messages` early exit if `isinstance(event, WebSocketMessageInjected)` and just clone the WebSocketMessage instead of going through all that logic again? E.g. why involve `Fragmentizer` at all for injected messages?

#### Checklist

 - [ ] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
