### PR TITLE
use default_factory for parser_options field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 * Remove overambitious assertions in the HTTP state machine,
   fix some error handling.
   ([#5383](https://github.com/mitmproxy/mitmproxy/issues/5383), @mhils)
+* Use default_factory for parser_options.
+  ([#5474](https://github.com/mitmproxy/mitmproxy/issues/5474), @rathann)
 
 ## 15 May 2022: mitmproxy 8.1.0
 

--- a/mitmproxy/contentviews/grpc.py
+++ b/mitmproxy/contentviews/grpc.py
@@ -951,7 +951,7 @@ def format_grpc(
 
 @dataclass
 class ViewConfig:
-    parser_options: ProtoParser.ParserOptions = ProtoParser.ParserOptions()
+    parser_options: ProtoParser.ParserOptions = field(default_factory=ProtoParser.ParserOptions)
     parser_rules: list[ProtoParser.ParserRule] = field(default_factory=list)
 
 


### PR DESCRIPTION
#### Description

Following https://github.com/python/cpython/issues/88840 , python 3.11a4 and later disallows unhashable objects to be defaults. This results in a `ValueError` exception when setting default value of `parser_options` field. Fixes #5474.

#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
