### PR TITLE
Add deepcopy to allow view.flows.resolve (issue #4916)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Upstream replays don't do CONNECT on plaintext HTTP requests (#4876, @HoffmannP)
 * Remove workarounds for old pyOpenSSL versions (#4831, @KarlParkinson)
 * Add fonts to asset filter (~a) (#4928, @elespike)
+* Fix bug that crashed when using `view.flows.resolve` (#4916, @rbdixon)
 
 ## 28 September 2021: mitmproxy 7.0.4
 

--- a/mitmproxy/controller.py
+++ b/mitmproxy/controller.py
@@ -61,9 +61,17 @@ class Reply:
         self.obj.error = flow.Error(flow.Error.KILLED_MESSAGE)
 
     def __del__(self):
-        if self.state != "committed":
+        if self.state != "committed" and self.obj is not None:
             # This will be ignored by the interpreter, but emit a warning
             raise exceptions.ControlException(f"Uncommitted reply: {self.obj}")
+
+    def __deepcopy__(self, memo):
+        cls = self.__class__
+        result = cls.__new__(cls)
+        memo[id(self)] = result
+        result.obj = None
+        result._state = self._state
+        return result
 
 
 class DummyReply(Reply):
@@ -89,3 +97,8 @@ class DummyReply(Reply):
 
     def __del__(self):
         pass
+
+    def __deepcopy__(self, memo):
+        result = super().__deepcopy__(memo)
+        result._should_reset = self._should_reset
+        return result

--- a/mitmproxy/controller.py
+++ b/mitmproxy/controller.py
@@ -66,12 +66,8 @@ class Reply:
             raise exceptions.ControlException(f"Uncommitted reply: {self.obj}")
 
     def __deepcopy__(self, memo):
-        cls = self.__class__
-        result = cls.__new__(cls)
-        memo[id(self)] = result
-        result.obj = None
-        result._state = self._state
-        return result
+        # some parts of the console ui may use deepcopy, see https://github.com/mitmproxy/mitmproxy/issues/4916
+        return memo.setdefault(id(self), DummyReply())
 
 
 class DummyReply(Reply):
@@ -97,8 +93,3 @@ class DummyReply(Reply):
 
     def __del__(self):
         pass
-
-    def __deepcopy__(self, memo):
-        result = super().__deepcopy__(memo)
-        result._should_reset = self._should_reset
-        return result

--- a/mitmproxy/controller.py
+++ b/mitmproxy/controller.py
@@ -61,7 +61,7 @@ class Reply:
         self.obj.error = flow.Error(flow.Error.KILLED_MESSAGE)
 
     def __del__(self):
-        if self.state != "committed" and self.obj is not None:
+        if self.state != "committed":
             # This will be ignored by the interpreter, but emit a warning
             raise exceptions.ControlException(f"Uncommitted reply: {self.obj}")
 


### PR DESCRIPTION
#### Description

Add a `__deepcopy__()` method so that when an intercepted flow or a flow loaded from a file is displayed using `view.flows.resolve` the flows are able to be deepcopy()'ed.

#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
