### PR TITLE
Prevent connection lost in mitmweb when pressing Download button.

### DIFF
--- a/web/src/js/components/Header/FlowMenu.tsx
+++ b/web/src/js/components/Header/FlowMenu.tsx
@@ -80,6 +80,11 @@ export default function FlowMenu(): JSX.Element {
     )
 }
 
+// Reference: https://stackoverflow.com/a/63627688/9921431
+const openInNewTab = (url) => {
+  const newWindow = window.open(url, '_blank', 'noopener,noreferrer')
+  if (newWindow) newWindow.opener = null
+}
 
 function DownloadButton({flow}: { flow: Flow }) {
     if (flow.type !== "http")
@@ -87,23 +92,23 @@ function DownloadButton({flow}: { flow: Flow }) {
 
     if (flow.request.contentLength && !flow.response?.contentLength) {
         return <Button icon="fa-download"
-                       onClick={() => window.location.href = MessageUtils.getContentURL(flow, flow.request)}
+                       onClick={() => openInNewTab(MessageUtils.getContentURL(flow, flow.request))}
         >Download</Button>
     }
     if (flow.response) {
         const response = flow.response;
         if (!flow.request.contentLength && flow.response.contentLength) {
             return <Button icon="fa-download"
-                           onClick={() => window.location.href = MessageUtils.getContentURL(flow, response)}
+                           onClick={() => openInNewTab(MessageUtils.getContentURL(flow, response))}
             >Download</Button>
         }
         if (flow.request.contentLength && flow.response.contentLength) {
             return <Dropdown text={
                 <Button icon="fa-download" onClick={() => 1}>Download▾</Button>
             } options={{"placement": "bottom-start"}}>
-                <MenuItem onClick={() => window.location.href = MessageUtils.getContentURL(flow, flow.request)}>Download
+                <MenuItem onClick={() => openInNewTab(MessageUtils.getContentURL(flow, flow.request))}>Download
                     request</MenuItem>
-                <MenuItem onClick={() => window.location.href = MessageUtils.getContentURL(flow, response)}>Download
+                <MenuItem onClick={() => openInNewTab(MessageUtils.getContentURL(flow, response))}>Download
                     response</MenuItem>
             </Dropdown>
         }


### PR DESCRIPTION
#### Description

Previously, when someone clicks Download button, it will go to respond/request url on the same tab by changing `window.location.href`, which causes connection lost on the web interface (something related to WebSocket, according to the console in web browser) and a refresh is needed for the interface to show new flows. In this commit, it will open the link in a new tab instead and prevent connection lost issue, allowing mitmweb to continue working without having to refresh the page.

P/s: `mitmweb` runs fine on my laptop after this but `npm test` has issue on my machine so I don't know whether the test suite will work with this commit or not.
```
(mitmproxy) C:\Users\starc\PycharmProjects\mitmproxy\web>npm test

> test
> tsc --noEmit && jest --coverage

Error: EISDIR: illegal operation on a directory, realpath 'T:\Temp'
    at Function.realpathSync.native (node:fs:2550:3)
    at tryRealpath (C:\Users\starc\PycharmProjects\mitmproxy\web\node_modules\jest-util\build\tryRealpath.js:26:39)
    at getCacheDirectory (C:\Users\starc\PycharmProjects\mitmproxy\web\node_modules\jest-config\build\getCacheDirectory.js:89:33)
    at Object.<anonymous> (C:\Users\starc\PycharmProjects\mitmproxy\web\node_modules\jest-config\build\Defaults.js:59:50)
    at Module._compile (node:internal/modules/cjs/loader:1101:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1153:10)
    at Module.load (node:internal/modules/cjs/loader:981:32)
    at Function.Module._load (node:internal/modules/cjs/loader:822:12)
    at Module.require (node:internal/modules/cjs/loader:1005:19)
    at require (node:internal/modules/cjs/helpers:102:18)
```

#### Checklist

 - [ ] I have updated tests where applicable.
 - [ ] I have added an entry to the CHANGELOG.
