### PR TITLE
Fix WSGI HTTPS example

### DIFF
--- a/examples/addons/wsgi-flask-app.py
+++ b/examples/addons/wsgi-flask-app.py
@@ -19,9 +19,10 @@ def hello_world() -> str:
 addons = [
     # Host app at the magic domain "example.com" on port 80. Requests to this
     # domain and port combination will now be routed to the WSGI app instance.
-    asgiapp.WSGIApp(app, "example.com", 80)
-    # SSL works too, but the magic domain needs to be resolvable from the mitmproxy machine due to mitmproxy's design.
-    # mitmproxy will connect to said domain and use serve its certificate (unless --no-upstream-cert is set)
-    # but won't send any data.
-    # mitmproxy.ctx.master.apps.add(app, "example.com", 443)
+    asgiapp.WSGIApp(app, "example.com", 80),
+    # TLS works too, but the magic domain needs to be resolvable from the mitmproxy machine due to mitmproxy's design.
+    # mitmproxy will connect to said domain and use its certificate but won't send any data.
+    # By using `--set upstream_cert=false` and `--set connection_strategy_lazy` the local certificate is used instead.
+    # asgiapp.WSGIApp(app, "example.com", 443),
+
 ]


### PR DESCRIPTION
#### Description

Update the WSGI addon example.
The WSGI example still had old documentation for HTTPS usage and I updated it to make clear how to use it with HTTPS (#3786).

#### Checklist

 - [ ] I have updated tests where applicable.
 - [ ] I have added an entry to the CHANGELOG.
