### PR TITLE
Fix #4902

### DIFF
--- a/mitmproxy/tools/console/commandexecutor.py
+++ b/mitmproxy/tools/console/commandexecutor.py
@@ -19,7 +19,7 @@ class CommandExecutor:
             except exceptions.CommandError as e:
                 ctx.log.error(str(e))
             else:
-                if ret:
+                if ret is not None:
                     if type(ret) == typing.Sequence[flow.Flow]:
                         signals.status_message.send(
                             message="Command returned %s flows" % len(ret)

--- a/mitmproxy/tools/console/grideditor/editors.py
+++ b/mitmproxy/tools/console/grideditor/editors.py
@@ -215,7 +215,7 @@ class DataViewer(base.GridEditor, layoutwidget.LayoutWidget):
                 typing.List[typing.Any],
                 typing.Any,
             ]) -> None:
-        if vals:
+        if vals is not None:
             # Whatever vals is, make it a list of rows containing lists of column values.
             if not isinstance(vals, list):
                 vals = [vals]

--- a/mitmproxy/tools/console/grideditor/editors.py
+++ b/mitmproxy/tools/console/grideditor/editors.py
@@ -213,7 +213,7 @@ class DataViewer(base.GridEditor, layoutwidget.LayoutWidget):
             vals: typing.Union[
                 typing.List[typing.List[typing.Any]],
                 typing.List[typing.Any],
-                str,
+                typing.Any,
             ]) -> None:
         if vals:
             # Whatever vals is, make it a list of rows containing lists of column values.

--- a/mitmproxy/tools/console/grideditor/editors.py
+++ b/mitmproxy/tools/console/grideditor/editors.py
@@ -217,7 +217,7 @@ class DataViewer(base.GridEditor, layoutwidget.LayoutWidget):
             ]) -> None:
         if vals:
             # Whatever vals is, make it a list of rows containing lists of column values.
-            if isinstance(vals, str):
+            if not isinstance(vals, list):
                 vals = [vals]
             if not isinstance(vals[0], list):
                 vals = [[i] for i in vals]

--- a/test/mitmproxy/tools/console/test_integration.py
+++ b/test/mitmproxy/tools/console/test_integration.py
@@ -55,6 +55,7 @@ def test_options_home_end(console):
 def test_keybindings_home_end(console):
     console.type("K<home><end>")
 
+
 @pytest.mark.asyncio
 def test_replay_count(console):
     console.type(":replay.server.count<enter>")

--- a/test/mitmproxy/tools/console/test_integration.py
+++ b/test/mitmproxy/tools/console/test_integration.py
@@ -54,3 +54,7 @@ def test_options_home_end(console):
 @pytest.mark.asyncio
 def test_keybindings_home_end(console):
     console.type("K<home><end>")
+
+@pytest.mark.asyncio
+def test_replay_count(console):
+    console.type(":replay.server.count<enter>")


### PR DESCRIPTION
#### Description

Convert all non-list types into list, rather than blindly assuming `vals` must either be a string or a list.

#### Checklist

 - [x] I have updated tests where applicable.
 - [ ] I have added an entry to the CHANGELOG.
