### PR TITLE
[web] fix query editing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,8 @@
   ([#5658](https://github.com/mitmproxy/mitmproxy/issues/5658), [#5661](https://github.com/mitmproxy/mitmproxy/issues/5661), @LIU-shuyi, @mhils)
 * Added Docs for Transparent Mode on Windows.
   ([#5402](https://github.com/mitmproxy/mitmproxy/issues/5402), @stephenspol)
+* Fix query editing and replacement on mitmweb.
+  ([#5574](https://github.com/mitmproxy/mitmproxy/pull/5574), @yesmeck)
 
 
 ## 28 June 2022: mitmproxy 8.1.1

--- a/web/src/js/__tests__/components/contentviews/__snapshots__/HttpMessageSpec.tsx.snap
+++ b/web/src/js/__tests__/components/contentviews/__snapshots__/HttpMessageSpec.tsx.snap
@@ -126,7 +126,11 @@ exports[`HttpMessage 2`] = `
     </div>
     <div
       class="codeeditor"
-    />
+    >
+      <div>
+        {"lines":[[["text","rawdata"]],[["text","rawdata"]],[["text","rawdata"]],[["text","rawdata"]],[["text","rawdata"]]],"description":"Raw"}
+      </div>
+    </div>
   </div>
 </DocumentFragment>
 `;
@@ -219,6 +223,189 @@ exports[`HttpMessage 3`] = `
           class="text"
         >
           rawdata
+        </span>
+      </div>
+    </pre>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`HttpMessage 4`] = `
+<DocumentFragment>
+  <div
+    class="contentview"
+  >
+    <div
+      class="controls"
+    >
+      <h5>
+        Loading...
+      </h5>
+      <button
+        class="btn-xs btn btn-default"
+      >
+        <i
+          class="fa fa-edit"
+        />
+         Edit
+      </button>
+       
+      <a
+        class="btn btn-default btn-xs"
+        href="#"
+        title="Upload a file to replace the content."
+      >
+        <i
+          class="fa fa-fw fa-upload"
+        />
+        Replace
+        <input
+          class="hidden"
+          type="file"
+        />
+      </a>
+       
+      <a
+        class="btn btn-default btn-xs"
+        href="#"
+      >
+        <span>
+          <i
+            class="fa fa-fw fa-files-o"
+          />
+           
+          <b>
+            View:
+          </b>
+           raw 
+          <span
+            class="caret"
+          />
+        </span>
+      </a>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`HttpMessage edit query string 1`] = `
+<DocumentFragment>
+  <div
+    class="contentview"
+  >
+    <div
+      class="controls"
+    >
+      <h5>
+        [Editing]
+      </h5>
+      <button
+        class="btn-xs btn btn-default"
+      >
+        <i
+          class="fa fa-check text-success"
+        />
+         Done
+      </button>
+       
+      <button
+        class="btn-xs btn btn-default"
+      >
+        <i
+          class="fa fa-times text-danger"
+        />
+         Cancel
+      </button>
+    </div>
+    <div
+      class="codeeditor"
+    >
+      <div>
+        foo=1
+bar=2
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`HttpMessage edit query string 2`] = `
+<DocumentFragment>
+  <div
+    class="contentview"
+  >
+    <div
+      class="controls"
+    >
+      <h5>
+        Query
+      </h5>
+      <button
+        class="btn-xs btn btn-default"
+      >
+        <i
+          class="fa fa-edit"
+        />
+         Edit
+      </button>
+       
+      <a
+        class="btn btn-default btn-xs"
+        href="#"
+        title="Upload a file to replace the content."
+      >
+        <i
+          class="fa fa-fw fa-upload"
+        />
+        Replace
+        <input
+          class="hidden"
+          type="file"
+        />
+      </a>
+       
+      <a
+        class="btn btn-default btn-xs"
+        href="#"
+      >
+        <span>
+          <i
+            class="fa fa-fw fa-files-o"
+          />
+           
+          <b>
+            View:
+          </b>
+           auto 
+          <span
+            class="caret"
+          />
+        </span>
+      </a>
+    </div>
+    <pre>
+      <div>
+        <span
+          class="header"
+        >
+          foo
+        </span>
+        <span
+          class="text"
+        >
+          1
+        </span>
+      </div>
+      <div>
+        <span
+          class="header"
+        >
+          bar
+        </span>
+        <span
+          class="text"
+        >
+          2
         </span>
       </div>
     </pre>

--- a/web/src/js/components/contentviews/useContent.tsx
+++ b/web/src/js/components/contentviews/useContent.tsx
@@ -9,7 +9,7 @@ export type ContentViewData = {
     timestamp?: number
 }
 
-export function useContent(url: string, hash?: string): string | undefined {
+export function useContent(url: string, hash?: string, path?: string): string | undefined {
     const [content, setContent] = useState<string>(),
         [abort, setAbort] = useState<AbortController>();
 
@@ -42,7 +42,7 @@ export function useContent(url: string, hash?: string): string | undefined {
                     controller.abort();
             }
         },
-        [url, hash]
+        [url, hash, path]
     );
 
     return content;

--- a/web/src/js/ducks/flows.ts
+++ b/web/src/js/ducks/flows.ts
@@ -202,6 +202,12 @@ export function uploadContent(flow: Flow, file, type) {
     return dispatch => fetchApi(`/flows/${flow.id}/${type}/content.data`, {method: 'POST', body})
 }
 
+export function uploadQuery(flow: Flow, file) {
+    const body = new FormData()
+    file = new window.Blob([file], {type: 'plain/text'})
+    body.append('file', file)
+    return dispatch => fetchApi(`/flows/${flow.id}/request/query.data`, {method: 'POST', body})
+}
 
 export function clear() {
     return dispatch => fetchApi('/clear', {method: 'POST'})

--- a/web/src/js/flow/utils.ts
+++ b/web/src/js/flow/utils.ts
@@ -66,6 +66,10 @@ export class MessageUtils {
         const lineStr = lines ? `?lines=${lines}` : "";
         return `./flows/${flow.id}/${part}/` + (view ? `content/${encodeURIComponent(view)}.json${lineStr}` : 'content.data');
     }
+
+    static getQueryURL(flow: Flow): string {
+        return `./flows/${flow.id}/request/query.data`;
+    }
 }
 
 export class RequestUtils extends MessageUtils {


### PR DESCRIPTION
#### Description

As https://github.com/mitmproxy/mitmproxy/issues/4565#issuecomment-823912831 said, an empty body would show when editing a query string. This PR tries to fix the query editing logic. Also, fixed query replacement.

I added a new API for retrieving and updating query string

fix #4565

#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
