### PR TITLE
Fix a bug where an excess empty chunk has been sent for chunked HEAD request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * Support specifying the local address for outgoing connections
   ([#5364](https://github.com/mitmproxy/mitmproxy/discussions/5364), @meitinger)
+* Fix a bug where an excess empty chunk has been sent for chunked HEAD request.
+  ([#5372](https://github.com/mitmproxy/mitmproxy/discussions/5372), @jixunmoe)
 
 ## 15 May 2022: mitmproxy 8.1.0
 

--- a/mitmproxy/proxy/layers/http/_http1.py
+++ b/mitmproxy/proxy/layers/http/_http1.py
@@ -243,6 +243,7 @@ class Http1Server(Http1Connection):
             if raw:
                 yield commands.SendData(self.conn, raw)
         elif isinstance(event, ResponseEndOfMessage):
+            assert self.request
             assert self.response
             if self.request.method.upper() != "HEAD" and "chunked" in self.response.headers.get("transfer-encoding", "").lower():
                 yield commands.SendData(self.conn, b"0\r\n\r\n")

--- a/mitmproxy/proxy/layers/http/_http1.py
+++ b/mitmproxy/proxy/layers/http/_http1.py
@@ -244,7 +244,7 @@ class Http1Server(Http1Connection):
                 yield commands.SendData(self.conn, raw)
         elif isinstance(event, ResponseEndOfMessage):
             assert self.response
-            if "chunked" in self.response.headers.get("transfer-encoding", "").lower():
+            if self.request.method.upper() != "HEAD" and "chunked" in self.response.headers.get("transfer-encoding", "").lower():
                 yield commands.SendData(self.conn, b"0\r\n\r\n")
             yield from self.mark_done(response=True)
         elif isinstance(event, ResponseProtocolError):


### PR DESCRIPTION
#### Description

See #5372 for initial bug report with reproduction steps.

> TL;DR: An excess empty chunk `\r\n0\r\n` has been sent to the downstream for HEAD request.

#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
