### PR TITLE
Don't set 'content-length' with 'transfer-encoding'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 * Windows: Switch to Python's default asyncio event loop, which increases the number of sockets
   that can be processed simultaneously (@mhils)
 
+## 28 September 2021: mitmproxy 7.0.4
+
+* Do not add a Content-Length header for chunked HTTP/1 messages (@matthewhughes934)
+
 ## 16 September 2021: mitmproxy 7.0.3
 
 * [CVE-2021-39214](https://github.com/mitmproxy/mitmproxy/security/advisories/GHSA-22gh-3r9q-xf38):

--- a/mitmproxy/http.py
+++ b/mitmproxy/http.py
@@ -372,7 +372,13 @@ class Message(serializable.Serializable):
             # Let's remove it!
             del self.headers["content-encoding"]
             self.raw_content = value
-        self.headers["content-length"] = str(len(self.raw_content))
+
+        if "transfer-encoding" in self.headers:
+            # https://httpwg.org/specs/rfc7230.html#header.content-length
+            # don't set content-length if a transfer-encoding is provided
+            pass
+        else:
+            self.headers["content-length"] = str(len(self.raw_content))
 
     def get_content(self, strict: bool = True) -> Optional[bytes]:
         """

--- a/test/mitmproxy/proxy/layers/http/test_http.py
+++ b/test/mitmproxy/proxy/layers/http/test_http.py
@@ -1276,3 +1276,46 @@ def test_invalid_content_length(tctx):
         >> reply()
     )
     assert b"Invalid Content-Length header" in err()
+
+
+def test_chunked_and_content_length_set_by_addon(tctx):
+    """Test that we don't crash when an addon sets a transfer-encoding header
+
+    We reject a request with both transfer-encoding and content-length header to
+    thwart request smuggling, but if a user explicitly sets it we should not crash.
+    """
+    server = Placeholder(Server)
+    flow = Placeholder(HTTPFlow)
+
+    def make_chunked(flow: HTTPFlow):
+        if flow.response:
+            flow.response.headers["Transfer-Encoding"] = "chunked"
+        else:
+            flow.request.headers["Transfer-Encoding"] = "chunked"
+
+    assert (
+            Playbook(http.HttpLayer(tctx, HTTPMode.regular))
+            >> DataReceived(tctx.client, b"POST http://example.com/ HTTP/1.1\r\n"
+                                         b"Host: example.com\r\n"
+                                         b"Content-Length: 0\r\n\r\n")
+            << http.HttpRequestHeadersHook(flow)
+            >> reply(side_effect=make_chunked)
+            << http.HttpRequestHook(flow)
+            >> reply()
+            << OpenConnection(server)
+            >> reply(None)
+            << SendData(server, b"POST / HTTP/1.1\r\n"
+                                b"Host: example.com\r\n"
+                                b"Content-Length: 0\r\n"
+                                b"Transfer-Encoding: chunked\r\n\r\n"
+                                b"0\r\n\r\n")
+            >> DataReceived(server, b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n")
+            << http.HttpResponseHeadersHook(flow)
+            >> reply()
+            << http.HttpResponseHook(flow)
+            >> reply(side_effect=make_chunked)
+            << SendData(tctx.client, b"HTTP/1.1 200 OK\r\n"
+                                     b"Content-Length: 0\r\n"
+                                     b"Transfer-Encoding: chunked\r\n\r\n"
+                                     b"0\r\n\r\n")
+    )

--- a/test/mitmproxy/test_http.py
+++ b/test/mitmproxy/test_http.py
@@ -916,6 +916,13 @@ class TestMessage:
         assert resp.data.content == b"bar"
         assert resp.headers["content-length"] == "0"
 
+    def test_content_length_not_added_for_response_with_transfer_encoding(self):
+        headers = Headers(((b"transfer-encoding", b"chunked"),))
+        resp = tresp(headers=headers)
+        resp.content = b"bar"
+
+        assert "content-length" not in resp.headers
+
     def test_headers(self):
         _test_passthrough_attr(tresp(), "headers")
 


### PR DESCRIPTION
When updating the response content for a response, avoid adding the
'content-length' header if the response contains a 'transfer-encoding'
header, from the spec [1]:

> When a message does not have a Transfer-Encoding header field, a
Content-Length header field can provide the anticipated size, as a
decimal number of octets, for a potential payload body

Note the 'transfer-encoding' header is not used with HTTP/2

https://httpwg.org/specs/rfc7230.html#header.content-length

#### Description

<!-- describe your changes here -->

#### Checklist

 - [X] I have updated tests where applicable.
 - [ ] I have added an entry to the CHANGELOG.
