### PR TITLE
Example specified incorrect header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * Add fonts to asset filter (~a) (#4928, @elespike)
 * Fix bug that crashed when using `view.flows.resolve` (#4916, @rbdixon)
 * Fix a bug where `running()` is invoked twice on startup (#3584, @mhils)
+* Correct documentation example for User-Agent header modification
 
 ## 28 September 2021: mitmproxy 7.0.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 * Add fonts to asset filter (~a) (#4928, @elespike)
 * Fix bug that crashed when using `view.flows.resolve` (#4916, @rbdixon)
 * Fix a bug where `running()` is invoked twice on startup (#3584, @mhils)
-* Correct documentation example for User-Agent header modification
+* Correct documentation example for User-Agent header modification (#4997, @jamesyale)
 
 ## 28 September 2021: mitmproxy 7.0.4
 

--- a/docs/src/content/overview-features.md
+++ b/docs/src/content/overview-features.md
@@ -275,7 +275,7 @@ Set the `User-Agent` header to the data read from `~/useragent.txt` for all requ
 (existing `User-Agent` headers are replaced):
 
 ```
-/~q/Host/@~/useragent.txt
+/~q/User-Agent/@~/useragent.txt
 ```
 
 Remove existing `Host` headers from all requests:


### PR DESCRIPTION
#### Description

Trivial documentation fix, the `User-Agent` header modification [example](https://docs.mitmproxy.org/stable/overview-features/#examples-4) was incorrect, specifying the `Host` header. Copy/paste error by the looks of it. 

#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
