### PR TITLE
Add content view syntax highlighting for JSON and msgpack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,8 @@
   ([#5562](https://github.com/mitmproxy/mitmproxy/pull/5562), @decathorpe, @mhils)
 * Fix mitmweb not properly opening a browser and being stuck on some Linux.
   ([#5522](https://github.com/mitmproxy/mitmproxy/issues/5522), @Prinzhorn)
-
+* Add syntax highlighting to JSON and msgpack content view.
+  ([#5623](https://github.com/mitmproxy/mitmproxy/issues/5623), @SapiensAnatis)
 
 ## 28 June 2022: mitmproxy 8.1.1
 

--- a/mitmproxy/contentviews/json.py
+++ b/mitmproxy/contentviews/json.py
@@ -28,7 +28,10 @@ def format_json(data: Any) -> Iterator[base.TViewLine]:
             yield current_line
             current_line = []
         if re.match(r'\s*"', chunk):
-            current_line.append(("json_string", chunk))
+            if len(current_line) == 1 and current_line[0][0] == "text" and current_line[0][1].isspace():
+                current_line.append(("json_key", chunk))
+            else:
+                current_line.append(("json_string", chunk))
         elif re.match(r"\s*\d", chunk):
             current_line.append(("json_number", chunk))
         elif re.match(r"\s*(true|null|false)", chunk):

--- a/mitmproxy/contentviews/json.py
+++ b/mitmproxy/contentviews/json.py
@@ -29,13 +29,13 @@ def format_json(data: Any) -> Iterator[base.TViewLine]:
             current_line = []
         if re.match(r'\s*"', chunk):
             if len(current_line) == 1 and current_line[0][0] == "text" and current_line[0][1].isspace():
-                current_line.append(("json_key", chunk))
+                current_line.append(("Token_Name_Tag", chunk))
             else:
-                current_line.append(("json_string", chunk))
+                current_line.append(("Token_Literal_String", chunk))
         elif re.match(r"\s*\d", chunk):
-            current_line.append(("json_number", chunk))
+            current_line.append(("Token_Literal_Number", chunk))
         elif re.match(r"\s*(true|null|false)", chunk):
-            current_line.append(("json_boolean", chunk))
+            current_line.append(("Token_Keyword_Constant", chunk))
         else:
             current_line.append(("text", chunk))
     yield current_line

--- a/mitmproxy/contentviews/msgpack.py
+++ b/mitmproxy/contentviews/msgpack.py
@@ -25,28 +25,26 @@ def format_msgpack(data: Any, output = None, indent_count: int = 0) -> list[base
         token = [("msgpack_string", f"\"{data}\"")]
         output[-1] += token
 
-        # If that was the first token, this is the sole msgpack object, so we need to return
-        # as there is no dict/list loop which will do so for us
-        if len(output) == 1:
-            return output
+        # Need to return if single value, but return is discarded in dict/list loop
+        return output
 
     elif type(data) is float or type(data) is int:
         token = [("msgpack_number", repr(data))]
         output[-1] += token
-        if len(output) == 1:
-            return output
+
+        return output
 
     elif type(data) is bool:
         token = [("msgpack_boolean", repr(data))]
         output[-1] += token
-        if len(output) == 1:
-            return output
+
+        return output
 
     elif type(data) is dict:
         output[-1] += [("text", "{")]
         for key in data:
             output.append([indent, ("text", "    "), ("msgpack_key", f'"{key}"'), ("text", ": ")])
-            format_msgpack(data[key], output, indent_count + 1)
+            _ = format_msgpack(data[key], output, indent_count + 1)
 
             if key != list(data)[-1]:
                 output[-1] += [("text", ",")]
@@ -59,7 +57,7 @@ def format_msgpack(data: Any, output = None, indent_count: int = 0) -> list[base
         output[-1] += [("text", "[")]
         for item in data:
             output.append([indent, ("text", "    ")])
-            format_msgpack(item, output, indent_count + 1)
+            _ = format_msgpack(item, output, indent_count + 1)
 
             if item != data[-1]:
                 output[-1] += [("text", ",")]
@@ -71,8 +69,8 @@ def format_msgpack(data: Any, output = None, indent_count: int = 0) -> list[base
     else:
         token = [("text", repr(data))]
         output[-1] += token
-        if len(output) == 1:
-            return output
+
+        return output
 
 
 class ViewMsgPack(base.View):

--- a/mitmproxy/contentviews/msgpack.py
+++ b/mitmproxy/contentviews/msgpack.py
@@ -57,7 +57,7 @@ def format_msgpack(data: Any, output = None, indent_count: int = 0) -> list[base
         output[-1] += [("text", "[")]
         for item in data:
             output.append([indent, ("text", "    ")])
-            _ = format_msgpack(item, output, indent_count + 1)
+            format_msgpack(item, output, indent_count + 1)
 
             if item != data[-1]:
                 output[-1] += [("text", ",")]

--- a/mitmproxy/contentviews/msgpack.py
+++ b/mitmproxy/contentviews/msgpack.py
@@ -44,7 +44,7 @@ def format_msgpack(data: Any, output = None, indent_count: int = 0) -> list[base
         output[-1] += [("text", "{")]
         for key in data:
             output.append([indent, ("text", "    "), ("Token_Name_Tag", f'"{key}"'), ("text", ": ")])
-            _ = format_msgpack(data[key], output, indent_count + 1)
+            format_msgpack(data[key], output, indent_count + 1)
 
             if key != list(data)[-1]:
                 output[-1] += [("text", ",")]
@@ -83,7 +83,7 @@ class ViewMsgPack(base.View):
     def __call__(self, data, **metadata):
         data = parse_msgpack(data)
         if data is not PARSE_ERROR:
-            return "MsgPack", (line for line in format_msgpack(data))
+            return "MsgPack", format_msgpack(data)
 
     def render_priority(
         self, data: bytes, *, content_type: Optional[str] = None, **metadata

--- a/mitmproxy/contentviews/msgpack.py
+++ b/mitmproxy/contentviews/msgpack.py
@@ -22,20 +22,20 @@ def format_msgpack(data: Any, output = None, indent_count: int = 0) -> list[base
     indent = ("text", "    " * indent_count)
 
     if type(data) is str:
-        token = [("msgpack_string", f"\"{data}\"")]
+        token = [("Token_Literal_String", f"\"{data}\"")]
         output[-1] += token
 
         # Need to return if single value, but return is discarded in dict/list loop
         return output
 
     elif type(data) is float or type(data) is int:
-        token = [("msgpack_number", repr(data))]
+        token = [("Token_Literal_Number", repr(data))]
         output[-1] += token
 
         return output
 
     elif type(data) is bool:
-        token = [("msgpack_boolean", repr(data))]
+        token = [("Token_Keyword_Constant", repr(data))]
         output[-1] += token
 
         return output
@@ -43,7 +43,7 @@ def format_msgpack(data: Any, output = None, indent_count: int = 0) -> list[base
     elif type(data) is dict:
         output[-1] += [("text", "{")]
         for key in data:
-            output.append([indent, ("text", "    "), ("msgpack_key", f'"{key}"'), ("text", ": ")])
+            output.append([indent, ("text", "    "), ("Token_Name_Tag", f'"{key}"'), ("text", ": ")])
             _ = format_msgpack(data[key], output, indent_count + 1)
 
             if key != list(data)[-1]:

--- a/mitmproxy/tools/console/palettes.py
+++ b/mitmproxy/tools/console/palettes.py
@@ -69,10 +69,11 @@ class Palette:
         "mark",
         # Hex view
         "offset",
-        # JSON view
-        "json_string",
-        "json_number",
-        "json_boolean",
+        # JSON/msgpack view
+        "Token_Name_Tag",
+        "Token_Literal_String",
+        "Token_Literal_Number",
+        "Token_Keyword_Constant",
         # TCP flow details
         "from_client",
         "to_client",
@@ -207,10 +208,11 @@ class LowDark(Palette):
         mark=("light red", "default"),
         # Hex view
         offset=("dark cyan", "default"),
-        # JSON view
-        json_string=("dark blue", "default"),
-        json_number=("light magenta", "default"),
-        json_boolean=("dark magenta", "default"),
+        # JSON/msgpack view
+        Token_Name_Tag=("dark green", "default"),
+        Token_Literal_String=("dark blue", "default"),
+        Token_Literal_Number=("light magenta", "default"),
+        Token_Keyword_Constant=("dark magenta", "default"),
         # TCP flow details
         from_client=("light blue", "default"),
         to_client=("light red", "default"),
@@ -306,10 +308,11 @@ class LowLight(Palette):
         mark=("dark red", "default"),
         # Hex view
         offset=("dark blue", "default"),
-        # JSON view
-        json_string=("dark blue", "default"),
-        json_number=("light magenta", "default"),
-        json_boolean=("dark magenta", "default"),
+        # JSON/msgpack view
+        Token_Name_Tag=("dark green", "default"),
+        Token_Literal_String=("dark blue", "default"),
+        Token_Literal_Number=("light magenta", "default"),
+        Token_Keyword_Constant=("dark magenta", "default"),
         # TCP flow details
         from_client=("dark blue", "default"),
         to_client=("dark red", "default"),
@@ -427,10 +430,11 @@ class SolarizedLight(LowLight):
         ),
         # Hex view
         offset=(sol_cyan, "default"),
-        # JSON view
-        json_string=(sol_cyan, "default"),
-        json_number=(sol_blue, "default"),
-        json_boolean=(sol_magenta, "default"),
+        # JSON/msgpack view
+        Token_Name_Tag=(sol_green, "default"),
+        Token_Literal_String=(sol_cyan, "default"),
+        Token_Literal_Number=(sol_blue, "default"),
+        Token_Keyword_Constant=(sol_magenta, "default"),
         # TCP flow details
         from_client=(sol_blue, "default"),
         to_client=(sol_red, "default"),
@@ -506,10 +510,11 @@ class SolarizedDark(LowDark):
         ),
         # Hex view
         offset=(sol_cyan, "default"),
-        # JSON view
-        json_string=(sol_cyan, "default"),
-        json_number=(sol_blue, "default"),
-        json_boolean=(sol_magenta, "default"),
+        # JSON/msgpack view
+        Token_Name_Tag=(sol_green, "default"),
+        Token_Literal_String=(sol_cyan, "default"),
+        Token_Literal_Number=(sol_blue, "default"),
+        Token_Keyword_Constant=(sol_magenta, "default"),
         # TCP flow details
         from_client=(sol_blue, "default"),
         to_client=(sol_red, "default"),

--- a/test/mitmproxy/contentviews/test_json.py
+++ b/test/mitmproxy/contentviews/test_json.py
@@ -17,6 +17,32 @@ def test_parse_json():
 
 def test_format_json():
     assert list(json.format_json({"data": ["str", 42, True, False, None, {}, []]}))
+    assert list(json.format_json({"string": "test"})) == [
+        [('text', '{'), ('text', '')],
+        [('text', '    '), ('json_key', '"string"'), ('text', ': '), ('json_string', '"test"'), ('text', '')],
+        [('text', ''), ('text', '}')]]
+    assert list(json.format_json({"num": 4})) == [
+        [('text', '{'), ('text', '')],
+        [('text', '    '), ('json_key', '"num"'), ('text', ': '), ('json_number', '4'), ('text', '')],
+        [('text', ''), ('text', '}')]]
+    assert list(json.format_json({"bool": True})) == [
+        [('text', '{'), ('text', '')],
+        [('text', '    '), ('json_key', '"bool"'), ('text', ': '), ('json_boolean', 'true'), ('text', '')],
+        [('text', ''), ('text', '}')]]
+    assert list(json.format_json({"object": {"int": 1}})) == [
+        [('text', '{'), ('text', '')],
+        [('text', '    '), ('json_key', '"object"'), ('text', ': '), ('text', '{'), ('text', '')],
+        [('text', '        '), ('json_key', '"int"'), ('text', ': '), ('json_number', '1'), ('text', '')],
+        [('text', '    '), ('text', '}'), ('text', '')],
+        [('text', ''), ('text', '}')]]
+    assert list(json.format_json({"list": ["string", 1, True]})) == [
+        [('text', '{'), ('text', '')],
+        [('text', '    '), ('json_key', '"list"'), ('text', ': '), ('text', '[')],
+        [('json_string', '        "string"'), ('text', ',')],
+        [('json_number', '        1'), ('text', ',')],
+        [('json_boolean', '        true'), ('text', '')],
+        [('text', '    '), ('text', ']'), ('text', '')],
+        [('text', ''), ('text', '}')]]
 
 
 def test_view_json():

--- a/test/mitmproxy/contentviews/test_json.py
+++ b/test/mitmproxy/contentviews/test_json.py
@@ -19,28 +19,28 @@ def test_format_json():
     assert list(json.format_json({"data": ["str", 42, True, False, None, {}, []]}))
     assert list(json.format_json({"string": "test"})) == [
         [('text', '{'), ('text', '')],
-        [('text', '    '), ('json_key', '"string"'), ('text', ': '), ('json_string', '"test"'), ('text', '')],
+        [('text', '    '), ('Token_Name_Tag', '"string"'), ('text', ': '), ('Token_Literal_String', '"test"'), ('text', '')],
         [('text', ''), ('text', '}')]]
     assert list(json.format_json({"num": 4})) == [
         [('text', '{'), ('text', '')],
-        [('text', '    '), ('json_key', '"num"'), ('text', ': '), ('json_number', '4'), ('text', '')],
+        [('text', '    '), ('Token_Name_Tag', '"num"'), ('text', ': '), ('Token_Literal_Number', '4'), ('text', '')],
         [('text', ''), ('text', '}')]]
     assert list(json.format_json({"bool": True})) == [
         [('text', '{'), ('text', '')],
-        [('text', '    '), ('json_key', '"bool"'), ('text', ': '), ('json_boolean', 'true'), ('text', '')],
+        [('text', '    '), ('Token_Name_Tag', '"bool"'), ('text', ': '), ('Token_Keyword_Constant', 'true'), ('text', '')],
         [('text', ''), ('text', '}')]]
     assert list(json.format_json({"object": {"int": 1}})) == [
         [('text', '{'), ('text', '')],
-        [('text', '    '), ('json_key', '"object"'), ('text', ': '), ('text', '{'), ('text', '')],
-        [('text', '        '), ('json_key', '"int"'), ('text', ': '), ('json_number', '1'), ('text', '')],
+        [('text', '    '), ('Token_Name_Tag', '"object"'), ('text', ': '), ('text', '{'), ('text', '')],
+        [('text', '        '), ('Token_Name_Tag', '"int"'), ('text', ': '), ('Token_Literal_Number', '1'), ('text', '')],
         [('text', '    '), ('text', '}'), ('text', '')],
         [('text', ''), ('text', '}')]]
     assert list(json.format_json({"list": ["string", 1, True]})) == [
         [('text', '{'), ('text', '')],
-        [('text', '    '), ('json_key', '"list"'), ('text', ': '), ('text', '[')],
-        [('json_string', '        "string"'), ('text', ',')],
-        [('json_number', '        1'), ('text', ',')],
-        [('json_boolean', '        true'), ('text', '')],
+        [('text', '    '), ('Token_Name_Tag', '"list"'), ('text', ': '), ('text', '[')],
+        [('Token_Literal_String', '        "string"'), ('text', ',')],
+        [('Token_Literal_Number', '        1'), ('text', ',')],
+        [('Token_Keyword_Constant', '        true'), ('text', '')],
         [('text', '    '), ('text', ']'), ('text', '')],
         [('text', ''), ('text', '}')]]
 

--- a/test/mitmproxy/contentviews/test_msgpack.py
+++ b/test/mitmproxy/contentviews/test_msgpack.py
@@ -18,9 +18,24 @@ def test_parse_msgpack():
 
 
 def test_format_msgpack():
-    assert list(
-        msgpack.format_msgpack({"data": ["str", 42, True, False, None, {}, []]})
-    )
+    assert list(msgpack.format_msgpack({"string": "test", "int": 1, "float": 1.44, "bool": True})) == [
+        [('text', '{')],
+        [('text', ''), ('text', '    '), ('msgpack_key', '"string"'), ('text', ': '), ('msgpack_string', '"test"'), ('text', ',')],
+        [('text', ''), ('text', '    '), ('msgpack_key', '"int"'), ('text', ': '), ('msgpack_number', '1'), ('text', ',')],
+        [('text', ''), ('text', '    '), ('msgpack_key', '"float"'), ('text', ': '), ('msgpack_number', '1.44'), ('text', ',')],
+        [('text', ''), ('text', '    '), ('msgpack_key', '"bool"'), ('text', ': '), ('msgpack_boolean', 'True')],
+        [('text', ''), ('text', '}')]
+    ]
+
+    assert list(msgpack.format_msgpack({"object": {"key": "value"}, "list": [1]})) == [
+        [('text', '{')],
+        [('text', ''), ('text', '    '), ('msgpack_key', '"object"'), ('text', ': '), ('text', '{')],
+        [('text', '    '), ('text', '    '), ('msgpack_key', '"key"'), ('text', ': '), ('msgpack_string', '"value"')],
+        [('text', '    '), ('text', '}'), ('text', ',')],
+        [('text', ''), ('text', '    '), ('msgpack_key', '"list"'), ('text', ': '), ('text', '[')],
+        [('text', '    '), ('text', '    '), ('msgpack_number', '1')],
+        [('text', '    '), ('text', ']')],
+        [('text', ''), ('text', '}')]]
 
 
 def test_view_msgpack():

--- a/test/mitmproxy/contentviews/test_msgpack.py
+++ b/test/mitmproxy/contentviews/test_msgpack.py
@@ -20,28 +20,28 @@ def test_parse_msgpack():
 def test_format_msgpack():
     assert list(msgpack.format_msgpack({"string": "test", "int": 1, "float": 1.44, "bool": True})) == [
         [('text', '{')],
-        [('text', ''), ('text', '    '), ('msgpack_key', '"string"'), ('text', ': '), ('msgpack_string', '"test"'), ('text', ',')],
-        [('text', ''), ('text', '    '), ('msgpack_key', '"int"'), ('text', ': '), ('msgpack_number', '1'), ('text', ',')],
-        [('text', ''), ('text', '    '), ('msgpack_key', '"float"'), ('text', ': '), ('msgpack_number', '1.44'), ('text', ',')],
-        [('text', ''), ('text', '    '), ('msgpack_key', '"bool"'), ('text', ': '), ('msgpack_boolean', 'True')],
+        [('text', ''), ('text', '    '), ('Token_Name_Tag', '"string"'), ('text', ': '), ('Token_Literal_String', '"test"'), ('text', ',')],
+        [('text', ''), ('text', '    '), ('Token_Name_Tag', '"int"'), ('text', ': '), ('Token_Literal_Number', '1'), ('text', ',')],
+        [('text', ''), ('text', '    '), ('Token_Name_Tag', '"float"'), ('text', ': '), ('Token_Literal_Number', '1.44'), ('text', ',')],
+        [('text', ''), ('text', '    '), ('Token_Name_Tag', '"bool"'), ('text', ': '), ('Token_Keyword_Constant', 'True')],
         [('text', ''), ('text', '}')]
     ]
 
     assert list(msgpack.format_msgpack({"object": {"key": "value"}, "list": [1]})) == [
         [('text', '{')],
-        [('text', ''), ('text', '    '), ('msgpack_key', '"object"'), ('text', ': '), ('text', '{')],
-        [('text', '    '), ('text', '    '), ('msgpack_key', '"key"'), ('text', ': '), ('msgpack_string', '"value"')],
+        [('text', ''), ('text', '    '), ('Token_Name_Tag', '"object"'), ('text', ': '), ('text', '{')],
+        [('text', '    '), ('text', '    '), ('Token_Name_Tag', '"key"'), ('text', ': '), ('Token_Literal_String', '"value"')],
         [('text', '    '), ('text', '}'), ('text', ',')],
-        [('text', ''), ('text', '    '), ('msgpack_key', '"list"'), ('text', ': '), ('text', '[')],
-        [('text', '    '), ('text', '    '), ('msgpack_number', '1')],
+        [('text', ''), ('text', '    '), ('Token_Name_Tag', '"list"'), ('text', ': '), ('text', '[')],
+        [('text', '    '), ('text', '    '), ('Token_Literal_Number', '1')],
         [('text', '    '), ('text', ']')],
         [('text', ''), ('text', '}')]]
 
-    assert list(msgpack.format_msgpack('string')) == [[('msgpack_string', '"string"')]]
+    assert list(msgpack.format_msgpack('string')) == [[('Token_Literal_String', '"string"')]]
 
-    assert list(msgpack.format_msgpack(1.2)) == [[('msgpack_number', '1.2')]]
+    assert list(msgpack.format_msgpack(1.2)) == [[('Token_Literal_Number', '1.2')]]
 
-    assert list(msgpack.format_msgpack(True)) == [[('msgpack_boolean', 'True')]]
+    assert list(msgpack.format_msgpack(True)) == [[('Token_Keyword_Constant', 'True')]]
 
     assert list(msgpack.format_msgpack(b'\x01\x02\x03')) == [[('text', "b'\\x01\\x02\\x03'")]]
 

--- a/test/mitmproxy/contentviews/test_msgpack.py
+++ b/test/mitmproxy/contentviews/test_msgpack.py
@@ -37,6 +37,14 @@ def test_format_msgpack():
         [('text', '    '), ('text', ']')],
         [('text', ''), ('text', '}')]]
 
+    assert list(msgpack.format_msgpack('string')) == [[('msgpack_string', '"string"')]]
+
+    assert list(msgpack.format_msgpack(1.2)) == [[('msgpack_number', '1.2')]]
+
+    assert list(msgpack.format_msgpack(True)) == [[('msgpack_boolean', 'True')]]
+
+    assert list(msgpack.format_msgpack(b'\x01\x02\x03')) == [[('text', "b'\\x01\\x02\\x03'")]]
+
 
 def test_view_msgpack():
     v = full_eval(msgpack.ViewMsgPack())

--- a/web/src/css/contentview.less
+++ b/web/src/css/contentview.less
@@ -14,28 +14,16 @@
     .codeeditor{
         margin-bottom: 12px;
     }
-    .json_key{
+    .Token_Name_Tag{
         color: darkgreen;
     }
-    .json_string{
+    .Token_Literal_String{
         color: firebrick;
     }
-    .json_number{
+    .Token_Literal_Number{
         color: purple;
     }
-    .json_boolean{
-        color: blue;
-    }
-    .msgpack_key{
-        color: darkgreen;
-    }
-    .msgpack_string{
-        color: firebrick;
-    }
-    .msgpack_number{
-        color: purple;
-    }
-    .msgpack_boolean{
+    .Token_Keyword_Constant{
         color: blue;
     }
 }

--- a/web/src/css/contentview.less
+++ b/web/src/css/contentview.less
@@ -15,15 +15,27 @@
         margin-bottom: 12px;
     }
     .json_key{
-        color: green;
+        color: darkgreen;
     }
     .json_string{
         color: firebrick;
     }
     .json_number{
-        color: deeppink;
+        color: purple;
     }
     .json_boolean{
+        color: blue;
+    }
+    .msgpack_key{
+        color: darkgreen;
+    }
+    .msgpack_string{
+        color: firebrick;
+    }
+    .msgpack_number{
+        color: purple;
+    }
+    .msgpack_boolean{
         color: blue;
     }
 }

--- a/web/src/css/contentview.less
+++ b/web/src/css/contentview.less
@@ -14,4 +14,16 @@
     .codeeditor{
         margin-bottom: 12px;
     }
+    .json_key{
+        color: green;
+    }
+    .json_string{
+        color: firebrick;
+    }
+    .json_number{
+        color: deeppink;
+    }
+    .json_boolean{
+        color: blue;
+    }
 }


### PR DESCRIPTION
#### Description

Adds support for syntax highlighting in the mitmweb content view for JSON and msgpack bodies. Closes #5623

Visually speaking, they look identical in the content view, except msgpack supports a few types which JSON does not. These are left unhighlighted, but the formatting function should be easy to extend to cover these if desired.

![image](https://user-images.githubusercontent.com/5047192/195956583-6f563c98-45e1-439d-9eea-a2516b5555ff.png)

Summary of changes:

 - Modified existing JSON token labelling function to distinguish keys from regular strings
 - Modified msgpack formatting function to add token labelling 
 - Added stylesheet colours for msgpack and json colours 
     - I just picked a few random colours that looked half-decent, but I haven't given too much thought to accessibility/colourblindness. Open to discussion on changing these.
 - Modified test_json.py and test_msgpack.py to test the output of the format function

#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
