### PR TITLE
Make urwid work with ProactorEventLoop

### DIFF
--- a/mitmproxy/tools/console/master.py
+++ b/mitmproxy/tools/console/master.py
@@ -13,6 +13,8 @@ import typing  # noqa
 import contextlib
 import threading
 
+from tornado.platform.asyncio import AddThreadSelectorEventLoop
+
 import urwid
 
 from mitmproxy import addons
@@ -22,6 +24,7 @@ from mitmproxy.addons import intercept
 from mitmproxy.addons import eventstore
 from mitmproxy.addons import readfile
 from mitmproxy.addons import view
+from mitmproxy.tools.console import common
 from mitmproxy.tools.console import consoleaddons
 from mitmproxy.tools.console import defaultkeys
 from mitmproxy.tools.console import keymap
@@ -199,9 +202,13 @@ class ConsoleMaster(master.Master):
             self.set_palette,
             ["console_palette", "console_palette_transparent"]
         )
+        loop = asyncio.get_event_loop()
+        if common.IS_WINDOWS:
+            # fix for https://bugs.python.org/issue37373
+            loop = AddThreadSelectorEventLoop(loop)
         self.loop = urwid.MainLoop(
             urwid.SolidFill("x"),
-            event_loop=urwid.AsyncioEventLoop(loop=asyncio.get_event_loop()),
+            event_loop=urwid.AsyncioEventLoop(loop=loop),
             screen = self.ui,
             handle_mouse = self.options.console_mouse,
         )

--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,7 @@ setup(
         "pyperclip>=1.6.0,<1.9",
         "ruamel.yaml>=0.16,<0.17.17",
         "sortedcontainers>=2.3,<2.5",
-        "tornado>=4.3,<7",
+        "tornado>=6.1,<7",
         "urwid>=2.1.1,<2.2",
         "wsproto>=1.0,<1.1",
         "publicsuffix2>=2.20190812,<3",


### PR DESCRIPTION
The ProactorEventLoop does not support `loop.add_reader` (which urwid depends on), so we make use of Tornado's workaround for this, which emulates those calls using a selector event loop in a separate thread.