### PR TITLE
await server_connected hook before doing something with the connection, fixes #5108

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * Fix random connection stalls (#5040, @EndUser509)
 * Add `n` new flow keybind to mitmweb (#5061, @ianklatzco)
 * Fix compatibility with BoringSSL (@pmoulton)
+* Await the `server_connected` hook before doing something with the connection, e.g. before HTTP `request` hook (@Prinzhorn)
 
 ## 28 September 2021: mitmproxy 7.0.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,8 @@
 * Fix random connection stalls (#5040, @EndUser509)
 * Add `n` new flow keybind to mitmweb (#5061, @ianklatzco)
 * Fix compatibility with BoringSSL (@pmoulton)
-* Await the `server_connected` hook before doing something with the connection, e.g. before HTTP `request` hook (@Prinzhorn)
+* Change connection event hooks to be blocking.
+  Processing will only resume once the event hook has finished. (@Prinzhorn)
 
 ## 28 September 2021: mitmproxy 7.0.4
 

--- a/mitmproxy/proxy/server.py
+++ b/mitmproxy/proxy/server.py
@@ -176,14 +176,7 @@ class ConnectionHandler(metaclass=abc.ABCMeta):
                 else:
                     addr = human.format_address(command.connection.address)
                 self.log(f"server connect {addr}")
-                connected_hook = asyncio_utils.create_task(
-                    self.handle_hook(server_hooks.ServerConnectedHook(hook_data)),
-                    name=f"handle_hook(server_connected) {addr}",
-                    client=self.client.peername,
-                )
-                if not connected_hook:
-                    return  # this should not be needed, see asyncio_utils.create_task
-
+                await self.handle_hook(server_hooks.ServerConnectedHook(hook_data))
                 self.server_event(events.OpenConnectionCompleted(command, None))
 
                 # during connection opening, this function is the designated handler that can be cancelled.
@@ -201,7 +194,6 @@ class ConnectionHandler(metaclass=abc.ABCMeta):
 
                 self.log(f"server disconnect {addr}")
                 command.connection.timestamp_end = time.time()
-                await connected_hook  # wait here for this so that closed always comes after connected.
                 await self.handle_hook(server_hooks.ServerDisconnectedHook(hook_data))
 
     async def handle_connection(self, connection: Connection) -> None:

--- a/mitmproxy/proxy/server_hooks.py
+++ b/mitmproxy/proxy/server_hooks.py
@@ -20,7 +20,6 @@ class ClientDisconnectedHook(commands.StartHook):
     """
     A client connection has been closed (either by us or the client).
     """
-    blocking = False
     client: connection.Client
 
 
@@ -50,7 +49,6 @@ class ServerConnectedHook(commands.StartHook):
     """
     Mitmproxy has connected to a server.
     """
-    blocking = False
     data: ServerConnectionHookData
 
 
@@ -59,5 +57,4 @@ class ServerDisconnectedHook(commands.StartHook):
     """
     A server connection has been closed (either by us or the server).
     """
-    blocking = False
     data: ServerConnectionHookData


### PR DESCRIPTION
#### Description

I tried with some live traffic and it behaved as expected. Also the demo add-on no longer logs server_connected and request interleaved.

#### Checklist

 - [ ] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
