### PR TITLE
gRPC view: special case decoding

### DIFF
--- a/mitmproxy/contentviews/grpc.py
+++ b/mitmproxy/contentviews/grpc.py
@@ -147,7 +147,7 @@ class ProtoParser:
         # helper
         unknown = 18
         # special
-        # googleapis traffic has found to include varint length prefixes to nested messages in some cases
+        # googleapis traffic was found to include varint length prefixes to nested messages in some cases
         len_prefixed_message = 19
 
     class Message:

--- a/test/mitmproxy/contentviews/test_grpc.py
+++ b/test/mitmproxy/contentviews/test_grpc.py
@@ -445,7 +445,6 @@ def test_special_decoding():
     nested_res = fields[7].safe_decode_as(ProtoParser.DecodedTypes.len_prefixed_message)
     assert nested_res[0] == ProtoParser.DecodedTypes.len_prefixed_message
     assert isinstance(nested_res[1], ProtoParser.Message)
-    nested_res[1]
     nested_fields = list(nested_res[1].gen_fields())
     assert nested_fields[0].safe_decode_as(ProtoParser.DecodedTypes.bytes) == (ProtoParser.DecodedTypes.bytes, b"nested with length prefix")
 


### PR DESCRIPTION
#### Description

It appears that Protobuf based communication with Google endpoints uses field values slightly deviating from the specs (created by Google, too).

More specifically cases have been observed, were field values containing nested Protobuf messages got prefixed with an additional length value (encoded as variable-length integer). Such values could not be decoded, as the parser expected raw messages (without prefixes) as payload of length delimited fields.

While this is a special case, it is easy to test for in the current gRPC contentview implementation - with minimal computing overhead and without disrupting expected decoding behavior for other protobuf traffic.

I consider this encoding scheme a "common case" as it is used by Google itself.

The gRPC contentview was extended to handle this case (tests included).

1. The screenshot shows a protobuf message, containing a nested message which can not be decoded without the adjustment (Field `1.5`):

![google-special1](https://user-images.githubusercontent.com/13119970/137505988-d6e0822e-52e9-40a7-a23f-a058b63ce5c6.png)

2. The screenshot shows an excerpt of the same message, with this patch applied (Field `1.5` got decoded and holds a valid protobuf message):

![google-special2](https://user-images.githubusercontent.com/13119970/137506349-53e6eaab-8721-4ab3-9f63-9e09a10463cd.png)

As shown in the screenshot, messages decoded like this are marked with `len_prefixed_message`. This decoding was inserted into the default decoding-failover-strategy. It is still possible to use custom definitions, to enforce decoding as `bytes` for such fields.

Beside this, a missing MIME type for protobuf messages was added.

#### Checklist

 - [x] I have updated tests where applicable.
