### PR TITLE
render application/prpc as grpc protobuf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * DTLS support ([#5397](https://github.com/mitmproxy/mitmproxy/pull/5397), @kckeiks).
 * Added Magisk module generation for Android onboarding (@jorants).
 * Update Linux binary builder to Ubuntu 20.04, bumping the minimum glibc version to 2.31. (@jorants)
+* Render application/prpc content as gRPC/Protocol Buffers (@selfisekai)
 
 ## 28 June 2022: mitmproxy 8.1.1
 

--- a/mitmproxy/contentviews/grpc.py
+++ b/mitmproxy/contentviews/grpc.py
@@ -966,6 +966,9 @@ class ViewGrpcProtobuf(base.View):
     ]
     __content_types_grpc = [
         "application/grpc",
+        # seems specific to chromium infra tooling
+        # https://chromium.googlesource.com/infra/luci/luci-go/+/refs/heads/main/grpc/prpc/
+        "application/prpc",
     ]
 
     # first value serves as default algorithm for compressed messages, if 'grpc-encoding' header is missing

--- a/test/mitmproxy/contentviews/test_grpc.py
+++ b/test/mitmproxy/contentviews/test_grpc.py
@@ -796,4 +796,5 @@ def test_render_priority():
     assert v.render_priority(b"data", content_type="application/x-protobuffer")
     assert v.render_priority(b"data", content_type="application/grpc-proto")
     assert v.render_priority(b"data", content_type="application/grpc")
+    assert v.render_priority(b"data", content_type="application/prpc")
     assert not v.render_priority(b"data", content_type="text/plain")


### PR DESCRIPTION
#### Description

content-type `application/prpc` is being used for gRPC communication by a chromium infra tool, luci-go/cipd. seems to be an internal abstraction over gRPC?

luci-go/cipd source code: https://chromium.googlesource.com/infra/luci/luci-go/+/refs/heads/main/cipd/
luci-go/cipd binary builds: https://chrome-infra-packages.appspot.com/p/infra/tools/cipd
example flows from luci-go/cipd: https://matrix.laura.pm/_matrix/media/r0/download/laura.pm/iFkCPHZPthZJgzzLGiAviixw

#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
