### PR TITLE
Optmanager Modifications for Deferred Options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 4 August 2021: mitmproxy 7.0.2
 
 * Fix a WebSocket crash introduced in 7.0.1 (@mhils)
+* Fix a logic error when processing deferred options in optmanager (@af001)
 
 ## 3 August 2021: mitmproxy 7.0.1
 

--- a/mitmproxy/optmanager.py
+++ b/mitmproxy/optmanager.py
@@ -319,11 +319,10 @@ class OptManager:
             have since been added.
         """
         update = {}
-        for optname, optvals in self.deferred.items():
+        for optname, optval in self.deferred.items():
             if optname in self._options:
-                for optval in optvals:
-                    optval = self.parse_setval(self._options[optname], optval, update.get(optname))
-                    update[optname] = optval
+                optval = self.parse_setval(self._options[optname], optval, update.get(optname))
+                update[optname] = optval
         self.update(**update)
         for k in update.keys():
             del self.deferred[k]


### PR DESCRIPTION
#### Description

The modifications made from the June 23 commit to address #4210 include a for loop that results in inaccurate string values and a TypeError for integer values when reading user-defined options from config.yaml. Options that are known are updated immediately, but the user-defined options are deferred and incorrectly processed due to the new logic. As a result, user-defined options that are strings only displays the last character, and integers trigger a TypeError. 

#### Steps to recreate
1. Copy config.yaml to ~/.mitmproxy
2. Copy test.py to ~/.mitmproxy
3. Run ```mitmdump```
4. Modify browser proxy to 127.0.0.1:80
5. Navigate to example.com
6. View mitmdump output to observe ctx.options values
7. To trigger the TypeError, add a custom option in config.yaml, i.e. ```test_int: 1200```

**Original**
![original](https://user-images.githubusercontent.com/10587919/128776723-9ffe64e8-3774-4177-b644-eb003f901c9a.png)

**Modified**
![modified](https://user-images.githubusercontent.com/10587919/128776721-64ce49f2-268b-4b5c-a961-dcb4284ef096.png)

**Test Files**
[test.py](https://github.com/mitmproxy/mitmproxy/files/6957540/test.py.txt)
[config.yaml](https://github.com/mitmproxy/mitmproxy/files/6957539/config.yaml.txt)

#### Checklist

 - [ x] I have updated tests where applicable.
 - [x ] I have added an entry to the CHANGELOG.

