### PR TITLE
docs: Fix wrong option type

### DIFF
--- a/docs/src/content/addons-options.md
+++ b/docs/src/content/addons-options.md
@@ -95,4 +95,4 @@ The following types are supported for options.
 
 - Primitive types - `str`, `int`, `float`, `bool`.
 - Optional values, annotated using `typing.Optional`.
-- Sequences of values, annotated using `typing.Sequence`.
+- Sequences of values, annotated using `collections.abc.Sequence`.


### PR DESCRIPTION
#### Description

Changed ```typing.Sequence``` that results errors to ```collections.abc.Sequence```.

Issue #5610.