### PR TITLE
Use the slim base image for container

### DIFF
--- a/release/docker/Dockerfile
+++ b/release/docker/Dockerfile
@@ -4,7 +4,7 @@ ARG MITMPROXY_WHEEL
 COPY $MITMPROXY_WHEEL /wheels/
 RUN pip install wheel && pip wheel --wheel-dir /wheels /wheels/${MITMPROXY_WHEEL}
 
-FROM python:3.9-bullseye
+FROM python:3.9-slim-bullseye
 
 RUN useradd -mU mitmproxy
 RUN apt-get update \


### PR DESCRIPTION
#### Description

Container sizes went from [`73MB` in Version 7.0.4](https://hub.docker.com/layers/mitmproxy/mitmproxy/7.0.4/images/sha256-36e9f5397302341d55fec03953e04cd69c47038e051d5ccec6d9e84f987527cc?context=explore) to [`359MB` in `dev`](https://hub.docker.com/layers/mitmproxy/mitmproxy/dev/images/sha256-c418f4eda4a30f486b76a3004e6a04e8fd172095ac29b29de8371b06d41aed25?context=explore). Also the image now contains tools like `imagemagick`, `git` and `libbluetooth3`.

The change was introduced in [commit `fffed0cb`](https://github.com/mitmproxy/mitmproxy/commit/fffed0cb3aa121b6c3735ca3f6beeb4b2356b4e6#diff-5ff03f5acddd8edc535d5ec30b70e78468bf1e748e126ba3ac39c67a28a6af40) where the base image was changed from `python:3.9-slim-buster` to `python:3.9-bullseye`. It was probably an oversight that "slim" was dropped.


#### Checklist

 - [x] I have updated tests where applicable.
 - [x] ~~I have added an entry to the CHANGELOG.~~ Mention of updated base image is already in the changelog and has not yet been released
