### PR TITLE
Pass the flow to the stream modify function

### DIFF
--- a/mitmproxy/http.py
+++ b/mitmproxy/http.py
@@ -250,7 +250,7 @@ class Message(serializable.Serializable):
         self.data.set_state(state)
 
     data: MessageData
-    stream: Union[Callable[[bytes], Union[Iterable[bytes], bytes]], bool] = False
+    stream: Union[Callable[[bytes, flow.Flow], Union[Iterable[bytes], bytes]], bool] = False
     """
     This attribute controls if the message body should be streamed.
 

--- a/mitmproxy/proxy/layers/http/__init__.py
+++ b/mitmproxy/proxy/layers/http/__init__.py
@@ -231,7 +231,7 @@ class HttpStream(layer.Layer):
     def state_stream_request_body(self, event: Union[RequestData, RequestEndOfMessage]) -> layer.CommandGenerator[None]:
         if isinstance(event, RequestData):
             if callable(self.flow.request.stream):
-                chunks = self.flow.request.stream(event.data)
+                chunks = self.flow.request.stream(event.data, self.flow)
                 if isinstance(chunks, bytes):
                     chunks = [chunks]
             else:
@@ -243,7 +243,7 @@ class HttpStream(layer.Layer):
             self.flow.request.trailers = event.trailers
         elif isinstance(event, RequestEndOfMessage):
             if callable(self.flow.request.stream):
-                chunks = self.flow.request.stream(b"")
+                chunks = self.flow.request.stream(b"", self.flow)
                 if chunks == b"":
                     chunks = []
                 elif isinstance(chunks, bytes):
@@ -325,7 +325,7 @@ class HttpStream(layer.Layer):
         assert self.flow.response
         if isinstance(event, ResponseData):
             if callable(self.flow.response.stream):
-                chunks = self.flow.response.stream(event.data)
+                chunks = self.flow.response.stream(event.data, self.flow)
                 if isinstance(chunks, bytes):
                     chunks = [chunks]
             else:
@@ -337,7 +337,7 @@ class HttpStream(layer.Layer):
             # will be sent in send_response() after the response hook.
         elif isinstance(event, ResponseEndOfMessage):
             if callable(self.flow.response.stream):
-                chunks = self.flow.response.stream(b"")
+                chunks = self.flow.response.stream(b"", self.flow)
                 if chunks == b"":
                     chunks = []
                 elif isinstance(chunks, bytes):


### PR DESCRIPTION
#### Description

I need the flow and I think as second parameter it's not a breaking change and won't hurt?
Do I even need to write a test for this?

I'm currently doing this:

```py
def responseheaders(flow):
    if flow.response.headers.get('content-type', '').startswith('text/event-stream'):
        def modify(data: bytes) -> Union[bytes, Iterable[bytes]]:
            # Do something here that requires the flow to decide what to do with data.
            print(flow.id, data)
            return data

        flow.response.stream = modify
```

which doesn't look Python (JS callbacks anyone?) and also leaks memory because when the flow is done processing `stream` keeps pointing to the function that is never being called any longer.

#### Checklist

 - [ ] I have updated tests where applicable.