### PR TITLE
Make mitmweb use option "content_view_lines_cutoff"

### DIFF
--- a/web/src/js/__tests__/components/ProxyAppSpec.tsx
+++ b/web/src/js/__tests__/components/ProxyAppSpec.tsx
@@ -8,7 +8,7 @@ enableFetchMocks();
 
 test("ProxyApp", async () => {
     const cv: ContentViewData = {lines: [[["text", "my data"]]], description: ""}
-    fetchMock.doMockOnceIf("./flows/flow2/request/content/Auto.json?lines=81", JSON.stringify(cv));
+    fetchMock.doMockOnceIf("./flows/flow2/request/content/Auto.json?lines=513", JSON.stringify(cv));
     render(<ProxyApp/>);
     expect(screen.getByTitle("Mitmproxy Version")).toBeDefined();
     await waitFor(() => screen.getByText("my data"));

--- a/web/src/js/__tests__/components/contentviews/HttpMessageSpec.tsx
+++ b/web/src/js/__tests__/components/contentviews/HttpMessageSpec.tsx
@@ -3,20 +3,19 @@ import * as React from 'react';
 import HttpMessage, {ViewImage} from '../../../components/contentviews/HttpMessage'
 import {fireEvent, render, screen, waitFor} from "../../test-utils"
 import fetchMock, {enableFetchMocks} from "jest-fetch-mock";
-import {SHOW_MAX_LINES} from "../../../components/contentviews/useContent";
 
 jest.mock("../../../contrib/CodeMirror")
 
 enableFetchMocks();
 
 test("HttpMessage", async () => {
-    const lines = Array(SHOW_MAX_LINES).fill([["text", "data"]]).concat(
-        Array(SHOW_MAX_LINES).fill([["text", "additional"]])
+    const lines = Array(512).fill([["text", "data"]]).concat(
+        Array(512).fill([["text", "additional"]])
     );
 
     fetchMock.mockResponses(
         JSON.stringify({
-            lines: lines.slice(0, SHOW_MAX_LINES + 1),
+            lines: lines.slice(0, 512 + 1),
             description: "Auto"
         }), JSON.stringify({
             lines,

--- a/web/src/js/components/FlowView/Messages.tsx
+++ b/web/src/js/components/FlowView/Messages.tsx
@@ -2,7 +2,7 @@ import {Flow, MessagesMeta} from "../../flow";
 import {useAppDispatch, useAppSelector} from "../../ducks";
 import * as React from "react";
 import {useCallback, useMemo, useState} from "react";
-import {ContentViewData, SHOW_MAX_LINES, useContent} from "../contentviews/useContent";
+import {ContentViewData, useContent} from "../contentviews/useContent";
 import {MessageUtils} from "../../flow/utils";
 import ViewSelector from "../contentviews/ViewSelector";
 import {setContentViewFor} from "../../ducks/ui/flow";
@@ -18,7 +18,7 @@ export default function Messages({flow, messages_meta}: MessagesPropTypes) {
     const dispatch = useAppDispatch();
 
     const contentView = useAppSelector(state => state.ui.flow.contentViewFor[flow.id + "messages"] || "Auto");
-    let [maxLines, setMaxLines] = useState<number>(SHOW_MAX_LINES);
+    let [maxLines, setMaxLines] = useState<number>(useAppSelector(state => state.options.content_view_lines_cutoff));
     const showMore = useCallback(() => setMaxLines(Math.max(1024, maxLines * 2)), [maxLines]);
     const content = useContent(
         MessageUtils.getContentURL(flow, "messages", contentView, maxLines + 1),

--- a/web/src/js/components/contentviews/HttpMessage.tsx
+++ b/web/src/js/components/contentviews/HttpMessage.tsx
@@ -2,7 +2,7 @@ import React, {useCallback, useMemo, useRef, useState} from "react";
 import {HTTPFlow, HTTPMessage} from "../../flow";
 import {useAppDispatch, useAppSelector} from "../../ducks";
 import {setContentViewFor} from "../../ducks/ui/flow";
-import {ContentViewData, SHOW_MAX_LINES, useContent} from "./useContent";
+import {ContentViewData, useContent} from "./useContent";
 import {MessageUtils} from "../../flow/utils";
 import FileChooser from "../common/FileChooser";
 import * as flowActions from "../../ducks/flows";
@@ -23,7 +23,7 @@ export default function HttpMessage({flow, message}: HttpMessageProps) {
     const part = flow.request === message ? "request" : "response";
     const contentView = useAppSelector(state => state.ui.flow.contentViewFor[flow.id + part] || "Auto");
     const editorRef = useRef<CodeEditor>(null);
-    const [maxLines, setMaxLines] = useState<number>(SHOW_MAX_LINES);
+    const [maxLines, setMaxLines] = useState<number>(useAppSelector(state => state.options.content_view_lines_cutoff));
     const showMore = useCallback(() => setMaxLines(Math.max(1024, maxLines * 2)), [maxLines]);
     const [edit, setEdit] = useState<boolean>(false);
     let url;

--- a/web/src/js/components/contentviews/useContent.tsx
+++ b/web/src/js/components/contentviews/useContent.tsx
@@ -1,7 +1,6 @@
 import {useEffect, useState} from "react"
 import {fetchApi} from "../../utils";
 
-export const SHOW_MAX_LINES = 80;
 
 export type ContentViewData = {
     lines: [style: string, text: string][][],


### PR DESCRIPTION
#### Description

Make mitmweb use option "content_view_lines_cutoff" (https://github.com/mitmproxy/mitmproxy/issues/5398)

The previous pr was automatically merged as I tried the sync fork feature of github.
The content_view_lines_cutoff is used when viewing details of the request. so the component needs to wait response before rendering.

#### Checklist

 - [x] I have updated tests where applicable.
 - [ ] I have added an entry to the CHANGELOG.
