### PR TITLE
Remove asyncio event loop workaround for tornado

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased: mitmproxy next
 
 * fix some responses not being decoded properly if the encoding was uppercase #4735 (@Mattwmaster58)
+* Windows: Switch to Python's default asyncio event loop, which increases the number of sockets
+  that can be processed simultaneously.
 
 ## 4 August 2021: mitmproxy 7.0.2
 

--- a/mitmproxy/__init__.py
+++ b/mitmproxy/__init__.py
@@ -1,9 +1,0 @@
-import asyncio
-import sys
-
-if sys.platform == 'win32':
-    # workaround for
-    # https://github.com/tornadoweb/tornado/issues/2751
-    # https://www.tornadoweb.org/en/stable/index.html#installation
-    # (copied multiple times in the codebase, please remove all occurrences)
-    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())

--- a/test/mitmproxy/tools/web/test_app.py
+++ b/test/mitmproxy/tools/web/test_app.py
@@ -2,17 +2,9 @@ import asyncio
 import json as _json
 import logging
 import os
-import sys
 from unittest import mock
 
 import pytest
-
-if sys.platform == 'win32':
-    # workaround for
-    # https://github.com/tornadoweb/tornado/issues/2751
-    # https://www.tornadoweb.org/en/stable/index.html#installation
-    # (copied multiple times in the codebase, please remove all occurrences)
-    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
 
 import tornado.testing  # noqa
 from tornado import httpclient  # noqa


### PR DESCRIPTION
This is not necessary anymore, and greatly improves the number of open sockets we can handle on Windows.

fixes #4742