### PR TITLE
Perf: reuse OpenSSL context to reduce number of TLS handshakes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Use local IP address as certificate subject if no other info is available (@mhils).
 * Disable HTTP/2 CONNECT for Secure Web Proxies to fix compatibility with Firefox. (@mhils)
 * Allow no-op assignments to `Server.address` when connection is open. (@SaladDais)
+* Performance: Re-use OpenSSL context to enable TLS session resumption. (@mhils)
 
 ## 16 July 2021: mitmproxy 7.0
 

--- a/mitmproxy/addons/tlsconfig.py
+++ b/mitmproxy/addons/tlsconfig.py
@@ -140,13 +140,13 @@ class TlsConfig:
         ssl_ctx = net_tls.create_client_proxy_context(
             min_version=net_tls.Version[ctx.options.tls_version_client_min],
             max_version=net_tls.Version[ctx.options.tls_version_client_max],
-            cipher_list=cipher_list,
+            cipher_list=tuple(cipher_list),
             cert=entry.cert,
             key=entry.privatekey,
             chain_file=entry.chain_file,
             request_client_cert=False,
             alpn_select_callback=alpn_select_callback,
-            extra_chain_certs=extra_chain_certs,
+            extra_chain_certs=tuple(extra_chain_certs),
             dhparams=self.certstore.dhparams,
         )
         tls_start.ssl_conn = SSL.Connection(ssl_ctx)
@@ -216,13 +216,13 @@ class TlsConfig:
         ssl_ctx = net_tls.create_proxy_server_context(
             min_version=net_tls.Version[ctx.options.tls_version_client_min],
             max_version=net_tls.Version[ctx.options.tls_version_client_max],
-            cipher_list=cipher_list,
+            cipher_list=tuple(cipher_list),
             verify=verify,
             hostname=server.sni,
             ca_path=ctx.options.ssl_verify_upstream_trusted_confdir,
             ca_pemfile=ctx.options.ssl_verify_upstream_trusted_ca,
             client_cert=client_cert,
-            alpn_protos=server.alpn_offers,
+            alpn_protos=tuple(server.alpn_offers),
         )
 
         tls_start.ssl_conn = SSL.Connection(ssl_ctx)

--- a/mitmproxy/certs.py
+++ b/mitmproxy/certs.py
@@ -52,6 +52,9 @@ class Cert(serializable.Serializable):
     def __repr__(self):
         return f"<Cert(cn={self.cn!r}, altnames={self.altnames!r})>"
 
+    def __hash__(self):
+        return self._cert.__hash__()
+
     @classmethod
     def from_state(cls, state):
         return cls.from_pem(state)

--- a/mitmproxy/net/tls.py
+++ b/mitmproxy/net/tls.py
@@ -3,8 +3,9 @@ import ipaddress
 import os
 import threading
 from enum import Enum
+from functools import lru_cache
 from pathlib import Path
-from typing import Iterable, Callable, Optional, Sequence, Tuple, List, Any, BinaryIO
+from typing import Iterable, Callable, Optional, Tuple, List, Any, BinaryIO
 
 import certifi
 
@@ -127,17 +128,18 @@ def _create_ssl_context(
     return context
 
 
+@lru_cache(256)
 def create_proxy_server_context(
         *,
         min_version: Version,
         max_version: Version,
-        cipher_list: Optional[Iterable[str]],
+        cipher_list: Optional[Tuple[str, ...]],
         verify: Verify,
         hostname: Optional[str],
         ca_path: Optional[str],
         ca_pemfile: Optional[str],
         client_cert: Optional[str],
-        alpn_protos: Optional[Sequence[bytes]],
+        alpn_protos: Optional[Tuple[bytes, ...]],
 ) -> SSL.Context:
     context: SSL.Context = _create_ssl_context(
         method=Method.TLS_CLIENT_METHOD,
@@ -194,17 +196,18 @@ def create_proxy_server_context(
     return context
 
 
+@lru_cache(256)
 def create_client_proxy_context(
         *,
         min_version: Version,
         max_version: Version,
-        cipher_list: Optional[Iterable[str]],
+        cipher_list: Optional[Tuple[str, ...]],
         cert: certs.Cert,
         key: rsa.RSAPrivateKey,
         chain_file: Optional[Path],
         alpn_select_callback: Optional[Callable[[SSL.Connection, List[bytes]], Any]],
         request_client_cert: bool,
-        extra_chain_certs: Iterable[certs.Cert],
+        extra_chain_certs: Tuple[certs.Cert, ...],
         dhparams: certs.DHParams,
 ) -> SSL.Context:
     context: SSL.Context = _create_ssl_context(

--- a/test/mitmproxy/test_certs.py
+++ b/test/mitmproxy/test_certs.py
@@ -165,6 +165,7 @@ class TestCert:
         assert c1.cn == "google.com"
         assert len(c1.altnames) == 436
         assert c1.organization == "Google Inc"
+        assert hash(c1)
 
         with open(tdata.path("mitmproxy/net/data/text_cert_2"), "rb") as f:
             d = f.read()


### PR DESCRIPTION
I initially wanted to reuse a single OpenSSL context for all client requests, but that does not work as some of the APIs we are using are not connection-specific (e.g. `SSL_CTX_add_extra_chain_cert` has no `SSL_add_extra_chain_cert` equivalent). Turns out we can tackle this entire problem much easier by just caching per host! We only need to cache calls to `create_proxy_server_context` and `create_client_proxy_context`. This allows us to perform session resumption instead of full TLS handshakes in a significant number of cases.