### PR TITLE
[mitmweb] Fix hide response type menu

### DIFF
--- a/web/src/css/flowdetail.less
+++ b/web/src/css/flowdetail.less
@@ -14,6 +14,8 @@
         padding: 5px 12px 10px;
 
         > footer {
+            position: absolute;
+            bottom: 0;
             box-shadow: 0 0 3px gray;
             padding: 2px;
             margin: 0;


### PR DESCRIPTION
#### Description

Continuation of the previous PR(#4644):
The problem still exists
When the answer type list is displayed, part of this list will be hidden if the answer is low

## Example:
![Screenshot from 2021-08-27 15-48-39](https://user-images.githubusercontent.com/77061285/131122313-d81a538d-d52b-49f0-aba9-84bfb252c5ec.png)

## Fixed problem result:
![Screenshot from 2021-08-27 15-51-00](https://user-images.githubusercontent.com/77061285/131122351-b0de5178-0e20-4e9c-be94-94ce913516a3.png)

#### Checklist

 - [ ] I have updated tests where applicable.
 - [ ] I have added an entry to the CHANGELOG.
