### PR TITLE
Fix mitmweb export copy failed in non-secure domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,9 @@
   ([#3965](https://github.com/mitmproxy/mitmproxy/issues/3965), @mhils)
 * Fix text truncation for full-width characters 
   ([#4278](https://github.com/mitmproxy/mitmproxy/issues/4278), @kjy00302)
-
+* Fix mitmweb export copy failed in non-secure domain.
+  ([#5264](https://github.com/mitmproxy/mitmproxy/issues/5264), @Pactortester)
+  
 ## 19 March 2022: mitmproxy 8.0.0
 
 ### Major Changes

--- a/web/src/js/contrib/clipboard.tsx
+++ b/web/src/js/contrib/clipboard.tsx
@@ -1,0 +1,27 @@
+// Adapted from https://stackoverflow.com/a/65996386/934719
+/**
+ * `navigator.clipboard.writeText()`, but with an additional fallback for non-secure contexts.
+ */
+export function copyToClipboard(text: string): Promise<void> {
+    // navigator clipboard requires a security context such as https
+    if (navigator.clipboard && window.isSecureContext) {
+        return navigator.clipboard.writeText(text);
+    } else {
+        let t = document.createElement("textarea");
+        t.value = text;
+        t.style.position = "absolute";
+        t.style.opacity = "0";
+        document.body.appendChild(t);
+        try {
+            t.focus();
+            t.select();
+            document.execCommand("copy");
+            return Promise.resolve();
+        } catch (err) {
+            alert(text);
+            return Promise.reject(err);
+        } finally {
+            t.remove();
+        }
+    }
+}

--- a/web/src/js/flow/export.ts
+++ b/web/src/js/flow/export.ts
@@ -1,11 +1,37 @@
 import {fetchApi, runCommand} from "../utils";
 import {Flow} from "../flow";
 
+function copyToClipboard(textToCopy) {
+    // navigator clipboard requires a security context such as https
+    if (navigator.clipboard && window.isSecureContext) {
+        // navigator clipboard write text to the clipboard
+        return navigator.clipboard.writeText(textToCopy);
+    } else {
+        // create text area
+        let textArea = document.createElement("textarea");
+        textArea.value = textToCopy;
+        // make the text area not in the viewport, and set it to be invisible
+        textArea.style.position = "absolute";
+        textArea.style.opacity = String(0);
+        textArea.style.left = "-999999px";
+        textArea.style.top = "-999999px";
+        document.body.appendChild(textArea);
+        textArea.focus();
+        textArea.select();
+        return new Promise((res, rej) => {
+            // execute the copy command and remove the text box
+            document.execCommand('copy') ? res() : rej();
+            textArea.remove();
+
+        });
+    }
+}
+
 export const copy = async (flow: Flow, format: string): Promise<void> => {
     let ret = await runCommand("export", format, `@${flow.id}`);
-    if(ret.value) {
-        await navigator.clipboard.writeText(ret.value);
-    } else if(ret.error) {
+    if (ret.value) {
+        await copyToClipboard(ret.value);
+    } else if (ret.error) {
         alert(ret.error)
     } else {
         console.error(ret);

--- a/web/src/js/flow/export.ts
+++ b/web/src/js/flow/export.ts
@@ -18,11 +18,10 @@ function copyToClipboard(textToCopy) {
         document.body.appendChild(textArea);
         textArea.focus();
         textArea.select();
-        return new Promise((res, rej) => {
+        return new Promise<void>((res, rej) => {
             // execute the copy command and remove the text box
             document.execCommand('copy') ? res() : rej();
             textArea.remove();
-
         });
     }
 }

--- a/web/src/js/flow/export.ts
+++ b/web/src/js/flow/export.ts
@@ -1,30 +1,7 @@
-import {fetchApi, runCommand} from "../utils";
+import {runCommand} from "../utils";
 import {Flow} from "../flow";
+import {copyToClipboard} from "../contrib/clipboard";
 
-function copyToClipboard(textToCopy) {
-    // navigator clipboard requires a security context such as https
-    if (navigator.clipboard && window.isSecureContext) {
-        // navigator clipboard write text to the clipboard
-        return navigator.clipboard.writeText(textToCopy);
-    } else {
-        // create text area
-        let textArea = document.createElement("textarea");
-        textArea.value = textToCopy;
-        // make the text area not in the viewport, and set it to be invisible
-        textArea.style.position = "absolute";
-        textArea.style.opacity = String(0);
-        textArea.style.left = "-999999px";
-        textArea.style.top = "-999999px";
-        document.body.appendChild(textArea);
-        textArea.focus();
-        textArea.select();
-        return new Promise<void>((res, rej) => {
-            // execute the copy command and remove the text box
-            document.execCommand('copy') ? res() : rej();
-            textArea.remove();
-        });
-    }
-}
 
 export const copy = async (flow: Flow, format: string): Promise<void> => {
     let ret = await runCommand("export", format, `@${flow.id}`);


### PR DESCRIPTION
https://github.com/mitmproxy/mitmproxy/issues/5264

#### Description

The browser disables the navigator.clipboard object for non-secure domains.

- startup parameters: `mitmweb -p 8888 --web-host 192.168.0.124`
- browser console error : `Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'writeText')`

The security domain includes addresses for local access and TLS security authentication, such as `https` protocol addresses, `127.0.0.1` or `localhost`.

So I submit a PR:
- Use `navigator.clipboard` in the secure domain to improve efficiency, and fall back to `document.execCommand('copy');` in the non-secure domain to ensure that the function is available.

#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
