### PR TITLE
WebSockets: don't assert that server is connected upon initialization

### DIFF
--- a/mitmproxy/proxy/layers/websocket.py
+++ b/mitmproxy/proxy/layers/websocket.py
@@ -86,7 +86,6 @@ class WebsocketLayer(layer.Layer):
     def __init__(self, context: Context, flow: http.HTTPFlow):
         super().__init__(context)
         self.flow = flow
-        assert context.server.connected
 
     @expect(events.Start)
     def start(self, _) -> layer.CommandGenerator[None]:


### PR DESCRIPTION
There may already have been a disconnect, which is still in the processing queue.

fix #4931
