### PR TITLE
Multi-Server Mode

### DIFF
--- a/mitmproxy/addons/core.py
+++ b/mitmproxy/addons/core.py
@@ -8,8 +8,6 @@ from mitmproxy import exceptions
 from mitmproxy import command
 from mitmproxy import flow
 from mitmproxy import optmanager
-from mitmproxy import platform
-from mitmproxy.net import server_spec
 from mitmproxy.net.http import status_codes
 import mitmproxy.types
 
@@ -25,20 +23,6 @@ class Core:
             raise exceptions.OptionsError(
                 "add_upstream_certs_to_client_chain requires the upstream_cert option to be enabled."
             )
-        if "mode" in updated:
-            mode = opts.mode
-            if mode.startswith("reverse:") or mode.startswith("upstream:"):
-                try:
-                    server_spec.parse_with_mode(mode)
-                except ValueError as e:
-                    raise exceptions.OptionsError(str(e)) from e
-            elif mode == "transparent":
-                if not platform.original_addr:
-                    raise exceptions.OptionsError(
-                        "Transparent mode not supported on this platform."
-                    )
-            elif mode not in ["regular", "socks5"]:
-                raise exceptions.OptionsError("Invalid mode specification: %s" % mode)
         if "client_certs" in updated:
             if opts.client_certs:
                 client_certs = os.path.expanduser(opts.client_certs)

--- a/mitmproxy/addons/proxyserver.py
+++ b/mitmproxy/addons/proxyserver.py
@@ -1,112 +1,60 @@
+"""
+This addon is responsible for starting/stopping the proxy server sockets/instances specified by the mode option.
+"""
+from __future__ import annotations
+
 import asyncio
-from asyncio import base_events
+import collections
 import ipaddress
-import re
-import struct
+from contextlib import contextmanager
 from typing import Optional
+
+from wsproto.frame_protocol import Opcode
 
 from mitmproxy import (
     command,
     ctx,
     exceptions,
-    flow,
     http,
-    log,
-    master,
-    options,
     platform,
     tcp,
     websocket,
 )
 from mitmproxy.connection import Address
 from mitmproxy.flow import Flow
-from mitmproxy.net import udp
-from mitmproxy.proxy import commands, events, layers, server_hooks
-from mitmproxy.proxy import server
+from mitmproxy.proxy import events, mode_specs, server_hooks
 from mitmproxy.proxy.layers.tcp import TcpMessageInjected
 from mitmproxy.proxy.layers.websocket import WebSocketMessageInjected
-from mitmproxy.utils import asyncio_utils, human
-from wsproto.frame_protocol import Opcode
+from mitmproxy.proxy.mode_servers import ProxyConnectionHandler, ServerInstance, ServerManager
+from mitmproxy.utils import human
 
 
-class ProxyConnectionHandler(server.LiveConnectionHandler):
-    master: master.Master
-
-    def __init__(self, master, r, w, options, timeout=None):
-        self.master = master
-        super().__init__(r, w, options)
-        self.log_prefix = f"{human.format_address(self.client.peername)}: "
-        if timeout is not None:
-            self.timeout_watchdog.CONNECTION_TIMEOUT = timeout
-
-    async def handle_hook(self, hook: commands.StartHook) -> None:
-        with self.timeout_watchdog.disarm():
-            # We currently only support single-argument hooks.
-            (data,) = hook.args()
-            await self.master.addons.handle_lifecycle(hook)
-            if isinstance(data, flow.Flow):
-                await data.wait_for_resume()
-
-    def log(self, message: str, level: str = "info") -> None:
-        x = log.LogEntry(self.log_prefix + message, level)
-        asyncio_utils.create_task(
-            self.master.addons.handle_lifecycle(log.AddLogHook(x)),
-            name="ProxyConnectionHandler.log",
-        )
-
-
-class Proxyserver:
+class Proxyserver(ServerManager):
     """
     This addon runs the actual proxy server.
     """
-
-    tcp_server: Optional[base_events.Server]
-    dns_server: Optional[udp.UdpServer]
-    connect_addr: Optional[Address]
-    listen_port: int
-    dns_reverse_addr: Optional[tuple[str, int]]
-    master: master.Master
-    options: options.Options
+    connections: dict[tuple, ProxyConnectionHandler]
+    servers: dict[str, ServerInstance]
     is_running: bool
-    _connections: dict[tuple, ProxyConnectionHandler]
+    _lock: asyncio.Lock
+    _connect_addr: Optional[Address] = None
 
     def __init__(self):
-        self._lock = asyncio.Lock()
-        self.tcp_server = None
-        self.dns_server = None
-        self.connect_addr = None
-        self.dns_reverse_addr = None
+        self.connections = {}
+        self.servers = {}
         self.is_running = False
-        self._connections = {}
+        self._lock = asyncio.Lock()
 
     def __repr__(self):
-        return f"ProxyServer({'running' if self.running_servers else 'stopped'}, {len(self._connections)} active conns)"
+        return f"Proxyserver({len(self.connections)} active conns)"
 
-    @property
-    def _server_desc(self):
-        yield "Proxy", self.tcp_server, lambda x: setattr(
-            self, "tcp_server", x
-        ), ctx.options.server, lambda: asyncio.start_server(
-            self.handle_tcp_connection,
-            self.options.listen_host,
-            self.options.listen_port,
-        )
-        yield "DNS", self.dns_server, lambda x: setattr(
-            self, "dns_server", x
-        ), ctx.options.dns_server, lambda: udp.start_server(
-            self.handle_dns_datagram,
-            self.options.dns_listen_host or "127.0.0.1",
-            self.options.dns_listen_port,
-            transparent=self.options.dns_mode == "transparent",
-        )
-
-    @property
-    def running_servers(self):
-        return tuple(
-            instance
-            for _, instance, _, _, _ in self._server_desc
-            if instance is not None
-        )
+    @contextmanager
+    def register_connection(self, connection_id: tuple, handler: ProxyConnectionHandler):
+        self.connections[connection_id] = handler
+        try:
+            yield
+        finally:
+            del self.connections[connection_id]
 
     def load(self, loader):
         loader.add_option(
@@ -178,30 +126,11 @@ class Proxyserver:
             None,
             """Set the local IP address that mitmproxy should use when connecting to upstream servers.""",
         )
-        loader.add_option(
-            "dns_server", bool, False, """Start a DNS server. Disabled by default."""
-        )
-        loader.add_option(
-            "dns_listen_host", str, "", """Address to bind DNS server to."""
-        )
-        loader.add_option("dns_listen_port", int, 53, """DNS server service port.""")
-        loader.add_option(
-            "dns_mode",
-            str,
-            "regular",
-            """
-            One of "regular", "reverse:<ip>[:<port>]" or "transparent".
-            regular....: requests will be resolved using the local resolver
-            reverse....: forward queries to another DNS server
-            transparent: transparent mode
-            """,
-        )
 
     async def running(self):
-        self.master = ctx.master
-        self.options = ctx.options
         self.is_running = True
-        await self.refresh_server()
+        # TODO: Do this before running()
+        await self.setup_servers()
 
     def configure(self, updated):
         if "stream_large_bodies" in updated:
@@ -222,146 +151,90 @@ class Proxyserver:
                 )
         if "connect_addr" in updated:
             try:
-                self.connect_addr = (str(ipaddress.ip_address(ctx.options.connect_addr)), 0) if ctx.options.connect_addr else None
+                if ctx.options.connect_addr:
+                    self._connect_addr = str(ipaddress.ip_address(ctx.options.connect_addr)), 0
+                else:
+                    self._connect_addr = None
             except ValueError:
                 raise exceptions.OptionsError(
-                    f"Invalid connection address {ctx.options.connect_addr!r}, specify a valid IP address."
+                    f"Invalid value for connect_addr: {ctx.options.connect_addr!r}. Specify a valid IP address."
                 )
-
-        if "dns_mode" in updated:
-            m = re.match(
-                r"^(regular|reverse:(?P<host>[^:]+)(:(?P<port>\d+))?|transparent)$",
-                ctx.options.dns_mode,
-            )
-            if not m:
-                raise exceptions.OptionsError(
-                    f"Invalid DNS mode {ctx.options.dns_mode!r}."
-                )
-            if m["host"]:
+        if "mode" in updated or "server" in updated:
+            # Make sure that all modes are syntactically valid...
+            modes: list[mode_specs.ProxyMode] = []
+            for mode in ctx.options.mode:
                 try:
-                    self.dns_reverse_addr = (
-                        str(ipaddress.ip_address(m["host"])),
-                        int(m["port"]) if m["port"] is not None else 53,
+                    modes.append(
+                        mode_specs.ProxyMode.parse(mode)
                     )
-                except ValueError:
-                    raise exceptions.OptionsError(
-                        f"Invalid DNS reverse mode, expected 'reverse:ip[:port]' got {ctx.options.dns_mode!r}."
-                    )
-            else:
-                self.dns_reverse_addr = None
-        if "mode" in updated and ctx.options.mode == "transparent":  # pragma: no cover
-            platform.init_transparent_mode()
-        if self.is_running and any(
-            x in updated
-            for x in [
-                "server",
-                "listen_host",
-                "listen_port",
-                "dns_server",
-                "dns_mode",
-                "dns_listen_host",
-                "dns_listen_port",
+                except ValueError as e:
+                    raise exceptions.OptionsError(f"Invalid proxy mode specification: {mode} ({e})")
+
+            # ...and don't listen on the same address.
+            listen_addrs = [
+                (
+                    m.listen_host(ctx.options.listen_host),
+                    m.listen_port(ctx.options.listen_port),
+                    m.transport_protocol
+                )
+                for m in modes
             ]
-        ):
-            asyncio.create_task(self.refresh_server())
+            if len(set(listen_addrs)) != len(listen_addrs):
+                (host, port, _) = collections.Counter(listen_addrs).most_common(1)[0][0]
+                dup_addr = human.format_address((host or "0.0.0.0", port))
+                raise exceptions.OptionsError(f"Cannot spawn multiple servers on the same address: {dup_addr}")
 
-    async def refresh_server(self):
-        async with self._lock:
-            await self.shutdown_server()
-            if ctx.options.server and not ctx.master.addons.get("nextlayer"):
+            if ctx.options.mode and not ctx.master.addons.get("nextlayer"):
                 ctx.log.warn("Warning: Running proxyserver without nextlayer addon!")
-            for name, instance, set_instance, enabled, start in self._server_desc:
-                if instance is None and enabled:
-                    try:
-                        instance = await start()
-                    except OSError as e:
-                        ctx.log.error(str(e))
-                    else:
-                        set_instance(instance)
-                        # TODO: This is a bit confusing currently for `-p 0`.
-                        addrs = {
-                            f"{human.format_address(s.getsockname())}"
-                            for s in instance.sockets
-                        }
-                        ctx.log.info(
-                            f"{name} server listening at {' and '.join(addrs)}"
-                        )
-
-    async def shutdown_server(self):
-        for name, instance, set_instance, _, _ in self._server_desc:
-            if instance is not None:
-                ctx.log.info(f"Stopping {name} server...")
-                try:
-                    instance.close()
-                    await instance.wait_closed()
-                except OSError as e:
-                    ctx.log.error(str(e))
+            if any(isinstance(m, mode_specs.TransparentMode) for m in modes):
+                if platform.original_addr:
+                    platform.init_transparent_mode()
                 else:
-                    set_instance(None)
+                    raise exceptions.OptionsError("Transparent mode not supported on this platform.")
 
-    async def handle_connection(self, connection_id: tuple):
-        handler = self._connections[connection_id]
-        task = asyncio.current_task()
-        assert task
-        asyncio_utils.set_task_debug_info(
-            task,
-            name=f"Proxyserver.handle_connection",
-            client=handler.client.peername,
-        )
-        try:
-            await handler.handle_client()
-        finally:
-            del self._connections[connection_id]
+            if self.is_running:
+                asyncio.create_task(self.setup_servers())
 
-    async def handle_tcp_connection(
-        self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
-    ) -> None:
-        connection_id = (
-            "tcp",
-            writer.get_extra_info("peername"),
-            writer.get_extra_info("sockname"),
-        )
-        self._connections[connection_id] = ProxyConnectionHandler(
-            self.master, reader, writer, self.options
-        )
-        await self.handle_connection(connection_id)
+    async def setup_servers(self) -> bool:
+        all_ok = True
+        async with self._lock:
+            new_servers: dict[str, ServerInstance] = dict.fromkeys(ctx.options.mode)  # type: ignore
+            if not ctx.options.server:
+                new_servers.clear()
 
-    def handle_dns_datagram(
-        self,
-        transport: asyncio.DatagramTransport,
-        data: bytes,
-        remote_addr: Address,
-        local_addr: Address,
-    ) -> None:
-        try:
-            dns_id = struct.unpack_from("!H", data, 0)
-        except struct.error:
-            ctx.log.info(
-                f"Invalid DNS datagram received from {human.format_address(remote_addr)}."
-            )
-            return
-        connection_id = ("udp", dns_id, remote_addr, local_addr)
-        if connection_id not in self._connections:
-            reader = udp.DatagramReader()
-            writer = udp.DatagramWriter(transport, remote_addr, reader)
-            handler = ProxyConnectionHandler(
-                self.master, reader, writer, self.options, 20
-            )
-            handler.layer = layers.DNSLayer(handler.layer.context)
-            handler.layer.context.server.address = (
-                local_addr
-                if self.options.dns_mode == "transparent"
-                else self.dns_reverse_addr
-            )
-            handler.layer.context.server.transport_protocol = "udp"
-            self._connections[connection_id] = handler
-            asyncio.create_task(self.handle_connection(connection_id))
-        else:
-            handler = self._connections[connection_id]
-            client_reader = handler.transports[handler.client].reader
-            assert isinstance(client_reader, udp.DatagramReader)
-            reader = client_reader
-        reader.feed_data(data, remote_addr)
+            # Shutdown modes that have been removed from the list.
+            shutdown_tasks = [
+                s.stop() for spec, s in self.servers.items()
+                if spec not in new_servers
+            ]
+            for ret in await asyncio.gather(*shutdown_tasks, return_exceptions=True):
+                if ret:
+                    all_ok = False
+                    ctx.log.error(str(ret))
+
+            new_instances: list[ServerInstance] = []
+            for spec in new_servers:
+                if existing := self.servers.get(spec, None):
+                    new_servers[spec] = existing
+                else:
+                    instance: ServerInstance = ServerInstance.make(spec, self)
+                    new_instances.append(instance)
+                    new_servers[spec] = instance
+
+            for ret in await asyncio.gather(*[m.start() for m in new_instances], return_exceptions=True):
+                if ret:
+                    all_ok = False
+                    ctx.log.error(str(ret))
+
+            self.servers = new_servers
+            return all_ok
+
+    def listen_addrs(self) -> list[Address]:
+        return [
+            addr
+            for server in self.servers.values()
+            for addr in server.listen_addrs
+        ]
 
     def inject_event(self, event: events.MessageInjected):
         connection_id = (
@@ -369,9 +242,9 @@ class Proxyserver:
             event.flow.client_conn.peername,
             event.flow.client_conn.sockname,
         )
-        if connection_id not in self._connections:
+        if connection_id not in self.connections:
             raise ValueError("Flow is not from a live connection.")
-        self._connections[connection_id].server_event(event)
+        self.connections[connection_id].server_event(event)
 
     @command.command("inject.websocket")
     def inject_websocket(
@@ -400,23 +273,29 @@ class Proxyserver:
         except ValueError as e:
             ctx.log.warn(str(e))
 
-    def server_connect(self, ctx: server_hooks.ServerConnectionHookData):
-        assert ctx.server.address
-        # FIXME: Move this to individual proxy modes.
-        self_connect = ctx.server.address[1] in (
-            self.options.dns_listen_port,
-            self.options.listen_port,
-        ) and ctx.server.address[0] in (
-            "localhost",
-            "127.0.0.1",
-            "::1",
-            self.options.listen_host,
-            self.options.dns_listen_host,
-        )
-        if self_connect:
-            ctx.server.error = (
-                "Request destination unknown. "
-                "Unable to figure out where this request should be forwarded to."
-            )
-        if ctx.server.sockname is None:
-            ctx.server.sockname = self.connect_addr
+    def server_connect(self, data: server_hooks.ServerConnectionHookData):
+        if data.server.sockname is None:
+            data.server.sockname = self._connect_addr
+
+        # Prevent mitmproxy from recursively connecting to itself.
+        assert data.server.address
+        connect_host, connect_port, *_ = data.server.address
+
+        for server in self.servers.values():
+            for listen_host, listen_port, *_ in server.listen_addrs:
+                self_connect = (
+                    connect_port == listen_port
+                    and connect_host in (
+                        "localhost",
+                        "127.0.0.1",
+                        "::1",
+                        listen_host
+                    )
+                    and server.mode.transport_protocol == data.server.transport_protocol
+                )
+                if self_connect:
+                    data.server.error = (
+                        "Request destination unknown. "
+                        "Unable to figure out where this request should be forwarded to."
+                    )
+                    return

--- a/mitmproxy/addons/upstream_auth.py
+++ b/mitmproxy/addons/upstream_auth.py
@@ -5,6 +5,7 @@ from typing import Optional
 from mitmproxy import exceptions
 from mitmproxy import ctx
 from mitmproxy import http
+from mitmproxy.proxy import mode_specs
 from mitmproxy.utils import strutils
 
 
@@ -52,7 +53,7 @@ class UpstreamAuth:
 
     def requestheaders(self, f: http.HTTPFlow):
         if self.auth:
-            if ctx.options.mode.startswith("upstream") and f.request.scheme == "http":
+            if isinstance(f.client_conn.proxy_mode, mode_specs.UpstreamMode) and f.request.scheme == "http":
                 f.request.headers["Proxy-Authorization"] = self.auth
-            elif ctx.options.mode.startswith("reverse"):
+            elif isinstance(f.client_conn.proxy_mode, mode_specs.ReverseMode):
                 f.request.headers["Authorization"] = self.auth

--- a/mitmproxy/connection.py
+++ b/mitmproxy/connection.py
@@ -6,6 +6,7 @@ from enum import Flag
 from typing import Literal, Optional
 
 from mitmproxy import certs
+from mitmproxy.proxy import mode_specs
 from mitmproxy.coretypes import serializable
 from mitmproxy.net import server_spec
 from mitmproxy.utils import human
@@ -158,6 +159,9 @@ class Client(Connection):
     The certificate used by mitmproxy to establish TLS with the client.
     """
 
+    proxy_mode: mode_specs.ProxyMode
+    """The proxy server type this client has been connecting to."""
+
     timestamp_start: float
     """*Timestamp:* TCP SYN received"""
 
@@ -168,6 +172,7 @@ class Client(Connection):
         timestamp_start: float,
         *,
         transport_protocol: TransportProtocol = "tcp",
+        proxy_mode: mode_specs.ProxyMode = mode_specs.ProxyMode.parse("regular"),
     ):
         self.id = str(uuid.uuid4())
         self.peername = peername
@@ -175,6 +180,7 @@ class Client(Connection):
         self.timestamp_start = timestamp_start
         self.state = ConnectionState.OPEN
         self.transport_protocol = transport_protocol
+        self.proxy_mode = proxy_mode
 
     def __str__(self):
         if self.alpn:
@@ -211,6 +217,7 @@ class Client(Connection):
             "certificate_list": [x.get_state() for x in self.certificate_list],
             "alpn_offers": self.alpn_offers,
             "cipher_list": self.cipher_list,
+            "proxy_mode": self.proxy_mode.get_state(),
         }
 
     @classmethod
@@ -244,6 +251,7 @@ class Client(Connection):
         )
         self.alpn_offers = state["alpn_offers"]
         self.cipher_list = state["cipher_list"]
+        self.proxy_mode = mode_specs.ProxyMode.from_state(state["proxy_mode"])
 
     @property
     def address(self):  # pragma: no cover

--- a/mitmproxy/io/compat.py
+++ b/mitmproxy/io/compat.py
@@ -380,6 +380,12 @@ def convert_16_17(data):
     return data
 
 
+def convert_17_18(data):
+    data["version"] = 18
+    data["client_conn"]["proxy_mode"] = "regular"
+    return data
+
+
 def _convert_dict_keys(o: Any) -> Any:
     if isinstance(o, dict):
         return {strutils.always_str(k): _convert_dict_keys(v) for k, v in o.items()}
@@ -441,6 +447,7 @@ converters = {
     14: convert_14_15,
     15: convert_15_16,
     16: convert_16_17,
+    17: convert_17_18,
 }
 
 

--- a/mitmproxy/master.py
+++ b/mitmproxy/master.py
@@ -8,8 +8,8 @@ from mitmproxy import eventsequence
 from mitmproxy import http
 from mitmproxy import log
 from mitmproxy import options
-from mitmproxy.net import server_spec
 from . import ctx as mitmproxy_ctx
+from .proxy.mode_specs import ReverseMode
 
 
 class Master:
@@ -45,6 +45,7 @@ class Master:
 
             # Handle scheduled tasks (configure()) first.
             await asyncio.sleep(0)
+            # TODO: Bind proxy server here before invoking running().
             await self.running()
             try:
                 await self.should_exit.wait()
@@ -90,14 +91,14 @@ class Master:
         Loads a flow
         """
 
-        if isinstance(f, http.HTTPFlow):
-            if self.options.mode.startswith("reverse:"):
-                # When we load flows in reverse proxy mode, we adjust the target host to
-                # the reverse proxy destination for all flows we load. This makes it very
-                # easy to replay saved flows against a different host.
-                _, upstream_spec = server_spec.parse_with_mode(self.options.mode)
-                f.request.host, f.request.port = upstream_spec.address
-                f.request.scheme = upstream_spec.scheme
+        if isinstance(f, http.HTTPFlow) and len(self.options.mode) == 1 and self.options.mode[0].startswith("reverse:"):
+            # When we load flows in reverse proxy mode, we adjust the target host to
+            # the reverse proxy destination for all flows we load. This makes it very
+            # easy to replay saved flows against a different host.
+            # We may change this in the future so that clientplayback always replays to the first mode.
+            mode = ReverseMode.parse(self.options.mode[0])
+            f.request.host, f.request.port, *_ = mode.address
+            f.request.scheme = mode.scheme
 
         for e in eventsequence.iterate(f):
             await self.addons.handle_lifecycle(e)

--- a/mitmproxy/net/server_spec.py
+++ b/mitmproxy/net/server_spec.py
@@ -1,17 +1,16 @@
 """
 Server specs are used to describe an upstream proxy or server.
 """
-import functools
 import re
-from typing import Literal, NamedTuple
+from functools import cache
+from typing import Literal
 
 from mitmproxy.net import check
 
-
-class ServerSpec(NamedTuple):
-    scheme: Literal["http", "https"]
-    address: tuple[str, int]
-
+ServerSpec = tuple[
+    Literal["http", "https", "tcp", "tls", "dns"],
+    tuple[str, int]
+]
 
 server_spec_re = re.compile(
     r"""
@@ -26,8 +25,8 @@ server_spec_re = re.compile(
 )
 
 
-@functools.lru_cache
-def parse(server_spec: str) -> ServerSpec:
+@cache
+def parse(server_spec: str, default_scheme: str) -> ServerSpec:
     """
     Parses a server mode specification, e.g.:
 
@@ -45,8 +44,8 @@ def parse(server_spec: str) -> ServerSpec:
     if m.group("scheme"):
         scheme = m.group("scheme")
     else:
-        scheme = "https" if m.group("port") in ("443", None) else "http"
-    if scheme not in ("http", "https"):
+        scheme = default_scheme
+    if scheme not in ("tcp", "tls", "dns", "http", "https"):
         raise ValueError(f"Invalid server scheme: {scheme}")
 
     host = m.group("host")
@@ -59,19 +58,15 @@ def parse(server_spec: str) -> ServerSpec:
     if m.group("port"):
         port = int(m.group("port"))
     else:
-        port = {"http": 80, "https": 443}[scheme]
+        try:
+            port = {
+                "http": 80,
+                "https": 443,
+                "dns": 53,
+            }[scheme]
+        except KeyError:
+            raise ValueError(f"Port specification missing.")
     if not check.is_valid_port(port):
         raise ValueError(f"Invalid port: {port}")
 
-    return ServerSpec(scheme, (host, port))  # type: ignore
-
-
-def parse_with_mode(mode: str) -> tuple[str, ServerSpec]:
-    """
-    Parse a proxy mode specification, which is usually just `(reverse|upstream):server-spec`.
-
-    *Raises:*
-     - ValueError, if the specification is invalid.
-    """
-    mode, server_spec = mode.split(":", maxsplit=1)
-    return mode, parse(server_spec)
+    return scheme, (host, port)  # type: ignore

--- a/mitmproxy/net/udp.py
+++ b/mitmproxy/net/udp.py
@@ -76,8 +76,13 @@ class TransparentSocket(socket.socket):
     ) -> tuple[bytes, tuple[SockAddress, SockAddress]]:
         """Same as recvfrom, but always returns source and destination addresses."""
 
+        # (unavailable on Windows, hence the type checking exclusion)
+        space = socket.CMSG_SPACE(1024)  # type: ignore
+
         data, ancdata, _, client_addr = self._recvmsg(
-            bufsize, socket.CMSG_SPACE(1024), flags
+            bufsize,
+            space,
+            flags
         )
         for cmsg_level, cmsg_type, cmsg_data in ancdata:
             if (
@@ -87,7 +92,7 @@ class TransparentSocket(socket.socket):
                 server_addr = TransparentSocket._unpack_addr(cmsg_data)
                 break
         else:
-            raise OSError("recvmsg did not return th original destination address")
+            raise OSError("recvmsg did not return the original destination address")
         return data, (client_addr, server_addr)
 
 

--- a/mitmproxy/options.py
+++ b/mitmproxy/options.py
@@ -5,7 +5,6 @@ from mitmproxy import optmanager
 
 CONF_DIR = "~/.mitmproxy"
 CONF_BASENAME = "mitmproxy"
-LISTEN_PORT = 8080
 CONTENT_VIEW_LINES_CUTOFF = 512
 KEY_SIZE = 2048
 
@@ -91,16 +90,25 @@ class Options(optmanager.OptManager):
             """,
         )
         self.add_option("allow_hosts", Sequence[str], [], "Opposite of --ignore-hosts.")
-        self.add_option("listen_host", str, "", "Address to bind proxy to.")
-        self.add_option("listen_port", int, LISTEN_PORT, "Proxy service port.")
+        self.add_option("listen_host", str, "",
+                        "Address to bind proxy server(s) to (may be overridden for individual modes, see `mode`).")
+        self.add_option("listen_port", Optional[int], None,
+                        "Port to bind proxy server(s) to (may be overridden for individual modes, see `mode`). "
+                        "By default, the port is mode-specific. The default regular HTTP proxy spawns on port 8080.")
         self.add_option(
             "mode",
-            str,
-            "regular",
+            Sequence[str],
+            ["regular"],
             """
-            Mode can be "regular", "transparent", "socks5", "reverse:SPEC",
-            or "upstream:SPEC". For reverse and upstream proxy modes, SPEC
+            The proxy server type(s) to spawn. Can be passed multiple times.
+
+            Mitmproxy supports "regular" (HTTP), "transparent", "socks5", "reverse:SPEC",
+            and "upstream:SPEC" proxy servers. For reverse and upstream proxy modes, SPEC
             is host specification in the form of "http[s]://host[:port]".
+
+            You may append `@listen_port` or `@listen_host:listen_port` to override `listen_host` or `listen_port` for
+            a specific proxy mode. Features such as client playback will use the first mode to determine
+            which upstream server to use.
             """,
         )
         self.add_option(

--- a/mitmproxy/proxy/layers/http/__init__.py
+++ b/mitmproxy/proxy/layers/http/__init__.py
@@ -2,6 +2,7 @@ import collections
 import enum
 import time
 from dataclasses import dataclass
+from functools import cached_property
 from typing import Optional, Union
 
 import wsproto.handshake
@@ -42,6 +43,7 @@ from ._hooks import (  # noqa
 from ._http1 import Http1Client, Http1Connection, Http1Server
 from ._http2 import Http2Client, Http2Server
 from ...context import Context
+from ...mode_specs import ReverseMode, UpstreamMode
 
 
 class HTTPMode(enum.Enum):
@@ -124,7 +126,7 @@ class HttpStream(layer.Layer):
     stream_id: StreamId
     child_layer: Optional[layer.Layer] = None
 
-    @property
+    @cached_property
     def mode(self):
         i = self.context.layers.index(self)
         parent: HttpLayer = self.context.layers[i - 1]
@@ -222,7 +224,7 @@ class HttpStream(layer.Layer):
 
         # update host header in reverse proxy mode
         if (
-            self.context.options.mode.startswith("reverse:")
+            isinstance(self.context.client.proxy_mode, ReverseMode)
             and not self.context.options.keep_host_header
         ):
             assert self.context.server.address
@@ -835,9 +837,9 @@ class HttpLayer(layer.Layer):
         if isinstance(event, events.Start):
             yield from self.event_to_child(self.connections[self.context.client], event)
             if self.mode is HTTPMode.upstream:
-                self.context.server.via = server_spec.parse_with_mode(
-                    self.context.options.mode
-                )[1]
+                proxy_mode = self.context.client.proxy_mode
+                assert isinstance(proxy_mode, UpstreamMode)
+                self.context.server.via = (proxy_mode.scheme, proxy_mode.address)
         elif isinstance(event, events.Wakeup):
             stream = self.command_sources.pop(event.command)
             yield from self.event_to_child(stream, event)
@@ -996,7 +998,6 @@ class HttpLayer(layer.Layer):
 
             if event.via:
                 context.server.via = event.via
-                assert event.via.scheme in ("http", "https")
                 # We always send a CONNECT request, *except* for plaintext absolute-form HTTP requests in upstream mode.
                 send_connect = event.tls or self.mode != HTTPMode.upstream
                 stack /= _upstream_proxy.HttpUpstreamProxy.make(context, send_connect)

--- a/mitmproxy/proxy/layers/http/_upstream_proxy.py
+++ b/mitmproxy/proxy/layers/http/_upstream_proxy.py
@@ -26,16 +26,16 @@ class HttpUpstreamProxy(tunnel.TunnelLayer):
 
     @classmethod
     def make(cls, ctx: context.Context, send_connect: bool) -> tunnel.LayerStack:
-        spec = ctx.server.via
-        assert spec
-        assert spec.scheme in ("http", "https")
+        assert ctx.server.via
+        scheme, address = ctx.server.via
+        assert scheme in ("http", "https")
 
-        http_proxy = connection.Server(spec.address)
+        http_proxy = connection.Server(address)
 
         stack = tunnel.LayerStack()
-        if spec.scheme == "https":
+        if scheme == "https":
             http_proxy.alpn_offers = tls.HTTP1_ALPNS
-            http_proxy.sni = spec.address[0]
+            http_proxy.sni = address[0]
             stack /= tls.ServerTLSLayer(ctx, http_proxy)
         stack /= cls(ctx, http_proxy, send_connect)
 

--- a/mitmproxy/proxy/mode_servers.py
+++ b/mitmproxy/proxy/mode_servers.py
@@ -1,0 +1,260 @@
+"""
+This module defines "server instances", which manage
+the TCP/UDP servers spawned my mitmproxy as specified by the proxy mode.
+
+Example:
+
+    mode = ProxyMode.parse("reverse:https://example.com")
+    inst = ServerInstance.make(mode, manager_that_handles_callbacks)
+    await inst.start()
+    # TCP server is running now.
+"""
+from __future__ import annotations
+
+import asyncio
+import struct
+import typing
+from abc import ABCMeta, abstractmethod
+from contextlib import contextmanager
+from functools import cached_property
+from typing import ClassVar, Generic, TypeVar, cast, get_args
+
+from mitmproxy import ctx, flow, log
+from mitmproxy.connection import Address
+from mitmproxy.master import Master
+from mitmproxy.net import udp
+from mitmproxy.proxy import commands, layers, mode_specs, server
+from mitmproxy.proxy.context import Context
+from mitmproxy.proxy.layer import Layer
+from mitmproxy.utils import asyncio_utils, human
+
+
+class ProxyConnectionHandler(server.LiveConnectionHandler):
+    master: Master
+
+    def __init__(self, master, r, w, options, mode):
+        self.master = master
+        super().__init__(r, w, options, mode)
+        self.log_prefix = f"{human.format_address(self.client.peername)}: "
+
+    async def handle_hook(self, hook: commands.StartHook) -> None:
+        with self.timeout_watchdog.disarm():
+            # We currently only support single-argument hooks.
+            (data,) = hook.args()
+            await self.master.addons.handle_lifecycle(hook)
+            if isinstance(data, flow.Flow):
+                await data.wait_for_resume()  # pragma: no cover
+
+    def log(self, message: str, level: str = "info") -> None:
+        x = log.LogEntry(self.log_prefix + message, level)
+        asyncio_utils.create_task(
+            self.master.addons.handle_lifecycle(log.AddLogHook(x)),
+            name="ProxyConnectionHandler.log",
+        )
+
+
+M = TypeVar('M', bound=mode_specs.ProxyMode)
+
+
+class ServerManager(typing.Protocol):
+    connections: dict[tuple, ProxyConnectionHandler]
+
+    @contextmanager
+    def register_connection(self, connection_id: tuple, handler: ProxyConnectionHandler):
+        ...  # pragma: no cover
+
+
+class ServerInstance(Generic[M], metaclass=ABCMeta):
+
+    __modes: ClassVar[dict[str, type[ServerInstance]]] = {}
+
+    def __init__(self, mode: M, manager: ServerManager):
+        self.mode: M = mode
+        self.manager: ServerManager = manager
+
+    def __init_subclass__(cls, **kwargs):
+        """Register all subclasses so that make() finds them."""
+        # extract mode from Generic[Mode].
+        mode = get_args(cls.__orig_bases__[0])[0]
+        if mode != M:
+            assert mode.type not in ServerInstance.__modes
+            ServerInstance.__modes[mode.type] = cls
+
+    @staticmethod
+    def make(
+        mode: mode_specs.ProxyMode | str,
+        manager: ServerManager,
+    ) -> ServerInstance:
+        if isinstance(mode, str):
+            mode = mode_specs.ProxyMode.parse(mode)
+        return ServerInstance.__modes[mode.type](mode, manager)
+
+    @abstractmethod
+    async def start(self) -> None:
+        pass
+
+    @abstractmethod
+    async def stop(self) -> None:
+        pass
+
+    @property
+    @abstractmethod
+    def listen_addrs(self) -> tuple[Address, ...]:
+        pass
+
+
+class TcpServerInstance(ServerInstance[M], metaclass=ABCMeta):
+    server: asyncio.Server | None = None
+
+    @abstractmethod
+    def make_top_layer(self, context: Context) -> Layer:
+        pass
+
+    async def handle_tcp_connection(
+        self,
+        reader: asyncio.StreamReader,
+        writer: asyncio.StreamWriter,
+    ) -> None:
+        connection_id = (
+            "tcp",
+            writer.get_extra_info("peername"),
+            writer.get_extra_info("sockname"),
+        )
+        handler = ProxyConnectionHandler(
+            ctx.master, reader, writer, ctx.options, self.mode
+        )
+        handler.layer = self.make_top_layer(handler.layer.context)
+        with self.manager.register_connection(connection_id, handler):
+            await handler.handle_client()
+
+    async def start(self):
+        assert not self.server
+        self.server = await asyncio.start_server(
+            self.handle_tcp_connection,
+            self.mode.listen_host(ctx.options.listen_host),
+            self.mode.listen_port(ctx.options.listen_port),
+        )
+
+        addrs = {f"{human.format_address(s)}" for s in self.listen_addrs}
+        ctx.log.info(
+            f"{self.log_desc} listening at {' and '.join(addrs)}."
+        )
+
+    @property
+    @abstractmethod
+    def log_desc(self) -> str:
+        pass
+
+    async def stop(self):
+        assert self.server
+        self.server.close()
+        await self.server.wait_closed()
+        ctx.log.info(f"Stopped {self.mode.type} proxy server.")
+
+    @cached_property
+    def listen_addrs(self) -> tuple[Address, ...]:
+        assert self.server
+        return tuple(s.getsockname() for s in self.server.sockets)
+
+
+class RegularInstance(TcpServerInstance[mode_specs.RegularMode]):
+    log_desc = "HTTP(S) proxy"
+
+    def make_top_layer(self, context: Context) -> Layer:
+        return layers.modes.HttpProxy(context)
+
+
+class UpstreamInstance(TcpServerInstance[mode_specs.UpstreamMode]):
+    log_desc = "HTTP(S) proxy (upstream mode)"
+
+    def make_top_layer(self, context: Context) -> Layer:
+        return layers.modes.HttpUpstreamProxy(context)
+
+
+class TransparentInstance(TcpServerInstance[mode_specs.TransparentMode]):
+    log_desc = "Transparent proxy"
+
+    def make_top_layer(self, context: Context) -> Layer:
+        return layers.modes.TransparentProxy(context)
+
+
+class ReverseInstance(TcpServerInstance[mode_specs.ReverseMode]):
+    @property
+    def log_desc(self) -> str:
+        return f"Reverse proxy to {self.mode.data}"
+
+    def make_top_layer(self, context: Context) -> Layer:
+        return layers.modes.ReverseProxy(context)
+
+
+class Socks5Instance(TcpServerInstance[mode_specs.Socks5Mode]):
+    log_desc = "SOCKS v5 proxy"
+
+    def make_top_layer(self, context: Context) -> Layer:
+        return layers.modes.Socks5Proxy(context)
+
+
+class DnsInstance(ServerInstance[mode_specs.DnsMode]):
+    server: udp.UdpServer | None = None
+
+    async def start(self):
+        assert not self.server
+        self.server = await udp.start_server(
+            self.handle_dns_datagram,
+            self.mode.listen_host(ctx.options.listen_host),
+            self.mode.listen_port(ctx.options.listen_port),
+            transparent=False
+        )
+        addrs = {f"{human.format_address(s)}" for s in self.listen_addrs}
+        ctx.log.info(
+            f"DNS server listening at {' and '.join(addrs)}."
+        )
+
+    async def stop(self):
+        assert self.server
+        self.server.close()
+        await self.server.wait_closed()
+        ctx.log.info(f"Stopped {self.mode.type} proxy server.")
+
+    def handle_dns_datagram(
+        self,
+        transport: asyncio.DatagramTransport,
+        data: bytes,
+        remote_addr: Address,
+        local_addr: Address,
+    ) -> None:
+        try:
+            dns_id = struct.unpack_from("!H", data, 0)
+        except struct.error:
+            ctx.log.info(
+                f"Invalid DNS datagram received from {human.format_address(remote_addr)}."
+            )
+            return
+        connection_id = ("udp", dns_id, remote_addr, local_addr)
+        if connection_id not in self.manager.connections:
+            reader = udp.DatagramReader()
+            writer = udp.DatagramWriter(transport, remote_addr, reader)
+            handler = ProxyConnectionHandler(
+                ctx.master, reader, writer, ctx.options, self.mode
+            )
+            handler.timeout_watchdog.CONNECTION_TIMEOUT = 20
+            handler.layer = layers.DNSLayer(handler.layer.context)
+            handler.layer.context.server.address = (self.mode.data or "resolve-local", 53)
+            handler.layer.context.server.transport_protocol = "udp"
+
+            # pre-register here - we may get datagrams before the task is executed.
+            self.manager.connections[connection_id] = handler
+            asyncio.create_task(self.handle_dns_connection(connection_id, handler))
+        else:
+            handler = self.manager.connections[connection_id]
+            reader = cast(udp.DatagramReader, handler.transports[handler.client].reader)
+        reader.feed_data(data, remote_addr)
+
+    async def handle_dns_connection(self, connection_id, handler):
+        with self.manager.register_connection(connection_id, handler):
+            await handler.handle_client()
+
+    @cached_property
+    def listen_addrs(self) -> tuple[Address, ...]:
+        assert self.server
+        return tuple(s.getsockname() for s in self.server.sockets)

--- a/mitmproxy/proxy/mode_specs.py
+++ b/mitmproxy/proxy/mode_specs.py
@@ -1,0 +1,202 @@
+"""
+This module is responsible for parsing proxy mode specifications such as
+`"regular"`, `"reverse:https://example.com"`, or `"socks5@1234"`. The general syntax is
+
+    mode [: mode_configuration] [@ [listen_addr:]listen_port]
+
+For a full example, consider `reverse:https://example.com@127.0.0.1:443`.
+This would spawn a reverse proxy on port 443 bound to localhost.
+The mode is `reverse`, and the mode data is `https://example.com`.
+Examples:
+
+    mode = ProxyMode.parse("regular@1234")
+    assert mode.listen_port == 1234
+    assert isinstance(mode, RegularMode)
+
+    ProxyMode.parse("reverse:example.com@invalid-port")  # ValueError
+
+"""
+
+from __future__ import annotations
+
+from abc import ABCMeta, abstractmethod
+from dataclasses import dataclass
+from functools import cache
+from typing import ClassVar, Literal, Type, TypeVar
+
+from mitmproxy.coretypes.serializable import Serializable
+from mitmproxy.net import server_spec
+
+
+# Python 3.11: Use typing.Self
+Self = TypeVar("Self", bound="ProxyMode")
+
+
+@dataclass(frozen=True)  # type: ignore
+class ProxyMode(Serializable, metaclass=ABCMeta):
+    """
+    Parsed representation of a proxy mode spec. Subclassed for each specific mode,
+    which then does its own data validation.
+    """
+    full_spec: str
+    data: str
+    custom_listen_host: str | None
+    custom_listen_port: int | None
+
+    transport_protocol: ClassVar[Literal["tcp", "udp"]] = "tcp"
+    """
+    The transport protocol used by this mode. Used to detect multiple servers targeting the same proto+port.
+    """
+    default_port: ClassVar[int] = 8080
+    __modes: ClassVar[dict[str, type[ProxyMode]]] = {}
+
+    @abstractmethod
+    def __post_init__(self) -> None:
+        """Validation of data happens here."""
+
+    def listen_host(self, default: str | None = None) -> str:
+        if self.custom_listen_host is not None:
+            return self.custom_listen_host
+        elif default is not None:
+            return default
+        else:
+            return ""
+
+    def listen_port(self, default: int | None = None) -> int:
+        if self.custom_listen_port is not None:
+            return self.custom_listen_port
+        elif default is not None:
+            return default
+        else:
+            return self.default_port
+
+    @classmethod
+    @property
+    def type(cls) -> str:
+        return cls.__name__.removesuffix("Mode").lower()
+
+    @classmethod
+    @cache
+    def parse(cls: Type[Self], spec: str) -> Self:
+        head, _, listen_at = spec.rpartition("@")
+        if not head:
+            head = listen_at
+            listen_at = ""
+
+        mode, _, data = head.partition(":")
+
+        if listen_at:
+            if ":" in listen_at:
+                host, _, port_str = listen_at.rpartition(":")
+            else:
+                host = None
+                port_str = listen_at
+            try:
+                port = int(port_str)
+                if port < 0 or 65535 < port:
+                    raise ValueError
+            except ValueError:
+                raise ValueError(f"invalid port: {port_str}")
+        else:
+            host = None
+            port = None
+
+        try:
+            mode_cls = ProxyMode.__modes[mode.lower()]
+        except KeyError:
+            raise ValueError(f"unknown mode")
+
+        if not issubclass(mode_cls, cls):
+            raise ValueError(f"{mode!r} is not a spec for a {cls.type} mode")
+
+        return mode_cls(
+            full_spec=spec,
+            data=data,
+            custom_listen_host=host,
+            custom_listen_port=port
+        )
+
+    def __init_subclass__(cls, **kwargs):
+        t = cls.type.lower()
+        assert t not in ProxyMode.__modes
+        ProxyMode.__modes[t] = cls
+
+    @classmethod
+    def from_state(cls, state):
+        return ProxyMode.parse(state)
+
+    def get_state(self):
+        return self.full_spec
+
+    def set_state(self, state):
+        if state != self.full_spec:
+            raise RuntimeError("Proxy modes are frozen.")
+
+
+def _check_empty(data):
+    if data:
+        raise ValueError("mode takes no arguments")
+
+
+class RegularMode(ProxyMode):
+    def __post_init__(self) -> None:
+        _check_empty(self.data)
+
+
+class TransparentMode(ProxyMode):
+    def __post_init__(self) -> None:
+        _check_empty(self.data)
+
+
+class UpstreamMode(ProxyMode):
+    scheme: Literal["http", "https"]
+    address: tuple[str, int]
+
+    # noinspection PyDataclass
+    def __post_init__(self) -> None:
+        scheme, self.address = server_spec.parse(self.data, default_scheme="http")
+        if scheme != "http" and scheme != "https":
+            raise ValueError("invalid upstream proxy scheme")
+        self.scheme = scheme
+
+
+class ReverseMode(ProxyMode):
+    scheme: Literal["http", "https", "tcp", "tls"]
+    address: tuple[str, int]
+
+    # noinspection PyDataclass
+    def __post_init__(self) -> None:
+        scheme, self.address = server_spec.parse(self.data, default_scheme="https")
+        if scheme != "http" and scheme != "https" and scheme != "tcp" and scheme != "tls":
+            raise ValueError("invalid reverse proxy scheme")
+        self.scheme = scheme
+
+
+class Socks5Mode(ProxyMode):
+    default_port = 1080
+
+    def __post_init__(self) -> None:
+        _check_empty(self.data)
+
+
+class DnsMode(ProxyMode):
+    default_port = 53
+    transport_protocol: ClassVar[Literal["tcp", "udp"]] = "udp"
+    scheme: Literal["dns"]  # DoH, DoQ, ...
+    address: tuple[str, int] | None = None
+
+    # noinspection PyDataclass
+    def __post_init__(self) -> None:
+        if self.data in ["", "resolve-local", "transparent"]:
+            return
+        m, _, server = self.data.partition(":")
+        if m != "reverse":
+            raise ValueError("invalid dns mode")
+        scheme, self.address = server_spec.parse(server, "dns")
+        if scheme != "dns":
+            raise ValueError("invalid dns scheme")
+        self.scheme = scheme
+
+    @property
+    def resolve_local(self) -> bool:
+        return self.data in ["", "resolve-local"]

--- a/mitmproxy/test/tflow.py
+++ b/mitmproxy/test/tflow.py
@@ -7,6 +7,7 @@ from mitmproxy import flow
 from mitmproxy import http
 from mitmproxy import tcp
 from mitmproxy import websocket
+from mitmproxy.proxy.mode_specs import ProxyMode
 from mitmproxy.test.tutils import tdnsreq, tdnsresp
 from mitmproxy.test.tutils import treq, tresp
 from wsproto.frame_protocol import Opcode
@@ -103,6 +104,7 @@ def tdnsflow(
     """Create a DNS flow for testing."""
     if client_conn is None:
         client_conn = tclient_conn()
+        client_conn.proxy_mode = ProxyMode.parse("dns")
         client_conn.transport_protocol = "udp"
     if server_conn is None:
         server_conn = tserver_conn()
@@ -206,6 +208,7 @@ def tclient_conn() -> connection.Client:
             certificate_list=[],
             alpn_offers=[],
             cipher_list=[],
+            proxy_mode="regular",
         )
     )
     return c

--- a/mitmproxy/tools/cmdline.py
+++ b/mitmproxy/tools/cmdline.py
@@ -74,7 +74,6 @@ def common_options(parser, opts):
     opts.make_parser(group, "certs", metavar="SPEC")
     opts.make_parser(group, "cert_passphrase", metavar="PASS")
     opts.make_parser(group, "ssl_insecure", short="k")
-    opts.make_parser(group, "key_size", metavar="KEY_SIZE")
 
     # Client replay
     group = parser.add_argument_group("Client Replay")
@@ -141,7 +140,6 @@ def mitmweb(opts):
     opts.make_parser(group, "web_open_browser")
     opts.make_parser(group, "web_port", metavar="PORT")
     opts.make_parser(group, "web_host", metavar="HOST")
-    opts.make_parser(group, "web_columns")
 
     common_options(parser, opts)
     group = parser.add_argument_group(

--- a/mitmproxy/tools/console/statusbar.py
+++ b/mitmproxy/tools/console/statusbar.py
@@ -8,6 +8,7 @@ from mitmproxy.tools.console import commandexecutor
 from mitmproxy.tools.console import common
 from mitmproxy.tools.console import signals
 from mitmproxy.tools.console.commander import commander
+from mitmproxy.utils import human
 
 
 class PromptPath:
@@ -281,8 +282,8 @@ class StatusBar(urwid.WidgetWrap):
         if opts:
             r.append("[%s]" % (":".join(opts)))
 
-        if self.master.options.mode != "regular":
-            r.append("[%s]" % self.master.options.mode)
+        if self.master.options.mode != ["regular"]:
+            r.append(f"[{','.join(self.master.options.mode)}]")
         if self.master.options.scripts:
             r.append("[scripts:%s]" % len(self.master.options.scripts))
 
@@ -311,11 +312,12 @@ class StatusBar(urwid.WidgetWrap):
             ("heading", (f"{arrow} {marked} [{offset}/{fc}]").ljust(11)),
         ]
 
-        if self.master.options.server:
-            host = self.master.options.listen_host
-            if host == "0.0.0.0" or host == "":
-                host = "*"
-            boundaddr = f"[{host}:{self.master.options.listen_port}]"
+        listen_addrs: list[str] = list(dict.fromkeys(
+            human.format_address(a)
+            for a in self.master.addons.get("proxyserver").listen_addrs()
+        ))
+        if listen_addrs:
+            boundaddr = f"[{', '.join(listen_addrs)}]"
         else:
             boundaddr = ""
         t.extend(self.get_status())

--- a/mitmproxy/tools/main.py
+++ b/mitmproxy/tools/main.py
@@ -26,11 +26,12 @@ def process_options(parser, opts, args):
         args.termlog_verbosity = "debug"
         args.flow_detail = 2
 
-    adict = {}
-    for n in dir(args):
-        if n in opts:
-            adict[n] = getattr(args, n)
-    opts.merge(adict)
+    adict = {
+        key: val
+        for key, val in vars(args).items()
+        if key in opts and val is not None
+    }
+    opts.update(**adict)
 
 
 T = TypeVar("T", bound=master.Master)

--- a/mitmproxy/utils/typecheck.py
+++ b/mitmproxy/utils/typecheck.py
@@ -3,7 +3,7 @@ from collections import abc
 
 try:
     from types import UnionType
-except ImportError:
+except ImportError:  # pragma: no cover
     UnionType = object()  # type: ignore
 
 Type = typing.Union[

--- a/mitmproxy/version.py
+++ b/mitmproxy/version.py
@@ -7,7 +7,7 @@ MITMPROXY = "mitmproxy " + VERSION
 
 # Serialization format version. This is displayed nowhere, it just needs to be incremented by one
 # for each change in the file format.
-FLOW_FORMAT_VERSION = 17
+FLOW_FORMAT_VERSION = 18
 
 
 def get_dev_version() -> str:

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,7 @@ exclude_lines =
     if typing.TYPE_CHECKING:
     if TYPE_CHECKING:
     @overload
+    @abstractmethod
 
 [mypy]
 ignore_missing_imports = True

--- a/test/individual_coverage.py
+++ b/test/individual_coverage.py
@@ -87,6 +87,8 @@ def main():
     src_files = [
         f for f in src_files if not any(os.path.normpath(p) in f for p in excluded)
     ]
+    if len(sys.argv) > 1:
+        src_files = [f for f in src_files if sys.argv[1] in str(f)]
 
     ps = []
     for src in sorted(src_files):

--- a/test/mitmproxy/addons/test_asgiapp.py
+++ b/test/mitmproxy/addons/test_asgiapp.py
@@ -55,8 +55,8 @@ async def test_asgi_full():
         tctx.master.addons.add(next_layer.NextLayer())
         tctx.configure(ps, listen_host="127.0.0.1", listen_port=0)
         await ps.running()
-        await tctx.master.await_log("Proxy server listening", level="info")
-        proxy_addr = ps.tcp_server.sockets[0].getsockname()[:2]
+        await tctx.master.await_log("HTTP(S) proxy listening", level="info")
+        proxy_addr = ("127.0.0.1", ps.listen_addrs()[0][1])
 
         reader, writer = await asyncio.open_connection(*proxy_addr)
         req = f"GET http://testapp:80/ HTTP/1.1\r\n\r\n"

--- a/test/mitmproxy/addons/test_clientplayback.py
+++ b/test/mitmproxy/addons/test_clientplayback.py
@@ -52,7 +52,7 @@ async def test_playback(mode, concurrency):
             flow = tflow.tflow(live=False)
             flow.request.content = b"data"
             if mode == "upstream":
-                tctx.options.mode = f"upstream:http://{addr[0]}:{addr[1]}"
+                tctx.options.mode = [f"upstream:http://{addr[0]}:{addr[1]}"]
                 flow.request.authority = f"{addr[0]}:{addr[1]}"
                 flow.request.host, flow.request.port = "address", 22
             else:
@@ -86,7 +86,7 @@ async def test_playback_https_upstream():
             flow = tflow.tflow(live=False)
             flow.request.scheme = b"https"
             flow.request.content = b"data"
-            tctx.options.mode = f"upstream:http://{addr[0]}:{addr[1]}"
+            tctx.options.mode = [f"upstream:http://{addr[0]}:{addr[1]}"]
             cp.start_replay([flow])
             assert cp.count() == 1
             await asyncio.wait_for(cp.queue.join(), 5)

--- a/test/mitmproxy/addons/test_core.py
+++ b/test/mitmproxy/addons/test_core.py
@@ -1,5 +1,3 @@
-from unittest import mock
-
 from mitmproxy.addons import core
 from mitmproxy.test import taddons
 from mitmproxy.test import tflow
@@ -10,9 +8,9 @@ import pytest
 def test_set():
     sa = core.Core()
     with taddons.context(loadcore=False) as tctx:
-        assert tctx.master.options.server
-        tctx.command(sa.set, "server", "false")
-        assert not tctx.master.options.server
+        assert tctx.master.options.upstream_cert
+        tctx.command(sa.set, "upstream_cert", "false")
+        assert not tctx.master.options.upstream_cert
 
         with pytest.raises(exceptions.CommandError):
             tctx.command(sa.set, "nonexistent")
@@ -167,25 +165,6 @@ def test_validation_simple():
             tctx.configure(
                 sa, add_upstream_certs_to_client_chain=True, upstream_cert=False
             )
-        with pytest.raises(exceptions.OptionsError, match="Invalid mode"):
-            tctx.configure(sa, mode="Flibble")
-
-
-@mock.patch("mitmproxy.platform.original_addr", None)
-def test_validation_no_transparent():
-    sa = core.Core()
-    with taddons.context() as tctx:
-        with pytest.raises(Exception, match="Transparent mode not supported"):
-            tctx.configure(sa, mode="transparent")
-
-
-@mock.patch("mitmproxy.platform.original_addr")
-def test_validation_modes(m):
-    sa = core.Core()
-    with taddons.context() as tctx:
-        tctx.configure(sa, mode="reverse:http://localhost")
-        with pytest.raises(Exception, match="Invalid server specification"):
-            tctx.configure(sa, mode="reverse:")
 
 
 def test_client_certs(tdata):

--- a/test/mitmproxy/addons/test_dns_resolver.py
+++ b/test/mitmproxy/addons/test_dns_resolver.py
@@ -8,6 +8,7 @@ import pytest
 from mitmproxy import dns
 from mitmproxy.addons import dns_resolver, proxyserver
 from mitmproxy.connection import Address
+from mitmproxy.proxy.mode_specs import ProxyMode
 from mitmproxy.test import taddons, tflow, tutils
 
 
@@ -17,13 +18,13 @@ async def test_simple(monkeypatch):
     )
 
     dr = dns_resolver.DnsResolver()
-    with taddons.context(dr, proxyserver.Proxyserver()) as tctx:
+    with taddons.context(dr, proxyserver.Proxyserver()):
         f = tflow.tdnsflow()
         await dr.dns_request(f)
         assert f.response
 
-        tctx.options.dns_mode = "reverse:8.8.8.8"
         f = tflow.tdnsflow()
+        f.client_conn.proxy_mode = ProxyMode.parse("dns:reverse:8.8.8.8")
         await dr.dns_request(f)
         assert not f.response
 

--- a/test/mitmproxy/addons/test_proxyserver.py
+++ b/test/mitmproxy/addons/test_proxyserver.py
@@ -1,9 +1,11 @@
 import asyncio
 from contextlib import asynccontextmanager
 import socket
+from unittest.mock import Mock
 
 import pytest
 
+import mitmproxy.platform
 from mitmproxy import dns, exceptions
 from mitmproxy.addons import dns_resolver
 from mitmproxy.addons.proxyserver import Proxyserver
@@ -20,7 +22,6 @@ class HelperAddon:
     def __init__(self):
         self.flows = []
         self.layers = [
-            lambda ctx: layers.modes.HttpProxy(ctx),
             lambda ctx: layers.HttpLayer(ctx, HTTPMode.regular),
             lambda ctx: layers.TCPLayer(ctx),
         ]
@@ -60,12 +61,12 @@ async def test_start_stop():
         tctx.master.addons.add(state)
         async with tcp_server(server_handler) as addr:
             tctx.configure(ps, listen_host="127.0.0.1", listen_port=0)
-            assert not ps.tcp_server
+            assert not ps.servers
             await ps.running()
-            await tctx.master.await_log("Proxy server listening", level="info")
-            assert ps.tcp_server
+            await tctx.master.await_log("HTTP(S) proxy listening", level="info")
+            assert ps.servers
 
-            proxy_addr = ps.tcp_server.sockets[0].getsockname()[:2]
+            proxy_addr = ps.listen_addrs()[0]
             reader, writer = await asyncio.open_connection(*proxy_addr)
             req = f"GET http://{addr[0]}:{addr[1]}/hello HTTP/1.1\r\n\r\n"
             writer.write(req.encode())
@@ -73,17 +74,20 @@ async def test_start_stop():
                 await reader.readuntil(b"\r\n\r\n")
                 == b"HTTP/1.1 204 No Content\r\n\r\n"
             )
-            assert repr(ps) == "ProxyServer(running, 1 active conns)"
+            assert repr(ps) == "Proxyserver(1 active conns)"
 
+            await ps.setup_servers()  # assert this can always be called without side effects
             tctx.configure(ps, server=False)
-            await tctx.master.await_log("Stopping Proxy server", level="info")
-            assert not ps.tcp_server
+            await tctx.master.await_log("Stopped regular proxy server.", level="info")
+            async with ps._lock:
+                pass  # wait until start/stop is finished.
+            assert not ps.servers
             assert state.flows
             assert state.flows[0].request.path == "/hello"
             assert state.flows[0].response.status_code == 204
 
             # Waiting here until everything is really torn down... takes some effort.
-            conn_handler = list(ps._connections.values())[0]
+            conn_handler = list(ps.connections.values())[0]
             client_handler = conn_handler.transports[conn_handler.client].handler
             writer.close()
             await writer.wait_closed()
@@ -94,7 +98,7 @@ async def test_start_stop():
             for _ in range(5):
                 # Get all other scheduled coroutines to run.
                 await asyncio.sleep(0)
-            assert repr(ps) == "ProxyServer(stopped, 0 active conns)"
+            assert repr(ps) == "Proxyserver(0 active conns)"
 
 
 async def test_inject() -> None:
@@ -111,8 +115,8 @@ async def test_inject() -> None:
         async with tcp_server(server_handler) as addr:
             tctx.configure(ps, listen_host="127.0.0.1", listen_port=0)
             await ps.running()
-            await tctx.master.await_log("Proxy server listening", level="info")
-            proxy_addr = ps.tcp_server.sockets[0].getsockname()[:2]
+            await tctx.master.await_log("HTTP(S) proxy listening", level="info")
+            proxy_addr = ps.servers["regular"].listen_addrs[0]
             reader, writer = await asyncio.open_connection(*proxy_addr)
 
             req = f"CONNECT {addr[0]}:{addr[1]} HTTP/1.1\r\n\r\n"
@@ -155,13 +159,9 @@ async def test_warn_no_nextlayer():
     """
     ps = Proxyserver()
     with taddons.context(ps) as tctx:
-        tctx.configure(ps, listen_host="127.0.0.1", listen_port=0)
+        tctx.configure(ps, listen_host="127.0.0.1", listen_port=0, server=False)
         await ps.running()
-        await tctx.master.await_log("Proxy server listening at", level="info")
-        assert tctx.master.has_log(
-            "Warning: Running proxyserver without nextlayer addon!", level="warn"
-        )
-        await ps.shutdown_server()
+        await tctx.master.await_log("Warning: Running proxyserver without nextlayer addon!", level="warn")
 
 
 async def test_self_connect():
@@ -170,40 +170,37 @@ async def test_self_connect():
     server.address = ("localhost", 8080)
     ps = Proxyserver()
     with taddons.context(ps) as tctx:
-        # not calling .running() here to avoid unnecessary socket
-        ps.options = tctx.options
+        tctx.configure(ps, listen_host="127.0.0.1", listen_port=0)
+        await ps.running()
+        await tctx.master.await_log("HTTP(S) proxy listening", level="info")
+        assert ps.servers
+        server.address = ("localhost", ps.servers["regular"].listen_addrs[0][1])
         ps.server_connect(server_hooks.ServerConnectionHookData(server, client))
         assert "Request destination unknown" in server.error
+        tctx.configure(ps, server=False)
 
 
 def test_options():
     ps = Proxyserver()
     with taddons.context(ps) as tctx:
         with pytest.raises(exceptions.OptionsError):
+            tctx.configure(ps, stream_large_bodies="invalid")
+        tctx.configure(ps, stream_large_bodies="1m")
+
+        with pytest.raises(exceptions.OptionsError):
             tctx.configure(ps, body_size_limit="invalid")
         tctx.configure(ps, body_size_limit="1m")
 
         with pytest.raises(exceptions.OptionsError):
-            tctx.configure(ps, stream_large_bodies="invalid")
-        tctx.configure(ps, stream_large_bodies="1m")
-        with pytest.raises(exceptions.OptionsError):
-            tctx.configure(ps, dns_mode="invalid")
-        tctx.configure(ps, dns_mode="regular")
-
-        with pytest.raises(exceptions.OptionsError):
-            tctx.configure(ps, dns_mode="reverse")
-        tctx.configure(ps, dns_mode="reverse:8.8.8.8")
-        assert ps.dns_reverse_addr == ("8.8.8.8", 53)
-
-        with pytest.raises(exceptions.OptionsError):
-            tctx.configure(ps, dns_mode="reverse:invalid:53")
-        tctx.configure(ps, dns_mode="reverse:8.8.8.8:53")
-        assert ps.dns_reverse_addr == ("8.8.8.8", 53)
-
-        with pytest.raises(exceptions.OptionsError):
             tctx.configure(ps, connect_addr="invalid")
         tctx.configure(ps, connect_addr="1.2.3.4")
-        assert ps.connect_addr == ("1.2.3.4", 0)
+        assert ps._connect_addr == ("1.2.3.4", 0)
+
+        with pytest.raises(exceptions.OptionsError):
+            tctx.configure(ps, mode=["invalid!"])
+        with pytest.raises(exceptions.OptionsError):
+            tctx.configure(ps, mode=["regular", "reverse:example.com"])
+        tctx.configure(ps, mode=["regular"], server=False)
 
 
 async def test_startup_err(monkeypatch) -> None:
@@ -219,19 +216,18 @@ async def test_startup_err(monkeypatch) -> None:
 
 
 async def test_shutdown_err() -> None:
-    def _raise(*_):
+    async def _raise(*_):
         raise OSError("cannot close")
 
     ps = Proxyserver()
     with taddons.context(ps) as tctx:
         tctx.configure(ps, listen_host="127.0.0.1", listen_port=0)
         await ps.running()
-        assert ps.running_servers
-        for server in ps.running_servers:
-            setattr(server, "close", _raise)
-        await ps.shutdown_server()
+        assert ps.servers
+        for server in ps.servers.values():
+            setattr(server, "stop", _raise)
+        tctx.configure(ps, server=False)
         await tctx.master.await_log("cannot close", level="error")
-        assert ps.running_servers
 
 
 class DummyResolver:
@@ -251,16 +247,12 @@ async def test_dns() -> None:
     with taddons.context(ps, DummyResolver()) as tctx:
         tctx.configure(
             ps,
-            server=False,
-            dns_server=True,
-            dns_listen_host="127.0.0.1",
-            dns_listen_port=0,
-            dns_mode="regular",
+            mode=["dns@127.0.0.1:0"],
         )
         await ps.running()
         await tctx.master.await_log("DNS server listening at", level="info")
-        assert ps.dns_server
-        dns_addr = ps.dns_server.sockets[0].getsockname()[:2]
+        assert ps.servers
+        dns_addr = ps.servers["dns@127.0.0.1:0"].listen_addrs[0]
         r, w = await udp.open_connection(*dns_addr)
         w.write(b"\x00")
         await tctx.master.await_log("Invalid DNS datagram received", level="info")
@@ -268,15 +260,33 @@ async def test_dns() -> None:
         w.write(req.packed)
         resp = dns.Message.unpack(await r.read(udp.MAX_DATAGRAM_SIZE))
         assert req.id == resp.id and "8.8.8.8" in str(resp)
-        assert len(ps._connections) == 1
+        assert len(ps.connections) == 1
         w.write(req.packed)
         resp = dns.Message.unpack(await r.read(udp.MAX_DATAGRAM_SIZE))
         assert req.id == resp.id and "8.8.8.8" in str(resp)
-        assert len(ps._connections) == 1
+        assert len(ps.connections) == 1
         req.id = req.id + 1
         w.write(req.packed)
         resp = dns.Message.unpack(await r.read(udp.MAX_DATAGRAM_SIZE))
         assert req.id == resp.id and "8.8.8.8" in str(resp)
-        assert len(ps._connections) == 2
-        await ps.shutdown_server()
-        await tctx.master.await_log("Stopping DNS server", level="info")
+        assert len(ps.connections) == 2
+        tctx.configure(ps, server=False)
+        await tctx.master.await_log("Stopped dns proxy server.", level="info")
+
+
+def test_validation_no_transparent(monkeypatch):
+    monkeypatch.setattr(mitmproxy.platform, "original_addr", None)
+    ps = Proxyserver()
+    with taddons.context(ps) as tctx:
+        with pytest.raises(Exception, match="Transparent mode not supported"):
+            tctx.configure(ps, mode=["transparent"])
+
+
+def test_transparent_init(monkeypatch):
+    init = Mock()
+    monkeypatch.setattr(mitmproxy.platform, "original_addr", lambda: 1)
+    monkeypatch.setattr(mitmproxy.platform, "init_transparent_mode", init)
+    ps = Proxyserver()
+    with taddons.context(ps) as tctx:
+        tctx.configure(ps, mode=["transparent"], server=False)
+        assert init.called

--- a/test/mitmproxy/addons/test_script.py
+++ b/test/mitmproxy/addons/test_script.py
@@ -185,14 +185,14 @@ class TestScriptLoader:
         with taddons.context(loadcore=False) as tctx:
             tctx.master.addons.add(sc)
             sc.running()
-            assert len(tctx.master.addons) == 1
+            assert len(tctx.master.addons) == 2
             tctx.master.options.update(
                 scripts=[tdata.path("mitmproxy/data/addonscripts/recorder/recorder.py")]
             )
-            assert len(tctx.master.addons) == 1
+            assert len(tctx.master.addons) == 2
             assert len(sc.addons) == 1
             tctx.master.options.update(scripts=[])
-            assert len(tctx.master.addons) == 1
+            assert len(tctx.master.addons) == 2
             assert len(sc.addons) == 0
 
     def test_dupes(self):

--- a/test/mitmproxy/addons/test_upstream_auth.py
+++ b/test/mitmproxy/addons/test_upstream_auth.py
@@ -2,6 +2,7 @@ import base64
 import pytest
 
 from mitmproxy import exceptions
+from mitmproxy.proxy.mode_specs import ProxyMode
 from mitmproxy.test import taddons
 from mitmproxy.test import tflow
 from mitmproxy.addons import upstream_auth
@@ -41,10 +42,10 @@ def test_simple():
         assert "proxy-authorization" not in f.request.headers
         assert "authorization" not in f.request.headers
 
-        tctx.configure(up, mode="upstream:127.0.0.1")
+        f.client_conn.proxy_mode = ProxyMode.parse("upstream:127.0.0.1")
         up.requestheaders(f)
         assert "proxy-authorization" in f.request.headers
 
-        tctx.configure(up, mode="reverse:127.0.0.1")
+        f.client_conn.proxy_mode = ProxyMode.parse("reverse:127.0.0.1")
         up.requestheaders(f)
         assert "authorization" in f.request.headers

--- a/test/mitmproxy/addons/test_view.py
+++ b/test/mitmproxy/addons/test_view.py
@@ -329,6 +329,12 @@ def test_movement():
         v.focus_prev()
         assert v.focus.index == 0
 
+        v.clear()
+        v.focus_next()
+        assert v.focus.index is None
+        v.focus_prev()
+        assert v.focus.index is None
+
 
 def test_duplicate():
     v = view.View()

--- a/test/mitmproxy/contentviews/test_xml_html_data/test-formatted.html
+++ b/test/mitmproxy/contentviews/test_xml_html_data/test-formatted.html
@@ -40,5 +40,6 @@
                               <p>
                               esse cillum dolore
                               <p>eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+                            </no-start-tag>
 </body>
 </html>

--- a/test/mitmproxy/contentviews/test_xml_html_data/test.html
+++ b/test/mitmproxy/contentviews/test_xml_html_data/test.html
@@ -9,6 +9,6 @@
         <p>Ut enim ad minim <p>veniam, quis nostrud <p>exercitation <p>ullamco laboris <p>
         nisi ut aliquip ex ea <p>commodo consequat.<p>Duis aute irure <p>dolor in reprehenderit <p>in voluptate velit<p> esse cillum dolore <p>eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
 
-
+</no-start-tag>
 </body>
 </html>

--- a/test/mitmproxy/net/test_server_spec.py
+++ b/test/mitmproxy/net/test_server_spec.py
@@ -4,40 +4,34 @@ from mitmproxy.net import server_spec
 
 
 @pytest.mark.parametrize(
-    "spec,out",
+    "spec,default_scheme,out",
     [
-        ("example.com", ("https", ("example.com", 443))),
-        ("http://example.com", ("http", ("example.com", 80))),
-        ("smtp.example.com:25", ("http", ("smtp.example.com", 25))),
-        ("http://127.0.0.1", ("http", ("127.0.0.1", 80))),
-        ("http://[::1]", ("http", ("::1", 80))),
-        ("http://[::1]/", ("http", ("::1", 80))),
-        ("https://[::1]/", ("https", ("::1", 443))),
-        ("http://[::1]:8080", ("http", ("::1", 8080))),
+        ("example.com", "https", ("https", ("example.com", 443))),
+        ("http://example.com", "https", ("http", ("example.com", 80))),
+        ("smtp.example.com:25", "tcp", ("tcp", ("smtp.example.com", 25))),
+        ("http://127.0.0.1", "https", ("http", ("127.0.0.1", 80))),
+        ("http://[::1]", "https", ("http", ("::1", 80))),
+        ("http://[::1]/", "https", ("http", ("::1", 80))),
+        ("https://[::1]/", "https", ("https", ("::1", 443))),
+        ("http://[::1]:8080", "https", ("http", ("::1", 8080))),
     ],
 )
-def test_parse(spec, out):
-    assert server_spec.parse(spec) == out
+def test_parse(spec, default_scheme, out):
+    assert server_spec.parse(spec, default_scheme) == out
 
 
 def test_parse_err():
     with pytest.raises(ValueError, match="Invalid server specification"):
-        server_spec.parse(":")
+        server_spec.parse(":", "https")
 
     with pytest.raises(ValueError, match="Invalid server scheme"):
-        server_spec.parse("ftp://example.com")
+        server_spec.parse("ftp://example.com", "https")
 
     with pytest.raises(ValueError, match="Invalid hostname"):
-        server_spec.parse("$$$")
+        server_spec.parse("$$$", "https")
 
     with pytest.raises(ValueError, match="Invalid port"):
-        server_spec.parse("example.com:999999")
+        server_spec.parse("example.com:999999", "https")
 
-
-def test_parse_with_mode():
-    assert server_spec.parse_with_mode("m:example.com") == (
-        "m",
-        ("https", ("example.com", 443)),
-    )
-    with pytest.raises(ValueError):
-        server_spec.parse_with_mode("moo")
+    with pytest.raises(ValueError, match="Port specification missing"):
+        server_spec.parse("example.com", "tcp")

--- a/test/mitmproxy/proxy/layers/http/test_http.py
+++ b/test/mitmproxy/proxy/layers/http/test_http.py
@@ -4,7 +4,6 @@ import pytest
 
 from mitmproxy.connection import ConnectionState, Server
 from mitmproxy.http import HTTPFlow, Response
-from mitmproxy.net.server_spec import ServerSpec
 from mitmproxy.proxy import layer
 from mitmproxy.proxy.commands import CloseConnection, Log, OpenConnection, SendData
 from mitmproxy.proxy.events import ConnectionClosed, DataReceived
@@ -12,6 +11,7 @@ from mitmproxy.proxy.layers import TCPLayer, http, tls
 from mitmproxy.proxy.layers.http import HTTPMode
 from mitmproxy.proxy.layers.tcp import TcpMessageInjected, TcpStartHook
 from mitmproxy.proxy.layers.websocket import WebsocketStartHook
+from mitmproxy.proxy.mode_specs import ProxyMode
 from mitmproxy.tcp import TCPFlow, TCPMessage
 from test.mitmproxy.proxy.tutils import (
     BytesMatching,
@@ -729,7 +729,7 @@ def test_upstream_proxy(tctx, redirect, domain, scheme):
     server = Placeholder(Server)
     server2 = Placeholder(Server)
     flow = Placeholder(HTTPFlow)
-    tctx.options.mode = "upstream:http://proxy:8080"
+    tctx.client.proxy_mode = ProxyMode.parse("upstream:http://proxy:8080")
     playbook = Playbook(http.HttpLayer(tctx, HTTPMode.upstream), hooks=False)
 
     if scheme == "http":
@@ -782,7 +782,7 @@ def test_upstream_proxy(tctx, redirect, domain, scheme):
         flow().request.host = domain + b".test"
         flow().request.host_header = domain
     elif redirect == "change-proxy":
-        flow().server_conn.via = ServerSpec("http", address=("other-proxy", 1234))
+        flow().server_conn.via = ("http", ("other-proxy", 1234))
     playbook >> reply()
 
     if redirect:
@@ -829,10 +829,10 @@ def test_upstream_proxy(tctx, redirect, domain, scheme):
 
     if redirect == "change-proxy":
         assert (
-            server2().address == flow().server_conn.via.address == ("other-proxy", 1234)
+            server2().address == flow().server_conn.via[1] == ("other-proxy", 1234)
         )
     else:
-        assert server2().address == flow().server_conn.via.address == ("proxy", 8080)
+        assert server2().address == flow().server_conn.via[1] == ("proxy", 8080)
 
     playbook >> ConnectionClosed(tctx.client)
     playbook << CloseConnection(tctx.client)
@@ -848,10 +848,10 @@ def test_http_proxy_tcp(tctx, mode, close_first):
     tctx.options.connection_strategy = "lazy"
 
     if mode == "upstream":
-        tctx.options.mode = "upstream:http://proxy:8080"
+        tctx.client.proxy_mode = ProxyMode.parse("upstream:http://proxy:8080")
         toplayer = http.HttpLayer(tctx, HTTPMode.upstream)
     else:
-        tctx.options.mode = "regular"
+        tctx.client.proxy_mode = ProxyMode.parse("regular")
         toplayer = http.HttpLayer(tctx, HTTPMode.regular)
 
     playbook = Playbook(toplayer, hooks=False)

--- a/test/mitmproxy/proxy/test_mode_servers.py
+++ b/test/mitmproxy/proxy/test_mode_servers.py
@@ -1,0 +1,77 @@
+import asyncio
+from typing import cast
+from unittest.mock import AsyncMock, MagicMock, Mock
+
+from mitmproxy.net import udp
+from mitmproxy.proxy.mode_servers import DnsInstance, ServerInstance
+from mitmproxy.test import taddons
+
+
+def test_make():
+    manager = Mock()
+    context = MagicMock()
+    assert ServerInstance.make("regular", manager)
+
+    for mode in ["regular", "upstream:example.com", "transparent", "reverse:example.com", "socks5"]:
+        inst = ServerInstance.make(mode, manager)
+        assert inst
+        assert inst.make_top_layer(context)
+        assert inst.log_desc
+
+
+async def test_tcp_start_stop():
+    manager = MagicMock()
+
+    with taddons.context() as tctx:
+        inst = ServerInstance.make("regular@127.0.0.1:0", manager)
+        await inst.start()
+        assert await tctx.master.await_log("proxy listening")
+
+        host, port, *_ = inst.listen_addrs[0]
+        reader, writer = await asyncio.open_connection(host, port)
+        assert await tctx.master.await_log("client connect")
+
+        writer.close()
+        await writer.wait_closed()
+        assert await tctx.master.await_log("client disconnect")
+
+        await inst.stop()
+        assert await tctx.master.await_log("Stopped regular proxy server.")
+
+
+async def test_udp_start_stop():
+    manager = MagicMock()
+
+    with taddons.context() as tctx:
+        inst = ServerInstance.make("dns@127.0.0.1:0", manager)
+        await inst.start()
+        assert await tctx.master.await_log("server listening")
+
+        host, port, *_ = inst.listen_addrs[0]
+        reader, writer = await udp.open_connection(host, port)
+        writer.write(b"\x00")
+        assert await tctx.master.await_log("Invalid DNS datagram received")
+
+        writer.write(b"\x00\x00\x01")
+        assert await tctx.master.await_log("sent an invalid message")
+
+        writer.close()
+
+        await inst.stop()
+        assert await tctx.master.await_log("Stopped")
+
+
+async def test_udp_connection_reuse(monkeypatch):
+    manager = MagicMock()
+    manager.connections = {}
+
+    monkeypatch.setattr(udp, "DatagramWriter", MagicMock())
+    monkeypatch.setattr(DnsInstance, "handle_dns_connection", AsyncMock())
+
+    with taddons.context():
+        inst = cast(DnsInstance, ServerInstance.make("dns", manager))
+        inst.handle_dns_datagram(MagicMock(), b"\x00\x00\x01", ("remoteaddr", 0), ("localaddr", 0))
+        inst.handle_dns_datagram(MagicMock(), b"\x00\x00\x02", ("remoteaddr", 0), ("localaddr", 0))
+        await asyncio.sleep(0)
+
+        assert len(inst.manager.connections) == 1

--- a/test/mitmproxy/proxy/test_mode_specs.py
+++ b/test/mitmproxy/proxy/test_mode_specs.py
@@ -1,0 +1,73 @@
+import pytest
+
+from mitmproxy.proxy.mode_specs import ProxyMode, Socks5Mode
+
+
+def test_parse():
+    m = ProxyMode.parse("reverse:https://example.com/@127.0.0.1:443")
+    m = ProxyMode.from_state(m.get_state())
+
+    assert m.type == "reverse"
+    assert m.full_spec == "reverse:https://example.com/@127.0.0.1:443"
+    assert m.data == "https://example.com/"
+    assert m.custom_listen_host == "127.0.0.1"
+    assert m.custom_listen_port == 443
+
+    with pytest.raises(ValueError, match="unknown mode"):
+        ProxyMode.parse("flibbel")
+
+    with pytest.raises(ValueError, match="invalid port"):
+        ProxyMode.parse("regular@invalid-port")
+
+    with pytest.raises(ValueError, match="invalid port"):
+        ProxyMode.parse("regular@99999")
+
+    m.set_state(m.get_state())
+    with pytest.raises(RuntimeError, match="Proxy modes are frozen"):
+        m.set_state("regular")
+
+
+def test_parse_subclass():
+    assert Socks5Mode.parse("socks5")
+    with pytest.raises(ValueError, match="'regular' is not a spec for a socks5 mode"):
+        Socks5Mode.parse("regular")
+
+
+def test_listen_addr():
+    assert ProxyMode.parse("regular").listen_port() == 8080
+    assert ProxyMode.parse("regular@1234").listen_port() == 1234
+    assert ProxyMode.parse("regular").listen_port(default=4424) == 4424
+    assert ProxyMode.parse("regular@1234").listen_port(default=4424) == 1234
+
+    assert ProxyMode.parse("regular").listen_host() == ""
+    assert ProxyMode.parse("regular@127.0.0.2:8080").listen_host() == "127.0.0.2"
+    assert ProxyMode.parse("regular").listen_host(default="127.0.0.3") == "127.0.0.3"
+    assert ProxyMode.parse("regular@127.0.0.2:8080").listen_host(default="127.0.0.3") == "127.0.0.2"
+
+
+def test_parse_specific_modes():
+    assert ProxyMode.parse("regular")
+    assert ProxyMode.parse("transparent")
+    assert ProxyMode.parse("upstream:https://proxy")
+    assert ProxyMode.parse("reverse:https://host@443")
+    assert ProxyMode.parse("socks5")
+    assert ProxyMode.parse("dns").resolve_local
+    assert ProxyMode.parse("dns:reverse:8.8.8.8")
+
+    with pytest.raises(ValueError, match="invalid port"):
+        ProxyMode.parse("regular@invalid-port")
+
+    with pytest.raises(ValueError, match="takes no arguments"):
+        ProxyMode.parse("regular:configuration")
+
+    with pytest.raises(ValueError, match="invalid upstream proxy scheme"):
+        ProxyMode.parse("upstream:dns://example.com")
+
+    with pytest.raises(ValueError, match="invalid reverse proxy scheme"):
+        ProxyMode.parse("reverse:dns://example.com")
+
+    with pytest.raises(ValueError, match="invalid dns mode"):
+        ProxyMode.parse("dns:invalid")
+
+    with pytest.raises(ValueError, match="invalid dns scheme"):
+        ProxyMode.parse("dns:reverse:https://example.com")

--- a/test/mitmproxy/test_addonmanager.py
+++ b/test/mitmproxy/test_addonmanager.py
@@ -131,7 +131,7 @@ async def test_mixed_async_sync():
     with taddons.context(loadcore=False) as tctx:
         a = tctx.master.addons
 
-        assert len(a) == 0
+        assert len(a) == 1
         a1 = TAddon("sync")
         a2 = AsyncTAddon("async")
         a.add(a1)
@@ -177,15 +177,16 @@ async def test_simple():
     with taddons.context(loadcore=False) as tctx:
         a = tctx.master.addons
 
-        assert len(a) == 0
+        assert len(a) == 1
         a.add(TAddon("one"))
         assert a.get("one")
         assert not a.get("two")
-        assert len(a) == 1
+        assert len(a) == 2
         a.clear()
         assert len(a) == 0
         assert not a.chain
 
+    with taddons.context(loadcore=False) as tctx:
         a.add(TAddon("one"))
 
         a.trigger("nonexistent")

--- a/test/mitmproxy/test_flow.py
+++ b/test/mitmproxy/test_flow.py
@@ -114,7 +114,7 @@ class TestSerialize:
 
 class TestFlowMaster:
     async def test_load_http_flow_reverse(self):
-        opts = options.Options(mode="reverse:https://use-this-domain")
+        opts = options.Options(mode=["reverse:https://use-this-domain"])
         s = State()
         with taddons.context(s, options=opts) as ctx:
             f = tflow.tflow(resp=True)
@@ -122,7 +122,7 @@ class TestFlowMaster:
             assert s.flows[0].request.host == "use-this-domain"
 
     async def test_all(self):
-        opts = options.Options(mode="reverse:https://use-this-domain")
+        opts = options.Options(mode=["reverse:https://use-this-domain"])
         s = State()
         with taddons.context(s, options=opts) as ctx:
             f = tflow.tflow(req=None)

--- a/test/mitmproxy/tools/console/test_statusbar.py
+++ b/test/mitmproxy/tools/console/test_statusbar.py
@@ -24,7 +24,7 @@ async def test_statusbar(monkeypatch):
         server_replay_kill_extra=True,
         upstream_cert=False,
         stream_large_bodies="3m",
-        mode="transparent",
+        mode=["transparent"],
     )
 
     m.options.update(view_order="url", console_focus_follow=True)

--- a/test/mitmproxy/tools/web/test_app.py
+++ b/test/mitmproxy/tools/web/test_app.py
@@ -110,6 +110,8 @@ async def test_generate_options_js():
             return "string[]"
         if t == Optional[str]:
             return "string | undefined"
+        if t == Optional[int]:
+            return "number | undefined"
         raise RuntimeError(t)
 
     with redirect_stdout(io.StringIO()) as s:

--- a/web/src/js/__tests__/components/Modal/__snapshots__/ModalSpec.tsx.snap
+++ b/web/src/js/__tests__/components/Modal/__snapshots__/ModalSpec.tsx.snap
@@ -193,6 +193,15 @@ exports[`Modal Component 2`] = `
                         value="8080"
                       />
                     </div>
+                    <div
+                      class="small"
+                    >
+                      Default: 
+                      <strong>
+                         8080 
+                      </strong>
+                       
+                    </div>
                   </div>
                 </div>
               </div>

--- a/web/src/js/components/Footer.tsx
+++ b/web/src/js/components/Footer.tsx
@@ -6,14 +6,14 @@ import {useAppSelector} from "../ducks";
 export default function Footer() {
     const version = useAppSelector(state => state.conf.version);
     let {
-        mode, intercept, showhost, upstream_cert, rawtcp, dns_server, http2, websocket, anticache, anticomp,
+        mode, intercept, showhost, upstream_cert, rawtcp, http2, websocket, anticache, anticomp,
         stickyauth, stickycookie, stream_large_bodies, listen_host, listen_port, server, ssl_insecure
     } = useAppSelector(state => state.options);
 
     return (
         <footer>
-            {mode && mode !== "regular" && (
-                <span className="label label-success">{mode} mode</span>
+            {mode && (mode.length !== 1 || mode[0] !== "regular") && (
+                <span className="label label-success">{mode.join(",")}</span>
             )}
             {intercept && (
                 <span className="label label-success">Intercept: {intercept}</span>
@@ -29,9 +29,6 @@ export default function Footer() {
             )}
             {!rawtcp && (
                 <span className="label label-success">no-raw-tcp</span>
-            )}
-            {dns_server && (
-                <span className="label label-success">dns-server</span>
             )}
             {!http2 && (
                 <span className="label label-success">no-http2</span>

--- a/web/src/js/ducks/_options_gen.ts
+++ b/web/src/js/ducks/_options_gen.ts
@@ -21,10 +21,6 @@ export interface OptionsState {
     connection_strategy: string
     console_focus_follow: boolean
     content_view_lines_cutoff: number
-    dns_listen_host: string
-    dns_listen_port: number
-    dns_mode: string
-    dns_server: boolean
     export_preserve_original_ip: boolean
     http2: boolean
     http2_ping_keepalive: number
@@ -34,10 +30,10 @@ export interface OptionsState {
     keep_host_header: boolean
     key_size: number
     listen_host: string
-    listen_port: number
+    listen_port: number | undefined
     map_local: string[]
     map_remote: string[]
-    mode: string
+    mode: string[]
     modify_body: string[]
     modify_headers: string[]
     normalize_outbound_headers: boolean
@@ -115,10 +111,6 @@ export const defaultState: OptionsState = {
     connection_strategy: "eager",
     console_focus_follow: false,
     content_view_lines_cutoff: 512,
-    dns_listen_host: "",
-    dns_listen_port: 53,
-    dns_mode: "regular",
-    dns_server: false,
     export_preserve_original_ip: false,
     http2: true,
     http2_ping_keepalive: 58,
@@ -128,10 +120,10 @@ export const defaultState: OptionsState = {
     keep_host_header: false,
     key_size: 2048,
     listen_host: "",
-    listen_port: 8080,
+    listen_port: undefined,
     map_local: [],
     map_remote: [],
-    mode: "regular",
+    mode: ["regular"],
     modify_body: [],
     modify_headers: [],
     normalize_outbound_headers: true,


### PR DESCRIPTION
This is a very-much-work-in-progress implementation of the multi proxy mode discussed in https://github.com/mitmproxy/mitmproxy/discussions/5288:

```shell
$ mitmdump --mode regular --mode reverse:example.com@8443
HTTP(S) proxy listening at *:8080.
Reverse proxy to example.com listening at *:8443.
```

Tests are still failing, but the invocation above works. There are a few minor changes on the latest dicussions:

 - @Prinzhorn's question, *"what new properties does Flow need so we know where it came from?"*, to which I foolishly replied *"None. If you for some weird reason want different logic here, you can look at `flow.client_conn.sockname`"* was of course spot-on. There are some legitimate cases where we need this (e.g. proxyauth) and `Client.proxy_mode` is a thing now. 😄 
 - After pondering on this a bit, I think it's most sensible if we continue to default to a single HTTP(S) proxy on port 8080. However, we shall have super easy buttons in mitmproxy/mitmweb to quickly start up more services.
 - `dns`/`regular-dns`/... wording isn't fully fleshed out yet, we can make final decisions here once we have a raw UDP layer and/or QUIC.
 - @Meitinger / @decathorpe: Do `mitmproxy/proxy/mode_specs.py` and `mitmproxy/proxy/mode_servers.py` make sense to you? Does that work for WireGuard/QUIC?

TODO:

 - [ ] Fix tests.
 - [ ] Fail on duplicate ports.
 - [ ] Address remaining FIXMEs.
 - [ ] Adjust mitmweb.
 - [ ] Add migration code for `listen_host` and `listen_port`.
 - [ ] Docs.