### PR TITLE
fix the mounted local storage permission issue for the docker release

### DIFF
--- a/release/docker/DockerHub-README.md
+++ b/release/docker/DockerHub-README.md
@@ -5,11 +5,11 @@ Containerized version of [mitmproxy](https://mitmproxy.org/): an interactive, SS
 ## Usage
 
 ```sh
-$ docker run --rm -it [-v ~/.mitmproxy:/home/mitmproxy/.mitmproxy] -p 8080:8080 mitmproxy/mitmproxy
+$ docker run --rm -it [-v ~/.mitmproxy:/home/mitmproxy/.mitmproxy -e PUID=1001 -e PGID=1001] -p 8080:8080 mitmproxy/mitmproxy
 [terminal user interface of mitmproxy is launched...]
 ```
 
-The *volume mount* is optional: It's to store the generated CA certificates.
+The *volume mount* is optional: It's to store the generated CA certificates. And if you specific the -v parameter to mount your local storage, you should also set the PUID and PGID envionment variable to spcific the UID and GID of the local storage.  
 
 Once started, mitmproxy listens as a HTTP proxy on `localhost:8080`:
 

--- a/release/docker/Dockerfile
+++ b/release/docker/Dockerfile
@@ -17,6 +17,9 @@ RUN rm -rf /wheels
 
 VOLUME /home/mitmproxy/.mitmproxy
 
+ENV PUID= \
+    PGID= 
+
 COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]
 

--- a/release/docker/docker-entrypoint.sh
+++ b/release/docker/docker-entrypoint.sh
@@ -7,6 +7,9 @@ set -o nounset
 
 MITMPROXY_PATH="/home/mitmproxy/.mitmproxy"
 
+if [ ! "$(id -u mitmproxy)" -eq "$PUID" ]; then usermod -o -u "$PUID" mitmproxy ; fi
+if [ ! "$(id -g mitmproxy)" -eq "$PGID" ]; then groupmod -o -g "$PGID" mitmproxy ; fi
+
 if [[ "$1" = "mitmdump" || "$1" = "mitmproxy" || "$1" = "mitmweb" ]]; then
   mkdir -p "$MITMPROXY_PATH"
   chown -R mitmproxy:mitmproxy "$MITMPROXY_PATH"


### PR DESCRIPTION
#### Description

<!-- describe your changes here -->
add the capability to specific the UID and GID of the local storage which will be mounted to the docker container by -v.

if we don't specify the UID and GID, there will be a lot of issues like 
Permission denied: '/home/mitmproxy/.mitmproxy/mitmproxy-ca.pem' in this [issue #6](https://github.com/mitmproxy/docker-releases/issues/6)


