### PR TITLE
Fix #4876 Don't do CONNECT on plaintext HTTP replays via upstream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
   Includes example addon which applies custom definitions for selected gRPC traffic (@mame82)
 * Fix a crash caused when editing string option (#4852, @rbdixon)
 * Base container image bumped to Debian 11 Bullseye (@Kriechi)
+* Upstream replays don't do CONNECT on plaintext HTTP requests (#4876, @HoffmannP)
 
 ## 28 September 2021: mitmproxy 7.0.4
 

--- a/mitmproxy/addons/clientplayback.py
+++ b/mitmproxy/addons/clientplayback.py
@@ -78,7 +78,10 @@ class ReplayHandler(server.ConnectionHandler):
 
         super().__init__(context)
 
-        self.layer = layers.HttpLayer(context, HTTPMode.transparent)
+        if options.mode.startswith("upstream:"):
+            self.layer = layers.HttpLayer(context, HTTPMode.upstream)
+        else:
+            self.layer = layers.HttpLayer(context, HTTPMode.transparent)
         self.layer.connections[client] = MockServer(flow, context.fork())
         self.flow = flow
         self.done = asyncio.Event()

--- a/test/mitmproxy/addons/test_clientplayback.py
+++ b/test/mitmproxy/addons/test_clientplayback.py
@@ -19,6 +19,7 @@ async def tcp_server(handle_conn) -> Address:
     finally:
         server.close()
 
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize("mode", ["regular", "upstream", "err"])
 @pytest.mark.parametrize("concurrency", [-1, 1])

--- a/test/mitmproxy/addons/test_clientplayback.py
+++ b/test/mitmproxy/addons/test_clientplayback.py
@@ -19,7 +19,6 @@ async def tcp_server(handle_conn) -> Address:
     finally:
         server.close()
 
-
 @pytest.mark.asyncio
 @pytest.mark.parametrize("mode", ["regular", "upstream", "err"])
 @pytest.mark.parametrize("concurrency", [-1, 1])
@@ -33,7 +32,6 @@ async def test_playback(mode, concurrency):
             return
         req = await reader.readline()
         if mode == "upstream":
-            print(req)
             assert req == b'GET http://address:22/path HTTP/1.1\r\n'
         else:
             assert req == b'GET /path HTTP/1.1\r\n'

--- a/test/mitmproxy/addons/test_clientplayback.py
+++ b/test/mitmproxy/addons/test_clientplayback.py
@@ -31,10 +31,6 @@ async def test_playback(mode, concurrency):
             writer.close()
             handler_ok.set()
             return
-        if mode == "upstream":
-            conn_req = await reader.readuntil(b"\r\n\r\n")
-            assert conn_req == b'CONNECT address:22 HTTP/1.1\r\n\r\n'
-            writer.write(b"HTTP/1.1 200 Connection Established\r\n\r\n")
         req = await reader.readuntil(b"data")
         assert req == (
             b'GET /path HTTP/1.1\r\n'


### PR DESCRIPTION
#### Description

Upstream replays used to do a CONNECT even for plaintext HTTP which some proxies did not understand. This was removed, the test catching this deviation was removed

#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
