### PR TITLE
Docker: assume uid of who holds permissions

### DIFF
--- a/release/docker/DockerHub-README.md
+++ b/release/docker/DockerHub-README.md
@@ -45,6 +45,7 @@ Proxy server listening at http://*:8080
 [...]
 ```
 
+If `~/.mitmproxy/mitmproxy-ca.pem` is present in the container, mitmproxy will assume uid and gid from the file owner.
 For further details, please consult the mitmproxy [documentation](http://docs.mitmproxy.org/en/stable/).
 
 ## Tags

--- a/release/docker/docker-entrypoint.sh
+++ b/release/docker/docker-entrypoint.sh
@@ -9,7 +9,12 @@ MITMPROXY_PATH="/home/mitmproxy/.mitmproxy"
 
 if [[ "$1" = "mitmdump" || "$1" = "mitmproxy" || "$1" = "mitmweb" ]]; then
   mkdir -p "$MITMPROXY_PATH"
-  chown -R mitmproxy:mitmproxy "$MITMPROXY_PATH"
+  if [ -f "$MITMPROXY_PATH/mitmproxy-ca.pem" ]; then
+    usermod -o \
+        -u $(stat -c "%u" "$MITMPROXY_PATH/mitmproxy-ca.pem") \
+        -g $(stat -c "%g" "$MITMPROXY_PATH/mitmproxy-ca.pem") \
+        mitmproxy
+  fi
   gosu mitmproxy "$@"
 else
   exec "$@"


### PR DESCRIPTION
This PR changes our Docker entrypoint to not blindly `chown` an existing `~/.mitmproxy` folder, but instead just assume the uid/gid of the existing user. This idea was born out of #5419 to make sure that we don't break setups.

Not sure if this is the right approach, I'd definitely appreciate a second pair of eyes with more Docker experience.