### PR TITLE
Fix #4614 Options and Keybinding screen: home and end crash mitmproxy

### DIFF
--- a/mitmproxy/tools/console/keybindings.py
+++ b/mitmproxy/tools/console/keybindings.py
@@ -66,6 +66,8 @@ class KeyListWalker(urwid.ListWalker):
         self.index = index
         self.focus_obj = self._get(self.index)
         keybinding_focus_change.send(binding.help or "")
+        self._modified()
+
 
     def get_next(self, pos):
         if pos >= len(self.bindings) - 1:
@@ -78,6 +80,12 @@ class KeyListWalker(urwid.ListWalker):
         if pos < 0:
             return None, None
         return self._get(pos), pos
+
+    def positions(self, reverse=False):
+        if reverse:
+            return reversed(range(len(self.bindings)))
+        else:
+            return range(len(self.bindings))
 
 
 class KeyList(urwid.ListBox):

--- a/mitmproxy/tools/console/keybindings.py
+++ b/mitmproxy/tools/console/keybindings.py
@@ -68,7 +68,6 @@ class KeyListWalker(urwid.ListWalker):
         keybinding_focus_change.send(binding.help or "")
         self._modified()
 
-
     def get_next(self, pos):
         if pos >= len(self.bindings) - 1:
             return None, None

--- a/mitmproxy/tools/console/options.py
+++ b/mitmproxy/tools/console/options.py
@@ -144,7 +144,6 @@ class OptionListWalker(urwid.ListWalker):
         option_focus_change.send(opt.help)
         self._modified()
 
-
     def get_next(self, pos):
         if pos >= len(self.opts) - 1:
             return None, None
@@ -162,6 +161,7 @@ class OptionListWalker(urwid.ListWalker):
             return reversed(range(len(self.opts)))
         else:
             return range(len(self.opts))
+
 
 class OptionsList(urwid.ListBox):
     def __init__(self, master):

--- a/mitmproxy/tools/console/options.py
+++ b/mitmproxy/tools/console/options.py
@@ -142,6 +142,8 @@ class OptionListWalker(urwid.ListWalker):
         self.index = index
         self.focus_obj = self._get(self.index, self.editing)
         option_focus_change.send(opt.help)
+        self._modified()
+
 
     def get_next(self, pos):
         if pos >= len(self.opts) - 1:
@@ -155,6 +157,11 @@ class OptionListWalker(urwid.ListWalker):
             return None, None
         return self._get(pos, False), pos
 
+    def positions(self, reverse=False):
+        if reverse:
+            return reversed(range(len(self.opts)))
+        else:
+            return range(len(self.opts))
 
 class OptionsList(urwid.ListBox):
     def __init__(self, master):

--- a/test/mitmproxy/tools/console/test_integration.py
+++ b/test/mitmproxy/tools/console/test_integration.py
@@ -44,8 +44,10 @@ def test_integration(tdata, console):
     console.type("<enter><tab><tab>")
     console.type("<space><tab><tab>")  # view second flow
 
+
 def test_options_home_end(console):
     console.type("O<home><end>")
+
 
 def test_keybindings_home_end(console):
     console.type("K<home><end>")

--- a/test/mitmproxy/tools/console/test_integration.py
+++ b/test/mitmproxy/tools/console/test_integration.py
@@ -43,3 +43,9 @@ def test_integration(tdata, console):
     console.type(f":view.flows.load {tdata.path('mitmproxy/data/dumpfile-7.mitm')}<enter>")
     console.type("<enter><tab><tab>")
     console.type("<space><tab><tab>")  # view second flow
+
+def test_options_home_end(console):
+    console.type("O<home><end>")
+
+def test_keybindings_home_end(console):
+    console.type("K<home><end>")


### PR DESCRIPTION
#### Description

Per #4614 this change fixes a crash that results from using home or end keys in the options or keybindings windows.

#### Checklist

 - [x] I have updated tests where applicable.
 - [ ] ~~I have added an entry to the CHANGELOG~~. (bug fix)
