### PR TITLE
docs: add documentation for wireguard mode

### DIFF
--- a/docs/src/content/howto-transparent.md
+++ b/docs/src/content/howto-transparent.md
@@ -12,6 +12,14 @@ network layer, without any client configuration being required. This makes
 transparent proxying ideal for those situations where you can't change client
 behaviour - proxy-oblivious mobile applications being a common example.
 
+{{% note %}}
+The new [WireGuard mode]({{< relref "concepts-modes" >}}#wireguard-transparent-proxy)
+provides an alternative implementation for transparent proxying. It is much
+easier to set up, as it does not require setting up IP forwarding or modifying
+routing rules. Additionally, this mode also works on Windows, in addition to
+Linux and macOS, and setting it up does not require administrative privileges.
+{{% /note %}}
+
 To set up transparent proxying, we need two new components. The first is a
 redirection mechanism that transparently reroutes a TCP connection destined for
 a server on the Internet to a listening proxy server. This usually takes the


### PR DESCRIPTION
There's a new section for "wireguard" mode in the "Modes of operation" page, below the existing docs for the "transparent" mode. I included documentation for all configuration knobs (i.e. how to specify the path to the file with encryption keys, and how to set a custom listen port) and a short explanation of the limitations of the new mode.

I also added a short note to the "Transparent HOWTO" page pointing out that the new WireGuard mode might be easier to use and that it works on Windows (which `--mode transparent` apparently doesn't? TIL).