### PR TITLE
Fix warning in pytest

### DIFF
--- a/mitmproxy/http.py
+++ b/mitmproxy/http.py
@@ -98,7 +98,7 @@ class Headers(multidict.MultiDict):  # type: ignore
         *Args:*
          - *fields:* (optional) list of ``(name, value)`` header byte tuples,
            e.g. ``[(b"Host", b"example.com")]``. All names and values must be bytes.
-         - *\*\*headers:* Additional headers to set. Will overwrite existing values from `fields`.
+         - *\\*\\*headers:* Additional headers to set. Will overwrite existing values from `fields`.
            For convenience, underscores in header names will be transformed to dashes -
            this behaviour does not extend to other methods.
 


### PR DESCRIPTION
#### Description

Escape backslashes in pydocs containing '\*' (markdown escape sequence).
This removes the one warning I saw when running `pytest`:

    /mitmproxy/mitmproxy/http.py:97: DeprecationWarning: invalid escape sequence \*

<!-- describe your changes here -->

#### Checklist

 - [x] I have updated tests where applicable. (N/A)
 - [x] I have added an entry to the CHANGELOG. (N/A)
