### PR TITLE
add websocket messages in HAR file

### DIFF
--- a/examples/contrib/har_dump.py
+++ b/examples/contrib/har_dump.py
@@ -16,7 +16,6 @@ from datetime import datetime
 from datetime import timezone
 
 import zlib
-import uuid
 
 import mitmproxy
 from mitmproxy import connection
@@ -26,7 +25,6 @@ from mitmproxy.net.http import cookies
 from mitmproxy.utils import strutils
 
 HAR: dict = {}
-requestID_to_entry: dict = {}
 
 # A list of server seen till now is maintained so we can avoid
 # using 'connect' time for entries that use an existing connection.
@@ -52,32 +50,24 @@ def configure(updated):
         }
     })
 
-def websocket_end(flow: mitmproxy.http.HTTPFlow):
-    assert flow.websocket is not None
-    messages = flow.websocket.messages
-    websocketMessages = []
+def appendWebsocketMessages(flow: mitmproxy.http.HTTPFlow, entry):
+    if flow.websocket:
+        messages = flow.websocket.messages
+        websocketMessages = []
 
-    for message in messages:
-        websocketMessage = {
-        'type': 'send' if message.from_client else 'receive',
-        'time': message.timestamp,
-        'opcode': message.type.value,
-        'data': message.content.decode()
-        }
-        websocketMessages.append(websocketMessage)
+        for message in messages:
+            websocketMessage = {
+            'type': 'send' if message.from_client else 'receive',
+            'time': message.timestamp,
+            'opcode': message.type.value,
+            'data': message.content.decode()
+            }
+            websocketMessages.append(websocketMessage)
 
-    requestID_to_entry[flow.request.id]['_resourceType'] = 'websocket'
-    requestID_to_entry[flow.request.id]['_webSocketMessages'] = websocketMessages
+        entry['_resourceType'] = 'websocket'
+        entry['_webSocketMessages'] = websocketMessages
 
-def request(flow: mitmproxy.http.HTTPFlow):
-    request_uuid = uuid.uuid4()
-    print(f'request.id: {request_uuid}')
-    flow.request.id = request_uuid
-
-def response(flow: mitmproxy.http.HTTPFlow):
-    """
-       Called when a server response has been received.
-    """
+def flow_entry(flow: mitmproxy.http.HTTPFlow):
 
     # -1 indicates that these values do not apply to current request
     ssl_time = -1
@@ -176,9 +166,26 @@ def response(flow: mitmproxy.http.HTTPFlow):
 
     if flow.server_conn.connected:
         entry["serverIPAddress"] = str(flow.server_conn.peername[0])
-    requestID_to_entry[flow.request.id] = entry
+
+    appendWebsocketMessages(flow, entry)
+
     HAR["log"]["entries"].append(entry)
 
+def websocket_end(flow: mitmproxy.http.HTTPFlow):
+    assert flow.websocket is not None
+    flow_entry(flow)
+
+def request(flow: mitmproxy.http.HTTPFlow):
+    request_uuid = uuid.uuid4()
+    print(f'request.id: {request_uuid}')
+    flow.request.id = request_uuid
+
+def response(flow: mitmproxy.http.HTTPFlow):
+    """
+       Called when a server response has been received.
+    """
+    if flow.websocket is None:
+        flow_entry(flow)
 
 def done():
     """

--- a/examples/contrib/har_dump.py
+++ b/examples/contrib/har_dump.py
@@ -175,11 +175,6 @@ def websocket_end(flow: mitmproxy.http.HTTPFlow):
     assert flow.websocket is not None
     flow_entry(flow)
 
-def request(flow: mitmproxy.http.HTTPFlow):
-    request_uuid = uuid.uuid4()
-    print(f'request.id: {request_uuid}')
-    flow.request.id = request_uuid
-
 def response(flow: mitmproxy.http.HTTPFlow):
     """
        Called when a server response has been received.

--- a/examples/contrib/har_dump.py
+++ b/examples/contrib/har_dump.py
@@ -60,8 +60,9 @@ def appendWebsocketMessages(flow: mitmproxy.http.HTTPFlow, entry):
             'type': 'send' if message.from_client else 'receive',
             'time': message.timestamp,
             'opcode': message.type.value,
-            'data': message.content.decode()
+            'data': message.content.decode() if message.is_text else base64.b64encode(message.content).decode()
             }
+            print(dir(message.content))
             websocketMessages.append(websocketMessage)
 
         entry['_resourceType'] = 'websocket'


### PR DESCRIPTION
#### Description

<!-- describe your changes here -->
I wanted to dump websocket messages in har file under entries.

Like:

**<details><summary>mitmdump.har:</summary>**
<p>

```json
{
  "log": {
    "version": "1.2",
    "creator": {
      "name": "mitmproxy har_dump",
      "version": "0.1",
      "comment": "mitmproxy version mitmproxy 9.0.0.dev"
    },
    "entries": [
      {
        "startedDateTime": "2022-10-20T08:48:38.013394+00:00",
        "time": 900,
        "request": {
          "method": "GET",
          "url": "https://demo.piesocket.com/v3/channel_1?api_key=VCXCEuvhGcBDP7XhiJJUDvR1e1D3eiVjgZ9VRiaV&notify_self",
          "httpVersion": "HTTP/1.1",
          "cookies": [
            {
              "name": "_ga",
              "value": "GA1.2.1088248006.1666255585",
              "httpOnly": false,
              "secure": false
            },
            {
              "name": "_gid",
              "value": "GA1.2.117276119.1666255585",
              "httpOnly": false,
              "secure": false
            }
          ],
          "headers": [
            {
              "name": "Host",
              "value": "demo.piesocket.com"
            },
            {
              "name": "Connection",
              "value": "Upgrade"
            },
            {
              "name": "Pragma",
              "value": "no-cache"
            },
            {
              "name": "Cache-Control",
              "value": "no-cache"
            },
            {
              "name": "User-Agent",
              "value": "Mozilla/5.0 (Linux; Android 11; sdk_gphone_x86_64_arm64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Mobile Safari/537.36"
            },
            {
              "name": "Upgrade",
              "value": "websocket"
            },
            {
              "name": "Origin",
              "value": "https://www.piesocket.com"
            },
            {
              "name": "Sec-WebSocket-Version",
              "value": "13"
            },
            {
              "name": "Accept-Encoding",
              "value": "gzip, deflate, br"
            },
            {
              "name": "Accept-Language",
              "value": "en-US,en;q=0.9"
            },
            {
              "name": "Cookie",
              "value": "_ga=GA1.2.1088248006.1666255585; _gid=GA1.2.117276119.1666255585"
            },
            {
              "name": "Sec-WebSocket-Key",
              "value": "nfWMbNDg/HgZtrLTk9d/Lg=="
            },
            {
              "name": "Sec-WebSocket-Extensions",
              "value": "permessage-deflate; client_max_window_bits"
            }
          ],
          "queryString": [
            {
              "name": "api_key",
              "value": "VCXCEuvhGcBDP7XhiJJUDvR1e1D3eiVjgZ9VRiaV"
            },
            {
              "name": "notify_self",
              "value": ""
            }
          ],
          "headersSize": 692,
          "bodySize": 0
        },
        "response": {
          "status": 101,
          "statusText": "Switching Protocols",
          "httpVersion": "HTTP/1.1",
          "cookies": [],
          "headers": [
            {
              "name": "Date",
              "value": "Thu, 20 Oct 2022 08:48:38 GMT"
            },
            {
              "name": "Connection",
              "value": "upgrade"
            },
            {
              "name": "Upgrade",
              "value": "websocket"
            },
            {
              "name": "Sec-WebSocket-Accept",
              "value": "lr6dXdavz6JZsgFXACA++EZJO2M="
            },
            {
              "name": "X-Powered-By",
              "value": "Ratchet/0.4.4"
            }
          ],
          "content": {
            "size": 0,
            "compression": 0,
            "mimeType": "",
            "text": ""
          },
          "redirectURL": "",
          "headersSize": 206,
          "bodySize": 0
        },
        "cache": {},
        "timings": {
          "send": 0,
          "receive": 1,
          "wait": 226,
          "connect": 219,
          "ssl": 454
        },
        "_resourceType": "websocket",
        "_webSocketMessages": [
          {
            "type": "receive",
            "time": 1666255718.6583307,
            "opcode": 1,
            "data": "HAPPY world!"
          },
          {
            "type": "receive",
            "time": 1666255719.3767288,
            "opcode": 1,
            "data": "HAPPY world!"
          },
          {
            "type": "receive",
            "time": 1666255719.4212759,
            "opcode": 1,
            "data": "HAPPY world!"
          },
          {
            "type": "receive",
            "time": 1666255719.4237895,
            "opcode": 1,
            "data": "HAPPY world!"
          },
          {
            "type": "receive",
            "time": 1666255719.6134443,
            "opcode": 1,
            "data": "HAPPY world!"
          },
          {
            "type": "receive",
            "time": 1666255720.1513147,
            "opcode": 1,
            "data": "HAPPY world!"
          },
          {
            "type": "receive",
            "time": 1666255720.2099354,
            "opcode": 1,
            "data": "HAPPY world!"
          },
          {
            "type": "receive",
            "time": 1666255720.2776752,
            "opcode": 1,
            "data": "You connected "
          },
          {
            "type": "receive",
            "time": 1666255720.539432,
            "opcode": 1,
            "data": "HAPPY world!"
          },
          {
            "type": "receive",
            "time": 1666255720.8358681,
            "opcode": 1,
            "data": "{\"result\":true,\"errCode\":\"\",\"signalData\":{\"data\":[{\"rssiToMeter\":7,\"majorVer\":111123,\"minorVer\":1,\"txPower\":-50,\"UUID\":\"00000000-1111-2222-3333-aaabbbcccddd\",\"mac\":\"29:89:23:C4:CA:42\",\"rssi\":-67,\"battLevel\":100,\"sos\":0}],\"gps\":{\"time\":\"2022-10-20T17:48:40.655Z\",\"lng\":127.056113,\"lat\":37.034037},\"logDate\":\"2022-10-20 17:48:40.655\",\"scannerID\":\"10:78:CE:40:40:40:AA:BB:CC:DD:EE:FF\"}}"
          },
          {
            "type": "receive",
            "time": 1666255720.899063,
            "opcode": 1,
            "data": "HAPPY world!"
          },
          {
            "type": "receive",
            "time": 1666255721.0220823,
            "opcode": 1,
            "data": "HAPPY world!"
          },
          {
            "type": "receive",
            "time": 1666255721.3142264,
            "opcode": 1,
            "data": "HAPPY world!"
          },
          {
            "type": "receive",
            "time": 1666255721.3153458,
            "opcode": 1,
            "data": "HAPPY world!"
          },
          {
            "type": "receive",
            "time": 1666255722.19183,
            "opcode": 1,
            "data": "HAPPY world!"
          },
          {
            "type": "receive",
            "time": 1666255722.1941302,
            "opcode": 1,
            "data": "HAPPY world!"
          },
          {
            "type": "receive",
            "time": 1666255725.015803,
            "opcode": 1,
            "data": "HAPPY world!"
          },
          {
            "type": "receive",
            "time": 1666255725.7866318,
            "opcode": 1,
            "data": "HAPPY world!"
          },
          {
            "type": "send",
            "time": 1666255726.2308662,
            "opcode": 1,
            "data": "Hi"
          },
          {
            "type": "receive",
            "time": 1666255726.4530725,
            "opcode": 1,
            "data": "Hi"
          },
          {
            "type": "receive",
            "time": 1666255726.7119324,
            "opcode": 1,
            "data": "HAPPY world!"
          },
          {
            "type": "receive",
            "time": 1666255728.107094,
            "opcode": 1,
            "data": "HAPPY world!"
          },
          {
            "type": "receive",
            "time": 1666255728.2421448,
            "opcode": 1,
            "data": "HAPPY world!"
          },
          {
            "type": "receive",
            "time": 1666255728.3219364,
            "opcode": 1,
            "data": "HAPPY world!"
          }
        ]
      }
    ]
  }
}
```

</p>
</details>


Script appends two properties in the entry which gets websocket messages. These are `_webSocketMessages` and `_resourceType`.

**`_resourceType`** is **String** while **`_webSocketMessages`** is **Array**.

_resourceType is set as `websocket`, the Struct of one of `_webSocketMessages` 's items is like:

```JSON
{
    "type": String,// send | receive
    "time": Timestamp,//1666255719.0000001
    "opcode": Int,//1
    "data": String
}
```

For sure, this script would be able to added optional parameter like --websocketdump=true to enable to dump websocket messages in entries.


-   Note: Normally mitmdump file cannot have websocket connections. So I had to load `save.py` script when dumping. To read that dump file I use -nr params.


Thank you.
