### PR TITLE
fix huge (>65kb) http2 responses corrupted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
   ([#5372](https://github.com/mitmproxy/mitmproxy/discussions/5372), @jixunmoe)
 * Drop pkg_resources dependency.
   ([#5401](https://github.com/mitmproxy/mitmproxy/issues/5401), @PavelICS)
+* Fix huge (>65kb) http2 responses corrupted
+  ([#5428](https://github.com/mitmproxy/mitmproxy/issues/5428), @dhabensky)
 
 ## 15 May 2022: mitmproxy 8.1.0
 

--- a/mitmproxy/proxy/layers/http/_http2.py
+++ b/mitmproxy/proxy/layers/http/_http2.py
@@ -117,9 +117,7 @@ class Http2Connection(HttpConnection):
             elif isinstance(event, (RequestTrailers, ResponseTrailers)):
                 if self.is_open_for_us(event.stream_id):
                     trailers = [*event.trailers.fields]
-                    self.h2_conn.send_headers(
-                        event.stream_id, trailers, end_stream=True
-                    )
+                    self.h2_conn.send_trailers(event.stream_id, trailers)
             elif isinstance(event, (RequestEndOfMessage, ResponseEndOfMessage)):
                 if self.is_open_for_us(event.stream_id):
                     self.h2_conn.end_stream(event.stream_id)

--- a/mitmproxy/proxy/layers/http/_http_h2.py
+++ b/mitmproxy/proxy/layers/http/_http_h2.py
@@ -1,5 +1,5 @@
 import collections
-from typing import Any, Dict, NamedTuple
+from typing import Dict, List, NamedTuple, Tuple
 
 import h2.config
 import h2.connection
@@ -34,7 +34,7 @@ class BufferedH2Connection(h2.connection.H2Connection):
     """
 
     stream_buffers: collections.defaultdict[int, collections.deque[SendH2Data]]
-    stream_trailers: Dict[int, Any]
+    stream_trailers: Dict[int, List[Tuple[bytes, bytes]]]
 
     def __init__(self, config: h2.config.H2Configuration):
         super().__init__(config)
@@ -79,16 +79,17 @@ class BufferedH2Connection(h2.connection.H2Connection):
                 # We can't send right now, so we buffer.
                 self.stream_buffers[stream_id].append(SendH2Data(data, end_stream))
 
-    def send_trailers(self, stream_id, trailers):
+    def send_trailers(self, stream_id: int, trailers: List[Tuple[bytes, bytes]]):
         if self.stream_buffers.get(stream_id, None):
             # Though trailers are not subject to flow control, we need to queue them and send strictly after data frames
             self.stream_trailers[stream_id] = trailers
         else:
             self.send_headers(stream_id, trailers, end_stream=True)
 
-    def end_stream(self, stream_id) -> None:
-        if not self.stream_trailers.get(stream_id):
-            self.send_data(stream_id, b"", end_stream=True)
+    def end_stream(self, stream_id: int) -> None:
+        if stream_id in self.stream_trailers:
+            return  # we already have trailers queued up that will end the stream.
+        self.send_data(stream_id, b"", end_stream=True)
 
     def reset_stream(self, stream_id: int, error_code: int = 0) -> None:
         self.stream_buffers.pop(stream_id, None)
@@ -157,7 +158,7 @@ class BufferedH2Connection(h2.connection.H2Connection):
             available_window -= len(chunk.data)
             if not self.stream_buffers[stream_id]:
                 del self.stream_buffers[stream_id]
-                if self.stream_trailers.get(stream_id):
+                if stream_id in self.stream_trailers:
                     self.send_headers(stream_id, self.stream_trailers.pop(stream_id), end_stream=True)
             sent_any_data = True
 

--- a/mitmproxy/proxy/layers/http/_http_h2.py
+++ b/mitmproxy/proxy/layers/http/_http_h2.py
@@ -1,5 +1,5 @@
 import collections
-from typing import NamedTuple
+from typing import Dict, NamedTuple
 
 import h2.config
 import h2.connection
@@ -8,6 +8,7 @@ import h2.exceptions
 import h2.settings
 import h2.stream
 
+from mitmproxy import ctx
 
 class H2ConnectionLogger(h2.config.DummyLogger):
     def __init__(self, name: str):
@@ -34,10 +35,12 @@ class BufferedH2Connection(h2.connection.H2Connection):
     """
 
     stream_buffers: collections.defaultdict[int, collections.deque[SendH2Data]]
+    stream_trailers: Dict[int, any]
 
     def __init__(self, config: h2.config.H2Configuration):
         super().__init__(config)
         self.stream_buffers = collections.defaultdict(collections.deque)
+        self.stream_trailers = {}
 
     def send_data(
         self,
@@ -68,17 +71,31 @@ class BufferedH2Connection(h2.connection.H2Connection):
         else:
             available_window = self.local_flow_control_window(stream_id)
             if frame_size <= available_window:
+                ctx.log.info("BufferedH2Connection: send_data(stream_id={}, len={}, end_stream={})".format(stream_id, len(data), end_stream))
                 super().send_data(stream_id, data, end_stream)
             else:
                 if available_window:
                     can_send_now = data[:available_window]
+                    ctx.log.info("BufferedH2Connection: send_data(stream_id={}, len={}, end_stream={})".format(stream_id, len(can_send_now), end_stream))
                     super().send_data(stream_id, can_send_now, end_stream=False)
                     data = data[available_window:]
                 # We can't send right now, so we buffer.
                 self.stream_buffers[stream_id].append(SendH2Data(data, end_stream))
 
+    def send_trailers(self, stream_id, trailers):
+        if self.stream_buffers.get(stream_id, None):
+            # Though trailers are not subject to flow control, we need to queue them and send strictly after data frames
+            ctx.log.info("BufferedH2Connection: enqueue trailers")
+            self.stream_trailers[stream_id] = trailers
+            #self.stream_buffers[stream_id].append(SendH2Trailers(trailers))
+        else:
+            ctx.log.info("BufferedH2Connection: send trailers(stream_id={}, trailers={})".format(stream_id, trailers))
+            self.send_headers(stream_id, trailers, end_stream=True)
+
     def end_stream(self, stream_id) -> None:
-        self.send_data(stream_id, b"", end_stream=True)
+        ctx.log.info("BufferedH2Connection: end_stream(stream_id={})".format(stream_id))
+        if not self.stream_trailers.get(stream_id):
+            self.send_data(stream_id, b"", end_stream=True)
 
     def reset_stream(self, stream_id: int, error_code: int = 0) -> None:
         self.stream_buffers.pop(stream_id, None)
@@ -142,11 +159,15 @@ class BufferedH2Connection(h2.connection.H2Connection):
                     end_stream=False,
                 )
 
+            ctx.log.info("BufferedH2Connection: send_data(stream_id={}, len={}, end_stream={})".format(stream_id, len(chunk.data), chunk.end_stream))
             super().send_data(stream_id, data=chunk.data, end_stream=chunk.end_stream)
 
             available_window -= len(chunk.data)
             if not self.stream_buffers[stream_id]:
                 del self.stream_buffers[stream_id]
+                if self.stream_trailers.get(stream_id):
+                    ctx.log.info("BufferedH2Connection: send_trailers(stream_id={})".format(stream_id))
+                    self.send_headers(stream_id, self.stream_trailers.pop(stream_id), end_stream=True)
             sent_any_data = True
 
         return sent_any_data


### PR DESCRIPTION
#### Description

BufferedH2Connection is able to buffer huge response and send it to client, properly following flow control specs.
But trailers are not subject to flow control and were mistankenly sent immediate.
That led to the situation that mitmproxy worked fine on small responses (that fit in 65k bytes - initial size of flow control window) and broke on huge responses.

With this changes I delay trailers until all data gets sent.
I also altered `end_stream` method because it is hard to expose proper stream state to `Http2Connection.is_closed` now.
Without the change an empty data frame with `end_stream` flag was sent before trailers and it also violated protocol.

Fixes #5428

I will remove excessive logging and add tests/changelog in the next iterations.
@mhils are you ok with the solution?

#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
