### PR TITLE
Remove usage of deprecated mailcap module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@
   ([#5264](https://github.com/mitmproxy/mitmproxy/issues/5264), @Pactortester)
 * Added example script for manipulating cookies.
   ([#5278](https://github.com/mitmproxy/mitmproxy/issues/5278), @WillahScott)
+* Removed usage of deprecated for Python 3.11 module `mailcap`
+  ([#5297](https://github.com/mitmproxy/mitmproxy/issues/5297), @KORraNpl)
   
 ## 19 March 2022: mitmproxy 8.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,9 +28,10 @@
   ([#4278](https://github.com/mitmproxy/mitmproxy/issues/4278), @kjy00302)
 * Fix mitmweb export copy failed in non-secure domain.
   ([#5264](https://github.com/mitmproxy/mitmproxy/issues/5264), @Pactortester)
-* Added example script for manipulating cookies.
+* Add example script for manipulating cookies.
   ([#5278](https://github.com/mitmproxy/mitmproxy/issues/5278), @WillahScott)
-* Removed usage of deprecated for Python 3.11 module `mailcap`
+* When opening an external viewer for message contents, mailcap files are not considered anymore.  
+  This preempts the upcoming deprecation of Python's `mailcap` module. 
   ([#5297](https://github.com/mitmproxy/mitmproxy/issues/5297), @KORraNpl)
   
 ## 19 March 2022: mitmproxy 8.0.0


### PR DESCRIPTION
Resolves #5297

#### Description

Removed mailcap usage. Behaviour should not change on non-UNIX platforms, on UNIX it is unified with macOS and Windows.

#### Checklist

 - [ N/A ] I have updated tests where applicable.
 - [ N/A ] I have added an entry to the CHANGELOG.
