### PR TITLE
Fixes AttributeError in transparent mode

### DIFF
--- a/mitmproxy/platform/windows.py
+++ b/mitmproxy/platform/windows.py
@@ -76,7 +76,7 @@ class Resolver:
                 if addr is None:
                     raise RuntimeError("Cannot resolve original destination.")
                 return tuple(addr)
-            except (EOFError, OSError):
+            except (EOFError, OSError, AttributeError):
                 self._connect()
                 return self.original_addr(csock)
 


### PR DESCRIPTION
#### Description

If we haven't connected to the upstream host in transparent mode, then the call to `write` on line 74 will raise an `AttributeError` as we haven't initialised `self.wfile`.

If we add `AttributeError` to the `except` line, then we'll catch the exception and call `_connect`, which will in turn initialise `wfile`.

#### Checklist

 - [ ] I have updated tests where applicable.
 - [ ] I have added an entry to the CHANGELOG.
