### PR TITLE
Pass length of hostname.encode() to X509_VERIFY_PARAM_set1_host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * Correct documentation example for User-Agent header modification (#4997, @jamesyale)
 * Fix random connection stalls (#5040, @EndUser509)
 * Add `n` new flow keybind to mitmweb (#5061, @ianklatzco)
+* Fix crash from not passing length to OpenSSL library call (pmoulton@)
 
 ## 28 September 2021: mitmproxy 7.0.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 * Correct documentation example for User-Agent header modification (#4997, @jamesyale)
 * Fix random connection stalls (#5040, @EndUser509)
 * Add `n` new flow keybind to mitmweb (#5061, @ianklatzco)
-* Fix crash from not passing length to OpenSSL library call (pmoulton@)
+* Fix compatibility with BoringSSL (@pmoulton)
 
 ## 28 September 2021: mitmproxy 7.0.4
 

--- a/mitmproxy/net/tls.py
+++ b/mitmproxy/net/tls.py
@@ -157,7 +157,7 @@ def create_proxy_server_context(
             ip: bytes = ipaddress.ip_address(hostname).packed
         except ValueError:
             SSL._openssl_assert(  # type: ignore
-                SSL._lib.X509_VERIFY_PARAM_set1_host(param, hostname.encode(), 0) == 1  # type: ignore
+                SSL._lib.X509_VERIFY_PARAM_set1_host(param, hostname.encode(), len(hostname.encode())) == 1  # type: ignore
             )
         else:
             SSL._openssl_assert(  # type: ignore


### PR DESCRIPTION
#### Description

Passing zero for the size_t length argument of
X509_VERIFY_PARAM_set1_host causes MITM Proxy to crash when used with
BoringSSL.

https://www.openssl.org/docs/man1.1.1/man3/X509_VERIFY_PARAM_set1_host.html
https://boringssl.googlesource.com/boringssl/

#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.