### PR TITLE
Hard exit when mitmproxy cannot write logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased: mitmproxy next
 
+* Hard exit when mitmproxy cannot write logs, fixes endless loop when parent process exits
+  ([#4669](https://github.com/mitmproxy/mitmproxy/issues/4669), @Prinzhorn))
 
 
 ## 28 October 2022: mitmproxy 9.0.0

--- a/mitmproxy/addons/termlog.py
+++ b/mitmproxy/addons/termlog.py
@@ -51,7 +51,9 @@ class TermLogHandler(log.MitmLogHandler):
         self.formatter = log.MitmFormatter(self.has_vt_codes)
 
     def emit(self, record: logging.LogRecord) -> None:
-        print(
-            self.format(record),
-            file=self.file
-        )
+        try:
+            print(self.format(record), file=self.file)
+        except OSError:
+            # We cannot print, exit immediately.
+            # See https://github.com/mitmproxy/mitmproxy/issues/4669
+            sys.exit(1)

--- a/test/mitmproxy/addons/test_termlog.py
+++ b/test/mitmproxy/addons/test_termlog.py
@@ -1,4 +1,5 @@
 import asyncio
+import builtins
 import io
 import logging
 
@@ -55,3 +56,18 @@ async def test_styling(monkeypatch) -> None:
 
     assert "\x1b[33mhello\x1b[0m" in f.getvalue()
     t.done()
+
+
+def test_cannot_print(monkeypatch) -> None:
+    def _raise(*args, **kwargs):
+        raise OSError
+
+    monkeypatch.setattr(builtins, "print", _raise)
+
+    t = termlog.TermLog()
+    with taddons.context(t) as tctx:
+        tctx.configure(t)
+        with pytest.raises(SystemExit) as exc_info:
+            logging.info("Should not log this, but raise instead")
+
+        assert exc_info.value.args[0] == 1

--- a/test/mitmproxy/addons/test_termlog.py
+++ b/test/mitmproxy/addons/test_termlog.py
@@ -58,7 +58,7 @@ async def test_styling(monkeypatch) -> None:
     t.done()
 
 
-def test_cannot_print(monkeypatch) -> None:
+async def test_cannot_print(monkeypatch) -> None:
     def _raise(*args, **kwargs):
         raise OSError
 
@@ -71,3 +71,5 @@ def test_cannot_print(monkeypatch) -> None:
             logging.info("Should not log this, but raise instead")
 
         assert exc_info.value.args[0] == 1
+
+    t.done()


### PR DESCRIPTION
#### Description

Supersedes #5133, fixes #4669

I cannot figure out how to actually trigger the raise in the test (it successfully logs the `info` log), but I verified that the fix itself works.

#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.