### PR TITLE
Update core.py

### DIFF
--- a/mitmproxy/addons/core.py
+++ b/mitmproxy/addons/core.py
@@ -282,6 +282,8 @@ class Core:
             Save options to a file.
         """
         try:
+            if not path:
+        	    path = "%s/config.yaml" % opts.confdir
             optmanager.save(ctx.options, path)
         except OSError as e:
             raise exceptions.CommandError(


### PR DESCRIPTION
When Press "S" to save options to a file, there is no need to always fill the path, and save to the default path: {confdir}/config.yaml

#### Description

<!-- describe your changes here -->

#### Checklist

 - [ ] I have updated tests where applicable.
 - [ ] I have added an entry to the CHANGELOG.
