### PR TITLE
mitmweb: handle {en,de}coding on server-side

### DIFF
--- a/mitmproxy/tools/web/app.py
+++ b/mitmproxy/tools/web/app.py
@@ -439,11 +439,6 @@ class FlowContent(RequestHandler):
     def get(self, flow_id, message):
         message = getattr(self.flow, message)
 
-        content_encoding = message.headers.get("Content-Encoding", None)
-        if content_encoding:
-            content_encoding = re.sub(r"[^\w]", "", content_encoding)
-            self.set_header("Content-Encoding", content_encoding)
-
         original_cd = message.headers.get("Content-Disposition", None)
         filename = None
         if original_cd:
@@ -459,7 +454,7 @@ class FlowContent(RequestHandler):
         self.set_header("Content-Type", "application/text")
         self.set_header("X-Content-Type-Options", "nosniff")
         self.set_header("X-Frame-Options", "DENY")
-        self.write(message.raw_content)
+        self.write(message.get_content(strict=False))
 
 
 class FlowContentView(RequestHandler):

--- a/test/mitmproxy/tools/web/test_app.py
+++ b/test/mitmproxy/tools/web/test_app.py
@@ -310,7 +310,7 @@ class TestApp(tornado.testing.AsyncHTTPTestCase):
 
         f.revert()
 
-    def test_flow_content_reutrns_raw_content_when_decoding_fails(self):
+    def test_flow_content_returns_raw_content_when_decoding_fails(self):
         f = self.view.get_by_id("42")
         f.backup()
 

--- a/test/mitmproxy/tools/web/test_app.py
+++ b/test/mitmproxy/tools/web/test_app.py
@@ -1,5 +1,6 @@
 import asyncio
 import io
+import gzip
 import json
 import logging
 import textwrap
@@ -290,12 +291,10 @@ class TestApp(tornado.testing.AsyncHTTPTestCase):
     def test_flow_content(self):
         f = self.view.get_by_id("42")
         f.backup()
-        f.response.headers["Content-Encoding"] = "ran\x00dom"
         f.response.headers["Content-Disposition"] = 'inline; filename="filename.jpg"'
 
         r = self.fetch("/flows/42/response/content.data")
         assert r.body == b"message"
-        assert r.headers["Content-Encoding"] == "random"
         assert r.headers["Content-Disposition"] == 'attachment; filename="filename.jpg"'
 
         del f.response.headers["Content-Disposition"]
@@ -308,6 +307,21 @@ class TestApp(tornado.testing.AsyncHTTPTestCase):
         r = self.fetch("/flows/42/response/content.data")
         assert r.code == 200
         assert r.body == b""
+
+        f.revert()
+
+    def test_flow_content_reutrns_raw_content_when_decoding_fails(self):
+        f = self.view.get_by_id("42")
+        f.backup()
+
+        f.response.headers["Content-Encoding"] = "gzip"
+        # replace gzip magic number with garbage
+        invalid_encoded_content = gzip.compress(b"Hello world!").replace(b"\x1f\x8b", b"\xff\xff")
+        f.response.raw_content = invalid_encoded_content
+
+        r = self.fetch("/flows/42/response/content.data")
+        assert r.body == invalid_encoded_content
+        assert r.code == 200
 
         f.revert()
 


### PR DESCRIPTION
#### Description

Handle this server-side rather than passing the message content encoding
details back when fetching flow content. If {en,de}coding fails, return
the raw request contents.

This addresses https://github.com/mitmproxy/mitmproxy/issues/4809

<!-- describe your changes here -->

#### Checklist

 - [X] I have updated tests where applicable.
 - [ ] I have added an entry to the CHANGELOG.
