### PR TITLE
Add quick help bar

### DIFF
--- a/mitmproxy/tools/console/defaultkeys.py
+++ b/mitmproxy/tools/console/defaultkeys.py
@@ -1,6 +1,6 @@
 
 def map(km):
-    km.add("?", "console.view.help", ["quickhelp", "global"], "View help")  # TODO: common key?
+    km.add("?", "console.view.help", ["quickhelp", "global"], "View help")
     km.add("q", "console.view.pop", ["quickhelp", "commonkey", "global"], "Exit the current view", "Exit View")
     km.add(":", "console.command ", ["quickhelp", "commonkey", "global"], "Command prompt", "Command Prompt")
     km.add("O", "console.view.options", ["quickhelp", "commonkey", "global"], "View options", "Options")

--- a/mitmproxy/tools/console/defaultkeys.py
+++ b/mitmproxy/tools/console/defaultkeys.py
@@ -1,24 +1,24 @@
 
 def map(km):
-    km.add("?", "console.view.help", ["global"], "View help")  # TODO: common key?
-    km.add("q", "console.view.pop", ["commonkey", "global"], "Exit the current view")
-    km.add(":", "console.command ", ["commonkey", "global"], "Command prompt")
-    km.add("E", "console.view.eventlog", ["commonkey", "global"], "View event log")
-    km.add("O", "console.view.options", ["commonkey", "global"], "View options")
+    km.add("?", "console.view.help", ["quickhelp", "global"], "View help")  # TODO: common key?
+    km.add("q", "console.view.pop", ["quickhelp", "commonkey", "global"], "Exit the current view", "Exit View")
+    km.add(":", "console.command ", ["quickhelp", "commonkey", "global"], "Command prompt", "Command Prompt")
+    km.add("O", "console.view.options", ["quickhelp", "commonkey", "global"], "View options", "Options")
+    km.add("E", "console.view.eventlog", ["commonkey", "global"], "View event log", "Event Log")
     km.add("enter", "console.nav.select", ["commonkey", "global"], "Select")
     km.add("tab", "console.nav.next", ["commonkey", "global"], "Next")
 
     km.add("?", "console.view.pop", ["help"], "Exit help")
 
-    km.add("C", "console.view.commands", ["global"], "View commands")
-    km.add("P", "console.view.flow @focus", ["global"], "View flow details")
-    km.add("B", "browser.start", ["global"], "Start an attached browser")
-    km.add("K", "console.view.keybindings", ["global"], "View key bindings")
-    km.add("-", "console.layout.cycle", ["global"], "Cycle to next layout")
-    km.add("shift tab", "console.panes.next", ["global"], "Focus next layout pane")
-    km.add("ctrl right", "console.panes.next", ["global"], "Focus next layout pane")
+    km.add("C", "console.view.commands", ["global"], "View commands", "Commands")
+    km.add("P", "console.view.flow @focus", ["global"], "View flow details", "Flow Details")
+    km.add("B", "browser.start", ["global"], "Start an attached browser", "Start Browser")
+    km.add("K", "console.view.keybindings", ["global"], "View key bindings", "Key Bindings")
+    km.add("-", "console.layout.cycle", ["global"], "Cycle to next layout", "Next Layout")
+    km.add("shift tab", "console.panes.next", ["global"], "Focus next layout pane", "Next Layout Pane")
+    km.add("ctrl right", "console.panes.next", ["global"], "Focus next layout pane", "Next Layout Pane")
     km.add("g", "console.nav.start", ["global"], "Go to start")
-    km.add("G", "console.nav.end", ["global"], "Go to end")
+    km.add("G", "console.nav.end", ["global"], "Go to end", "Go To End")
     km.add("k", "console.nav.up", ["global"], "Up")
     km.add("j", "console.nav.down", ["global"], "Down")
     km.add("l", "console.nav.right", ["global"], "Right")
@@ -31,34 +31,25 @@ def map(km):
         "set intercept_active toggle",
         ["global"],
         "Toggle whether the filtering via the intercept option is enabled",
+        "Toggle Intercept Option"
     )
     km.add("i", "console.command.set intercept", ["global"], "Set intercept")
     km.add("W", "console.command.set save_stream_file", ["global"], "Stream to file")
 
 
-    km.add("f", "console.command.set view_filter", ["flowlist"], "Set view filter")
-    km.add("F", "set console_focus_follow toggle", ["flowlist"], "Set focus follow")
-    km.add("L", "console.command view.flows.load ", ["flowlist"], "Load flows from file")
-    km.add("m", "flow.mark.toggle @focus", ["flowlist"], "Toggle mark on this flow")
-    km.add("r", "replay.client @focus", ["flowlist", "flowview"], "Replay this flow")
-    km.add("S", "console.command replay.server ", ["flowlist"], "Start server replay")
-    km.add("v", "set view_order_reversed toggle", ["flowlist"], "Reverse flow list order")
-    km.add("U", "flow.mark @all false", ["flowlist"], "Un-set all marks")
-    km.add("X", "flow.kill @focus", ["flowlist"], "Kill this flow")
-    km.add("z", "view.flows.remove @all", ["flowlist"], "Clear flow list")
-    km.add("Z", "view.flows.remove @hidden", ["flowlist"], "Purge all flows not showing")
-    km.add(
-        "M",
-        "view.properties.marked.toggle",
-        ["flowlist"],
-        "Toggle viewing marked flows",
-    )
     km.add(
         "n",
         "console.command view.flows.create get https://example.com/",
         ["flowlist"],
         "Create a new flow",
+        "New Flow"
     )
+    km.add("D", "view.flows.duplicate @focus", ["flowlist", "flowview"], "Duplicate flow")
+    km.add("X", "flow.kill @focus", ["flowlist"], "Kill this flow", "Kill Flow")
+    km.add("f", "console.command.set view_filter", ["flowlist"], "Set view filter")
+    km.add("F", "set console_focus_follow toggle", ["flowlist"], "Set focus follow")
+    km.add("r", "replay.client @focus", ["flowlist", "flowview"], "Replay this flow", "Replay Flow")
+    km.add("z", "view.flows.remove @all", ["flowlist"], "Clear flow list", "Clear List")
     km.add(
         "o",
         """
@@ -67,6 +58,18 @@ def map(km):
         """,
         ["flowlist"],
         "Set flow list order",
+        "Set List Order"
+    )
+    km.add("m", "flow.mark.toggle @focus", ["flowlist"], "Toggle mark on this flow", "Mark Flow")
+    km.add("U", "flow.mark @all false", ["flowlist"], "Un-set all marks")
+    km.add("S", "console.command replay.server ", ["flowlist"], "Start server replay")
+    km.add("v", "set view_order_reversed toggle", ["flowlist"], "Reverse flow list order", "Reverse Flow List")
+    km.add("Z", "view.flows.remove @hidden", ["flowlist"], "Purge all flows not showing", "Purge")
+    km.add(
+        "M",
+        "view.properties.marked.toggle",
+        ["flowlist"],
+        "Toggle viewing marked flows",
     )
     km.add(
         "w",
@@ -75,9 +78,6 @@ def map(km):
         "Save listed flows to file",
     )
 
-    km.add("p", "view.focus.prev", ["flowview"], "Go to previous flow")
-    km.add("w", "console.command save.file @focus ", ["flowview"], "Save flow to file")
-    km.add("space", "view.focus.next", ["flowview"], "Go to next flow")
     km.add(
         "e",
         """
@@ -86,7 +86,19 @@ def map(km):
         """,
         ["flowview"],
         "Edit a flow component",
+        "Edit Flow"
     )
+    km.add(
+        "V",
+        "flow.revert @focus",
+        ["flowlist", "flowview"],
+        "Revert changes to this flow",
+        "Revert Flow Changes"
+    )
+    km.add("p", "view.focus.prev", ["flowview"], "Go to previous flow", "Prev Flow")
+    km.add("space", "view.focus.next", ["flowview"], "Go to next flow", "Next Flow")
+    km.add("L", "console.command view.flows.load ", ["flowlist"], "Load flows from file", "Load Flows")
+    km.add("w", "console.command save.file @focus ", ["flowview"], "Save flow to file", "Save Flow")
     km.add(
         "f",
         "view.settings.setval.toggle @focus fullcontents",
@@ -101,6 +113,7 @@ def map(km):
         """,
         ["flowview"],
         "View flow body in an external viewer",
+        "External View"
     )
     km.add(
         "m",
@@ -110,6 +123,7 @@ def map(km):
         """,
         ["flowview"],
         "Set flow view mode",
+        "Set View Mode"
     )
     km.add(
         "z",
@@ -122,31 +136,25 @@ def map(km):
     )
 
     km.add(
-        "V",
-        "flow.revert @focus",
-        ["flowlist", "flowview"],
-        "Revert changes to this flow",
-    )
-    km.add(
         "|",
         "console.command script.run @focus ",
         ["flowlist", "flowview"],
         "Run a script on this flow",
+        "Run Script On Flow"
     )
     km.add(
         "b",
         "console.command cut.save @focus response.content ",
         ["flowlist", "flowview"],
         "Save response body to file",
+        "Save Response"
     )
     km.add(
         "d",
         "view.flows.remove @focus",
         ["flowlist", "flowview"],
         "Delete flow from view",
-    )
-    km.add(
-        "D", "view.flows.duplicate @focus", ["flowlist", "flowview"], "Duplicate flow"
+        "Delete From View"
     )
     km.add(
         "e",
@@ -184,12 +192,12 @@ def map(km):
 
     km.add("L", "console.command options.load ", ["options"], "Load from file")
     km.add("S", "console.command options.save ", ["options"], "Save to file")
-    km.add("D", "options.reset", ["options"], "Reset all options")
-    km.add("d", "console.options.reset.focus", ["options"], "Reset this option")
+    km.add("D", "options.reset", ["options"], "Reset all options", "Reset All")
+    km.add("d", "console.options.reset.focus", ["options"], "Reset this option", "Reset Option")
 
-    km.add("a", "console.grideditor.add", ["grideditor"], "Add a row after cursor")
-    km.add("A", "console.grideditor.insert", ["grideditor"], "Insert a row before cursor")
-    km.add("d", "console.grideditor.delete", ["grideditor"], "Delete this row")
+    km.add("a", "console.grideditor.add", ["grideditor"], "Add a row after cursor", "Add Row")
+    km.add("A", "console.grideditor.insert", ["grideditor"], "Insert a row before cursor", "Insert Row")
+    km.add("d", "console.grideditor.delete", ["grideditor"], "Delete this row", "Delete Row")
     km.add(
         "r",
         "console.command console.grideditor.load",
@@ -220,22 +228,26 @@ def map(km):
         """,
         ["keybindings"],
         "Add a key binding",
+        "Add"
     )
     km.add(
         "d",
         "console.key.unbind.focus",
         ["keybindings"],
         "Unbind the currently focused key binding",
-    )
-    km.add(
-        "x",
-        "console.key.execute.focus",
-        ["keybindings"],
-        "Execute the currently focused key binding",
+        "Unbind"
     )
     km.add(
         "enter",
         "console.key.edit.focus",
         ["keybindings"],
         "Edit the currently focused key binding",
+        "Edit"
+    )
+    km.add(
+        "x",
+        "console.key.execute.focus",
+        ["keybindings"],
+        "Execute the currently focused key binding",
+        "Execute"
     )

--- a/mitmproxy/tools/console/defaultkeys.py
+++ b/mitmproxy/tools/console/defaultkeys.py
@@ -1,38 +1,31 @@
+
 def map(km):
-    km.add(":", "console.command ", ["commonkey", "global"], "Command prompt")
-    km.add(
-        ";",
-        "console.command flow.comment @focus ''",
-        ["flowlist", "flowview"],
-        "Add comment to flow",
-    )
-    km.add("?", "console.view.help", ["global"], "View help")
-    km.add("B", "browser.start", ["global"], "Start an attached browser")
-    km.add("C", "console.view.commands", ["global"], "View commands")
-    km.add("K", "console.view.keybindings", ["global"], "View key bindings")
-    km.add("O", "console.view.options", ["commonkey", "global"], "View options")
-    km.add("E", "console.view.eventlog", ["commonkey", "global"], "View event log")
-    km.add("Q", "console.exit", ["global"], "Exit immediately")
+    km.add("?", "console.view.help", ["global"], "View help")  # TODO: common key?
     km.add("q", "console.view.pop", ["commonkey", "global"], "Exit the current view")
-    km.add("-", "console.layout.cycle", ["global"], "Cycle to next layout")
-    km.add("shift tab", "console.panes.next", ["global"], "Focus next layout pane")
-    km.add("ctrl right", "console.panes.next", ["global"], "Focus next layout pane")
-    km.add("P", "console.view.flow @focus", ["global"], "View flow details")
+    km.add(":", "console.command ", ["commonkey", "global"], "Command prompt")
+    km.add("E", "console.view.eventlog", ["commonkey", "global"], "View event log")
+    km.add("O", "console.view.options", ["commonkey", "global"], "View options")
+    km.add("enter", "console.nav.select", ["commonkey", "global"], "Select")
+    km.add("tab", "console.nav.next", ["commonkey", "global"], "Next")
 
     km.add("?", "console.view.pop", ["help"], "Exit help")
 
+    km.add("C", "console.view.commands", ["global"], "View commands")
+    km.add("P", "console.view.flow @focus", ["global"], "View flow details")
+    km.add("B", "browser.start", ["global"], "Start an attached browser")
+    km.add("K", "console.view.keybindings", ["global"], "View key bindings")
+    km.add("-", "console.layout.cycle", ["global"], "Cycle to next layout")
+    km.add("shift tab", "console.panes.next", ["global"], "Focus next layout pane")
+    km.add("ctrl right", "console.panes.next", ["global"], "Focus next layout pane")
     km.add("g", "console.nav.start", ["global"], "Go to start")
     km.add("G", "console.nav.end", ["global"], "Go to end")
     km.add("k", "console.nav.up", ["global"], "Up")
     km.add("j", "console.nav.down", ["global"], "Down")
     km.add("l", "console.nav.right", ["global"], "Right")
     km.add("h", "console.nav.left", ["global"], "Left")
-    km.add("tab", "console.nav.next", ["commonkey", "global"], "Next")
-    km.add("enter", "console.nav.select", ["commonkey", "global"], "Select")
     km.add("space", "console.nav.pagedown", ["global"], "Page down")
     km.add("ctrl f", "console.nav.pagedown", ["global"], "Page down")
     km.add("ctrl b", "console.nav.pageup", ["global"], "Page up")
-
     km.add(
         "I",
         "set intercept_active toggle",
@@ -41,17 +34,104 @@ def map(km):
     )
     km.add("i", "console.command.set intercept", ["global"], "Set intercept")
     km.add("W", "console.command.set save_stream_file", ["global"], "Stream to file")
+
+
+    km.add("f", "console.command.set view_filter", ["flowlist"], "Set view filter")
+    km.add("F", "set console_focus_follow toggle", ["flowlist"], "Set focus follow")
+    km.add("L", "console.command view.flows.load ", ["flowlist"], "Load flows from file")
+    km.add("m", "flow.mark.toggle @focus", ["flowlist"], "Toggle mark on this flow")
+    km.add("r", "replay.client @focus", ["flowlist", "flowview"], "Replay this flow")
+    km.add("S", "console.command replay.server ", ["flowlist"], "Start server replay")
+    km.add("v", "set view_order_reversed toggle", ["flowlist"], "Reverse flow list order")
+    km.add("U", "flow.mark @all false", ["flowlist"], "Un-set all marks")
+    km.add("X", "flow.kill @focus", ["flowlist"], "Kill this flow")
+    km.add("z", "view.flows.remove @all", ["flowlist"], "Clear flow list")
+    km.add("Z", "view.flows.remove @hidden", ["flowlist"], "Purge all flows not showing")
     km.add(
-        "A",
-        "flow.resume @all",
-        ["flowlist", "flowview"],
-        "Resume all intercepted flows",
+        "M",
+        "view.properties.marked.toggle",
+        ["flowlist"],
+        "Toggle viewing marked flows",
     )
     km.add(
-        "a",
-        "flow.resume @focus",
+        "n",
+        "console.command view.flows.create get https://example.com/",
+        ["flowlist"],
+        "Create a new flow",
+    )
+    km.add(
+        "o",
+        """
+        console.choose.cmd Order view.order.options
+        set view_order {choice}
+        """,
+        ["flowlist"],
+        "Set flow list order",
+    )
+    km.add(
+        "w",
+        "console.command save.file @shown ",
+        ["flowlist"],
+        "Save listed flows to file",
+    )
+
+    km.add("p", "view.focus.prev", ["flowview"], "Go to previous flow")
+    km.add("w", "console.command save.file @focus ", ["flowview"], "Save flow to file")
+    km.add("space", "view.focus.next", ["flowview"], "Go to next flow")
+    km.add(
+        "e",
+        """
+        console.choose.cmd Part console.edit.focus.options
+        console.edit.focus {choice}
+        """,
+        ["flowview"],
+        "Edit a flow component",
+    )
+    km.add(
+        "f",
+        "view.settings.setval.toggle @focus fullcontents",
+        ["flowview"],
+        "Toggle viewing full contents on this flow",
+    )
+    km.add(
+        "v",
+        """
+        console.choose "View Part" request,response
+        console.bodyview @focus {choice}
+        """,
+        ["flowview"],
+        "View flow body in an external viewer",
+    )
+    km.add(
+        "m",
+        """
+        console.choose.cmd Mode console.flowview.mode.options
+        console.flowview.mode.set {choice}
+        """,
+        ["flowview"],
+        "Set flow view mode",
+    )
+    km.add(
+        "z",
+        """
+        console.choose "Part" request,response
+        flow.encode.toggle @focus {choice}
+        """,
+        ["flowview"],
+        "Encode/decode flow body",
+    )
+
+    km.add(
+        "V",
+        "flow.revert @focus",
         ["flowlist", "flowview"],
-        "Resume this intercepted flow",
+        "Revert changes to this flow",
+    )
+    km.add(
+        "|",
+        "console.command script.run @focus ",
+        ["flowlist", "flowview"],
+        "Run a script on this flow",
     )
     km.add(
         "b",
@@ -77,114 +157,29 @@ def map(km):
         ["flowlist", "flowview"],
         "Export this flow to file",
     )
-    km.add("f", "console.command.set view_filter", ["flowlist"], "Set view filter")
-    km.add("F", "set console_focus_follow toggle", ["flowlist"], "Set focus follow")
+    km.add(
+        ";",
+        "console.command flow.comment @focus ''",
+        ["flowlist", "flowview"],
+        "Add comment to flow",
+    )
+    km.add(
+        "A",
+        "flow.resume @all",
+        ["flowlist", "flowview"],
+        "Resume all intercepted flows",
+    )
+    km.add(
+        "a",
+        "flow.resume @focus",
+        ["flowlist", "flowview"],
+        "Resume this intercepted flow",
+    )
     km.add(
         "ctrl l",
         "console.command cut.clip ",
         ["flowlist", "flowview"],
         "Send cuts to clipboard",
-    )
-    km.add(
-        "L", "console.command view.flows.load ", ["flowlist"], "Load flows from file"
-    )
-    km.add("m", "flow.mark.toggle @focus", ["flowlist"], "Toggle mark on this flow")
-    km.add(
-        "M",
-        "view.properties.marked.toggle",
-        ["flowlist"],
-        "Toggle viewing marked flows",
-    )
-    km.add(
-        "n",
-        "console.command view.flows.create get https://example.com/",
-        ["flowlist"],
-        "Create a new flow",
-    )
-    km.add(
-        "o",
-        """
-        console.choose.cmd Order view.order.options
-        set view_order {choice}
-        """,
-        ["flowlist"],
-        "Set flow list order",
-    )
-    km.add("r", "replay.client @focus", ["flowlist", "flowview"], "Replay this flow")
-    km.add("S", "console.command replay.server ", ["flowlist"], "Start server replay")
-    km.add(
-        "v", "set view_order_reversed toggle", ["flowlist"], "Reverse flow list order"
-    )
-    km.add("U", "flow.mark @all false", ["flowlist"], "Un-set all marks")
-    km.add(
-        "w",
-        "console.command save.file @shown ",
-        ["flowlist"],
-        "Save listed flows to file",
-    )
-    km.add(
-        "V",
-        "flow.revert @focus",
-        ["flowlist", "flowview"],
-        "Revert changes to this flow",
-    )
-    km.add("X", "flow.kill @focus", ["flowlist"], "Kill this flow")
-    km.add("z", "view.flows.remove @all", ["flowlist"], "Clear flow list")
-    km.add(
-        "Z", "view.flows.remove @hidden", ["flowlist"], "Purge all flows not showing"
-    )
-    km.add(
-        "|",
-        "console.command script.run @focus ",
-        ["flowlist", "flowview"],
-        "Run a script on this flow",
-    )
-
-    km.add(
-        "e",
-        """
-        console.choose.cmd Part console.edit.focus.options
-        console.edit.focus {choice}
-        """,
-        ["flowview"],
-        "Edit a flow component",
-    )
-    km.add(
-        "f",
-        "view.settings.setval.toggle @focus fullcontents",
-        ["flowview"],
-        "Toggle viewing full contents on this flow",
-    )
-    km.add("w", "console.command save.file @focus ", ["flowview"], "Save flow to file")
-    km.add("space", "view.focus.next", ["flowview"], "Go to next flow")
-
-    km.add(
-        "v",
-        """
-        console.choose "View Part" request,response
-        console.bodyview @focus {choice}
-        """,
-        ["flowview"],
-        "View flow body in an external viewer",
-    )
-    km.add("p", "view.focus.prev", ["flowview"], "Go to previous flow")
-    km.add(
-        "m",
-        """
-        console.choose.cmd Mode console.flowview.mode.options
-        console.flowview.mode.set {choice}
-        """,
-        ["flowview"],
-        "Set flow view mode",
-    )
-    km.add(
-        "z",
-        """
-        console.choose "Part" request,response
-        flow.encode.toggle @focus {choice}
-        """,
-        ["flowview"],
-        "Encode/decode flow body",
     )
 
     km.add("L", "console.command options.load ", ["options"], "Load from file")
@@ -193,9 +188,7 @@ def map(km):
     km.add("d", "console.options.reset.focus", ["options"], "Reset this option")
 
     km.add("a", "console.grideditor.add", ["grideditor"], "Add a row after cursor")
-    km.add(
-        "A", "console.grideditor.insert", ["grideditor"], "Insert a row before cursor"
-    )
+    km.add("A", "console.grideditor.insert", ["grideditor"], "Insert a row before cursor")
     km.add("d", "console.grideditor.delete", ["grideditor"], "Delete this row")
     km.add(
         "r",

--- a/mitmproxy/tools/console/flowlist.py
+++ b/mitmproxy/tools/console/flowlist.py
@@ -92,7 +92,7 @@ class FlowListBox(urwid.ListBox, layoutwidget.LayoutWidget):
         self.master.options.subscribe(
             self.set_flowlist_layout, ["console_flowlist_layout"]
         )
-        self.custom_header = urwid.WidgetWrap(urwid.Text(""))
+        self.title_widget = urwid.WidgetWrap(urwid.Text(""))
 
         signals.flow_change.connect(self.sig_update)
         signals.flowlist_change.connect(self.sig_update)  # TODO: does this have a sender?
@@ -140,4 +140,4 @@ class FlowListBox(urwid.ListBox, layoutwidget.LayoutWidget):
         ]
 
         status = urwid.AttrWrap(urwid.Text([self.title, t]), "heading")
-        self.custom_header._w = status
+        self.title_widget._w = status

--- a/mitmproxy/tools/console/flowlist.py
+++ b/mitmproxy/tools/console/flowlist.py
@@ -95,7 +95,7 @@ class FlowListBox(urwid.ListBox, layoutwidget.LayoutWidget):
         self.title_widget = urwid.WidgetWrap(urwid.Text(""))
 
         signals.flow_change.connect(self.sig_update)
-        signals.flowlist_change.connect(self.sig_update)  # TODO: does this have a sender?
+        signals.flowlist_change.connect(self.sig_update)
         master.view.focus.sig_change.connect(self.sig_update)
         master.view.sig_view_add.connect(self.sig_update)
 

--- a/mitmproxy/tools/console/help.py
+++ b/mitmproxy/tools/console/help.py
@@ -44,7 +44,7 @@ class HelpView(tabs.Tabs, layoutwidget.LayoutWidget):
             k = b.key
             if b.key == " ":
                 k = "space"
-            kvs.append((k, b.help or b.command))
+            kvs.append((k, b.long_help or b.command))
         return common.format_keyvals(kvs)
 
     def keybindings(self):

--- a/mitmproxy/tools/console/keybindings.py
+++ b/mitmproxy/tools/console/keybindings.py
@@ -65,7 +65,7 @@ class KeyListWalker(urwid.ListWalker):
         binding = self.bindings[index]
         self.index = index
         self.focus_obj = self._get(self.index)
-        keybinding_focus_change.send(binding.help or "")
+        keybinding_focus_change.send(binding.long_help or "")
         self._modified()
 
     def get_next(self, pos):

--- a/mitmproxy/tools/console/keymap.py
+++ b/mitmproxy/tools/console/keymap.py
@@ -131,6 +131,10 @@ class Keymap:
             return self.keys[context].get(key, None)
         return None
 
+    def filter(self, context: Sequence[str]) -> Sequence[Binding]:
+        filter = lambda b: bool([c for c in b.contexts if c in context])
+        return [x for x in self.bindings if filter(x)]
+
     def list(self, context: str) -> Sequence[Binding]:
         b = [x for x in self.bindings if context in x.contexts or context == "all"]
         single = [x for x in b if len(x.key.split()) == 1]

--- a/mitmproxy/tools/console/keymap.py
+++ b/mitmproxy/tools/console/keymap.py
@@ -48,9 +48,10 @@ navkeys = [
 
 
 class Binding:
-    def __init__(self, key, command, contexts, help):
+    def __init__(self, key, command, contexts, long_help, short_help):
         self.key, self.command, self.contexts = key, command, sorted(contexts)
-        self.help = help
+        self.long_help = long_help
+        self.short_help = short_help
 
     def keyspec(self):
         """
@@ -78,7 +79,7 @@ class Keymap:
             if c not in Contexts:
                 raise ValueError("Unsupported context: %s" % c)
 
-    def add(self, key: str, command: str, contexts: Sequence[str], help="") -> None:
+    def add(self, key: str, command: str, contexts: Sequence[str], long_help="", short_help="") -> None:
         """
         Add a key to the key map.
         """
@@ -87,13 +88,13 @@ class Keymap:
         for b in self.bindings:
             if b.key == key and b.command.strip() == command.strip():
                 b.contexts = sorted(list(set(b.contexts + contexts)))
-                if help:
-                    b.help = help
+                if long_help:
+                    b.long_help = long_help
                 self.bind(b)
                 break
         else:
             self.remove(key, contexts)
-            b = Binding(key=key, command=command, contexts=contexts, help=help)
+            b = Binding(key=key, command=command, contexts=contexts, long_help=long_help, short_help=short_help)
             self.bindings.append(b)
             self.bind(b)
         signals.keybindings_change.send(self)
@@ -205,7 +206,7 @@ class KeymapConfig:
                         key=v["key"],
                         command=v["cmd"],
                         contexts=user_ctxs,
-                        help=v.get("help", None),
+                        long_help=v.get("help", None),
                     )
                 except ValueError as e:
                     raise KeyBindingError(f"Error reading {p}: {e}") from e

--- a/mitmproxy/tools/console/keymap.py
+++ b/mitmproxy/tools/console/keymap.py
@@ -1,6 +1,6 @@
 import os
 from collections.abc import Sequence
-from typing import Optional
+from typing import Optional, Callable
 
 import ruamel.yaml
 import ruamel.yaml.error
@@ -30,6 +30,7 @@ Contexts = {
     "help",
     "keybindings",
     "options",
+    "quickhelp"
 }
 
 
@@ -131,9 +132,8 @@ class Keymap:
             return self.keys[context].get(key, None)
         return None
 
-    def filter(self, context: Sequence[str]) -> Sequence[Binding]:
-        filter = lambda b: bool([c for c in b.contexts if c in context])
-        return [x for x in self.bindings if filter(x)]
+    def all(self):
+        return self.bindings
 
     def list(self, context: str) -> Sequence[Binding]:
         b = [x for x in self.bindings if context in x.contexts or context == "all"]

--- a/mitmproxy/tools/console/signals.py
+++ b/mitmproxy/tools/console/signals.py
@@ -37,3 +37,6 @@ push_view_state = blinker.Signal()
 
 # Fired when the key bindings change
 keybindings_change = blinker.Signal()
+
+# Fired when context has changed
+context_change = blinker.Signal()

--- a/mitmproxy/tools/console/statusbar.py
+++ b/mitmproxy/tools/console/statusbar.py
@@ -185,10 +185,7 @@ class StatusBar(urwid.WidgetWrap):
         super().__init__(urwid.Pile([self.ib, self.ab]))
         signals.flow_change.connect(self.sig_update)
         signals.update_settings.connect(self.sig_update)
-        signals.flowlist_change.connect(self.sig_update)
-        master.options.changed.connect(self.sig_update)
-        master.view.focus.sig_change.connect(self.sig_update)
-        master.view.sig_view_add.connect(self.sig_update)
+        master.options.changed.connect(self.sig_update)  # wrap options.changed to route port number changes
         self.refresh()
 
     def refresh(self):
@@ -292,39 +289,13 @@ class StatusBar(urwid.WidgetWrap):
         return r
 
     def redraw(self):
-        fc = self.master.commands.execute("view.properties.length")
-        if self.master.view.focus.flow is None:
-            offset = 0
-        else:
-            offset = self.master.view.focus.index + 1
+        status = self.get_status()
+        if not status:
+            status.append("")
 
-        if self.master.options.view_order_reversed:
-            arrow = common.SYMBOL_UP
-        else:
-            arrow = common.SYMBOL_DOWN
-
-        marked = ""
-        if self.master.commands.execute("view.properties.marked"):
-            marked = "M"
-
-        t = [
-            ("heading", (f"{arrow} {marked} [{offset}/{fc}]").ljust(11)),
-        ]
-
-        if self.master.options.server:
-            host = self.master.options.listen_host
-            if host == "0.0.0.0" or host == "":
-                host = "*"
-            boundaddr = f"[{host}:{self.master.options.listen_port}]"
-        else:
-            boundaddr = ""
-        t.extend(self.get_status())
         status = urwid.AttrWrap(
             urwid.Columns(
-                [
-                    urwid.Text(t),
-                    urwid.Text(boundaddr, align="right"),
-                ]
+                [urwid.Text(status)]
             ),
             "heading",
         )

--- a/mitmproxy/tools/console/window.py
+++ b/mitmproxy/tools/console/window.py
@@ -364,15 +364,29 @@ class KeysDisplay(urwid.WidgetWrap):
 
         signals.context_change.connect(self.update_keys)
 
-    def update_keys(self, ctx="global", keys=None):
+    def update_keys(self, ctx=None, keys=None):
         if keys is None:
-            keys = [
-                urwid.Text(
-                    [("heading", u"{}".format(k.key)), " ",  k.long_help]
-                ) for k in list(self.master.keymap.filter(ctx))
-            ]
+            quickhelp_binds, global_binds, binds_for_ctx = (list(), list(), list())
+            for b in self.master.keymap.all():
+                if "quickhelp" in b.contexts:
+                    quickhelp_binds.append(b)
+                elif ctx is not None and ctx in b.contexts:
+                    binds_for_ctx.append(b)
+                elif "global" in b.contexts:
+                    global_binds.append(b)
+            bindings = quickhelp_binds + binds_for_ctx + global_binds
+
+            keys = list()
+            for b in bindings:
+                label = b.short_help if b.short_help else b.long_help
+                keys.append(
+                    urwid.Text(
+                        [("heading", u"{}".format(b.key)), " ", label.title()]
+                    )
+                )
 
         columns = [urwid.Pile([keys[i], keys[i+1]]) for i in range(0, len(keys) - 1, 2)]
+
         if len(keys) % 2 == 1:
             columns.append(urwid.Pile([keys[-1]]))
 

--- a/mitmproxy/tools/console/window.py
+++ b/mitmproxy/tools/console/window.py
@@ -328,10 +328,10 @@ class HeaderWidget(urwid.WidgetWrap):
         self.master = master
         self.columns = None
         self.title_widget = title_widget
-
         self.redraw()
 
-    # TODO: send signal when options change
+        master.options.changed.connect(self.sig_update)
+
     def sig_update(self, sender, flow=None, updated=None):
         self.redraw()
 

--- a/test/mitmproxy/tools/console/test_keymap.py
+++ b/test/mitmproxy/tools/console/test_keymap.py
@@ -5,7 +5,7 @@ import pytest
 
 
 def test_binding():
-    b = keymap.Binding("space", "cmd", ["options"], "")
+    b = keymap.Binding("space", "cmd", ["options"], "", "")
     assert b.keyspec() == " "
 
 
@@ -45,11 +45,11 @@ def test_join():
 
         assert len(km.bindings) == 1
         assert len(km.bindings[0].contexts) == 2
-        assert km.bindings[0].help == "help1"
+        assert km.bindings[0].long_help == "help1"
         km.add("key", "str", ["commands"], "help2")
         assert len(km.bindings) == 1
         assert len(km.bindings[0].contexts) == 2
-        assert km.bindings[0].help == "help2"
+        assert km.bindings[0].long_help == "help2"
 
         assert km.get("commands", "key")
         km.unbind(km.bindings[0])


### PR DESCRIPTION
#### Description

Issue #4515
This PR adds a Nano-looking quick help bar.

* Key display shows a small number of basic key bindings that are helpful (like exit or help).
* The set of keys displayed change depending on the context so bindings for flowlist only show when you're focused on the flowlist and change when you switch to flowview, for instance.
* Keys are chopped off at the right.  

We also read bindings defined in `defaultkeys.py` to display them. The order in which they are defined within a context (global, flowlist, etc.) matters. It might be a bit tedious to maintain if we are adding bindings often.

In addition, there are some proposed changes as suggested in #4515 . I moved the counter thingy (`[6/9]`), the listen_host and listen_port to the header to make better use of that space but, besides that, I left the status bar and action bar untouched in terms of functionality. I had some ideas about what to do with the status bar as it looks a bit empty now but did not want to invest more time until I got some feedback. Also, I wanted to change the quit prompt so that yes and no were displayed in the key display/quick help bar as I think it would look better. 

Here is what it looks like
![Screenshot from 2022-05-27 17-28-53](https://user-images.githubusercontent.com/24687641/170791599-fc12fa8f-04fc-484a-a64f-2c05c3354eba.png)
![Screenshot from 2022-05-27 17-33-17](https://user-images.githubusercontent.com/24687641/170791969-e3c7ce51-cfed-49a2-a70d-c478f85987c2.png)
![Screenshot from 2022-05-27 17-30-10](https://user-images.githubusercontent.com/24687641/170791697-af8eb79e-890f-4a41-be04-6094439c7004.png)
![Screenshot from 2022-05-27 17-37-27](https://user-images.githubusercontent.com/24687641/170792302-c7e81474-4598-4b4f-9beb-e86319d833e6.png)


#### Checklist

 - [ ] I have updated tests where applicable.
 - [ ] I have added an entry to the CHANGELOG.
