### PR TITLE
Improve http_manipulate_cookies.py example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,8 @@
   ([#5339](https://github.com/mitmproxy/mitmproxy/issues/5339), @mhils)
 * Fix handling of multiple Cookie headers when proxying HTTP/2 to HTTP/1
   ([#5337](https://github.com/mitmproxy/mitmproxy/issues/5337), @rinsuki)
+* Improve http_manipulate_cookies.py example.
+  ([#5578](https://github.com/mitmproxy/mitmproxy/issues/5578), @insilications)
 
 ## 19 March 2022: mitmproxy 8.0.0
 


### PR DESCRIPTION
#### Description

Improve the example helper functions to use the get_all functions recommended in the Header class docs for use with cookies data. This will avoid errors when dealing with multiple headers.

https://github.com/mitmproxy/mitmproxy/blob/cf655a664fda68de9f80de2056beabef95fafeb1/mitmproxy/http.py#L148 https://github.com/mitmproxy/mitmproxy/blob/cf655a664fda68de9f80de2056beabef95fafeb1/mitmproxy/http.py#L91

#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
