### PR TITLE
[wip] build python sdists along with wheel

### DIFF
--- a/release/cibuild.py
+++ b/release/cibuild.py
@@ -268,12 +268,12 @@ def build_wheel(be: BuildEnviron) -> None:  # pragma: no cover
         "bdist_wheel",
         "--dist-dir", be.dist_dir,
     ])
+    all_dist = be.dist_dir.glob('*')
+    click.echo(f"Found distributions: {all_dist}")
     whl, = be.dist_dir.glob('mitmproxy-*-py3-none-any.whl')
     click.echo(f"Found wheel package: {whl}")
-    sdist, = be.dist_dir.glob('mitmproxy-*.tar.gz')
-    click.echo(f"Found sdist package: {sdist}")
     subprocess.check_call(["tox", "-e", "wheeltest", "--", whl])
-
+    
 
 DOCKER_PLATFORMS = "linux/amd64,linux/arm64"
 

--- a/release/cibuild.py
+++ b/release/cibuild.py
@@ -269,7 +269,7 @@ def build_wheel(be: BuildEnviron) -> None:  # pragma: no cover
         "--dist-dir", be.dist_dir,
     ])
     all_dist = be.dist_dir.glob('*')
-    click.echo(f"Found distributions: {all_dist}")
+    click.echo(f"Found distributions: {[*all_dist]}")
     whl, = be.dist_dir.glob('mitmproxy-*-py3-none-any.whl')
     click.echo(f"Found wheel package: {whl}")
     subprocess.check_call(["tox", "-e", "wheeltest", "--", whl])

--- a/release/cibuild.py
+++ b/release/cibuild.py
@@ -263,7 +263,7 @@ def build_wheel(be: BuildEnviron) -> None:  # pragma: no cover
     subprocess.check_call([
         "python",
         "setup.py",
-        "-q",
+        # "-q",
         "sdist",
         "bdist_wheel",
         "--dist-dir", be.dist_dir,

--- a/release/cibuild.py
+++ b/release/cibuild.py
@@ -264,6 +264,7 @@ def build_wheel(be: BuildEnviron) -> None:  # pragma: no cover
         "python",
         "setup.py",
         "-q",
+        "sdist",
         "bdist_wheel",
         "--dist-dir", be.dist_dir,
     ])

--- a/release/cibuild.py
+++ b/release/cibuild.py
@@ -270,6 +270,8 @@ def build_wheel(be: BuildEnviron) -> None:  # pragma: no cover
     ])
     whl, = be.dist_dir.glob('mitmproxy-*-py3-none-any.whl')
     click.echo(f"Found wheel package: {whl}")
+    sdist, = be.dist_dir.glob('mitmproxy-*.tar.gz')
+    click.echo(f"Found sdist package: {sdist}")
     subprocess.check_call(["tox", "-e", "wheeltest", "--", whl])
 
 


### PR DESCRIPTION
#### Description

For #4892, this explores what the CI infrastructure _would_ do if there just happened to be an sdist built at the same time as the wheel. From a cursory look at the workflows and scripts, the `dist` folder seems to be handed around, rather than the `.whl` itself, so it's possible everything will "just work" up to deployment to pypi, even if it's not being further tested as an artifact.

#### Checklist

 - [ ] I have updated tests where applicable.
 - [ ] I have added an entry to the CHANGELOG.
