### PR TITLE
Fix websocket view jumps to top bug

### DIFF
--- a/mitmproxy/tools/console/searchable.py
+++ b/mitmproxy/tools/console/searchable.py
@@ -19,6 +19,7 @@ class Searchable(urwid.ListBox):
     def __init__(self, contents):
         self.walker = urwid.SimpleFocusListWalker(contents)
         urwid.ListBox.__init__(self, self.walker)
+        self.set_focus(len(self.walker) - 1)
         self.search_offset = 0
         self.current_highlight = None
         self.search_term = None


### PR DESCRIPTION
Resolves #4491 

Websocket view will now jump to bottom every time a new message arrives.
