### PR TITLE
fix vScroll calcuation, refs #5658

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,8 @@
 * DTLS support ([#5397](https://github.com/mitmproxy/mitmproxy/pull/5397), @kckeiks).
 * Added Magisk module generation for Android onboarding (@jorants).
 * Update Linux binary builder to Ubuntu 20.04, bumping the minimum glibc version to 2.31. (@jorants)
-* "Save filtered" button in mitmweb. ([#5531](https://github.com/mitmproxy/mitmproxy/pull/5531), @rnbwdsh, @mhils)
+* "Save filtered" button in mitmweb.
+  ([#5531](https://github.com/mitmproxy/mitmproxy/pull/5531), @rnbwdsh, @mhils)
 * DTLS support. 
   ([#5397](https://github.com/mitmproxy/mitmproxy/pull/5397), @kckeiks).
 * Added Magisk module generation for Android onboarding 
@@ -47,6 +48,8 @@
   ([#5522](https://github.com/mitmproxy/mitmproxy/issues/5522), @Prinzhorn)
 * Fix race condition when updating mitmweb WebSocket connections that are closing.
   ([#5405](https://github.com/mitmproxy/mitmproxy/issues/5405), @mhils)
+* Fix mitmweb crash when using filters.
+  ([#5658](https://github.com/mitmproxy/mitmproxy/issues/5658), [#5661](https://github.com/mitmproxy/mitmproxy/issues/5661), @LIU-shuyi, @mhils)
 
 
 ## 28 June 2022: mitmproxy 8.1.1

--- a/web/src/js/__tests__/components/__snapshots__/FlowTableSpec.tsx.snap
+++ b/web/src/js/__tests__/components/__snapshots__/FlowTableSpec.tsx.snap
@@ -9,7 +9,7 @@ exports[`FlowTable Component should render correctly 1`] = `
     <thead
       style={
         Object {
-          "transform": "translateY(undefinedpx)",
+          "transform": "translateY(0px)",
         }
       }
     >
@@ -72,6 +72,63 @@ exports[`FlowTable Component should render correctly 1`] = `
           }
         }
       />
+      <tr
+        className="has-request has-response"
+        onClick={[Function]}
+      >
+        <td
+          className="col-tls col-tls-https"
+        />
+        <td
+          className="col-icon"
+        >
+          <div
+            className="resource-icon resource-icon-websocket"
+          />
+        </td>
+        <td
+          className="col-path"
+        >
+          <i
+            className="fa fa-fw fa-exclamation pull-right"
+          />
+          <span
+            className="marker pull-right"
+          >
+            
+          </span>
+          http://address:22/path
+        </td>
+        <td
+          className="col-method"
+        >
+          WSS
+        </td>
+        <td
+          className="col-status"
+          style={
+            Object {
+              "color": "darkgreen",
+            }
+          }
+        >
+          200
+        </td>
+        <td
+          className="col-size"
+        >
+          43b
+        </td>
+        <td
+          className="col-time"
+        >
+          5s
+        </td>
+        <td
+          className="col-quickactions"
+          onClick={[Function]}
+        />
+      </tr>
       <tr
         style={
           Object {

--- a/web/src/js/__tests__/components/helpers/VirtualScrollSpec.tsx
+++ b/web/src/js/__tests__/components/helpers/VirtualScrollSpec.tsx
@@ -18,4 +18,17 @@ describe('VirtualScroll', () => {
             start: 0, end: 4, paddingTop: 0, paddingBottom: 100
         })
     })
+
+    it('should handle the case where lots of existing rows are removed without itemHeights', () => {
+        expect(calcVScroll({itemCount: 10, rowHeight: 32, viewportHeight: 400, viewportTop: 12_000})).toEqual({
+            start: 0, end: 10, paddingTop: 0, paddingBottom: 0
+        })
+    })
+
+    it('should handle the case where lots of existing rows are removed with itemHeights', () => {
+        expect(calcVScroll({itemCount: 4, itemHeights: [100, 100, 100, 100],
+            viewportHeight: 400, viewportTop: 12_000, rowHeight: 32})).toEqual({
+            start: 0, end: 4, paddingTop: 0, paddingBottom: 0
+        })
+    })
 })

--- a/web/src/js/components/FlowTable.jsx
+++ b/web/src/js/components/FlowTable.jsx
@@ -89,7 +89,14 @@ class FlowTable extends React.Component {
         })
 
         if (this.state.viewportTop !== viewportTop || !shallowEqual(this.state.vScroll, vScroll)) {
-            this.setState({ vScroll, viewportTop })
+            // the next rendered state may only have much lower number of rows compared to what the current
+            // viewportHeight anticipates. To make sure that we update (almost) at once, we already constrain
+            // the maximum viewportTop value. See https://github.com/mitmproxy/mitmproxy/pull/5658 for details.
+            let newViewportTop = Math.min(viewportTop, vScroll.end * this.props.rowHeight);
+            this.setState({
+                vScroll,
+                viewportTop: newViewportTop
+            });
         }
     }
 

--- a/web/src/js/components/FlowTable.jsx
+++ b/web/src/js/components/FlowTable.jsx
@@ -34,6 +34,10 @@ class FlowTable extends React.Component {
         window.addEventListener('resize', this.onViewportUpdate)
     }
 
+    componentDidMount() {
+        this.onViewportUpdate();
+    }
+
     UNSAFE_componentWillUnmount() {
         window.removeEventListener('resize', this.onViewportUpdate)
     }

--- a/web/src/js/components/helpers/VirtualScroll.tsx
+++ b/web/src/js/components/helpers/VirtualScroll.tsx
@@ -1,24 +1,3 @@
-/**
- * Calculate virtual scroll stuffs
- *
- * @param {?Object} opts Options for calculation
- *
- * @returns {Object} result
- *
- * __opts__ should have following properties:
- * - {number}         itemCount
- * - {number}         rowHeight
- * - {number}         viewportTop
- * - {number}         viewportHeight
- * - {Array<?number>} [itemHeights]
- *
- * __result__ have following properties:
- * - {number} start
- * - {number} end
- * - {number} paddingTop
- * - {number} paddingBottom
- */
-
 type VScrollArgs = {
     itemCount: number
     rowHeight: number
@@ -36,10 +15,10 @@ export type VScroll = {
 
 export function calcVScroll(opts: VScrollArgs | undefined = undefined) {
     if (!opts) {
-        return { start: 0, end: 0, paddingTop: 0, paddingBottom: 0 };
+        return {start: 0, end: 0, paddingTop: 0, paddingBottom: 0};
     }
 
-    const { itemCount, rowHeight, viewportTop, viewportHeight, itemHeights } = opts;
+    const {itemCount, rowHeight, viewportTop, viewportHeight, itemHeights} = opts;
     const viewportBottom = viewportTop + viewportHeight;
 
     let start = 0;
@@ -50,7 +29,8 @@ export function calcVScroll(opts: VScrollArgs | undefined = undefined) {
 
     if (itemHeights) {
 
-        for (let i = 0, pos = 0; i < itemCount; i++) {
+        let pos = 0;
+        for (let i = 0; i < itemCount; i++) {
             const height = itemHeights[i] || rowHeight;
 
             if (pos <= viewportTop && i % 2 === 0) {
@@ -66,21 +46,30 @@ export function calcVScroll(opts: VScrollArgs | undefined = undefined) {
 
             pos += height;
         }
+        // viewportTop + viewportHeight is larger than our total table height.
+        // this means that rows have been freshly removed and we need to calculate with
+        // an updated (smaller) viewportTop.
+        if(viewportTop > 0 && pos < viewportTop + viewportHeight)
+            return calcVScroll({itemCount, rowHeight, viewportTop: pos - viewportHeight, viewportHeight, itemHeights});
 
     } else {
+        // We may have removed a lot of rows since the last render,
+        // which means viewportTop will move up.
+        let newViewportTop = Math.min(
+            viewportTop,
+            Math.max(0, itemCount * rowHeight - viewportHeight)
+        );
 
         // Make sure that we start at an even row so that CSS `:nth-child(even)` is preserved
-        start = Math.max(0, Math.floor(viewportTop / rowHeight) - 1) & ~1;
+        start = Math.max(0, Math.floor(newViewportTop / rowHeight) - 1) & ~1;
         end = Math.min(
             itemCount,
             start + Math.ceil(viewportHeight / rowHeight) + 2
         );
 
-        // When a large trunk of elements is removed from the button, start may be far off the viewport.
-        // To make this issue less severe, limit the top placeholder to the total number of rows.
-        paddingTop = Math.min(start, itemCount) * rowHeight;
-        paddingBottom = Math.max(0, itemCount - end) * rowHeight;
+        paddingTop = start * rowHeight;
+        paddingBottom = (itemCount - end) * rowHeight;
     }
 
-    return { start, end, paddingTop, paddingBottom };
+    return {start, end, paddingTop, paddingBottom};
 }

--- a/web/src/js/components/helpers/VirtualScroll.tsx
+++ b/web/src/js/components/helpers/VirtualScroll.tsx
@@ -13,7 +13,7 @@ export type VScroll = {
     paddingBottom: number
 }
 
-export function calcVScroll(opts: VScrollArgs | undefined = undefined) {
+export function calcVScroll(opts: VScrollArgs | undefined = undefined): VScroll {
     if (!opts) {
         return {start: 0, end: 0, paddingTop: 0, paddingBottom: 0};
     }


### PR DESCRIPTION
This PR is an alternative fix for #5658: `calcVScroll` now bounds viewportTop so that additional checks should not be necessary.

@LIU-shuyi, can you verify that this works as expected please? 😃 