### PR TITLE
Add CI for Python 3.10rc1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,6 +66,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - os: ubuntu-latest
+            py: '3.10.0-rc - 3.10'
           - os: windows-latest
             py: 3.9
           - os: macos-latest

--- a/mitmproxy/proxy/events.py
+++ b/mitmproxy/proxy/events.py
@@ -72,9 +72,11 @@ class CommandCompleted(Event):
         return super().__new__(cls)
 
     def __init_subclass__(cls, **kwargs):
-        command_cls = cls.__annotations__["command"]
+        command_cls = cls.__annotations__.get("command", None)
         valid_command_subclass = (
-                issubclass(command_cls, commands.Command) and command_cls is not commands.Command
+                isinstance(command_cls, type)
+                and issubclass(command_cls, commands.Command)
+                and command_cls is not commands.Command
         )
         if not valid_command_subclass:
             warnings.warn(f"{command_cls} needs a properly annotated command attribute.", RuntimeWarning)


### PR DESCRIPTION
We will try to switch all builders to 3.10 once the final hits, but for now let's just run tests and see what happens.