### PR TITLE
Expose full ClientHello object in tls_clienthello hook

### DIFF
--- a/mitmproxy/proxy/layers/tls.py
+++ b/mitmproxy/proxy/layers/tls.py
@@ -100,7 +100,14 @@ HTTP_ALPNS = (b"h2",) + HTTP1_ALPNS
 @dataclass
 class ClientHelloData:
     context: context.Context
+    """The context object for this connection."""
+    client_hello: net_tls.ClientHello
+    """The entire parsed TLS ClientHello."""
     establish_server_tls_first: bool = False
+    """
+    If set to `True`, pause this handshake and establish TLS with an upstream server first.
+    This makes it possible to process the server certificate when generating an interception certificate.
+    """
 
 
 @dataclass
@@ -386,7 +393,7 @@ class ClientTLSLayer(_TLSLayer):
 
         self.conn.sni = client_hello.sni
         self.conn.alpn_offers = client_hello.alpn_protocols
-        tls_clienthello = ClientHelloData(self.context)
+        tls_clienthello = ClientHelloData(self.context, client_hello)
         yield TlsClienthelloHook(tls_clienthello)
 
         if tls_clienthello.establish_server_tls_first and not self.context.server.tls_established:

--- a/test/mitmproxy/addons/test_tlsconfig.py
+++ b/test/mitmproxy/addons/test_tlsconfig.py
@@ -93,7 +93,7 @@ class TestTlsConfig:
         ta = tlsconfig.TlsConfig()
         with taddons.context(ta) as tctx:
             ctx = context.Context(connection.Client(("client", 1234), ("127.0.0.1", 8080), 1605699329), tctx.options)
-            ch = tls.ClientHelloData(ctx)
+            ch = tls.ClientHelloData(ctx, None)  # type: ignore
             ta.tls_clienthello(ch)
             assert not ch.establish_server_tls_first
 


### PR DESCRIPTION
This PR makes it possible to access the raw [`ClientHello`](https://github.com/mitmproxy/mitmproxy/blob/c4dd46c3db97eabedf14fc54a23dae8d167fdad2/mitmproxy/net/tls.py#L284) object in the `tls_clienthello` hook as `data.client_hello`.

```python
def tls_clienthello(data):
    print(data.client_hello)
```