### PR TITLE
har_dump.py - get real url in transparent mode

### DIFF
--- a/examples/contrib/har_dump.py
+++ b/examples/contrib/har_dump.py
@@ -106,7 +106,7 @@ def response(flow: mitmproxy.http.HTTPFlow):
         "time": full_time,
         "request": {
             "method": flow.request.method,
-            "url": flow.request.url,
+            "url": flow.request.pretty_url,
             "httpVersion": flow.request.http_version,
             "cookies": format_request_cookies(flow.request.cookies.fields),
             "headers": name_value(flow.request.headers),


### PR DESCRIPTION
Dump the real url rather than the url containing ip address when mitmproxy works in transparent mode.

#### Description

Currently, flow.request.url shows the ip address rather than host name when mitmproxy works on transparent mode.

flow.request.pretty_url can show the correct url.


#### Checklist

 - [ ] I have updated tests where applicable.
 - [ ] I have added an entry to the CHANGELOG.
