### PR TITLE
Fix tests after 2037

### DIFF
--- a/test/mitmproxy/net/http/test_cookies.py
+++ b/test/mitmproxy/net/http/test_cookies.py
@@ -170,15 +170,15 @@ def test_parse_set_cookie_header():
             ],
         ],
         [
-            "foo=bar; expires=Mon, 24 Aug 2037",
+            "foo=bar; expires=Mon, 24 Aug 2133",
             [
-                ("foo", "bar", (("expires", "Mon, 24 Aug 2037"),)),
+                ("foo", "bar", (("expires", "Mon, 24 Aug 2133"),)),
             ],
         ],
         [
-            "foo=bar; expires=Mon, 24 Aug 2037 00:00:00 GMT, doo=dar",
+            "foo=bar; expires=Mon, 24 Aug 2133 00:00:00 GMT, doo=dar",
             [
-                ("foo", "bar", (("expires", "Mon, 24 Aug 2037 00:00:00 GMT"),)),
+                ("foo", "bar", (("expires", "Mon, 24 Aug 2133 00:00:00 GMT"),)),
                 ("doo", "dar", ()),
             ],
         ],
@@ -200,13 +200,13 @@ def test_parse_set_cookie_header():
 def test_refresh_cookie():
 
     # Invalid expires format, sent to us by Reddit.
-    c = "rfoo=bar; Domain=reddit.com; expires=Thu, 31 Dec 2037 23:59:59 GMT; Path=/"
+    c = "rfoo=bar; Domain=reddit.com; expires=Thu, 31 Dec 2133 23:59:59 GMT; Path=/"
     assert cookies.refresh_set_cookie_header(c, 60)
 
     c = "MOO=BAR; Expires=Tue, 08-Mar-2011 00:20:38 GMT; Path=foo.com; Secure"
     assert "00:21:38" in cookies.refresh_set_cookie_header(c, 60)
 
-    c = "rfoo=bar; Domain=reddit.com; expires=Thu, 31 Dec 2037; Path=/"
+    c = "rfoo=bar; Domain=reddit.com; expires=Thu, 31 Dec 2133; Path=/"
     assert "expires" not in cookies.refresh_set_cookie_header(c, 60)
 
     c = "foo,bar"
@@ -238,7 +238,7 @@ def test_get_expiration_ts(*args):
     F = cookies.get_expiration_ts
 
     assert F(CA([("Expires", "Thu, 01-Jan-1970 00:00:00 GMT")])) == 0
-    assert F(CA([("Expires", "Mon, 24-Aug-2037 00:00:00 GMT")])) == 2134684800
+    assert F(CA([("Expires", "Mon, 24-Aug-2133 00:00:00 GMT")])) == 5164128000
 
     assert F(CA([("Max-Age", "0")])) == now_ts
     assert F(CA([("Max-Age", "31")])) == now_ts + 31
@@ -259,10 +259,10 @@ def test_is_expired():
         CA([("Expires", "Thu, 01-Jan-1970 00:00:00 GMT"), ("Max-Age", "0")])
     )
 
-    assert not cookies.is_expired(CA([("Expires", "Mon, 24-Aug-2037 00:00:00 GMT")]))
+    assert not cookies.is_expired(CA([("Expires", "Mon, 24-Aug-2133 00:00:00 GMT")]))
     assert not cookies.is_expired(CA([("Max-Age", "1")]))
     assert not cookies.is_expired(
-        CA([("Expires", "Wed, 15-Jul-2037 00:00:00 GMT"), ("Max-Age", "1")])
+        CA([("Expires", "Wed, 15-Jul-2133 00:00:00 GMT"), ("Max-Age", "1")])
     )
 
     assert not cookies.is_expired(CA([("Max-Age", "nan")]))


### PR DESCRIPTION
Background:
As part of my work on reproducible builds for openSUSE, I check that software still gives identical build results in the future.
The usual offset is +16 years, because that is how long I expect some software will be used in some places.
This showed up failing tests in our package build.
See https://reproducible-builds.org/ for why this matters.


#### Description

Make tests pass after 2037

#### Checklist

 - [X] I have updated tests where applicable.
 - [ ] I have added an entry to the CHANGELOG.