### PR TITLE
Fix CommandError when loading a new contentview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@
 * When opening an external viewer for message contents, mailcap files are not considered anymore.  
   This preempts the upcoming deprecation of Python's `mailcap` module. 
   ([#5297](https://github.com/mitmproxy/mitmproxy/issues/5297), @KORraNpl)
+* Fixed hot reloading of contentviews.
+  ([#5319](https://github.com/mitmproxy/mitmproxy/issues/5319), @nneonneo)
   
 ## 19 March 2022: mitmproxy 8.0.0
 

--- a/mitmproxy/contentviews/__init__.py
+++ b/mitmproxy/contentviews/__init__.py
@@ -47,6 +47,8 @@ views: list[View] = []
 
 on_add = blinker.Signal()
 """A new contentview has been added."""
+on_remove = blinker.Signal()
+"""A contentview has been removed."""
 
 
 def get(name: str) -> Optional[View]:
@@ -68,6 +70,7 @@ def add(view: View) -> None:
 
 def remove(view: View) -> None:
     views.remove(view)
+    on_remove.send(view)
 
 
 def safe_to_print(lines, encoding="utf8"):

--- a/mitmproxy/tools/console/flowview.py
+++ b/mitmproxy/tools/console/flowview.py
@@ -50,7 +50,8 @@ class FlowDetails(tabs.Tabs):
         super().__init__([])
         self.show()
         self.last_displayed_body = None
-        contentviews.on_add.connect(self.contentview_added)
+        contentviews.on_add.connect(self.contentview_changed)
+        contentviews.on_remove.connect(self.contentview_changed)
 
     @property
     def view(self):
@@ -60,11 +61,12 @@ class FlowDetails(tabs.Tabs):
     def flow(self) -> mitmproxy.flow.Flow:
         return self.master.view.focus.flow
 
-    def contentview_added(self, view):
+    def contentview_changed(self, view):
         # this is called when a contentview addon is live-reloaded.
         # we clear our cache and then rerender
         self._get_content_view.cache_clear()
-        self.show()
+        if self.master.window.current_window("flowview"):
+            self.show()
 
     def focus_changed(self):
         f = self.flow

--- a/test/mitmproxy/tools/console/conftest.py
+++ b/test/mitmproxy/tools/console/conftest.py
@@ -42,5 +42,6 @@ async def console(monkeypatch) -> ConsoleTestMaster:  # noqa
     opts = options.Options()
     m = ConsoleTestMaster(opts)
     opts.server = False
+    opts.console_mouse = False
     await m.running()
     return m

--- a/test/mitmproxy/tools/console/test_contentview.py
+++ b/test/mitmproxy/tools/console/test_contentview.py
@@ -1,0 +1,39 @@
+from mitmproxy.test import tflow
+from mitmproxy import contentviews
+from mitmproxy.contentviews.base import format_text
+
+
+class TContentView(contentviews.View):
+    name = "Test View"
+
+    def __call__(self, data, **metadata):
+        return "TContentView", format_text("test_content")
+
+    def render_priority(self, data, *, content_type=None, **metadata) -> float:
+        return 2
+
+
+async def test_contentview_flowview(console):
+    assert "Flows" in console.screen_contents()
+    flow = tflow.tflow()
+    flow.request.headers["content-type"] = "text/html"
+    await console.load_flow(flow)
+    assert ">>" in console.screen_contents()
+    console.type("<enter>")
+    assert "Flow Details" in console.screen_contents()
+    assert "XML" in console.screen_contents()
+
+    view = TContentView()
+    contentviews.add(view)
+    assert "XML" not in console.screen_contents()
+    assert "TContentView" in console.screen_contents()
+    contentviews.remove(view)
+    assert "XML" in console.screen_contents()
+    assert "TContentView" not in console.screen_contents()
+
+    console.type("q")
+    assert "Flows" in console.screen_contents()
+    contentviews.add(view)
+    console.type("<enter>")
+    assert "Flow Details" in console.screen_contents()
+    assert "TContentView" in console.screen_contents()


### PR DESCRIPTION
#### Description

Fix CommandError when adding a custom view after startup.

Previously, hot-reloading a script with a custom view after at least one flow
was viewed could throw "CommandError: Not viewing a flow" due to show() being
called while the flow view window was not visible.

Additionally, this patch also refreshes the FlowView when a custom view is
removed.

Fixes #5319.

#### Checklist

 - [X] I have updated tests where applicable.
 - [X] I have added an entry to the CHANGELOG.
