### PR TITLE
Feature suggestion: Convert binary data to hex and back for external editors

### DIFF
--- a/mitmproxy/tools/console/master.py
+++ b/mitmproxy/tools/console/master.py
@@ -32,7 +32,8 @@ from mitmproxy.tools.console import keymap
 from mitmproxy.tools.console import palettes
 from mitmproxy.tools.console import signals
 from mitmproxy.tools.console import window
-from mitmproxy.utils.strutils import always_str, escape_control_characters
+from mitmproxy.utils import strutils
+from mitmproxy.utils.strutils import hexdump
 
 
 class ConsoleMaster(master.Master):
@@ -148,33 +149,8 @@ class ConsoleMaster(master.Master):
         info += b"# binary,once you close the editor." + LB
         info += b"# Whitespaces, Linebreaks and everything prefixed with '#' will be ignored when converting back to binary." + LB + LB
 
-        dhex = binascii.hexlify(data)
-        # some formatting
-        token_count = 0
-        line = b""
-        while len(dhex) > 0:
-            slice = dhex[:4]
-            info += slice
-            dhex = dhex[4:]
-            token_count += 1
-            line += slice
-            if token_count == 16:
-                part = binascii.unhexlify(line)
-                part_repr = always_str(
-                    escape_control_characters(
-                        part.decode("ascii", "replace").replace("\ufffd", "."),
-                        False
-                    )
-                )
-                info += b"  # " + part_repr.encode("utf-8")
-                info += LB
-                token_count = 0
-                line = b""
-            elif token_count == 8:
-                info += b"  "
-            else:
-                info += b" "
-
+        for offset, hexa, s in strutils.hexdump(data):
+            info += "{} # @{}: {}".format(hexa, offset, s).encode("utf-8") + LB
         return info
 
     def helper_editor_data_from_readable_hex(self, data: bytes) -> bytes:

--- a/mitmproxy/tools/console/master.py
+++ b/mitmproxy/tools/console/master.py
@@ -145,7 +145,7 @@ class ConsoleMaster(master.Master):
         info = b""
         info += b"# The data you want to edit is in binary format and was converted to a hexadecimal representation to allow editing." + LB
         info += b"# You can edit the hexadecimal representation as you like and save changes. The data will be converted back to" + LB
-        info += b"# binary,once you close the editor." + LB
+        info += b"# binary, once you save changes close the editor ." + LB
         info += b"# Whitespaces, Linebreaks and everything prefixed with '#' will be ignored when converting back to binary." + LB + LB
 
         for offset, hexa, s in strutils.hexdump(data):

--- a/mitmproxy/tools/console/master.py
+++ b/mitmproxy/tools/console/master.py
@@ -33,7 +33,6 @@ from mitmproxy.tools.console import palettes
 from mitmproxy.tools.console import signals
 from mitmproxy.tools.console import window
 from mitmproxy.utils import strutils
-from mitmproxy.utils.strutils import hexdump
 
 
 class ConsoleMaster(master.Master):


### PR DESCRIPTION
As discussed with @mhils recently.

No tests, neither are functions placed in proper modules.

Just a demo on how binary editing could be done with conversion to a readable format, before handing it over to an external editor.

For a quick test implementation, this already works pretty well. Formatting functionality could use some optimization, though.

## Workflow 

1. Binary message body in mitmproxy (hex view)

![hex1](https://user-images.githubusercontent.com/13119970/136946152-cb71d547-cef1-4d1d-bdc1-35750fcbd1c0.png)

2. Entering edit mode with `e` key (data gets converted to readable representation if not valid UTF-8, editor is Nano in this case)

![hex2](https://user-images.githubusercontent.com/13119970/136946457-c773fe85-a202-4845-b2d5-9dca3d3bdc1d.png)

3. Edit the "hexlified" data as you like (adding 0xdeadbeef here)

![hex3](https://user-images.githubusercontent.com/13119970/136946673-d76ec648-174e-4d8c-9396-18583a6e5c1b.png)

4. After saving in the editor, data gets converted back to binary (comments prefixed with `#` get stripped)

![hex4](https://user-images.githubusercontent.com/13119970/136946819-43569382-1e98-4f6a-8820-fb88da380259.png)


