### PR TITLE
Console: add error message for older Windows versions

### DIFF
--- a/mitmproxy/contrib/urwid/raw_display.py
+++ b/mitmproxy/contrib/urwid/raw_display.py
@@ -260,7 +260,9 @@ class Screen(BaseScreen, RealTerminal):
             )
 
             ok = win32.SetConsoleMode(hOut, dwOutMode)
-            assert ok
+            if not ok:
+                raise RuntimeError("Error enabling virtual terminal processing, "
+                                   "mitmproxy's console interface requires Windows 10 Build 10586 or above.")
             ok = win32.SetConsoleMode(hIn, dwInMode)
             assert ok
         else:


### PR DESCRIPTION
This fixes #4908.