### PR TITLE
Fix handling of multiple Cookie headers when proxying HTTP/2 to HTTP/1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
   ([#5339](https://github.com/mitmproxy/mitmproxy/issues/5339), @mhils)
 * Fix handling of multiple Cookie headers when proxying HTTP/2 to HTTP/1
   ([#5337](https://github.com/mitmproxy/mitmproxy/issues/5337), @rinsuki)
+
 ## 19 March 2022: mitmproxy 8.0.0
 
 ### Major Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,8 @@
   ([#5332](https://github.com/mitmproxy/mitmproxy/issues/5332), @mhils)
 * Improve performance and memory usage by reusing OpenSSL contexts.
   ([#5339](https://github.com/mitmproxy/mitmproxy/issues/5339), @mhils)
-
+* Fix handling of multiple Cookie headers when proxying HTTP/2 to HTTP/1
+  ([#5337](https://github.com/mitmproxy/mitmproxy/issues/5337), @rinsuki)
 ## 19 March 2022: mitmproxy 8.0.0
 
 ### Major Changes

--- a/mitmproxy/proxy/layers/http/_http1.py
+++ b/mitmproxy/proxy/layers/http/_http1.py
@@ -348,7 +348,8 @@ class Http1Client(Http1Connection):
                 if "Host" not in request.headers and request.authority:
                     request.headers.insert(0, "Host", request.authority)
                 request.authority = ""
-                if cookie_headers := request.headers.get_all("Cookie") and len(cookie_headers) > 1:
+                cookie_headers = request.headers.get_all("Cookie")
+                if len(cookie_headers) > 1:
                     # Only HTTP/2 supports multiple cookie headers, HTTP/1.x does not.
                     # see: https://www.rfc-editor.org/rfc/rfc6265#section-5.4
                     #      https://www.rfc-editor.org/rfc/rfc7540#section-8.1.2.5

--- a/mitmproxy/proxy/layers/http/_http1.py
+++ b/mitmproxy/proxy/layers/http/_http1.py
@@ -347,6 +347,11 @@ class Http1Client(Http1Connection):
                 request.http_version = "HTTP/1.1"
                 if "Host" not in request.headers and request.authority:
                     request.headers.insert(0, "Host", request.authority)
+                if "Cookie" in request.headers and len(request.headers.get_all("Cookie")) > 1:
+                    # we should merge multiple Cookie headers to one, since HTTP/2 supporting multiple cookie headers but HTTP/1.x is not.
+                    # see: https://www.rfc-editor.org/rfc/rfc6265#section-5.4
+                    #      https://www.rfc-editor.org/rfc/rfc7540#section-8.1.2.5
+                    request.headers.set_all("Cookie", ["; ".join(request.headers.get_all("Cookie"))])
                 request.authority = ""
             raw = http1.assemble_request_head(request)
             yield commands.SendData(self.conn, raw)

--- a/mitmproxy/proxy/layers/http/_http1.py
+++ b/mitmproxy/proxy/layers/http/_http1.py
@@ -347,12 +347,12 @@ class Http1Client(Http1Connection):
                 request.http_version = "HTTP/1.1"
                 if "Host" not in request.headers and request.authority:
                     request.headers.insert(0, "Host", request.authority)
+                request.authority = ""
                 if "Cookie" in request.headers and len(request.headers.get_all("Cookie")) > 1:
                     # we should merge multiple Cookie headers to one, since HTTP/2 supporting multiple cookie headers but HTTP/1.x is not.
                     # see: https://www.rfc-editor.org/rfc/rfc6265#section-5.4
                     #      https://www.rfc-editor.org/rfc/rfc7540#section-8.1.2.5
                     request.headers.set_all("Cookie", ["; ".join(request.headers.get_all("Cookie"))])
-                request.authority = ""
             raw = http1.assemble_request_head(request)
             yield commands.SendData(self.conn, raw)
         elif isinstance(event, RequestData):

--- a/mitmproxy/proxy/layers/http/_http1.py
+++ b/mitmproxy/proxy/layers/http/_http1.py
@@ -348,11 +348,11 @@ class Http1Client(Http1Connection):
                 if "Host" not in request.headers and request.authority:
                     request.headers.insert(0, "Host", request.authority)
                 request.authority = ""
-                if "Cookie" in request.headers and len(request.headers.get_all("Cookie")) > 1:
-                    # we should merge multiple Cookie headers to one, since HTTP/2 supporting multiple cookie headers but HTTP/1.x is not.
+                if cookie_headers := request.headers.get_all("Cookie") and len(cookie_headers) > 1:
+                    # Only HTTP/2 supports multiple cookie headers, HTTP/1.x does not.
                     # see: https://www.rfc-editor.org/rfc/rfc6265#section-5.4
                     #      https://www.rfc-editor.org/rfc/rfc7540#section-8.1.2.5
-                    request.headers.set_all("Cookie", ["; ".join(request.headers.get_all("Cookie"))])
+                    request.headers["Cookie"] = "; ".join(cookie_headers)
             raw = http1.assemble_request_head(request)
             yield commands.SendData(self.conn, raw)
         elif isinstance(event, RequestData):

--- a/test/mitmproxy/proxy/layers/http/test_http_version_interop.py
+++ b/test/mitmproxy/proxy/layers/http/test_http_version_interop.py
@@ -11,11 +11,19 @@ from mitmproxy.proxy.events import DataReceived
 from mitmproxy.proxy.layers import http
 from test.mitmproxy.proxy.layers.http.hyper_h2_test_helpers import FrameFactory
 from test.mitmproxy.proxy.layers.http.test_http2 import (
-    example_request_headers,
     example_response_headers,
     make_h2,
 )
 from test.mitmproxy.proxy.tutils import Placeholder, Playbook, reply
+
+example_request_headers = (
+    (b":method", b"GET"),
+    (b":scheme", b"http"),
+    (b":path", b"/"),
+    (b":authority", b"example.com"),
+    (b"cookie", "a=1"),
+    (b"cookie", "b=2"),
+)
 
 h2f = FrameFactory()
 
@@ -69,7 +77,7 @@ def test_h2_to_h1(tctx):
         >> reply()
         << OpenConnection(server)
         >> reply(None)
-        << SendData(server, b"GET / HTTP/1.1\r\nHost: example.com\r\n\r\n")
+        << SendData(server, b"GET / HTTP/1.1\r\nHost: example.com\r\ncookie: a=1; b=2\r\n\r\n")
         >> DataReceived(server, b"HTTP/1.1 200 OK\r\nContent-Length: 12\r\n\r\n")
         << http.HttpResponseHeadersHook(flow)
         >> reply()


### PR DESCRIPTION
#### Description

Merge multiple Cookie headers when proxying HTTP/2 to HTTP/1 (more information, please see #5337)

Fix #5337

#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
