### PR TITLE
Fix DeprecationWarning in har_dump.py

### DIFF
--- a/examples/contrib/har_dump.py
+++ b/examples/contrib/har_dump.py
@@ -154,7 +154,7 @@ def response(flow: mitmproxy.http.HTTPFlow):
         }
 
     if flow.server_conn.connected:
-        entry["serverIPAddress"] = str(flow.server_conn.ip_address[0])
+        entry["serverIPAddress"] = str(flow.server_conn.peername[0])
 
     HAR["log"]["entries"].append(entry)
 


### PR DESCRIPTION
#### Description

I noticed `DeprecationWarning` while running har_dump.py:
```python
examples/contrib/har_dump.py:157: DeprecationWarning: Server.ip_address is deprecated, use Server.peername instead.
  entry["serverIPAddress"] = str(flow.server_conn.ip_address[0])
```

#### Checklist

 - [ ] I have updated tests where applicable.
 - [ ] I have added an entry to the CHANGELOG.
