### PR TITLE
Fix #4926 - support for float options from addons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * New content view which handles gRPC/protobuf. Allows to apply custom definitions to visualize different field decodings.
   Includes example addon which applies custom definitions for selected gRPC traffic (@mame82)
 * Fix a crash caused when editing string option (#4852, @rbdixon)
+* Fix a occurring when editing a float option in the TUI (#4926, @triztian)
 * Base container image bumped to Debian 11 Bullseye (@Kriechi)
 * Upstream replays don't do CONNECT on plaintext HTTP requests (#4876, @HoffmannP)
 * Remove workarounds for old pyOpenSSL versions (#4831, @KarlParkinson)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,3 +100,41 @@ If a linting error is detected, the automated pull request checks will fail and 
 ## Documentation
 
 Please check [docs/README.md](./docs/README.md) for instructions.
+
+
+## Editor or IDE Setups
+
+Short pointers and instructions to get started with hacking `mitmproxy` using popular text editors and IDEs.
+### VSCode 
+
+> NOTE: These particular instructions were tested in macOS
+
+  1. Install `debugpy` by running: `pip install debugpy`
+  2. Follow the instructions of the `Development Setup` section in this document
+  3. Locate where is the `mitmproxy` command installed, you can find this by running `which mitmproxy`. If you're using [pyenv](https://github.com/pyenv/pyenv#simple-python-version-management-pyenv) it will be located at `$HOME/.pyenv/versions/$(pyenv global)/bin/mitmproxy` (full executable path)
+  4. Run the `mitmproxy` in debug mode by executing the following:
+     
+          python -m debugpy --listen 5678 /path/to/mitmproxy
+
+     The mitmproxy TUI should open as regular, you can also use it to debug `mitmdump` or `mitmweb`
+
+  5. Create a VSCode Launch process attach configuration:
+      
+          {
+            "name": "Python: Remote Attach",
+            "type": "python",
+            "request": "attach",
+            "connect": {
+              "host": "localhost",
+              "port": 5678
+            },
+            "pathMappings": [
+              {
+                "localRoot": "${workspaceFolder}",
+                "remoteRoot": "."
+              }
+            ]  
+          }
+
+  6. Run the attach configuration (F5) after starting mitmproxy in debug mode, after the vscode debugger attaches
+     you should be able to set break points and debug away.

--- a/mitmproxy/optmanager.py
+++ b/mitmproxy/optmanager.py
@@ -344,6 +344,16 @@ class OptManager:
                 raise exceptions.OptionsError("Option is required: %s" % o.name)
             else:
                 return None
+        elif o.typespec in (float, typing.Optional[float]):
+            if optstr:
+                try:
+                    return float(optstr)
+                except ValueError:
+                    raise exceptions.OptionsError("Not a float: %s" % optstr)
+            elif o.typespec == float:
+                raise exceptions.OptionsError("Option is float: %s" % o.name)
+            else:
+                return None
         elif o.typespec == bool:
             if optstr == "toggle":
                 return not o.current()

--- a/mitmproxy/tools/console/options.py
+++ b/mitmproxy/tools/console/options.py
@@ -16,7 +16,7 @@ HELP_HEIGHT = 5
 def can_edit_inplace(opt):
     if opt.choices:
         return False
-    if opt.typespec in [str, int, Optional[str], Optional[int]]:
+    if opt.typespec in [str, int, float, Optional[str], Optional[int], Optional[float]]:
         return True
 
 
@@ -45,7 +45,10 @@ class OptionItem(urwid.WidgetWrap):
         if self.opt.typespec == bool:
             displayval = "true" if val else "false"
         elif not val:
-            displayval = ""
+            if self.opt.typespec == float:
+                displayval = str(self.opt.default)
+            else:
+                displayval = ""
         elif self.opt.typespec == Sequence[str]:
             displayval = pprint.pformat(val, indent=1)
         else:


### PR DESCRIPTION
#### Description

Add support for option `float` types.

   * [Issue#4926](https://github.com/mitmproxy/mitmproxy/issues/4926)

#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
 - [x] Ran `tox -e py` 

Fixed functionality:

![mitmproxy-issue-4926-fix](https://user-images.githubusercontent.com/423034/142717510-6949e770-f9d8-432f-b8ad-068158123887.gif)


