### PR TITLE
Require pyOpenSSL version 22.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,7 @@ setup(
         "msgpack>=1.0.0, <1.1.0",
         "passlib>=1.6.5, <1.8",
         "protobuf>=3.14,<5",
-        "pyOpenSSL>=21.0,<22.1",
+        "pyOpenSSL>=22.0,<22.1",
         "pyparsing>=2.4.2,<3.1",
         "pyperclip>=1.6.0,<1.9",
         "ruamel.yaml>=0.16,<0.18",


### PR DESCRIPTION
#### Description

When pyOpenSSL version 21 is installed, mitmproxy won't start due to missing constants like `DTLS_SERVER_METHOD`.
These features have been introduced in https://github.com/pyca/pyopenssl/commit/e84e7b57d1838de70ab7a27089fbee78ce0d2106. Pumping to version 22 solves the issue.
