### PR TITLE
One of several required fields of the Pages object deleted (pageTimings)

### DIFF
--- a/examples/contrib/har_dump.py
+++ b/examples/contrib/har_dump.py
@@ -48,13 +48,11 @@ def configure(updated):
                     "version": "0.1",
                     "comment": "mitmproxy version %s" % version.MITMPROXY,
                 },
-                "pages": [{"pageTimings": {}}],
+                "pages": [],
                 "entries": [],
             }
         }
     )
-    # The `pages` attribute is needed for Firefox Dev Tools to load the HAR file.
-    # An empty value works fine.
 
 
 def flow_entry(flow: mitmproxy.http.HTTPFlow) -> dict:


### PR DESCRIPTION
The currently used implementation in browsers is HAR version 1.2. The `Pages` object is not required and can be an empty list. According to the documentation below, in case we decide to include other objects in the `Pages` list, they should contain four defined keys: `startedDateTime`, `id`, `title` and `pageTimings`. As it stands, only the `pageTimings` field is defined, which is redundant because it is empty.

Defining only one field can mislead third-party tools (such as `har-to-k6` [https://github.com/grafana/har-to-k6], which incorrectly reads fields for this very reason), because on the one hand we indicate that there is an object inside the `Pages` list, while it is incomplete. We can read in the documentation that:

> In case when an HTTP trace tool isn't able to group requests by a page, the `pages` array is empty.

This means that it is safest to remove the pageTimings field and leave the list empty. In the file, however, there is a comment that reads:

> The `pages` attribute is needed for Firefox Dev Tools to load the HAR file.

I assume it refers to the `pageTimings` key and an error that may have existed in the past with the imported har file. I checked the import to firefox with an empty list and everything works as it should. Tested on: Firefox 108.0 (64 bits).