### PR TITLE
Allow to close WS connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Improve error message on TLS version mismatch.
 * Windows: Switch to Python's default asyncio event loop, which increases the number of sockets
   that can be processed simultaneously.
+* Allow to close WS connections using `inject.websocket` command
 
 ## 4 August 2021: mitmproxy 7.0.2
 

--- a/examples/addons/websocket-inject-message.py
+++ b/examples/addons/websocket-inject-message.py
@@ -15,7 +15,29 @@ def websocket_message(flow: http.HTTPFlow):
     last_message = flow.websocket.messages[-1]
     if last_message.is_text and "secret" in last_message.text:
         last_message.drop()
-        ctx.master.commands.call("inject.websocket", flow, last_message.from_client, "ssssssh".encode())
+        ctx.master.commands.call(
+            "inject.websocket",           # Command to invoke
+            flow,                         # Flow where we want to inject the message
+            last_message.from_client,     # Whether we want to send it to the client
+            "ssssssh".encode()            # Contents of the message
+        )
+
+
+# Simple example: Inject a CLOSE message to close the WS connection
+
+def websocket_message(flow: http.HTTPFlow):
+    assert flow.websocket is not None  # make type checker happy
+    last_message = flow.websocket.messages[-1]
+    if last_message.is_text and "close-connection" in last_message.text:
+        last_message.drop()
+        ctx.master.commands.call(
+            "inject.websocket",           # Command to invoke
+            flow,                         # Flow that we want to close
+            last_message.from_client,     # Whether we want to close the conn to the client
+            "Closed by proxy".encode(),   # Reason message to close the conn
+            False,                        # Whether we want to inject a TEXT opcode -> sending a message
+            True                          # Whether we want to inject a CLOSE opcode -> closing the conn
+        )
 
 
 # Complex example: Schedule a periodic timer
@@ -24,7 +46,12 @@ async def inject_async(flow: http.HTTPFlow):
     msg = "hello from mitmproxy! "
     assert flow.websocket is not None  # make type checker happy
     while flow.websocket.timestamp_end is None:
-        ctx.master.commands.call("inject.websocket", flow, True, msg.encode())
+        ctx.master.commands.call(
+            "inject.websocket",           # Command to invoke
+            flow,                         # Flow where we want to inject the message
+            True,                         # Whether we want to send it to the client
+            msg.encode()                  # Contents of the message
+        )
         await asyncio.sleep(1)
         msg = msg[1:] + msg[:1]
 

--- a/mitmproxy/addons/proxyserver.py
+++ b/mitmproxy/addons/proxyserver.py
@@ -190,12 +190,19 @@ class Proxyserver:
         self._connections[event.flow.client_conn.peername].server_event(event)
 
     @command.command("inject.websocket")
-    def inject_websocket(self, flow: Flow, to_client: bool, message: bytes, is_text: bool = True):
+    def inject_websocket(self, flow: Flow, to_client: bool, message: bytes, is_text: bool = True, close_connection: bool = False):
         if not isinstance(flow, http.HTTPFlow) or not flow.websocket:
             ctx.log.warn("Cannot inject WebSocket messages into non-WebSocket flows.")
 
+        if is_text:
+            ws_msg_type = Opcode.TEXT
+        elif close_connection:
+            ws_msg_type = Opcode.CLOSE
+        else:
+            ws_msg_type = Opcode.BINARY
+
         msg = websocket.WebSocketMessage(
-            Opcode.TEXT if is_text else Opcode.BINARY,
+            ws_msg_type,
             not to_client,
             message
         )


### PR DESCRIPTION
#### Description

Addresses #4773.

Adds another option to the `inject` command to close the connection. This parameter is then managed to encode a CLOSE opcode into the flow that closes the WS connection with a user-defined reason (encoded as bytes).

#### Checklist

 - [ ] I have updated tests where applicable. (?) Didn't find any test related, I updated the docs examples though.
 - [x] I have added an entry to the CHANGELOG.
