### PR TITLE
Use latest codecov uploader

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -105,11 +105,9 @@ jobs:
           # run tests with loopback only. We need to sudo for unshare, which means we need an absolute path for tox.
           sudo unshare --net -- sh -c "ip link set lo up; $(which tox) -e py"
         if: matrix.os == 'ubuntu-latest'
-      - uses: codecov/codecov-action@a1ed4b322b4b38cb846afb5a0ebfa17086917d27
-        # mirrored below and at https://github.com/mitmproxy/mitmproxy/settings/actions
+      - uses: mhils/better-codecov-action@main
         with:
-          file: ./coverage.xml
-          name: ${{ matrix.os }}
+          arguments: '--file ./coverage.xml --name ${{ matrix.os }}'
 
   build:
     strategy:
@@ -174,11 +172,9 @@ jobs:
         run: npm ci
       - working-directory: ./web
         run: npm test
-      - uses: codecov/codecov-action@a1ed4b322b4b38cb846afb5a0ebfa17086917d27
-        # mirrored above and at https://github.com/mitmproxy/mitmproxy/settings/actions
+      - uses: mhils/better-codecov-action@main
         with:
-          file: ./web/coverage/coverage-final.json
-          name: web
+          arguments: '--file ./web/coverage/coverage-final.json'
 
   docs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
It looks like codecov finally shut down their v1 API, so we need to update to v3. The official codecov action is unusable for us as it cannot pinned, so I've come up with a custom action that is more sane.