### PR TITLE
accept newer protobuf versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ setup(
         "ldap3>=2.8,<2.10",
         "msgpack>=1.0.0, <1.1.0",
         "passlib>=1.6.5, <1.8",
-        "protobuf>=3.14,<3.21",
+        "protobuf>=3.14,<5",
         "pyOpenSSL>=21.0,<22.1",
         "pyparsing>=2.4.2,<3.1",
         "pyperclip>=1.6.0,<1.9",


### PR DESCRIPTION
#### Description

ProtoBuf has changed their versioning scheme and now they guarantee backward compatibility within a major version. See https://developers.google.com/protocol-buffers/docs/news/2022-05-06#versioning and https://github.com/protocolbuffers/protobuf/issues/9872#issuecomment-1135962265 for more details.

I have ran the tests with the current latest version 4.21.1, and now they guarantee there will be no breaking change until version 5, so it is safe to use the `protobuf>=3.14,<5` range instead of `protobuf>=3.14,<3.21`.

Fixes https://github.com/mitmproxy/mitmproxy/issues/5160

#### Checklist

 - [ ] I have updated tests where applicable.
 - [ ] I have added an entry to the CHANGELOG.
