### PR TITLE
Implement quick help bar prototype

### DIFF
--- a/mitmproxy/tools/console/window.py
+++ b/mitmproxy/tools/console/window.py
@@ -131,10 +131,30 @@ class WindowStack:
 class Window(urwid.Frame):
     def __init__(self, master):
         self.statusbar = statusbar.StatusBar(master)
+        self.quick_help = urwid.Text([
+            ("heading", u"?"),
+            u" Help ",
+            ("heading", u"k"),
+            u" Up ",
+            ("heading", u"j"),
+            u" Down ",
+            ("heading", u"h"),
+            u" Left ",
+            ("heading", u"l"),
+            u" Right ",
+            ("heading", u"q"),
+            u" Exit current view ",
+            ("heading", u"enter"),
+            u" Select ",
+            ("heading", u"tab"),
+            u" Next "])
+
         super().__init__(
             None,
             header=None,
-            footer=urwid.AttrWrap(self.statusbar, "background")
+            footer = urwid.Pile([
+                self.statusbar,
+                self.quick_help])
         )
         self.master = master
         self.master.view.sig_view_refresh.connect(self.view_changed)


### PR DESCRIPTION
#### Description
A prototype of a quick help bar as mentioned in issue #4515.

At the moment, it looks similar to the quick help bar seen in nano. Also it is a fixed widget so it will remain at the footer for as long as the mitmproxy is open. Perhaps a future improvement would be to display it until the user presses a key? Or after a certain amount of time has passed?

Please feel free to provide feedback and thoughts, I'd be happy to hear them. :smiley: 
<!-- describe your changes here -->

#### Checklist

 - [ ] I have updated tests where applicable.
 - [ ] I have added an entry to the CHANGELOG.
