### PR TITLE
Added a command for appending flows to server replay list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * ASGI/WSGI apps can now listen on all ports for a specific hostname. 
   This makes it simpler to accept both HTTP and HTTPS.
   ([#5725](https://github.com/mitmproxy/mitmproxy/pull/5725), @mhils)
-* Add `replay.server.add` command for adding flows to server replay buffer (@italankin)
+* Add `replay.server.add` command for adding flows to server replay buffer
 
 ### Breaking Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   This makes it simpler to accept both HTTP and HTTPS.
   ([#5725](https://github.com/mitmproxy/mitmproxy/pull/5725), @mhils)
 * Add `replay.server.add` command for adding flows to server replay buffer
+  ([#5851](https://github.com/mitmproxy/mitmproxy/pull/5851), @italankin)
 
 ### Breaking Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * ASGI/WSGI apps can now listen on all ports for a specific hostname. 
   This makes it simpler to accept both HTTP and HTTPS.
   ([#5725](https://github.com/mitmproxy/mitmproxy/pull/5725), @mhils)
+* Add `replay.server.add` command for adding flows to server replay buffer (@italankin)
 
 ### Breaking Changes
 

--- a/mitmproxy/addons/serverplayback.py
+++ b/mitmproxy/addons/serverplayback.py
@@ -114,6 +114,13 @@ class ServerPlayback:
         Replay server responses from flows.
         """
         self.flowmap = {}
+        self.add_flows(flows)
+
+    @command.command("replay.server.add")
+    def add_flows(self, flows: Sequence[flow.Flow]) -> None:
+        """
+        Add responses from flows to server replay list.
+        """
         for f in flows:
             if isinstance(f, http.HTTPFlow):
                 lst = self.flowmap.setdefault(self._hash(f), [])

--- a/test/mitmproxy/addons/test_serverplayback.py
+++ b/test/mitmproxy/addons/test_serverplayback.py
@@ -58,6 +58,27 @@ def test_server_playback():
         assert not sp.flowmap
 
 
+def test_add_flows():
+    sp = serverplayback.ServerPlayback()
+    with taddons.context(sp) as tctx:
+        tctx.configure(sp)
+        f1 = tflow.tflow(resp=True)
+        f2 = tflow.tflow(resp=True)
+
+        sp.load_flows([f1])
+        sp.add_flows([f2])
+
+        assert sp.next_flow(f1)
+        assert sp.flowmap
+        assert sp.next_flow(f2)
+        assert not sp.flowmap
+
+        sp.add_flows([f1])
+        assert sp.flowmap
+        assert sp.next_flow(f1)
+        assert not sp.flowmap
+
+
 def test_ignore_host():
     sp = serverplayback.ServerPlayback()
     with taddons.context(sp) as tctx:


### PR DESCRIPTION
#### Description

Added a command `replay.server.add` for appending flows to server replay responses.

I find it easier to use when you need to add new flows for server playback instead of replacing them.

#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
