### PR TITLE
Fix missing proxy port when starting a browser.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 
 ### Full Changelog
 
+* Fix missing default port when starting a browser. (@rbdixon)
 * Mitmproxy binaries now ship with Python 3.11.
   ([#5678](https://github.com/mitmproxy/mitmproxy/issues/5678), @mhils)
 * One mitmproxy instance can now spawn multiple proxy servers.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,6 @@
 
 ### Full Changelog
 
-* Fix missing default port when starting a browser. (@rbdixon)
 * Mitmproxy binaries now ship with Python 3.11.
   ([#5678](https://github.com/mitmproxy/mitmproxy/issues/5678), @mhils)
 * One mitmproxy instance can now spawn multiple proxy servers.
@@ -64,6 +63,8 @@
   ([#5405](https://github.com/mitmproxy/mitmproxy/issues/5405), [#5686](https://github.com/mitmproxy/mitmproxy/issues/5686), @mhils)
 * Fix mitmweb crash when using filters.
   ([#5658](https://github.com/mitmproxy/mitmproxy/issues/5658), [#5661](https://github.com/mitmproxy/mitmproxy/issues/5661), @LIU-shuyi, @mhils)
+* Fix missing default port when starting a browser.
+  ([#5687](https://github.com/mitmproxy/mitmproxy/issues/5687), @rbdixon)
 * Add docs for transparent mode on Windows.
   ([#5402](https://github.com/mitmproxy/mitmproxy/issues/5402), @stephenspol)
 

--- a/mitmproxy/addons/browser.py
+++ b/mitmproxy/addons/browser.py
@@ -85,7 +85,7 @@ class Browser:
                     *cmd,
                     "--user-data-dir=%s" % str(tdir.name),
                     "--proxy-server={}:{}".format(
-                        ctx.options.listen_host or "127.0.0.1", ctx.options.listen_port
+                        ctx.options.listen_host or "127.0.0.1", ctx.options.listen_port or "8080"
                     ),
                     "--disable-fre",
                     "--no-default-browser-check",


### PR DESCRIPTION
#### Description

When starting a browser with `browser.start` and the `listen_port` value set to default the proxy is started with `--proxy-server=127.0.0.1:None`. This causes Chrome to ignore the proxy.

#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
