### PR TITLE
tlsconfig: don't connect upstream if connection strategy is lazy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased: mitmproxy next
 
+* Setting `connection_strategy` to `lazy` now also disables early 
+  upstream connections to fetch TLS certificate details.
+  (@mhils)
+
 ## 28 June 2022: mitmproxy 8.1.1
 
 * Support specifying the local address for outgoing connections

--- a/mitmproxy/addons/tlsconfig.py
+++ b/mitmproxy/addons/tlsconfig.py
@@ -134,10 +134,8 @@ class TlsConfig:
 
     def tls_clienthello(self, tls_clienthello: tls.ClientHelloData):
         conn_context = tls_clienthello.context
-        tls_clienthello.establish_server_tls_first = conn_context.server.tls and (
-            ctx.options.connection_strategy == "eager"
-            or ctx.options.add_upstream_certs_to_client_chain
-            or ctx.options.upstream_cert
+        tls_clienthello.establish_server_tls_first = (
+            conn_context.server.tls and ctx.options.connection_strategy == "eager"
         )
 
     def tls_start_client(self, tls_start: tls.TlsData) -> None:


### PR DESCRIPTION
This led to confusion previously, see https://github.com/mitmproxy/mitmproxy/discussions/5416#discussioncomment-3079358.