### PR TITLE
fix issue #5198: mitmWeb crash

### DIFF
--- a/web/src/js/__tests__/components/FlowTable/__snapshots__/FlowColumnsSpec.tsx.snap
+++ b/web/src/js/__tests__/components/FlowTable/__snapshots__/FlowColumnsSpec.tsx.snap
@@ -214,9 +214,7 @@ exports[`should render columns: quickactions 1`] = `
       <tr>
         <td
           class="col-quickactions"
-        >
-          <div />
-        </td>
+        />
       </tr>
     </tbody>
   </table>

--- a/web/src/js/components/FlowTable/FlowColumns.tsx
+++ b/web/src/js/components/FlowTable/FlowColumns.tsx
@@ -223,7 +223,7 @@ export const quickactions: FlowColumn = ({flow}) => {
                 {resume_or_replay}
             </div>
         </td>
-    );
+    )
 }
 
 quickactions.headerName = ''

--- a/web/src/js/components/FlowTable/FlowColumns.tsx
+++ b/web/src/js/components/FlowTable/FlowColumns.tsx
@@ -218,7 +218,7 @@ export const quickactions: FlowColumn = ({flow}) => {
     }
 
     return (
-        <td className={classnames("col-quickactions", { hover: open })} onClick={() => 0}>
+        <td className={classnames("col-quickactions", {hover: open})} onClick={() => 0}>
             {resume_or_replay ? <div>{resume_or_replay}</div> : <></>}
         </td>
     )

--- a/web/src/js/components/FlowTable/FlowColumns.tsx
+++ b/web/src/js/components/FlowTable/FlowColumns.tsx
@@ -206,7 +206,7 @@ export const quickactions: FlowColumn = ({flow}) => {
     const dispatch = useDispatch()
     let [open, setOpen] = useState(false)
 
-    let resume_or_replay: ReactElement | null = null;
+    let resume_or_replay: ReactElement = <></>;
     if (flow.intercepted) {
         resume_or_replay = <a href="#" className="quickaction" onClick={() => dispatch(flowActions.resume(flow))}>
             <i className="fa fa-fw fa-play text-success"/>
@@ -218,8 +218,10 @@ export const quickactions: FlowColumn = ({flow}) => {
     }
 
     return (
-        <td className={classnames("col-quickactions", { hover: open })} onClick={() => 0} >
-            {resume_or_replay ? <div>{resume_or_replay}</div> : <></>}
+        <td className={classnames("col-quickactions", { hover: open })} onClick={() => 0}>
+            <div>
+                {resume_or_replay}
+            </div>
         </td>
     );
 }

--- a/web/src/js/components/FlowTable/FlowColumns.tsx
+++ b/web/src/js/components/FlowTable/FlowColumns.tsx
@@ -215,6 +215,10 @@ export const quickactions: FlowColumn = ({flow}) => {
         resume_or_replay = <a href="#" className="quickaction" onClick={() => dispatch(flowActions.replay(flow))}>
             <i className="fa fa-fw fa-repeat text-primary"/>
         </a>;
+    } else {
+        resume_or_replay = <a href="#" className="quickaction" onClick={() => 0}>
+            <i className="fa fa-fw text-primary"/>
+        </a>;
     }
 
     return (

--- a/web/src/js/components/FlowTable/FlowColumns.tsx
+++ b/web/src/js/components/FlowTable/FlowColumns.tsx
@@ -215,19 +215,13 @@ export const quickactions: FlowColumn = ({flow}) => {
         resume_or_replay = <a href="#" className="quickaction" onClick={() => dispatch(flowActions.replay(flow))}>
             <i className="fa fa-fw fa-repeat text-primary"/>
         </a>;
-    } else {
-        resume_or_replay = <a href="#" className="quickaction" onClick={() => 0}>
-            <i className="fa fa-fw text-primary"/>
-        </a>;
     }
 
     return (
-        <td className={classnames("col-quickactions", {hover: open})} onClick={() => 0}>
-            <div>
-                {resume_or_replay}
-            </div>
+        <td className={classnames("col-quickactions", { hover: open })} onClick={() => 0} >
+            {resume_or_replay ? <div>{resume_or_replay}</div> : <></>}
         </td>
-    )
+    );
 }
 
 quickactions.headerName = ''

--- a/web/src/js/components/FlowTable/FlowColumns.tsx
+++ b/web/src/js/components/FlowTable/FlowColumns.tsx
@@ -206,7 +206,7 @@ export const quickactions: FlowColumn = ({flow}) => {
     const dispatch = useDispatch()
     let [open, setOpen] = useState(false)
 
-    let resume_or_replay: ReactElement = <></>;
+    let resume_or_replay: ReactElement | null = null;
     if (flow.intercepted) {
         resume_or_replay = <a href="#" className="quickaction" onClick={() => dispatch(flowActions.resume(flow))}>
             <i className="fa fa-fw fa-play text-success"/>
@@ -219,9 +219,7 @@ export const quickactions: FlowColumn = ({flow}) => {
 
     return (
         <td className={classnames("col-quickactions", { hover: open })} onClick={() => 0}>
-            <div>
-                {resume_or_replay}
-            </div>
+            {resume_or_replay ? <div>{resume_or_replay}</div> : <></>}
         </td>
     )
 }


### PR DESCRIPTION
#### Description

issue #5198 mitmWeb crashed when scroll the window, and get error message like this:
Error: Maximum update depth exceeded. This can happen when a component repeatedly calls setState inside componentWillUpdate or componentDidUpdate. React limits the number of nested updates to prevent infinite loops.

code Logic:
Function "onViewportUpdate()" is used to control how many flows displayed in flow-table, In component FlowTable(components/Modal/FlowTable.jsx).
When user scroll the "flow-table", the procedure is as follows:
  step1 div whose className is"flow-table" onScroll callback onViewportUpdate() is called
  step2 setState({vScroll, viewportTop}) after calcVScroll()
  step3 componentDidUpdate() is called to update component "FlowTable"
  step4 onViewportUpdate() is called again
  step5 normally calcVScroll() will get same result with step2, and setState() is not called

why crash?
Flow-item's default height is '32px', but when some flow-item's height is not '32px', the viewport.scrollTop will be different in step1 and step3. This was because that step3 is after flow-tiem's render(), and the real flow-item's height is used, such as '38.5px' not '32px'. In this case step5 will do setState(), and do step3-step5 again.

As an example: when the scrollbar is at a specific position, calcVScroll() calculates flow-item 32-52 will be displayed,  in step2. Bacause of a heigher flow-item, calcVScroll() may calculates flow-item 30-50 will be displayed, in step5, and do setStete(). In the next loop of step3-step5, flow-item 30-50 do not contain the higher flow-item, calcVScroll() get result of flow-item 32-52 again, and do component upDate again.....
Result in an endless loop, and then you will get the Crash.

which flow-item has a higher？
The flow-item cannot "play" or "repeat", such as TCP and websocket:
![image](https://user-images.githubusercontent.com/110232125/182064241-9febdf8c-a59c-4849-9c84-79f12f432d51.png)

How to fix?
My way to fix this bug is to change higher flow-items to default height '32px'.
In FlowColumn() (components/FlowTable/FlowColumns.tsx), there was a if {...} else if {...}, but no else {} for default case. I try to add an else {} branch for default case, and mitmWeb do not crash in my computer.

#### Checklist

 - [ ] I have updated tests where applicable.
 - [ ] I have added an entry to the CHANGELOG.
