### PR TITLE
docs: sync mitmdump docs with code 📝

### DIFF
--- a/mitmproxy/addons/dumper.py
+++ b/mitmproxy/addons/dumper.py
@@ -156,7 +156,7 @@ class Dumper:
         else:
             url = flow.request.url
 
-        if ctx.options.flow_detail <= 1:
+        if ctx.options.flow_detail < 1:
             # We need to truncate before applying styles, so we just focus on the URL.
             terminal_width_limit = max(shutil.get_terminal_size()[0] - 25, 50)
             if len(url) > terminal_width_limit:

--- a/mitmproxy/addons/dumper.py
+++ b/mitmproxy/addons/dumper.py
@@ -38,10 +38,10 @@ class Dumper:
         loader.add_option(
             "flow_detail", int, 1,
             """
-            The display detail level for flows in mitmdump: 0 (almost quiet) to 3 (very verbose).
-              0: shortened request URL, response status code, WebSocket and TCP message notifications.
-              1: full request URL with response status code
-              2: 1 + HTTP headers
+            The display detail level for flows in mitmdump: 0 (no output) to 3 (very verbose).
+              0: no output
+              1: shortened request URL, response status code
+              2: full request URL + headers
               3: 2 + truncated response content, content of WebSocket and TCP messages
               4: 3 + nothing is truncated
             """


### PR DESCRIPTION
#### Description

<!-- describe your changes here -->
I have modified the docs to reflect the most recent changes inside the code. The previous version was out of sync.

The output of `mitmpdump --help` showed info that was not up to date.

This fixes #4832 

This is also the continuation of where #4837 left off.

#### Checklist

 - [ ] I have updated tests where applicable.
 - [ ] I have added an entry to the CHANGELOG.
