### PR TITLE
share `SSL.Context` for all client <-> proxy connections

### DIFF
--- a/mitmproxy/addons/tlsconfig.py
+++ b/mitmproxy/addons/tlsconfig.py
@@ -174,6 +174,7 @@ class TlsConfig:
         )
         tls_start.ssl_conn = SSL.Connection(ssl_ctx)
 
+        # Use pyOpenSSL API once it has shipped: https://github.com/pyca/pyopenssl/pull/1121
         ok = SSL._lib.SSL_use_certificate(tls_start.ssl_conn._ssl, entry.cert.to_pyopenssl()._x509)  # type: ignore
         SSL._openssl_assert(ok == 1)  # type: ignore
         ok = SSL._lib.SSL_use_PrivateKey(tls_start.ssl_conn._ssl, crypto.PKey.from_cryptography_key(entry.privatekey)._pkey)  # type: ignore

--- a/mitmproxy/net/tls.py
+++ b/mitmproxy/net/tls.py
@@ -8,9 +8,8 @@ from typing import Any, BinaryIO, Callable, Iterable, Optional
 import certifi
 
 from OpenSSL.crypto import X509
-from cryptography.hazmat.primitives.asymmetric import rsa
 
-from OpenSSL import SSL, crypto
+from OpenSSL import SSL
 from mitmproxy import certs
 
 
@@ -166,8 +165,6 @@ def create_client_proxy_context(
     min_version: Version,
     max_version: Version,
     cipher_list: Optional[tuple[str, ...]],
-    cert: certs.Cert,
-    key: rsa.RSAPrivateKey,
     chain_file: Optional[Path],
     alpn_select_callback: Optional[Callable[[SSL.Connection, list[bytes]], Any]],
     request_client_cert: bool,
@@ -181,8 +178,6 @@ def create_client_proxy_context(
         cipher_list=cipher_list,
     )
 
-    context.use_certificate(cert.to_pyopenssl())
-    context.use_privatekey(crypto.PKey.from_cryptography_key(key))
     if chain_file is not None:
         try:
             context.load_verify_locations(str(chain_file), None)


### PR DESCRIPTION
This should cause not functional differences, but increase performance and memory usage.
Currently depends on unreleased cryptography bindings which will be part of the 38.0 release (https://github.com/pyca/cryptography/pull/7210).