### PR TITLE
Fix terminal breakage if an error occurs at startup

### DIFF
--- a/mitmproxy/master.py
+++ b/mitmproxy/master.py
@@ -46,9 +46,11 @@ class Master:
             # Handle scheduled tasks (configure()) first.
             await asyncio.sleep(0)
             await self.running()
-            await self.should_exit.wait()
-
-            await self.done()
+            try:
+                await self.should_exit.wait()
+            finally:
+                # .wait might be cancelled (e.g. by sys.exit)
+                await self.done()
         finally:
             self.event_loop.set_exception_handler(old_handler)
 


### PR DESCRIPTION
sys.exit() causes a CancelledError to be thrown. ErrorCheck._shutdown_if_errored
fires sys.exit after self.running() returns, causing the CancelledError to
appear in Event.wait() and preventing Master.done() from being called. This can
result in terminal breakage when using the CLI, and is especially apparent if
any errors occur during startup (e.g. port is not available, script has a syntax
error, etc.).

#### Description

The fix is simply to ensure that Master.done always gets called.

Note that this doesn't handle the case of people calling `sys.exit` or throwing some other `BaseException` from a `running` hook; this ideally should be a very rare occurrence, so it's probably not worth specially handling.


#### Checklist

 - [ ] I have updated tests where applicable.
 - [ ] I have added an entry to the CHANGELOG.
