### PR TITLE
Fixed docstring of console.view.eventlog

### DIFF
--- a/mitmproxy/tools/console/consoleaddons.py
+++ b/mitmproxy/tools/console/consoleaddons.py
@@ -310,7 +310,7 @@ class ConsoleAddon:
 
     @command.command("console.view.eventlog")
     def view_eventlog(self) -> None:
-        """View the options editor."""
+        """View the event log."""
         self.master.switch_view("eventlog")
 
     @command.command("console.view.help")


### PR DESCRIPTION
#### Description

Fixed the incorrect docstring of console.view.eventlog inside `tools/console/consoleaddons.py`. Fixes issue #5671 

#### Checklist

 - [x] Updated docstring