### PR TITLE
Fix crush shutdown when MITM has it's own loop

### DIFF
--- a/mitmproxy/master.py
+++ b/mitmproxy/master.py
@@ -92,7 +92,7 @@ class Master:
             # This all needs to be simplified when the proxy server runs on asyncio as well.
             if not self.event_loop.is_running():  # pragma: no cover
                 try:
-                    self.event_loop.run_until_complete(asyncio.wrap_future(ret))
+                    self.event_loop.run_until_complete(asyncio.wrap_future(ret, loop=self.event_loop))
                 except RuntimeError:
                     pass  # Event loop stopped before Future completed.
 


### PR DESCRIPTION
#### Description

Set the loop explicit in `asyncio.wrap_future` call  

#### Problem

When I call shutdown with a different loop in the current thread from MITM loop, it's crashes with the error:
`ValueError: The future belongs to a different loop than the one specified as the loop argument`
