### PR TITLE
Properly encode hostname for upstream requests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@
 * When opening an external viewer for message contents, mailcap files are not considered anymore.  
   This preempts the upcoming deprecation of Python's `mailcap` module. 
   ([#5297](https://github.com/mitmproxy/mitmproxy/issues/5297), @KORraNpl)
+* Fix hostname encoding for IDNA domains in upstream mode.
+  ([#5316](https://github.com/mitmproxy/mitmproxy/issues/5316), @nneonneo)
   
 ## 19 March 2022: mitmproxy 8.0.0
 

--- a/mitmproxy/proxy/layers/http/_upstream_proxy.py
+++ b/mitmproxy/proxy/layers/http/_upstream_proxy.py
@@ -46,12 +46,13 @@ class HttpUpstreamProxy(tunnel.TunnelLayer):
             return (yield from super().start_handshake())
         assert self.conn.address
         flow = http.HTTPFlow(self.context.client, self.tunnel_connection)
+        authority = self.conn.address[0].encode("idna") + f":{self.conn.address[1]}".encode()
         flow.request = http.Request(
             host=self.conn.address[0],
             port=self.conn.address[1],
             method=b"CONNECT",
             scheme=b"",
-            authority=f"{self.conn.address[0]}:{self.conn.address[1]}".encode(),
+            authority=authority,
             path=b"",
             http_version=b"HTTP/1.1",
             headers=http.Headers(),


### PR DESCRIPTION
#### Description

Encode host part of authority using idna in upstream proxy, rather than the system encoding.

Fixes #5316.

#### Checklist

 - [X] I have updated tests where applicable.
 - [X] I have added an entry to the CHANGELOG.
