### PR TITLE
Fix Secure Web Proxy compatibility with some clients (#4689)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## Unreleased: mitmproxy next
 
-* Don't negotiate HTTP/2 on the outer TLS connection in Secure Web Proxy Mode.
-  This fixes compatibility with Firefox.
-
+* Use local IP address as certificate subject if no other info is available (@mhils).
+* Disable HTTP/2 CONNECT for Secure Web Proxies to fix compatibility with Firefox. (@mhils)
+* Allow no-op assignments to `Server.address` when connection is open. (@SaladDais)
 
 ## 16 July 2021: mitmproxy 7.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## Unreleased: mitmproxy next
+
+* Don't negotiate HTTP/2 on the outer TLS connection in Secure Web Proxy Mode.
+  This fixes compatibility with Firefox.
+
+
 ## 16 July 2021: mitmproxy 7.0
 
 ### New Proxy Core (@mhils, [blog post](https://www.mitmproxy.org/posts/releases/mitmproxy7/))

--- a/mitmproxy/addons/tlsconfig.py
+++ b/mitmproxy/addons/tlsconfig.py
@@ -118,13 +118,8 @@ class TlsConfig:
                 )
         )
 
-    def tls_start_client(self, tls_start: tls.TlsStartData):
-        self.create_client_proxy_ssl_conn(tls_start)
-
-    def tls_start_server(self, tls_start: tls.TlsStartData):
-        self.create_proxy_server_ssl_conn(tls_start)
-
-    def create_client_proxy_ssl_conn(self, tls_start: tls.TlsStartData) -> None:
+    def tls_start_client(self, tls_start: tls.TlsStartData) -> None:
+        """Establish TLS between client and proxy."""
         client: connection.Client = tls_start.context.client
         server: connection.Server = tls_start.context.server
 
@@ -161,7 +156,8 @@ class TlsConfig:
         ))
         tls_start.ssl_conn.set_accept_state()
 
-    def create_proxy_server_ssl_conn(self, tls_start: tls.TlsStartData) -> None:
+    def tls_start_server(self, tls_start: tls.TlsStartData) -> None:
+        """Establish TLS between proxy and server."""
         client: connection.Client = tls_start.context.client
         server: connection.Server = tls_start.context.server
         assert server.address
@@ -296,9 +292,10 @@ class TlsConfig:
         elif conn_context.server.address:
             altnames.append(conn_context.server.address[0])
 
-        # As a last resort, add *something* so that we have a certificate to serve.
+        # As a last resort, add our local IP address. This may be necessary for HTTPS Proxies which are addressed
+        # via IP. Here we neither have an upstream cert, nor can an IP be included in the server name indication.
         if not altnames:
-            altnames.append("mitmproxy")
+            altnames.append(conn_context.client.sockname[0])
 
         # only keep first occurrence of each hostname
         altnames = list(dict.fromkeys(altnames))

--- a/mitmproxy/certs.py
+++ b/mitmproxy/certs.py
@@ -49,6 +49,9 @@ class Cert(serializable.Serializable):
     def __eq__(self, other):
         return self.fingerprint() == other.fingerprint()
 
+    def __repr__(self):
+        return f"<Cert(cn={self.cn!r}, altnames={self.altnames!r})>"
+
     @classmethod
     def from_state(cls, state):
         return cls.from_pem(state)

--- a/mitmproxy/proxy/layers/tls.py
+++ b/mitmproxy/proxy/layers/tls.py
@@ -346,6 +346,23 @@ class ClientTLSLayer(_TLSLayer):
     client_hello_parsed: bool = False
 
     def __init__(self, context: context.Context):
+        if context.client.tls:
+            # In the case of TLS-over-TLS, we already have client TLS. As the outer TLS connection between client
+            # and proxy isn't that interesting to us, we just unset the attributes here and keep the inner TLS
+            # session's attributes.
+            # Alternatively we could create a new Client instance,
+            # but for now we keep it simple. There is a proof-of-concept at
+            # https://github.com/mitmproxy/mitmproxy/commit/9b6e2a716888b7787514733b76a5936afa485352.
+            context.client.alpn = None
+            context.client.cipher = None
+            context.client.sni = None
+            context.client.timestamp_tls_setup = None
+            context.client.tls_version = None
+            context.client.certificate_list = []
+            context.client.mitmcert = None
+            context.client.alpn_offers = []
+            context.client.cipher_list = []
+
         super().__init__(context, context.client)
         self.server_tls_available = isinstance(self.context.layers[-2], ServerTLSLayer)
         self.recv_buffer = bytearray()

--- a/test/mitmproxy/addons/test_tlsconfig.py
+++ b/test/mitmproxy/addons/test_tlsconfig.py
@@ -66,9 +66,10 @@ class TestTlsConfig:
 
             ctx = context.Context(connection.Client(("client", 1234), ("127.0.0.1", 8080), 1605699329), tctx.options)
 
-            # Edge case first: We don't have _any_ idea about the server, so we just return "mitmproxy" as subject.
+            # Edge case first: We don't have _any_ idea about the server nor is there a SNI,
+            # so we just return our local IP as subject.
             entry = ta.get_cert(ctx)
-            assert entry.cert.cn == "mitmproxy"
+            assert entry.cert.cn == "127.0.0.1"
 
             # Here we have an existing server connection...
             ctx.server.address = ("server-address.example", 443)

--- a/test/mitmproxy/test_certs.py
+++ b/test/mitmproxy/test_certs.py
@@ -180,6 +180,7 @@ class TestCert:
         assert c2.issuer
         assert c2.to_pem()
         assert c2.has_expired() is not None
+        assert repr(c2) == "<Cert(cn='www.inode.co.nz', altnames=['www.inode.co.nz', 'inode.co.nz'])>"
 
         assert c1 != c2
 


### PR DESCRIPTION
This PR fixes the two issues described in #4689:

1. When the client did not send a SNI and we don't know anything about an upstream server, we now use our local IP address as the certificate subject. This is necessary for secure web proxies that are interfaced by IP address as the TLS SNI must not contain a raw IP address.
2. Firefox apparently now supports HTTP/2 proxies, i.e. proxies where the `CONNECT` request is handled via HTTP/2 as well. We don't support that (yet), so with this PR we make sure that we don't negotiate a `h2` ALPN. I'm not sure if we want to support the HTTP/2 proxy protocol in the future, things get quite unwieldy once we have a ton of TLS negotiations in a single connection. We'd essentially need to clone our `context.Client` object for each CONNECT stream so that we have separate TLS attributes everywhere, this just all gets rather ugly for no apparent benefit.

fixes #4689