### PR TITLE
Restrict version of transitive dependency pyasn1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased: mitmproxy next
 
+* Restrict version of transitive dependency pyasn1
+  ([#5527](https://github.com/mitmproxy/mitmproxy/pull/5527), @szemek)
 * Include server information in bind/listen errors.
   ([#5495](https://github.com/mitmproxy/mitmproxy/pull/5495), @meitinger)
 * Include information about lazy connection_strategy in related errors.

--- a/setup.py
+++ b/setup.py
@@ -86,6 +86,7 @@ setup(
         "msgpack>=1.0.0, <1.1.0",
         "passlib>=1.6.5, <1.8",
         "protobuf>=3.14,<5",
+        "pyasn1>=0.4.6,<0.5.0",
         "pyOpenSSL>=22.0,<22.1",
         "pyparsing>=2.4.2,<3.1",
         "pyperclip>=1.6.0,<1.9",


### PR DESCRIPTION
#### Description

Changes:
 * restricted version of pyasn1 to fix `ImportError: cannot import name 'tagMap' from 'pyasn1.codec.ber.encoder'` 

Recent version of pyasn1 (0.5.0rc1 PRE-RELEASE) (depedency of ldap3) causes following issues:

```
 ➜ mitmdump --version
Traceback (most recent call last):
  File "/Users/szemek//mitmproxy/.venv/bin/mitmdump", line 33, in <module>
    sys.exit(load_entry_point('mitmproxy==9.0.0.dev0', 'console_scripts', 'mitmdump')())
  File "/Users/szemek//mitmproxy/.venv/lib/python3.10/site-packages/mitmproxy-9.0.0.dev0-py3.10.egg/mitmproxy/tools/main.py", line 126, in mitmdump
    from mitmproxy.tools import dump
  File "/Users/szemek//mitmproxy/.venv/lib/python3.10/site-packages/mitmproxy-9.0.0.dev0-py3.10.egg/mitmproxy/tools/dump.py", line 1, in <module>
    from mitmproxy import addons
  File "/Users/szemek//mitmproxy/.venv/lib/python3.10/site-packages/mitmproxy-9.0.0.dev0-py3.10.egg/mitmproxy/addons/__init__.py", line 17, in <module>
    from mitmproxy.addons import proxyauth
  File "/Users/szemek//mitmproxy/.venv/lib/python3.10/site-packages/mitmproxy-9.0.0.dev0-py3.10.egg/mitmproxy/addons/proxyauth.py", line 9, in <module>
    import ldap3
  File "/Users/szemek//mitmproxy/.venv/lib/python3.10/site-packages/ldap3-2.9.1-py3.10.egg/ldap3/__init__.py", line 141, in <module>
    from .core.connection import Connection
  File "/Users/szemek//mitmproxy/.venv/lib/python3.10/site-packages/ldap3-2.9.1-py3.10.egg/ldap3/core/connection.py", line 38, in <module>
    from ..extend import ExtendedOperationsRoot
  File "/Users/szemek//mitmproxy/.venv/lib/python3.10/site-packages/ldap3-2.9.1-py3.10.egg/ldap3/extend/__init__.py", line 29, in <module>
    from .microsoft.dirSync import DirSync
  File "/Users/szemek//mitmproxy/.venv/lib/python3.10/site-packages/ldap3-2.9.1-py3.10.egg/ldap3/extend/microsoft/dirSync.py", line 27, in <module>
    from ...protocol.microsoft import dir_sync_control, extended_dn_control, show_deleted_control
  File "/Users/szemek//mitmproxy/.venv/lib/python3.10/site-packages/ldap3-2.9.1-py3.10.egg/ldap3/protocol/microsoft.py", line 32, in <module>
    from .controls import build_control
  File "/Users/szemek//mitmproxy/.venv/lib/python3.10/site-packages/ldap3-2.9.1-py3.10.egg/ldap3/protocol/controls.py", line 27, in <module>
    from ..utils.asn1 import encode
  File "/Users/szemek//mitmproxy/.venv/lib/python3.10/site-packages/ldap3-2.9.1-py3.10.egg/ldap3/utils/asn1.py", line 50, in <module>
    from pyasn1.codec.ber.encoder import tagMap, typeMap, AbstractItemEncoder
ImportError: cannot import name 'tagMap' from 'pyasn1.codec.ber.encoder' (/Users/szemek//mitmproxy/.venv/lib/python3.10/site-packages/pyasn1-0.5.0rc1-py3.10.egg/pyasn1/codec/ber/encoder.py)
```

After restricting version pyasn1>=0.4.6,<0.5.0 I can successfully run:

```
➜ mitmdump --version
Mitmproxy: 9.0.0.dev (+58, commit 51684e1)
Python:    3.10.1
OpenSSL:   OpenSSL 3.0.5 5 Jul 2022
Platform:  macOS-12.3-x86_64-i386-64bit
```

I set pyasn1>=0.4.6,<0.5.0 after checking
https://github.com/cannatag/ldap3/blob/v2.8/requirements.txt
https://github.com/cannatag/ldap3/blob/v2.9.1/requirements.txt

ldap3 has a fix for this issue, but no new version has been released since Jul 18, 2021
https://github.com/cannatag/ldap3/pull/983/files

#### Checklist

 - [ ] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
