### PR TITLE
fix mitmWeb crash, when using filter

### DIFF
--- a/web/src/js/components/FlowTable.jsx
+++ b/web/src/js/components/FlowTable.jsx
@@ -85,7 +85,7 @@ class FlowTable extends React.Component {
         })
 
         if (this.state.viewportTop !== viewportTop || !shallowEqual(this.state.vScroll, vScroll)) {
-            this.setState({ vScroll, viewportTop })
+            this.setState({ vScroll, viewportTop: vScroll.start > vScroll.end ? 0 : viewportTop })
         }
     }
 


### PR DESCRIPTION
#### Description

mitmWeb crash, when using filter.

- How to reproduction:
  - catch more than 2000+ flows
  - scroll to the end of flowTable
  - input a filter condition, which only hits a small number of flow items. Maybe less than 100 flow items
  - then the flow table's height reduces from `2000 * 32px` to `100 *32 px`
  - you will get the crash

- Root cause:
FlowTable.jsx->FlowTable: the variable `viewportTop` is set to `viewport.scrollTop` in componentDidUpdate().
in the above case, `vScroll.end, vScroll.paddingTop, vScroll.paddingBottom` is small, but `viewportTop` is still a large number
this will case "<thead ref="head" style={{ transform: `translateY(${viewportTop}px)` }}>" more higher than excepted.
`scrollTop` only reduce offsetHeight each time FlowTable render()
then " Maximum update depth exceeded.", mitmWeb crash

- How to fix:
set viewportTop to *0*, when `vScroll.start > vScroll.end`

#### Checklist

 - [ ] I have updated tests where applicable.
 - [ ] I have added an entry to the CHANGELOG.