### PR TITLE
iOS 15 certificate installation instructions update

### DIFF
--- a/mitmproxy/addons/onboardingapp/templates/index.html
+++ b/mitmproxy/addons/onboardingapp/templates/index.html
@@ -68,10 +68,8 @@
     <h5>iOS 13+</h5>
     <ol>
         <li>Use Safari to download the certificate. Other browsers may not open the proper installation prompt.</li>
-        <li>Install the new Profile (<samp>Settings -> General -> VPN & Device Management</samp>).
-        </li>
-        <li><span class="text-danger"><strong>Important: </strong> Goto
-            <samp>Settings -> General -> About -> Certificate Trust Settings</samp>.
+        <li>Install the new Profile (<samp>Settings -> General -> VPN & Device Management</samp>).</li>
+        <li><span class="text-danger"><strong>Important:</strong> Go to <samp>Settings -> General -> About -> Certificate Trust Settings</samp>.
             Toggle <samp>mitmproxy</samp> to <samp>ON</samp>.</span></li>
     </ol>
     {% endcall %}

--- a/mitmproxy/addons/onboardingapp/templates/index.html
+++ b/mitmproxy/addons/onboardingapp/templates/index.html
@@ -68,8 +68,7 @@
     <h5>iOS 13+</h5>
     <ol>
         <li>Use Safari to download the certificate. Other browsers may not open the proper installation prompt.</li>
-        <li>Install the new Profile and activate it (<samp>Settings -> General</samp> ->
-            <samp>Profile</samp>).
+        <li>Install the new Profile (<samp>Settings -> General -> VPN & Device Management</samp>).
         </li>
         <li><span class="text-danger"><strong>Important: </strong> Goto
             <samp>Settings -> General -> About -> Certificate Trust Settings</samp>.


### PR DESCRIPTION
#### Description

I have updated instructions for installing certificate on iOS 15 (basing on version 15.1). The second commit contains small formatting fixes and a typo within the source file.

I don't think it's worth to mention this in the CHANGELOG.

#### Checklist

 - [] I have updated tests where applicable.
 - [] I have added an entry to the CHANGELOG.
