### PR TITLE
Feature #5019 - allow context configuration changes in tls_* hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * Fix bug that crashed when using `view.flows.resolve` (#4916, @rbdixon)
 * Fix a bug where `running()` is invoked twice on startup (#3584, @mhils)
 * Correct documentation example for User-Agent header modification (#4997, @jamesyale)
+* Allow context configuration changes in `tls_*` hooks (#5019, @jsmucr)
 
 ## 28 September 2021: mitmproxy 7.0.4
 

--- a/mitmproxy/addons/tlsconfig.py
+++ b/mitmproxy/addons/tlsconfig.py
@@ -172,7 +172,9 @@ class TlsConfig:
         server: connection.Server = tls_start.context.server
         assert server.address
 
-        if ctx.options.ssl_insecure:
+        options = tls_start.context.options
+
+        if options.ssl_insecure:
             verify = net_tls.Verify.VERIFY_NONE
         else:
             verify = net_tls.Verify.VERIFY_PEER
@@ -182,7 +184,7 @@ class TlsConfig:
 
         if not server.alpn_offers:
             if client.alpn_offers:
-                if ctx.options.http2:
+                if options.http2:
                     # We would perfectly support HTTP/1 -> HTTP/2, but we want to keep things on the same protocol
                     # version. There are some edge cases where we want to mirror the regular server's behavior
                     # accurately, for example header capitalization.
@@ -197,14 +199,14 @@ class TlsConfig:
                 #   or falls back to HTTP.
                 server.alpn_offers = []
 
-        if not server.cipher_list and ctx.options.ciphers_server:
-            server.cipher_list = ctx.options.ciphers_server.split(":")
+        if not server.cipher_list and options.ciphers_server:
+            server.cipher_list = options.ciphers_server.split(":")
         # don't assign to client.cipher_list, doesn't need to be stored.
         cipher_list = server.cipher_list or DEFAULT_CIPHERS
 
         client_cert: Optional[str] = None
-        if ctx.options.client_certs:
-            client_certs = os.path.expanduser(ctx.options.client_certs)
+        if options.client_certs:
+            client_certs = os.path.expanduser(options.client_certs)
             if os.path.isfile(client_certs):
                 client_cert = client_certs
             else:
@@ -214,13 +216,13 @@ class TlsConfig:
                     client_cert = p
 
         ssl_ctx = net_tls.create_proxy_server_context(
-            min_version=net_tls.Version[ctx.options.tls_version_client_min],
-            max_version=net_tls.Version[ctx.options.tls_version_client_max],
+            min_version=net_tls.Version[options.tls_version_client_min],
+            max_version=net_tls.Version[options.tls_version_client_max],
             cipher_list=tuple(cipher_list),
             verify=verify,
             hostname=server.sni,
-            ca_path=ctx.options.ssl_verify_upstream_trusted_confdir,
-            ca_pemfile=ctx.options.ssl_verify_upstream_trusted_ca,
+            ca_path=options.ssl_verify_upstream_trusted_confdir,
+            ca_pemfile=options.ssl_verify_upstream_trusted_ca,
             client_cert=client_cert,
             alpn_protos=tuple(server.alpn_offers),
         )

--- a/mitmproxy/options.py
+++ b/mitmproxy/options.py
@@ -2,6 +2,8 @@ from typing import Optional, Sequence
 
 from mitmproxy import optmanager
 
+import copy
+
 CONF_DIR = "~/.mitmproxy"
 CONF_BASENAME = "mitmproxy"
 LISTEN_PORT = 8080
@@ -154,3 +156,10 @@ class Options(optmanager.OptManager):
         )
 
         self.update(**kwargs)
+
+    def __deepcopy__(self, memodict = None):
+        o = Options()
+        o.__dict__["_options"] = copy.deepcopy(self._options, memodict)
+        return o
+
+    __copy__ = __deepcopy__

--- a/mitmproxy/proxy/context.py
+++ b/mitmproxy/proxy/context.py
@@ -3,6 +3,8 @@ from typing import List, TYPE_CHECKING
 from mitmproxy import connection
 from mitmproxy.options import Options
 
+import copy
+
 if TYPE_CHECKING:
     import mitmproxy.proxy.layer
 
@@ -36,7 +38,8 @@ class Context:
         options: Options,
     ) -> None:
         self.client = client
-        self.options = options
+        # Always copy the options to prevent modifications from different contexts
+        self.options = copy.deepcopy(options)
         self.server = connection.Server(None)
         self.layers = []
 


### PR DESCRIPTION
#### Description

Creating a new `Context` now clones the `Options` passed to it so that these options can be changed later in the process without changing anything globally.

This makes it possible to set for example `ssl_insecure` for each request individually from within the `tls_start_server` hook.

```python
from mitmproxy import ctx

def tls_start_server(data: any):
    address = data.context.server.address[0] + ":" + str(data.context.server.address[1])
    if address == 'as2.pipechain.com:10443':
        data.context.options.ssl_insecure = True
    ctx.log.info("ssl_insecure[" + address + "] => " + str(data.context.options.ssl_insecure))
```

#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
