### PR TITLE
Make HAR files compatible with Firefox DevTools

### DIFF
--- a/examples/contrib/har_dump.py
+++ b/examples/contrib/har_dump.py
@@ -46,9 +46,16 @@ def configure(updated):
                 "version": "0.1",
                 "comment": "mitmproxy version %s" % version.MITMPROXY
             },
+            "pages": [
+                {
+                    "pageTimings": {}
+                }
+            ],
             "entries": []
         }
     })
+    # The `pages` attribute is needed for Firefox Dev Tools to load the HAR file.
+    # An empty value works fine.
 
 
 def response(flow: mitmproxy.http.HTTPFlow):


### PR DESCRIPTION
Firefox Developer Tools reject to load HAR files that do not have `har.log.pages` element (see
<https://bugzilla.mozilla.org/show_bug.cgi?id=1691240>). Adding a placeholder entry fixes it.

