### PR TITLE
Adapt contrib/mitmproxywrapper.py to Python 3 strings

### DIFF
--- a/examples/contrib/mitmproxywrapper.py
+++ b/examples/contrib/mitmproxywrapper.py
@@ -20,7 +20,7 @@ class Wrapper:
         self.extra_arguments = extra_arguments
 
     def run_networksetup_command(self, *arguments):
-        return subprocess.check_output(["sudo", "networksetup"] + list(arguments))
+        return subprocess.check_output(["sudo", "networksetup"] + list(arguments)).decode()
 
     def proxy_state_for_service(self, service):
         state = self.run_networksetup_command("-getwebproxy", service).splitlines()
@@ -47,8 +47,8 @@ class Wrapper:
 
     def run_command_with_input(self, command, input):
         popen = subprocess.Popen(command, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
-        (stdout, stderr) = popen.communicate(input)
-        return stdout
+        (stdout, stderr) = popen.communicate(input.encode())
+        return stdout.decode()
 
     def primary_interace_name(self):
         scutil_script = "get State:/Network/Global/IPv4\nd.show\n"


### PR DESCRIPTION
This fixes errors like this one: 

`TypeError: memoryview: a bytes-like object is required, not 'str'`

#### Description

<!-- describe your changes here -->

#### Checklist

 - [ ] I have updated tests where applicable.
 - [ ] I have added an entry to the CHANGELOG.
