### PR TITLE
Add font types to asset filter (~a)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 * Base container image bumped to Debian 11 Bullseye (@Kriechi)
 * Upstream replays don't do CONNECT on plaintext HTTP requests (#4876, @HoffmannP)
 * Remove workarounds for old pyOpenSSL versions (#4831, @KarlParkinson)
-* Add fonts to asset filter (~a) (#TODO, @elespike)
+* Add fonts to asset filter (~a) (#4928, @elespike)
 
 ## 28 September 2021: mitmproxy 7.0.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Base container image bumped to Debian 11 Bullseye (@Kriechi)
 * Upstream replays don't do CONNECT on plaintext HTTP requests (#4876, @HoffmannP)
 * Remove workarounds for old pyOpenSSL versions (#4831, @KarlParkinson)
+* Add fonts to asset filter (~a) (#TODO, @elespike)
 
 ## 28 September 2021: mitmproxy 7.0.4
 

--- a/mitmproxy/flowfilter.py
+++ b/mitmproxy/flowfilter.py
@@ -15,7 +15,6 @@
                         application/javascript
                         text/css
                         image/*
-                        application/x-shockwave-flash ?
                         font/*
                         application/font-*
         ~h rex      Header line in either request or response

--- a/mitmproxy/flowfilter.py
+++ b/mitmproxy/flowfilter.py
@@ -15,7 +15,9 @@
                         application/javascript
                         text/css
                         image/*
-                        application/x-shockwave-flash
+                        application/x-shockwave-flash ?
+                        font/*
+                        application/font-*
         ~h rex      Header line in either request or response
         ~hq rex     Header in request
         ~hs rex     Header in response
@@ -167,13 +169,15 @@ def _check_content_type(rex, message):
 
 class FAsset(_Action):
     code = "a"
-    help = "Match asset in response: CSS, JavaScript, images."
+    help = "Match asset in response: CSS, JavaScript, images, fonts."
     ASSET_TYPES = [re.compile(x) for x in [
         b"text/javascript",
         b"application/x-javascript",
         b"application/javascript",
         b"text/css",
-        b"image/.*"
+        b"image/.*",
+        b"font/.*",
+        b"application/font-.*",
     ]]
 
     @only(http.HTTPFlow)

--- a/test/mitmproxy/test_flowfilter.py
+++ b/test/mitmproxy/test_flowfilter.py
@@ -107,8 +107,11 @@ class TestMatchingHTTPFlow:
     def test_asset(self):
         s = self.resp()
         assert not self.q("~a", s)
-        s.response.headers["content-type"] = "text/javascript"
-        assert self.q("~a", s)
+        for asset_regex in flowfilter.FAsset.ASSET_TYPES:
+            asset_str = asset_regex.pattern.decode()
+            asset_str = asset_str.replace(".*", "test")
+            s.response.headers["content-type"] = asset_str
+            assert self.q("~a", s)
 
     def test_fcontenttype(self):
         q = self.req()

--- a/test/mitmproxy/test_flowfilter.py
+++ b/test/mitmproxy/test_flowfilter.py
@@ -107,11 +107,8 @@ class TestMatchingHTTPFlow:
     def test_asset(self):
         s = self.resp()
         assert not self.q("~a", s)
-        for asset_regex in flowfilter.FAsset.ASSET_TYPES:
-            asset_str = asset_regex.pattern.decode()
-            asset_str = asset_str.replace(".*", "test")
-            s.response.headers["content-type"] = asset_str
-            assert self.q("~a", s)
+        s.response.headers["content-type"] = "text/javascript"
+        assert self.q("~a", s)
 
     def test_fcontenttype(self):
         q = self.req()

--- a/web/src/js/filt/filt.peg
+++ b/web/src/js/filt/filt.peg
@@ -45,7 +45,9 @@ var ASSET_TYPES = [
     new RegExp("application/x-javascript"),
     new RegExp("application/javascript"),
     new RegExp("text/css"),
-    new RegExp("image/.*")
+    new RegExp("image/.*"),
+    new RegExp("font/.*"),
+    new RegExp("application/font.*"),
 ];
 function assetFilter(flow) {
     if (flow.response) {


### PR DESCRIPTION
#### Description

Add 2 font MIME type patterns to the asset filter (~a) to both `mitmproxy` and `mitmweb`:
- `font/*`
- `application/font-*`

#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
