### PR TITLE
Replace blinker with custom implementation

### DIFF
--- a/mitmproxy/addonmanager.py
+++ b/mitmproxy/addonmanager.py
@@ -128,7 +128,7 @@ class AddonManager:
         self.master = master
         master.options.changed.connect(self._configure_all)
 
-    def _configure_all(self, options, updated):
+    def _configure_all(self, updated):
         self.trigger(hooks.ConfigureHook(updated))
 
     def clear(self):

--- a/mitmproxy/addons/eventstore.py
+++ b/mitmproxy/addons/eventstore.py
@@ -9,8 +9,8 @@ from mitmproxy.utils import signals
 class EventStore:
     def __init__(self, size=10000):
         self.data: collections.deque[LogEntry] = collections.deque(maxlen=size)
-        self.sig_add = signals.SyncSignal()
-        self.sig_refresh = signals.SyncSignal()
+        self.sig_add = signals.SyncSignal(lambda entry: None)
+        self.sig_refresh = signals.SyncSignal(lambda: None)
 
     @property
     def size(self) -> Optional[int]:
@@ -18,7 +18,7 @@ class EventStore:
 
     def add_log(self, entry: LogEntry) -> None:
         self.data.append(entry)
-        self.sig_add.send(self, entry=entry)
+        self.sig_add.send(entry)
 
     @command.command("eventstore.clear")
     def clear(self) -> None:
@@ -26,4 +26,4 @@ class EventStore:
         Clear the event log.
         """
         self.data.clear()
-        self.sig_refresh.send(self)
+        self.sig_refresh.send()

--- a/mitmproxy/addons/view.py
+++ b/mitmproxy/addons/view.py
@@ -56,7 +56,7 @@ class _OrderKey:
             self.view._view.remove(f)
             self.view.settings[f][k] = new
             self.view._view.add(f)
-            self.view.sig_view_refresh.send(self.view)
+            self.view.sig_view_refresh.send()
 
     def _key(self):
         return "_order_%s" % id(self)
@@ -131,6 +131,14 @@ orders = [
 ]
 
 
+def _signal_with_flow(flow: mitmproxy.flow.Flow) -> None:
+    ...
+
+
+def _sig_view_remove(flow: mitmproxy.flow.Flow, index: int) -> None:
+    ...
+
+
 class View(collections.abc.Sequence):
     def __init__(self):
         super().__init__()
@@ -155,19 +163,19 @@ class View(collections.abc.Sequence):
         # The sig_view* signals broadcast events that affect the view. That is,
         # an update to a flow in the store but not in the view does not trigger
         # a signal. All signals are called after the view has been updated.
-        self.sig_view_update = signals.SyncSignal()
-        self.sig_view_add = signals.SyncSignal()
-        self.sig_view_remove = signals.SyncSignal()
+        self.sig_view_update = signals.SyncSignal(_signal_with_flow)
+        self.sig_view_add = signals.SyncSignal(_signal_with_flow)
+        self.sig_view_remove = signals.SyncSignal(_sig_view_remove)
         # Signals that the view should be refreshed completely
-        self.sig_view_refresh = signals.SyncSignal()
+        self.sig_view_refresh = signals.SyncSignal(lambda: None)
 
         # The sig_store* signals broadcast events that affect the underlying
         # store. If a flow is removed from just the view, sig_view_remove is
         # triggered. If it is removed from the store while it is also in the
         # view, both sig_store_remove and sig_view_remove are triggered.
-        self.sig_store_remove = signals.SyncSignal()
+        self.sig_store_remove = signals.SyncSignal(_signal_with_flow)
         # Signals that the store should be refreshed completely
-        self.sig_store_refresh = signals.SyncSignal()
+        self.sig_store_refresh = signals.SyncSignal(lambda: None)
 
         self.focus = Focus(self)
         self.settings = Settings(self)
@@ -240,7 +248,7 @@ class View(collections.abc.Sequence):
                 continue
             if self.filter(i):
                 self._base_add(i)
-        self.sig_view_refresh.send(self)
+        self.sig_view_refresh.send()
 
     """ View API """
 
@@ -297,7 +305,7 @@ class View(collections.abc.Sequence):
     @command.command("view.order.reverse")
     def set_reversed(self, boolean: bool) -> None:
         self.order_reversed = boolean
-        self.sig_view_refresh.send(self)
+        self.sig_view_refresh.send()
 
     @command.command("view.order.set")
     def set_order(self, order_key: str) -> None:
@@ -349,8 +357,8 @@ class View(collections.abc.Sequence):
         """
         self._store.clear()
         self._view.clear()
-        self.sig_view_refresh.send(self)
-        self.sig_store_refresh.send(self)
+        self.sig_view_refresh.send()
+        self.sig_store_refresh.send()
 
     @command.command("view.clear_unmarked")
     def clear_not_marked(self) -> None:
@@ -362,7 +370,7 @@ class View(collections.abc.Sequence):
                 self._store.pop(flow.id)
 
         self._refilter()
-        self.sig_store_refresh.send(self)
+        self.sig_store_refresh.send()
 
     # View Settings
     @command.command("view.settings.getval")
@@ -425,9 +433,9 @@ class View(collections.abc.Sequence):
                     # sorting key, and we cannot reconstruct the index from that.
                     idx = self._view.index(f)
                     self._view.remove(f)
-                    self.sig_view_remove.send(self, flow=f, index=idx)
+                    self.sig_view_remove.send(flow=f, index=idx)
                 del self._store[f.id]
-                self.sig_store_remove.send(self, flow=f)
+                self.sig_store_remove.send(flow=f)
         if len(flows) > 1:
             ctx.log.alert("Removed %s flows" % len(flows))
 
@@ -502,7 +510,7 @@ class View(collections.abc.Sequence):
                     self._base_add(f)
                     if self.focus_follow:
                         self.focus.flow = f
-                    self.sig_view_add.send(self, flow=f)
+                    self.sig_view_add.send(flow=f)
 
     def get_by_id(self, flow_id: str) -> Optional[mitmproxy.flow.Flow]:
         """
@@ -624,14 +632,14 @@ class View(collections.abc.Sequence):
                         self._base_add(f)
                         if self.focus_follow:
                             self.focus.flow = f
-                        self.sig_view_add.send(self, flow=f)
+                        self.sig_view_add.send(flow=f)
                     else:
                         # This is a tad complicated. The sortedcontainers
                         # implementation assumes that the order key is stable. If
                         # it changes mid-way Very Bad Things happen. We detect when
                         # this happens, and re-fresh the item.
                         self.order_key.refresh(f)
-                        self.sig_view_update.send(self, flow=f)
+                        self.sig_view_update.send(flow=f)
                 else:
                     try:
                         idx = self._view.index(f)
@@ -639,7 +647,7 @@ class View(collections.abc.Sequence):
                         pass  # The value was not in the view
                     else:
                         self._view.remove(f)
-                        self.sig_view_remove.send(self, flow=f, index=idx)
+                        self.sig_view_remove.send(flow=f, index=idx)
 
 
 class Focus:
@@ -650,7 +658,7 @@ class Focus:
     def __init__(self, v: View) -> None:
         self.view = v
         self._flow: Optional[mitmproxy.flow.Flow] = None
-        self.sig_change = signals.SyncSignal()
+        self.sig_change = signals.SyncSignal(lambda: None)
         if len(self.view):
             self.flow = self.view[0]
         v.sig_view_add.connect(self._sig_view_add)
@@ -666,7 +674,7 @@ class Focus:
         if f is not None and f not in self.view:
             raise ValueError("Attempt to set focus to flow not in view")
         self._flow = f
-        self.sig_change.send(self)
+        self.sig_change.send()
 
     @property
     def index(self) -> Optional[int]:
@@ -683,21 +691,21 @@ class Focus:
     def _nearest(self, f, v):
         return min(v._bisect(f), len(v) - 1)
 
-    def _sig_view_remove(self, view, flow, index):
-        if len(view) == 0:
+    def _sig_view_remove(self, flow, index):
+        if len(self.view) == 0:
             self.flow = None
         elif flow is self.flow:
             self.index = min(index, len(self.view) - 1)
 
-    def _sig_view_refresh(self, view):
-        if len(view) == 0:
+    def _sig_view_refresh(self):
+        if len(self.view) == 0:
             self.flow = None
         elif self.flow is None:
-            self.flow = view[0]
-        elif self.flow not in view:
-            self.flow = view[self._nearest(self.flow, view)]
+            self.flow = self.view[0]
+        elif self.flow not in self.view:
+            self.flow = self.view[self._nearest(self.flow, self.view)]
 
-    def _sig_view_add(self, view, flow):
+    def _sig_view_add(self, flow):
         # We only have to act if we don't have a focus element
         if not self.flow:
             self.flow = flow
@@ -721,11 +729,11 @@ class Settings(collections.abc.Mapping):
             raise KeyError
         return self._values.setdefault(f.id, {})
 
-    def _sig_store_remove(self, view, flow):
+    def _sig_store_remove(self, flow):
         if flow.id in self._values:
             del self._values[flow.id]
 
-    def _sig_store_refresh(self, view):
+    def _sig_store_refresh(self):
         for fid in list(self._values.keys()):
-            if fid not in view._store:
+            if fid not in self.view._store:
                 del self._values[fid]

--- a/mitmproxy/contentviews/__init__.py
+++ b/mitmproxy/contentviews/__init__.py
@@ -44,9 +44,14 @@ from ..websocket import WebSocketMessage
 
 views: list[View] = []
 
-on_add = signals.SyncSignal()
+
+def _update(view: View) -> None:
+    ...
+
+
+on_add = signals.SyncSignal(_update)
 """A new contentview has been added."""
-on_remove = signals.SyncSignal()
+on_remove = signals.SyncSignal(_update)
 """A contentview has been removed."""
 
 

--- a/mitmproxy/optmanager.py
+++ b/mitmproxy/optmanager.py
@@ -82,12 +82,12 @@ class _UnconvertedStrings:
     val: list[str]
 
 
-def _sig_changed(updated: set[str]) -> None:
-    ...
+def _sig_changed_spec(updated: set[str]) -> None:  # pragma: no cover
+    ...  # expected function signature for OptManager.changed receivers.
 
 
-def _sig_errored(exc: Exception) -> None:
-    ...
+def _sig_errored_spec(exc: Exception) -> None:  # pragma: no cover
+    ...  # expected function signature for OptManager.errored receivers.
 
 
 class OptManager:
@@ -105,13 +105,13 @@ class OptManager:
 
     def __init__(self):
         self.deferred: dict[str, Any] = {}
-        self.changed = signals.SyncSignal(_sig_changed)
-        self.errored = signals.SyncSignal(_sig_errored)
+        self.changed = signals.SyncSignal(_sig_changed_spec)
+        self.changed.connect(self._notify_subscribers)
+        self.errored = signals.SyncSignal(_sig_errored_spec)
+        self._subscriptions: list[tuple[weakref.ref[Callable], set[str]]] = []
         # Options must be the last attribute here - after that, we raise an
         # error for attribute assignment to unknown options.
         self._options: dict[str, Any] = {}
-        self._subscriptions: list[tuple[weakref.ref[Callable], set[str]]] = []
-        self.changed.connect(self._notify_subscribers)
 
     def add_option(
         self,

--- a/mitmproxy/optmanager.py
+++ b/mitmproxy/optmanager.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import contextlib
 import copy
 import weakref

--- a/mitmproxy/tools/console/commandexecutor.py
+++ b/mitmproxy/tools/console/commandexecutor.py
@@ -12,7 +12,7 @@ class CommandExecutor:
     def __init__(self, master):
         self.master = master
 
-    def __call__(self, cmd):
+    def __call__(self, cmd: str) -> None:
         if cmd.strip():
             try:
                 ret = self.master.commands.execute(cmd)

--- a/mitmproxy/tools/console/commands.py
+++ b/mitmproxy/tools/console/commands.py
@@ -8,7 +8,7 @@ from mitmproxy.utils import signals as utils_signals
 
 HELP_HEIGHT = 5
 
-command_focus_change = utils_signals.SyncSignal()
+command_focus_change = utils_signals.SyncSignal(lambda text: None)
 
 
 class CommandItem(urwid.WidgetWrap):
@@ -63,7 +63,7 @@ class CommandListWalker(urwid.ListWalker):
     def get_focus(self):
         return self.focus_obj, self.index
 
-    def set_focus(self, index):
+    def set_focus(self, index: int) -> None:
         cmd = self.cmds[index]
         self.index = index
         self.focus_obj = self._get(self.index)
@@ -88,7 +88,7 @@ class CommandsList(urwid.ListBox):
         self.walker = CommandListWalker(master)
         super().__init__(self.walker)
 
-    def keypress(self, size, key):
+    def keypress(self, size: int, key: str):
         if key == "m_select":
             foc, idx = self.get_focus()
             signals.status_prompt_command.send(partial=foc.cmd.name + " ")

--- a/mitmproxy/tools/console/consoleaddons.py
+++ b/mitmproxy/tools/console/consoleaddons.py
@@ -325,7 +325,7 @@ class ConsoleAddon:
         Pop a view off the console stack. At the top level, this prompts the
         user to exit mitmproxy.
         """
-        signals.pop_view_state.send(self)
+        signals.pop_view_state.send()
 
     @command.command("console.bodyview")
     @command.argument("part", type=mitmproxy.types.Choice("console.bodyview.options"))
@@ -647,8 +647,8 @@ class ConsoleAddon:
     def running(self):
         self.started = True
 
-    def update(self, flows):
+    def update(self, flows) -> None:
         if not flows:
-            signals.update_settings.send(self)
+            signals.update_settings.send()
         for f in flows:
-            signals.flow_change.send(self, flow=f)
+            signals.flow_change.send(flow=f)

--- a/mitmproxy/tools/console/eventlog.py
+++ b/mitmproxy/tools/console/eventlog.py
@@ -42,7 +42,7 @@ class EventLog(urwid.ListBox, layoutwidget.LayoutWidget):
             self.set_focus(0)
         return super().keypress(size, key)
 
-    def add_event(self, event_store, entry: log.LogEntry):
+    def add_event(self, entry: log.LogEntry):
         if log.log_tier(self.master.options.console_eventlog_verbosity) < log.log_tier(
             entry.level
         ):
@@ -56,7 +56,7 @@ class EventLog(urwid.ListBox, layoutwidget.LayoutWidget):
         if self.master.options.console_focus_follow:
             self.walker.set_focus(len(self.walker) - 1)
 
-    def refresh_events(self, *_):
+    def refresh_events(self, *_) -> None:
         self.walker.clear()
         for event in self.master.events.data:
-            self.add_event(None, event)
+            self.add_event(event)

--- a/mitmproxy/tools/console/flowlist.py
+++ b/mitmproxy/tools/console/flowlist.py
@@ -105,5 +105,5 @@ class FlowListBox(urwid.ListBox, layoutwidget.LayoutWidget):
     def view_changed(self):
         self.body.view_changed()
 
-    def set_flowlist_layout(self, opts, updated):
+    def set_flowlist_layout(self, updated: set[str]) -> None:
         self.master.ui.clear()

--- a/mitmproxy/tools/console/grideditor/base.py
+++ b/mitmproxy/tools/console/grideditor/base.py
@@ -135,7 +135,7 @@ class GridWalker(urwid.ListWalker):
         if self.lst:
             return self.lst[self.focus][0][self.focus_col]
 
-    def set_current_value(self, val):
+    def set_current_value(self, val) -> None:
         errors = self.lst[self.focus][1]
         emsg = self.editor.is_error(self.focus_col, val)
         if emsg:
@@ -430,9 +430,9 @@ class FocusEditor(urwid.WidgetWrap, layoutwidget.LayoutWidget):
         """
         raise NotImplementedError
 
-    def set_data_update(self, vals, flow):
+    def set_data_update(self, vals, flow) -> None:
         self.set_data(vals, flow)
-        signals.flow_change.send(self, flow=flow)
+        signals.flow_change.send(flow=flow)
 
     def key_responder(self):
         return self._w

--- a/mitmproxy/tools/console/grideditor/col_bytes.py
+++ b/mitmproxy/tools/console/grideditor/col_bytes.py
@@ -44,5 +44,5 @@ class Edit(base.Cell):
         try:
             return strutils.escaped_str_to_bytes(txt)
         except ValueError:
-            signals.status_message.send(self, message="Invalid data.", expire=1000)
+            signals.status_message.send(message="Invalid data.", expire=1000)
             raise

--- a/mitmproxy/tools/console/grideditor/col_subgrid.py
+++ b/mitmproxy/tools/console/grideditor/col_subgrid.py
@@ -18,10 +18,10 @@ class Column(base.Column):
     def blank(self):
         return []
 
-    def keypress(self, key, editor):
+    def keypress(self, key: str, editor):
         if key in "rRe":
             signals.status_message.send(
-                self, message="Press enter to edit this field.", expire=1000
+                message="Press enter to edit this field.", expire=1000
             )
             return
         elif key == "m_select":

--- a/mitmproxy/tools/console/grideditor/col_text.py
+++ b/mitmproxy/tools/console/grideditor/col_text.py
@@ -35,7 +35,7 @@ class EncodingMixin:
         try:
             return data.decode(*self.encoding_args)
         except ValueError:
-            signals.status_message.send(self, message="Invalid encoding.", expire=1000)
+            signals.status_message.send(message="Invalid encoding.", expire=1000)
             raise
 
 

--- a/mitmproxy/tools/console/grideditor/editors.py
+++ b/mitmproxy/tools/console/grideditor/editors.py
@@ -176,7 +176,7 @@ class OptionsEditor(base.GridEditor, layoutwidget.LayoutWidget):
         self.name = name
         super().__init__(master, [[i] for i in vals], self.callback)
 
-    def callback(self, vals):
+    def callback(self, vals) -> None:
         try:
             setattr(self.master.options, self.name, [i[0] for i in vals])
         except exceptions.OptionsError as v:

--- a/mitmproxy/tools/console/keybindings.py
+++ b/mitmproxy/tools/console/keybindings.py
@@ -8,7 +8,7 @@ from mitmproxy.utils import signals as utils_signals
 HELP_HEIGHT = 5
 
 
-keybinding_focus_change = utils_signals.SyncSignal()
+keybinding_focus_change = utils_signals.SyncSignal(lambda text: None)
 
 
 class KeyItem(urwid.WidgetWrap):
@@ -47,7 +47,7 @@ class KeyListWalker(urwid.ListWalker):
         self.set_focus(0)
         signals.keybindings_change.connect(self.sig_modified)
 
-    def sig_modified(self, sender):
+    def sig_modified(self):
         self.bindings = list(self.master.keymap.list("all"))
         self.set_focus(min(self.index, len(self.bindings) - 1))
         self._modified()

--- a/mitmproxy/tools/console/keymap.py
+++ b/mitmproxy/tools/console/keymap.py
@@ -96,7 +96,7 @@ class Keymap:
             b = Binding(key=key, command=command, contexts=contexts, help=help)
             self.bindings.append(b)
             self.bind(b)
-        signals.keybindings_change.send(self)
+        signals.keybindings_change.send()
 
     def remove(self, key: str, contexts: Sequence[str]) -> None:
         """
@@ -111,7 +111,7 @@ class Keymap:
                 if b.contexts:
                     self.bindings.append(b)
                     self.bind(b)
-        signals.keybindings_change.send(self)
+        signals.keybindings_change.send()
 
     def bind(self, binding: Binding) -> None:
         for c in binding.contexts:

--- a/mitmproxy/tools/console/options.py
+++ b/mitmproxy/tools/console/options.py
@@ -27,7 +27,7 @@ def fcol(s, width, attr):
     return ("fixed", width, urwid.Text((attr, s)))
 
 
-option_focus_change = utils_signals.SyncSignal()
+option_focus_change = utils_signals.SyncSignal(lambda text: None)
 
 
 class OptionItem(urwid.WidgetWrap):

--- a/mitmproxy/tools/console/overlay.py
+++ b/mitmproxy/tools/console/overlay.py
@@ -124,14 +124,14 @@ class Chooser(urwid.WidgetWrap, layoutwidget.LayoutWidget):
         choice = self.walker.choice_by_shortcut(key)
         if choice:
             self.callback(choice)
-            signals.pop_view_state.send(self)
+            signals.pop_view_state.send()
             return
         if key == "m_select":
             self.callback(self.choices[self.walker.index])
-            signals.pop_view_state.send(self)
+            signals.pop_view_state.send()
             return
         elif key in ["q", "esc"]:
-            signals.pop_view_state.send(self)
+            signals.pop_view_state.send()
             return
 
         binding = self.master.keymap.get("global", key)

--- a/mitmproxy/tools/console/searchable.py
+++ b/mitmproxy/tools/console/searchable.py
@@ -22,7 +22,7 @@ class Searchable(urwid.ListBox):
         self.search_term = None
         self.last_search = None
 
-    def keypress(self, size, key):
+    def keypress(self, size, key: str):
         if key == "/":
             signals.status_prompt.send(
                 prompt="Search for", text="", callback=self.set_search
@@ -63,7 +63,7 @@ class Searchable(urwid.ListBox):
         else:
             return None
 
-    def find_next(self, backwards):
+    def find_next(self, backwards: bool):
         if not self.search_term:
             if self.last_search:
                 self.search_term = self.last_search

--- a/mitmproxy/tools/console/signals.py
+++ b/mitmproxy/tools/console/signals.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from mitmproxy.utils import signals
 
 

--- a/mitmproxy/tools/console/signals.py
+++ b/mitmproxy/tools/console/signals.py
@@ -2,38 +2,40 @@ from mitmproxy.utils import signals
 
 
 # Show a status message in the action bar
-status_message = signals.SyncSignal()
+def _status_message(message: tuple[str, str] | str, expire: int | None = None) -> None:
+    ...
+
+
+status_message = signals.SyncSignal(_status_message)
 
 # Prompt for input
-status_prompt = signals.SyncSignal()
-
-# Prompt for a path
-status_prompt_path = signals.SyncSignal()
+status_prompt = signals.SyncSignal(lambda prompt, text, callback, args=(): None)
 
 # Prompt for a single keystroke
-status_prompt_onekey = signals.SyncSignal()
+status_prompt_onekey = signals.SyncSignal(lambda prompt, keys, callback, args=(): None)
+
 
 # Prompt for a command
-status_prompt_command = signals.SyncSignal()
+def _status_prompt_command(partial: str = "", cursor: int | None = None) -> None:
+    ...
+
+
+status_prompt_command = signals.SyncSignal(_status_prompt_command)
 
 # Call a callback in N seconds
-call_in = signals.SyncSignal()
+call_in = signals.SyncSignal(lambda seconds, callback, args=(): None)
 
 # Focus the body, footer or header of the main window
-focus = signals.SyncSignal()
+focus = signals.SyncSignal(lambda section: None)
 
 # Fired when settings change
-update_settings = signals.SyncSignal()
+update_settings = signals.SyncSignal(lambda: None)
 
 # Fired when a flow changes
-flow_change = signals.SyncSignal()
-
-# Fired when the flow list or focus changes
-flowlist_change = signals.SyncSignal()
+flow_change = signals.SyncSignal(lambda flow: None)
 
 # Pop and push view state onto a stack
-pop_view_state = signals.SyncSignal()
-push_view_state = signals.SyncSignal()
+pop_view_state = signals.SyncSignal(lambda: None)
 
 # Fired when the key bindings change
-keybindings_change = signals.SyncSignal()
+keybindings_change = signals.SyncSignal(lambda: None)

--- a/mitmproxy/tools/console/statusbar.py
+++ b/mitmproxy/tools/console/statusbar.py
@@ -15,7 +15,7 @@ class PromptPath:
     def __init__(self, callback, args):
         self.callback, self.args = callback, args
 
-    def __call__(self, pth):
+    def __call__(self, pth: str):
         if not pth:
             return
         pth = os.path.expanduser(pth)
@@ -47,7 +47,7 @@ class ActionBar(urwid.WidgetWrap):
 
         self.onekey = False
 
-    def sig_message(self, sender, message, expire=1):
+    def sig_message(self, message: str, expire: int = 1) -> None:
         if self.prompting:
             return
         cols, _ = self.master.ui.get_cols_rows()
@@ -95,15 +95,15 @@ class ActionBar(urwid.WidgetWrap):
 
         return [(disp_attr, first_line), ("warn", prompt)]
 
-    def sig_prompt(self, sender, prompt, text, callback, args=()):
-        signals.focus.send(self, section="footer")
+    def sig_prompt(self, prompt, text, callback, args=()):
+        signals.focus.send(section="footer")
         self._w = urwid.Edit(self.prep_prompt(prompt), text or "")
         self.prompting = PromptStub(callback, args)
 
     def sig_prompt_command(
-        self, sender, partial: str = "", cursor: Optional[int] = None
+        self, partial: str = "", cursor: Optional[int] = None
     ):
-        signals.focus.send(self, section="footer")
+        signals.focus.send(section="footer")
         self._w = commander.CommandEdit(
             self.master,
             partial,
@@ -118,12 +118,12 @@ class ActionBar(urwid.WidgetWrap):
         execute = commandexecutor.CommandExecutor(self.master)
         execute(txt)
 
-    def sig_prompt_onekey(self, sender, prompt, keys, callback, args=()):
+    def sig_prompt_onekey(self, prompt, keys, callback, args=()) -> None:
         """
         Keys are a set of (word, key) tuples. The appropriate key in the
         word is highlighted.
         """
-        signals.focus.send(self, section="footer")
+        signals.focus.send(section="footer")
         prompt = [prompt, " ("]
         mkup = []
         for i, e in enumerate(keys):
@@ -161,13 +161,13 @@ class ActionBar(urwid.WidgetWrap):
         self._w = urwid.Text("")
         self.prompting = None
 
-    def prompt_done(self):
+    def prompt_done(self) -> None:
         self.prompting = None
         self.onekey = False
         signals.status_message.send(message="")
-        signals.focus.send(self, section="body")
+        signals.focus.send(section="body")
 
-    def prompt_execute(self, txt):
+    def prompt_execute(self, txt) -> None:
         p = self.prompting
         self.prompt_done()
         msg = p(txt)
@@ -186,17 +186,16 @@ class StatusBar(urwid.WidgetWrap):
         super().__init__(urwid.Pile([self.ib, self.ab]))
         signals.flow_change.connect(self.sig_update)
         signals.update_settings.connect(self.sig_update)
-        signals.flowlist_change.connect(self.sig_update)
         master.options.changed.connect(self.sig_update)
         master.view.focus.sig_change.connect(self.sig_update)
         master.view.sig_view_add.connect(self.sig_update)
         self.refresh()
 
-    def refresh(self):
+    def refresh(self) -> None:
         self.redraw()
         signals.call_in.send(seconds=self.REFRESHTIME, callback=self.refresh)
 
-    def sig_update(self, sender, flow=None, updated=None):
+    def sig_update(self, flow=None, updated=None):
         self.redraw()
 
     def keypress(self, *args, **kwargs):

--- a/mitmproxy/tools/console/window.py
+++ b/mitmproxy/tools/console/window.py
@@ -2,6 +2,7 @@ import os
 import re
 
 import urwid
+from mitmproxy import flow
 from mitmproxy.tools.console import commands
 from mitmproxy.tools.console import common
 from mitmproxy.tools.console import eventlog
@@ -146,17 +147,15 @@ class Window(urwid.Frame):
         signals.focus.connect(self.sig_focus)
         signals.flow_change.connect(self.flow_changed)
         signals.pop_view_state.connect(self.pop)
-        signals.push_view_state.connect(self.push)
 
-        self.master.options.subscribe(self.configure, ["console_layout"])
-        self.master.options.subscribe(self.configure, ["console_layout_headers"])
+        self.master.options.subscribe(self.configure, ["console_layout", "console_layout_headers"])
         self.pane = 0
         self.stacks = [WindowStack(master, "flowlist"), WindowStack(master, "eventlog")]
 
     def focus_stack(self):
         return self.stacks[self.pane]
 
-    def configure(self, otions, updated):
+    def configure(self, updated):
         self.refresh()
 
     def refresh(self):
@@ -191,7 +190,7 @@ class Window(urwid.Frame):
 
         self.body = urwid.AttrWrap(w, "background")
 
-    def flow_changed(self, sender, flow):
+    def flow_changed(self, flow: flow.Flow) -> None:
         if self.master.view.focus.flow:
             if flow.id == self.master.view.focus.flow.id:
                 self.focus_changed()
@@ -227,7 +226,7 @@ class Window(urwid.Frame):
         self.view_changed()
         self.focus_changed()
 
-    def pop(self, *args, **kwargs):
+    def pop(self) -> None:
         """
         Pop a window from the currently focused stack. If there is only one
         window on the stack, this prompts for exit.
@@ -270,7 +269,7 @@ class Window(urwid.Frame):
             if t.keyctx == keyctx:
                 return t
 
-    def sig_focus(self, sender, section):
+    def sig_focus(self, section):
         self.focus_position = section
 
     def switch(self):

--- a/mitmproxy/tools/web/master.py
+++ b/mitmproxy/tools/web/master.py
@@ -3,6 +3,7 @@ import tornado.httpserver
 import tornado.ioloop
 
 from mitmproxy import addons
+from mitmproxy import flow
 from mitmproxy import log
 from mitmproxy import master
 from mitmproxy import optmanager
@@ -44,32 +45,32 @@ class WebMaster(master.Master):
         )
         self.app = app.Application(self, self.options.web_debug)
 
-    def _sig_view_add(self, view, flow):
+    def _sig_view_add(self, flow: flow.Flow) -> None:
         app.ClientConnection.broadcast(
             resource="flows", cmd="add", data=app.flow_to_json(flow)
         )
 
-    def _sig_view_update(self, view, flow):
+    def _sig_view_update(self, flow: flow.Flow) -> None:
         app.ClientConnection.broadcast(
             resource="flows", cmd="update", data=app.flow_to_json(flow)
         )
 
-    def _sig_view_remove(self, view, flow, index):
+    def _sig_view_remove(self, flow: flow.Flow, index: int) -> None:
         app.ClientConnection.broadcast(resource="flows", cmd="remove", data=flow.id)
 
-    def _sig_view_refresh(self, view):
+    def _sig_view_refresh(self) -> None:
         app.ClientConnection.broadcast(resource="flows", cmd="reset")
 
-    def _sig_events_add(self, event_store, entry: log.LogEntry):
+    def _sig_events_add(self, entry: log.LogEntry) -> None:
         app.ClientConnection.broadcast(
             resource="events", cmd="add", data=app.logentry_to_json(entry)
         )
 
-    def _sig_events_refresh(self, event_store):
+    def _sig_events_refresh(self) -> None:
         app.ClientConnection.broadcast(resource="events", cmd="reset")
 
-    def _sig_options_update(self, options, updated):
-        options_dict = optmanager.dump_dicts(options, updated)
+    def _sig_options_update(self, updated: set[str]) -> None:
+        options_dict = optmanager.dump_dicts(self.options, updated)
         app.ClientConnection.broadcast(
             resource="options", cmd="update", data=options_dict
         )

--- a/mitmproxy/utils/signals.py
+++ b/mitmproxy/utils/signals.py
@@ -11,8 +11,8 @@ from __future__ import annotations
 import asyncio
 import inspect
 import weakref
-from collections.abc import Callable
-from typing import Any, Generic, TypeVar, cast, Awaitable
+from collections.abc import Callable, Awaitable
+from typing import Any, Generic, TypeVar, cast
 
 try:
     from typing import ParamSpec

--- a/mitmproxy/utils/signals.py
+++ b/mitmproxy/utils/signals.py
@@ -7,11 +7,12 @@ This is similar to the Blinker library (https://pypi.org/project/blinker/), with
   - supports type hints
   - supports async receivers.
 """
+from __future__ import annotations
 import asyncio
 import inspect
 import weakref
-from collections.abc import Awaitable, Callable
-from typing import Any, Generic, TypeVar, cast
+from collections.abc import Callable
+from typing import Any, Generic, TypeVar, cast, Awaitable
 
 try:
     from typing import ParamSpec

--- a/mitmproxy/utils/signals.py
+++ b/mitmproxy/utils/signals.py
@@ -16,7 +16,7 @@ from typing import Any, Generic, TypeVar, cast
 
 try:
     from typing import ParamSpec
-except ImportError:
+except ImportError:  # pragma: no cover
     # Python 3.9
     from typing_extensions import ParamSpec
 

--- a/mitmproxy/utils/signals.py
+++ b/mitmproxy/utils/signals.py
@@ -1,54 +1,128 @@
+"""
+This module provides signals, which are a simple dispatching system that allows any number of interested parties
+to subscribe to events ("signals").
+
+This is similar to the Blinker library (https://pypi.org/project/blinker/), with the following changes:
+  - provides only a small subset of Blinker's functionality
+  - supports type hints
+  - supports async receivers.
+"""
+import asyncio
 import inspect
-from typing import Any, Callable, TypeVar
-import blinker
+import weakref
+from collections.abc import Awaitable, Callable
+from typing import Any, Generic, TypeVar, cast
 
-# NOTE:
-# Once we drop support for Python 3.9, we should consider something like:
-#
-# P = ParamSpec("P")
-# R = TypeVar("R")
-#
-# class SyncSignal(Generic[P, R]):
-#     def connect(self, receiver: Callable[Concatenate[Any, P], R]) -> Callable[Concatenate[Any, P], R]:
-#         ...
-#
-#     def send(self, sender: Any, *args: P.args, **kwargs: P.kwargs) -> list[tuple[Callable[Concatenate[Any, P], R], R]]:
-#         ...
-#
-# Alternatively, once PEP 692 lands, we could make kwargs type-safe and use event args TypedDicts.
+try:
+    from typing import ParamSpec
+except ImportError:
+    # Python 3.9
+    from typing_extensions import ParamSpec
+
+P = ParamSpec("P")
+R = TypeVar("R")
 
 
-T = TypeVar("T", bound=Callable)
+def make_weak_ref(obj: Any) -> weakref.ReferenceType:
+    """
+    Like weakref.ref(), but using weakref.WeakMethod for bound methods.
+    """
+    if hasattr(obj, "__self__"):
+        return cast(weakref.ref, weakref.WeakMethod(obj))
+    else:
+        return weakref.ref(obj)
 
 
-class SyncSignal(blinker.Signal):
-    def connect(self, receiver: T, sender: Any = blinker.ANY, weak: bool = True) -> T:
-        if inspect.iscoroutinefunction(receiver):
-            raise TypeError(
-                f"Receiver {receiver} for {self} cannot be an asynchronous function."
-            )
-        return super().connect(receiver, sender, weak)
+# We're running into https://github.com/python/mypy/issues/6073 here,
+# which is why the base class is a mixin and not a generic superclass.
+class _SignalMixin:
+    def __init__(self):
+        self.receivers: list[weakref.ref[Callable]] = []
 
-    def send(self, *sender, **kwargs) -> list[tuple[Any, Any]]:
-        sent = super().send(*sender, **kwargs)
-        for receiver, ret in sent:
-            if ret is not None and inspect.isawaitable(ret):
-                raise RuntimeError(
-                    f"Receiver {receiver} for {self} returned awaitable {ret}."
-                )
-        return sent
+    def _connect(self, receiver: Callable) -> None:
+        receiver = make_weak_ref(receiver)
+        self.receivers.append(receiver)
+
+    def _disconnect(self, receiver: Callable) -> None:
+        self.receivers = [r for r in self.receivers if r() != receiver]
+
+    def _notify(self, *args, **kwargs):
+        cleanup = False
+        for ref in self.receivers:
+            r = ref()
+            if r is not None:
+                yield r(*args, **kwargs)
+            else:
+                cleanup = True
+        if cleanup:
+            self.receivers = [r for r in self.receivers if r() is not None]
 
 
-class AsyncSignal(blinker.Signal):
-    def connect(self, receiver: T, sender: Any = blinker.ANY, weak: bool = True) -> T:
-        # allow better typing than blinker
-        return super().connect(receiver, sender, weak)
+class _SyncSignal(Generic[P], _SignalMixin):
+    def connect(self, receiver: Callable[P, None]) -> None:
+        assert not asyncio.iscoroutinefunction(receiver)
+        self._connect(receiver)
 
-    async def send(self, *sender, **kwargs) -> list[tuple[Any, Any]]:
-        return [
-            (
-                receiver,
-                await ret if ret is not None and inspect.isawaitable(ret) else ret,
-            )
-            for receiver, ret in super().send(*sender, **kwargs)
-        ]
+    def disconnect(self, receiver: Callable[P, None]) -> None:
+        self._disconnect(receiver)
+
+    def send(self, *args: P.args, **kwargs: P.kwargs) -> None:
+        for ret in self._notify(*args, **kwargs):
+            assert ret is None or not inspect.isawaitable(ret)
+
+
+class _AsyncSignal(Generic[P], _SignalMixin):
+    def connect(self, receiver: Callable[P, Awaitable[None] | None]) -> None:
+        self._connect(receiver)
+
+    def disconnect(self, receiver: Callable[P, Awaitable[None] | None]) -> None:
+        self._disconnect(receiver)
+
+    async def send(self, *args: P.args, **kwargs: P.kwargs) -> None:
+        await asyncio.gather(*[
+            aws
+            for aws in self._notify(*args, **kwargs)
+            if aws is not None and inspect.isawaitable(aws)
+        ])
+
+
+# noinspection PyPep8Naming
+def SyncSignal(receiver_spec: Callable[P, None]) -> _SyncSignal[P]:
+    """
+    Create a synchronous signal with the given function signature for receivers.
+
+    Example:
+
+        s = SyncSignal(lambda event: None)  # all receivers must accept a single "event" argument.
+        def receiver(event):
+            print(event)
+
+        s.connect(receiver)
+        s.send("foo")  # prints foo
+        s.send(event="bar")  # prints bar
+
+        def receiver2():
+            ...
+
+        s.connect(receiver2)  # mypy complains about receiver2 not having the right signature
+
+        s2 = SyncSignal(lambda: None)  # this signal has no arguments
+        s2.send()
+    """
+    return cast(_SyncSignal[P], _SyncSignal())
+
+
+# noinspection PyPep8Naming
+def AsyncSignal(receiver_spec: Callable[P, Awaitable[None] | None]) -> _AsyncSignal[P]:
+    """
+    Create an signal that supports both regular and async receivers:
+
+    Example:
+
+        s = AsyncSignal(lambda event: None)
+        async def receiver(event):
+            print(event)
+        s.connect(receiver)
+        await s.send("foo")  # prints foo
+    """
+    return cast(_AsyncSignal[P], _AsyncSignal())

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ exclude_lines =
     if TYPE_CHECKING:
     @overload
     @abstractmethod
-    ...
+    \.\.\.
 
 [mypy]
 ignore_missing_imports = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,7 @@ exclude_lines =
     if TYPE_CHECKING:
     @overload
     @abstractmethod
+    ...
 
 [mypy]
 ignore_missing_imports = True

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,6 @@ setup(
     # It is not considered best practice to use install_requires to pin dependencies to specific versions.
     install_requires=[
         "asgiref>=3.2.10,<3.6",
-        "blinker>=1.4,<1.6",
         "Brotli>=1.0,<1.1",
         "certifi>=2019.9.11",  # no semver here - this should always be on the last release!
         "cryptography>=36,<38",
@@ -96,6 +95,7 @@ setup(
         "wsproto>=1.0,<1.2",
         "publicsuffix2>=2.20190812,<3",
         "zstandard>=0.11,<0.19",
+        "typing-extensions>=4.3,<4.4; python_version<'3.10'",
     ],
     extras_require={
         ':sys_platform == "win32"': [

--- a/test/mitmproxy/addons/test_eventstore.py
+++ b/test/mitmproxy/addons/test_eventstore.py
@@ -9,11 +9,11 @@ def test_simple():
     sig_add_called = False
     sig_refresh_called = False
 
-    def sig_add(event_store, entry):
+    def sig_add(entry):
         nonlocal sig_add_called
         sig_add_called = True
 
-    def sig_refresh(event_store):
+    def sig_refresh():
         nonlocal sig_refresh_called
         sig_refresh_called = True
 

--- a/test/mitmproxy/test_addonmanager.py
+++ b/test/mitmproxy/test_addonmanager.py
@@ -120,7 +120,7 @@ async def test_lifecycle():
     f = tflow.tflow()
     await a.handle_lifecycle(HttpRequestHook(f))
 
-    a._configure_all(o, o.keys())
+    a._configure_all(o.keys())
 
 
 def test_defaults():

--- a/test/mitmproxy/test_addonmanager.py
+++ b/test/mitmproxy/test_addonmanager.py
@@ -112,6 +112,8 @@ async def test_lifecycle():
     a = addonmanager.AddonManager(m)
     a.add(TAddon("one"))
 
+    assert str(a)
+
     with pytest.raises(exceptions.AddonManagerError):
         a.add(TAddon("one"))
     with pytest.raises(exceptions.AddonManagerError):

--- a/test/mitmproxy/test_optmanager.py
+++ b/test/mitmproxy/test_optmanager.py
@@ -233,8 +233,12 @@ def test_rollback():
 
 
 def test_simple():
-    assert repr(TO())
-    assert "one" in TO()
+    o = TO()
+    assert repr(o)
+    assert "one" in o
+
+    with pytest.raises(Exception, match="No such option"):
+        assert o.unknown
 
 
 def test_items():

--- a/test/mitmproxy/test_optmanager.py
+++ b/test/mitmproxy/test_optmanager.py
@@ -100,8 +100,8 @@ def test_options():
 
     rec = []
 
-    def sub(opts, updated):
-        rec.append(copy.copy(opts))
+    def sub(updated):
+        rec.append(copy.copy(o))
 
     o.changed.connect(sub)
 
@@ -159,7 +159,7 @@ def test_subscribe():
     else:
         raise AssertionError
 
-    assert len(o.changed.receivers) == 0
+    assert len(o._subscriptions) == 0
 
     o.subscribe(r, ["two"])
     o.one = 2
@@ -170,7 +170,7 @@ def test_subscribe():
     assert len(o.changed.receivers) == 1
     del r
     o.two = 4
-    assert len(o.changed.receivers) == 0
+    assert len(o._subscriptions) == 0
 
     class binder:
         def __init__(self):
@@ -193,18 +193,18 @@ def test_rollback():
 
     rec = []
 
-    def sub(opts, updated):
-        rec.append(copy.copy(opts))
+    def sub(updated):
+        rec.append(copy.copy(o))
 
     recerr = []
 
-    def errsub(opts, **kwargs):
+    def errsub(**kwargs):
         recerr.append(kwargs)
 
-    def err(opts, updated):
-        if opts.one == 10:
+    def err(updated):
+        if o.one == 10:
             raise exceptions.OptionsError()
-        if opts.bool is True:
+        if o.bool is True:
             raise exceptions.OptionsError()
 
     o.changed.connect(sub)

--- a/test/mitmproxy/utils/test_signals.py
+++ b/test/mitmproxy/utils/test_signals.py
@@ -1,95 +1,62 @@
-import asyncio
+from unittest import mock
+
 import pytest
 from mitmproxy.utils.signals import AsyncSignal, SyncSignal
 
 
-async def test_async_connect_to_sync():
-    is_connected = False
-    was_called = False
+def test_sync_signal() -> None:
+    m = mock.Mock()
 
-    def valid(sender):
-        nonlocal was_called
-        was_called = True
+    s = SyncSignal(lambda event: None)
+    s.connect(m)
+    s.send("foo")
 
-    async def invalid(sender):
-        assert False
+    assert m.call_args_list == [mock.call("foo")]
 
-    def check_connected(signal, receiver, sender, weak):
-        nonlocal is_connected
-        assert receiver is valid
-        is_connected = True
+    class Foo:
+        called = None
 
-    signal = SyncSignal()
-    signal.receiver_connected.connect(check_connected)
-    with pytest.raises(TypeError, match="cannot be an asynchronous function"):
-        signal.connect(invalid)
-    signal.connect(valid)
-    assert is_connected
+        def bound(self, event):
+            self.called = event
 
-    signal.send(signal)
-    assert was_called
+    f = Foo()
+    s.connect(f.bound)
+    s.send(event="bar")
+    assert f.called == "bar"
+    assert m.call_args_list == [mock.call("foo"), mock.call(event="bar")]
 
+    s.disconnect(m)
+    s.send("baz")
+    assert f.called == "baz"
+    assert m.call_count == 2
 
-async def test_async_returned_in_sync():
-    is_connected = False
+    def err(event):
+        raise RuntimeError
 
-    def delayed_invalid(sender):
-        async def invalid():
-            await asyncio.sleep(1)
-            return True
-
-        return invalid()
-
-    def check_connected(signal, receiver, sender, weak):
-        nonlocal is_connected
-        assert receiver is delayed_invalid
-        is_connected = True
-
-    signal = SyncSignal()
-    signal.receiver_connected.connect(check_connected)
-    signal.connect(delayed_invalid)
-    assert is_connected
-
-    with pytest.raises(RuntimeError, match="returned awaitable"):
-        signal.send(signal)
+    s.connect(err)
+    with pytest.raises(RuntimeError):
+        s.send(42)
 
 
-async def test_async():
-    is_connected_sync = False
-    is_connected_async = False
-    async_ret = object()
-    sync_ret = object()
+def test_sync_signal_async_receiver() -> None:
+    s = SyncSignal(lambda: None)
 
-    async def delayed(sender):
-        nonlocal async_ret
-        await asyncio.sleep(1)
-        return async_ret
+    with pytest.raises(AssertionError):
+        s.connect(mock.AsyncMock())
 
-    async def immediate(sender):
-        nonlocal sync_ret
-        return sync_ret
 
-    def check_connected(signal, receiver, sender, weak):
-        nonlocal is_connected_sync, is_connected_async
-        if receiver is delayed:
-            is_connected_async = True
-        elif receiver is immediate:
-            is_connected_sync = True
-        else:
-            assert False
+async def test_async_signal() -> None:
+    s = AsyncSignal(lambda event: None)
+    m1 = mock.AsyncMock()
+    m2 = mock.Mock()
 
-    signal = AsyncSignal()
-    signal.receiver_connected.connect(check_connected)
-    signal.connect(delayed)
-    signal.connect(immediate)
-    assert is_connected_async and is_connected_sync
+    s.connect(m1)
+    s.connect(m2)
+    await s.send("foo")
+    assert m1.call_args_list == m2.call_args_list == [mock.call("foo")]
 
-    res = await signal.send(signal)
-    assert len(res) == 2
-    for receiver, ret in res:
-        if receiver is delayed:
-            assert ret is async_ret
-        elif receiver is immediate:
-            assert ret is sync_ret
-        else:
-            assert False
+    s.disconnect(m2)
+
+    await s.send("bar")
+    assert m1.call_count == 2
+    assert m2.call_count == 1

--- a/test/mitmproxy/utils/test_signals.py
+++ b/test/mitmproxy/utils/test_signals.py
@@ -39,8 +39,8 @@ def test_sync_signal() -> None:
 
 
 def test_signal_weakref() -> None:
-    m1 = mock.Mock()
-    m2 = mock.Mock()
+    m1 = lambda: print(42)
+    m2 = lambda: print(43)
 
     s = SyncSignal(lambda: None)
     s.connect(m1)

--- a/test/mitmproxy/utils/test_signals.py
+++ b/test/mitmproxy/utils/test_signals.py
@@ -39,8 +39,11 @@ def test_sync_signal() -> None:
 
 
 def test_signal_weakref() -> None:
-    m1 = lambda: print(42)
-    m2 = lambda: print(43)
+    def m1():
+        pass
+
+    def m2():
+        pass
 
     s = SyncSignal(lambda: None)
     s.connect(m1)

--- a/test/mitmproxy/utils/test_signals.py
+++ b/test/mitmproxy/utils/test_signals.py
@@ -38,6 +38,18 @@ def test_sync_signal() -> None:
         s.send(42)
 
 
+def test_signal_weakref() -> None:
+    m1 = mock.Mock()
+    m2 = mock.Mock()
+
+    s = SyncSignal(lambda: None)
+    s.connect(m1)
+    s.connect(m2)
+    del m2
+    s.send()
+    assert len(s.receivers) == 1
+
+
 def test_sync_signal_async_receiver() -> None:
     s = SyncSignal(lambda: None)
 


### PR DESCRIPTION
@meitinger: Your comment on signal type hints was too much of a temptation, so here's a relatively simple Signal implementation that requires a function signature for receivers to be passed on creation and does not depend on Blinker anymore. 😃 