### PR TITLE
Make scripts in config.yml relative to config.yml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 * Fix empty cookie attributes being set to `Key=` instead of `Key`
   ([#5084](https://github.com/mitmproxy/mitmproxy/pull/5084), @Speedlulu)
+* Scripts with relative paths are now loaded relative to the config file and not where the command is ran
 
 
 ## 14 November 2023: mitmproxy 10.1.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Fix empty cookie attributes being set to `Key=` instead of `Key`
   ([#5084](https://github.com/mitmproxy/mitmproxy/pull/5084), @Speedlulu)
 * Scripts with relative paths are now loaded relative to the config file and not where the command is ran
+  ([#4860](https://github.com/mitmproxy/mitmproxy/pull/4860), @Speedlulu)
 
 
 ## 14 November 2023: mitmproxy 10.1.5

--- a/test/mitmproxy/data/test_config.yml
+++ b/test/mitmproxy/data/test_config.yml
@@ -1,0 +1,3 @@
+scripts: ['~/abc', 'abc', '../abc', '/abc']
+
+not_scripts: ['~/abc', 'abc', '../abc', '/abc']

--- a/test/mitmproxy/test_optmanager.py
+++ b/test/mitmproxy/test_optmanager.py
@@ -2,6 +2,7 @@ import argparse
 import copy
 import io
 from collections.abc import Sequence
+from pathlib import Path
 from typing import Optional
 
 import pytest
@@ -39,6 +40,13 @@ class TM(optmanager.OptManager):
         super().__init__()
         self.add_option("two", Sequence[str], ["foo"], "help")
         self.add_option("one", Optional[str], None, "help")
+
+
+class TS(optmanager.OptManager):
+    def __init__(self):
+        super().__init__()
+        self.add_option("scripts", Sequence[str], [], "help")
+        self.add_option("not_scripts", Sequence[str], [], "help")
 
 
 def test_defaults():
@@ -302,7 +310,7 @@ def test_serialize_defaults():
 def test_saving(tmpdir):
     o = TD2()
     o.three = "set"
-    dst = str(tmpdir.join("conf"))
+    dst = Path(tmpdir.join("conf"))
     optmanager.save(o, dst, defaults=True)
 
     o2 = TD2()
@@ -469,3 +477,43 @@ def test_set():
     opts.process_deferred()
     assert "deferredsequenceoption" not in opts.deferred
     assert opts.deferredsequenceoption == ["a", "b"]
+
+
+def test_load_paths(tdata):
+    opts = TS()
+    conf_path = tdata.path("mitmproxy/data/test_config.yml")
+    optmanager.load_paths(opts, conf_path)
+    assert opts.scripts == [
+        str(Path.home().absolute().joinpath("abc")),
+        str(Path(conf_path).parent.joinpath("abc")),
+        str(Path(conf_path).parent.joinpath("../abc")),
+        str(Path("/abc").absolute()),
+    ]
+    assert opts.not_scripts == ["~/abc", "abc", "../abc", "/abc"]
+
+
+@pytest.mark.parametrize(
+    "script_path, relative_to, expected",
+    (
+        ("~/abc", ".", Path.home().joinpath("abc")),
+        ("/abc", ".", Path("/abc")),
+        ("abc", ".", Path(".").joinpath("abc")),
+        ("../abc", ".", Path(".").joinpath("../abc")),
+        ("~/abc", "/tmp", Path.home().joinpath("abc")),
+        ("/abc", "/tmp", Path("/abc")),
+        ("abc", "/tmp", Path("/tmp").joinpath("abc")),
+        ("../abc", "/tmp", Path("/tmp").joinpath("../abc")),
+        ("~/abc", "foo", Path.home().joinpath("abc")),
+        ("/abc", "foo", Path("/abc")),
+        ("abc", "foo", Path("foo").joinpath("abc")),
+        ("../abc", "foo", Path("foo").joinpath("../abc")),
+    ),
+)
+def test_relative_path(script_path, relative_to, expected):
+    assert (
+        optmanager.relative_path(
+            script_path,
+            relative_to=relative_to,
+        )
+        == expected.absolute()
+    )


### PR DESCRIPTION
#### Description

Make the paths to scripts found in config.yml relative to
the directory where config.yml is instead of where the command
is ran.

#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
