### PR TITLE
charset detection: ignore case when searching in HTML

### DIFF
--- a/mitmproxy/http.py
+++ b/mitmproxy/http.py
@@ -408,13 +408,13 @@ class Message(serializable.Serializable):
             if "json" in self.headers.get("content-type", ""):
                 enc = "utf8"
         if not enc:
-            meta_charset = re.search(rb"""<meta[^>]+charset=['"]?([^'">]+)""", content)
+            meta_charset = re.search(rb"""<meta[^>]+charset=['"]?([^'">]+)""", content, re.IGNORECASE)
             if meta_charset:
                 enc = meta_charset.group(1).decode("ascii", "ignore")
         if not enc:
             if "text/css" in self.headers.get("content-type", ""):
                 # @charset rule must be the very first thing.
-                css_charset = re.match(rb"""@charset "([^"]+)";""", content)
+                css_charset = re.match(rb"""@charset "([^"]+)";""", content, re.IGNORECASE)
                 if css_charset:
                     enc = css_charset.group(1).decode("ascii", "ignore")
         if not enc:


### PR DESCRIPTION
We previously did not detect `<meta charSet="utf-8"/>` (only `<meta charset="utf-8"/>`), this PR fixes this. 😃 