### PR TITLE
bump docker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * New content view which handles gRPC/protobuf. Allows to apply custom definitions to visualize different field decodings.
   Includes example addon which applies custom definitions for selected gRPC traffic (@mame82)
 * Fix a crash caused when editing string option (#4852, @rbdixon)
+* Base container image bumped to Debian 11 Bullseye (@Kriechi)
 
 ## 28 September 2021: mitmproxy 7.0.4
 

--- a/release/docker/DockerHub-README.md
+++ b/release/docker/DockerHub-README.md
@@ -2,38 +2,52 @@
 
 Containerized version of [mitmproxy](https://mitmproxy.org/): an interactive, SSL/TLS-capable intercepting proxy for HTTP/1, HTTP/2, and WebSockets.
 
-# Usage
+## Usage
 
 ```sh
 $ docker run --rm -it [-v ~/.mitmproxy:/home/mitmproxy/.mitmproxy] -p 8080:8080 mitmproxy/mitmproxy
+[terminal user interface of mitmproxy is launched...]
 ```
+
 The *volume mount* is optional: It's to store the generated CA certificates.
 
 Once started, mitmproxy listens as a HTTP proxy on `localhost:8080`:
+
 ```sh
 $ http_proxy=http://localhost:8080/ curl http://example.com/
 $ https_proxy=http://localhost:8080/ curl -k https://example.com/
 ```
 
 You can also start `mitmdump` by just adding that to the end of the command-line:
+
 ```sh
 $ docker run --rm -it -p 8080:8080 mitmproxy/mitmproxy mitmdump
+Proxy server listening at http://*:8080
+[...]
 ```
 
 For `mitmweb`, you also need to expose port 8081:
+
 ```sh
 # this makes :8081 accessible to the local machine only
 $ docker run --rm -it -p 8080:8080 -p 127.0.0.1:8081:8081 mitmproxy/mitmproxy mitmweb --web-host 0.0.0.0
+Web server listening at http://0.0.0.0:8081/
+No web browser found. Please open a browser and point it to http://0.0.0.0:8081/
+Proxy server listening at http://*:8080
+[...]
 ```
 
 You can also pass options directly via the CLI:
+
 ```sh
 $ docker run --rm -it -p 8080:8080 mitmproxy/mitmproxy mitmdump --set ssl_insecure=true
+Proxy server listening at http://*:8080
+[...]
 ```
 
 For further details, please consult the mitmproxy [documentation](http://docs.mitmproxy.org/en/stable/).
 
-# Tags
+## Tags
 
 The available release tags can be seen
 [here](https://hub.docker.com/r/mitmproxy/mitmproxy/tags/).
@@ -42,7 +56,7 @@ The available release tags can be seen
 * `latest` always points to the same image as the most recent stable release, including bugfix releases (e.g., `4.0.0` and `4.0.1`).
 * `X.Y.Z` tags contain the mitmproxy release with this version number.
 
-# Security Notice
+## Security Notice
 
 Dependencies in the Docker images are frozen on release, and can’t be updated in
 situ. This means that we necessarily capture any bugs or security issues that

--- a/release/docker/Dockerfile
+++ b/release/docker/Dockerfile
@@ -1,10 +1,10 @@
-FROM python:3.9-buster as wheelbuilder
+FROM python:3.9-bullseye as wheelbuilder
 
 ARG MITMPROXY_WHEEL
 COPY $MITMPROXY_WHEEL /wheels/
 RUN pip install wheel && pip wheel --wheel-dir /wheels /wheels/${MITMPROXY_WHEEL}
 
-FROM python:3.9-slim-buster
+FROM python:3.9-bullseye
 
 RUN useradd -mU mitmproxy
 RUN apt-get update \


### PR DESCRIPTION
closes #4846

* bump Docker base image to Debian 11 / bullseye
* markdown lint and improved sample output