### PR TITLE
Fix a crash when refreshing headers with a negative unix timestamp

### DIFF
--- a/mitmproxy/http.py
+++ b/mitmproxy/http.py
@@ -1185,7 +1185,10 @@ class Response(Message):
                 d = parsedate_tz(self.headers[i])
                 if d:
                     new = mktime_tz(d) + delta
-                    self.headers[i] = formatdate(new, usegmt=True)
+                    try:
+                        self.headers[i] = formatdate(new, usegmt=True)
+                    except OSError:
+                        pass  # value out of bounds on Windows.
         c = []
         for set_cookie_header in self.headers.get_all("set-cookie"):
             try:

--- a/mitmproxy/http.py
+++ b/mitmproxy/http.py
@@ -1187,8 +1187,8 @@ class Response(Message):
                     new = mktime_tz(d) + delta
                     try:
                         self.headers[i] = formatdate(new, usegmt=True)
-                    except OSError:
-                        pass  # value out of bounds on Windows.
+                    except OSError:  # pragma: no cover
+                        pass  # value out of bounds on Windows only (which is why we exclude it from coverage).
         c = []
         for set_cookie_header in self.headers.get_all("set-cookie"):
             try:

--- a/test/mitmproxy/test_http.py
+++ b/test/mitmproxy/test_http.py
@@ -613,6 +613,11 @@ class TestResponseUtils:
             m.side_effect = ValueError
             r.refresh(n)
 
+        # Test negative unixtime, which raises on at least Windows.
+        r.headers["date"] = pre = "Mon, 01 Jan 1601 00:00:00 GMT"
+        r.refresh(946681202)
+        assert r.headers["date"] == pre
+
 
 class TestHTTPFlow:
 


### PR DESCRIPTION
fix #5054