### PR TITLE
Drop pkg_resources dependency used by kaitaistruct version checking (#5401)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
   ([#5364](https://github.com/mitmproxy/mitmproxy/discussions/5364), @meitinger)
 * Fix a bug where an excess empty chunk has been sent for chunked HEAD request.
   ([#5372](https://github.com/mitmproxy/mitmproxy/discussions/5372), @jixunmoe)
+* Drop pkg_resources dependency.
+  ([#5401](https://github.com/mitmproxy/mitmproxy/issues/5401), @PavelICS)
 
 ## 15 May 2022: mitmproxy 8.1.0
 

--- a/mitmproxy/contrib/kaitaistruct/exif.py
+++ b/mitmproxy/contrib/kaitaistruct/exif.py
@@ -4,13 +4,11 @@ import array
 import struct
 import zlib
 from enum import Enum
-from pkg_resources import parse_version
 
-from kaitaistruct import __version__ as ks_version, KaitaiStruct, KaitaiStream, BytesIO
+from kaitaistruct import KaitaiStruct, KaitaiStream, BytesIO
 
 
-if parse_version(ks_version) < parse_version('0.7'):
-    raise Exception("Incompatible Kaitai Struct Python API: 0.7 or later is required, but you have %s" % (ks_version))
+# manually removed version check, see https://github.com/mitmproxy/mitmproxy/issues/5401
 
 from .exif_le import ExifLe
 from .exif_be import ExifBe

--- a/mitmproxy/contrib/kaitaistruct/exif_be.py
+++ b/mitmproxy/contrib/kaitaistruct/exif_be.py
@@ -1,12 +1,10 @@
 # This is a generated file! Please edit source .ksy file and use kaitai-struct-compiler to rebuild
 
-from pkg_resources import parse_version
-from kaitaistruct import __version__ as ks_version, KaitaiStruct, KaitaiStream, BytesIO
+from kaitaistruct import KaitaiStruct, KaitaiStream, BytesIO
 from enum import Enum
 
 
-if parse_version(ks_version) < parse_version('0.7'):
-    raise Exception("Incompatible Kaitai Struct Python API: 0.7 or later is required, but you have %s" % (ks_version))
+# manually removed version check, see https://github.com/mitmproxy/mitmproxy/issues/5401
 
 class ExifBe(KaitaiStruct):
     def __init__(self, _io, _parent=None, _root=None):

--- a/mitmproxy/contrib/kaitaistruct/exif_le.py
+++ b/mitmproxy/contrib/kaitaistruct/exif_le.py
@@ -1,12 +1,10 @@
 # This is a generated file! Please edit source .ksy file and use kaitai-struct-compiler to rebuild
 
-from pkg_resources import parse_version
-from kaitaistruct import __version__ as ks_version, KaitaiStruct, KaitaiStream, BytesIO
+from kaitaistruct import KaitaiStruct, KaitaiStream, BytesIO
 from enum import Enum
 
 
-if parse_version(ks_version) < parse_version('0.7'):
-    raise Exception("Incompatible Kaitai Struct Python API: 0.7 or later is required, but you have %s" % (ks_version))
+# manually removed version check, see https://github.com/mitmproxy/mitmproxy/issues/5401
 
 class ExifLe(KaitaiStruct):
     def __init__(self, _io, _parent=None, _root=None):

--- a/mitmproxy/contrib/kaitaistruct/gif.py
+++ b/mitmproxy/contrib/kaitaistruct/gif.py
@@ -4,13 +4,11 @@ import array
 import struct
 import zlib
 from enum import Enum
-from pkg_resources import parse_version
 
-from kaitaistruct import __version__ as ks_version, KaitaiStruct, KaitaiStream, BytesIO
+from kaitaistruct import KaitaiStruct, KaitaiStream, BytesIO
 
 
-if parse_version(ks_version) < parse_version('0.7'):
-    raise Exception("Incompatible Kaitai Struct Python API: 0.7 or later is required, but you have %s" % (ks_version))
+# manually removed version check, see https://github.com/mitmproxy/mitmproxy/issues/5401
 
 class Gif(KaitaiStruct):
 

--- a/mitmproxy/contrib/kaitaistruct/google_protobuf.py
+++ b/mitmproxy/contrib/kaitaistruct/google_protobuf.py
@@ -1,12 +1,11 @@
 # This is a generated file! Please edit source .ksy file and use kaitai-struct-compiler to rebuild
 
-from pkg_resources import parse_version
-from kaitaistruct import __version__ as ks_version, KaitaiStruct, KaitaiStream, BytesIO
+
+from kaitaistruct import KaitaiStruct, KaitaiStream, BytesIO
 from enum import Enum
 
 
-if parse_version(ks_version) < parse_version('0.7'):
-    raise Exception("Incompatible Kaitai Struct Python API: 0.7 or later is required, but you have %s" % (ks_version))
+# manually removed version check, see https://github.com/mitmproxy/mitmproxy/issues/5401
 
 from .vlq_base128_le import VlqBase128Le
 class GoogleProtobuf(KaitaiStruct):

--- a/mitmproxy/contrib/kaitaistruct/ico.py
+++ b/mitmproxy/contrib/kaitaistruct/ico.py
@@ -1,12 +1,10 @@
 # This is a generated file! Please edit source .ksy file and use kaitai-struct-compiler to rebuild
 
-from pkg_resources import parse_version
-from kaitaistruct import __version__ as ks_version, KaitaiStruct, KaitaiStream, BytesIO
+from kaitaistruct import KaitaiStruct, KaitaiStream, BytesIO
 import struct
 
 
-if parse_version(ks_version) < parse_version('0.7'):
-    raise Exception("Incompatible Kaitai Struct Python API: 0.7 or later is required, but you have %s" % (ks_version))
+# manually removed version check, see https://github.com/mitmproxy/mitmproxy/issues/5401
 
 class Ico(KaitaiStruct):
     """Microsoft Windows uses specific file format to store applications

--- a/mitmproxy/contrib/kaitaistruct/jpeg.py
+++ b/mitmproxy/contrib/kaitaistruct/jpeg.py
@@ -4,13 +4,11 @@ import array
 import struct
 import zlib
 from enum import Enum
-from pkg_resources import parse_version
 
-from kaitaistruct import __version__ as ks_version, KaitaiStruct, KaitaiStream, BytesIO
+from kaitaistruct import KaitaiStruct, KaitaiStream, BytesIO
 
 
-if parse_version(ks_version) < parse_version('0.7'):
-    raise Exception("Incompatible Kaitai Struct Python API: 0.7 or later is required, but you have %s" % (ks_version))
+# manually removed version check, see https://github.com/mitmproxy/mitmproxy/issues/5401
 
 from .exif import Exif
 

--- a/mitmproxy/contrib/kaitaistruct/png.py
+++ b/mitmproxy/contrib/kaitaistruct/png.py
@@ -4,13 +4,11 @@ import array
 import struct
 import zlib
 from enum import Enum
-from pkg_resources import parse_version
 
-from kaitaistruct import __version__ as ks_version, KaitaiStruct, KaitaiStream, BytesIO
+from kaitaistruct import KaitaiStruct, KaitaiStream, BytesIO
 
 
-if parse_version(ks_version) < parse_version('0.7'):
-    raise Exception("Incompatible Kaitai Struct Python API: 0.7 or later is required, but you have %s" % (ks_version))
+# manually removed version check, see https://github.com/mitmproxy/mitmproxy/issues/5401
 
 class Png(KaitaiStruct):
 

--- a/mitmproxy/contrib/kaitaistruct/tls_client_hello.py
+++ b/mitmproxy/contrib/kaitaistruct/tls_client_hello.py
@@ -4,12 +4,10 @@ import array
 import struct
 import zlib
 from enum import Enum
-from pkg_resources import parse_version
 
-from kaitaistruct import __version__ as ks_version, KaitaiStruct, KaitaiStream, BytesIO
+from kaitaistruct import KaitaiStruct, KaitaiStream, BytesIO
 
-if parse_version(ks_version) < parse_version('0.7'):
-    raise Exception("Incompatible Kaitai Struct Python API: 0.7 or later is required, but you have %s" % (ks_version))
+# manually removed version check, see https://github.com/mitmproxy/mitmproxy/issues/5401
 
 
 class TlsClientHello(KaitaiStruct):

--- a/mitmproxy/contrib/kaitaistruct/vlq_base128_le.py
+++ b/mitmproxy/contrib/kaitaistruct/vlq_base128_le.py
@@ -1,11 +1,9 @@
 # This is a generated file! Please edit source .ksy file and use kaitai-struct-compiler to rebuild
 
-from pkg_resources import parse_version
-from kaitaistruct import __version__ as ks_version, KaitaiStruct, KaitaiStream, BytesIO
+from kaitaistruct import KaitaiStruct, KaitaiStream, BytesIO
 
 
-if parse_version(ks_version) < parse_version('0.7'):
-    raise Exception("Incompatible Kaitai Struct Python API: 0.7 or later is required, but you have %s" % (ks_version))
+# manually removed version check, see https://github.com/mitmproxy/mitmproxy/issues/5401
 
 class VlqBase128Le(KaitaiStruct):
     """A variable-length unsigned integer using base128 encoding. 1-byte groups

--- a/setup.py
+++ b/setup.py
@@ -87,8 +87,6 @@ setup(
         "pyparsing>=2.4.2,<3.1",
         "pyperclip>=1.6.0,<1.9",
         "ruamel.yaml>=0.16,<0.18",
-        # Kaitai parsers depend on setuptools, remove once https://github.com/kaitai-io/kaitai_struct_python_runtime/issues/62 is fixed
-        "setuptools",
         "sortedcontainers>=2.3,<2.5",
         "tornado>=6.1,<7",
         "urwid>=2.1.1,<2.2",


### PR DESCRIPTION
#### Description
Droped pkg_resources dependency used by kaitaistruct version checking
Droped kaitaistruct version checks
Removed setuptools that provides pkg_resources from setup.py

#### Checklist

 - [ ] I have updated tests where applicable.
 - [ ] I have added an entry to the CHANGELOG.
