### PR TITLE
Add Fedora certificate installation instructions

### DIFF
--- a/docs/src/content/concepts-certificates.md
+++ b/docs/src/content/concepts-certificates.md
@@ -62,6 +62,7 @@ documentation for some common platforms. The mitmproxy CA cert is located in
 - [macOS (automated)](https://www.dssw.co.uk/reference/security.html):
   `sudo security add-trusted-cert -d -p ssl -p basic -k /Library/Keychains/System.keychain ~/.mitmproxy/mitmproxy-ca-cert.pem`
 - [Ubuntu/Debian]( https://askubuntu.com/questions/73287/how-do-i-install-a-root-certificate/94861#94861)
+- [Fedora](https://docs.fedoraproject.org/en-US/quick-docs/using-shared-system-certificates/#proc_adding-new-certificates)
 - [Mozilla Firefox](https://wiki.mozilla.org/MozillaRootCertificate#Mozilla_Firefox)
 - [Chrome on Linux](https://stackoverflow.com/a/15076602/198996)
 - [iOS](http://jasdev.me/intercepting-ios-traffic)  

--- a/mitmproxy/addons/onboardingapp/templates/index.html
+++ b/mitmproxy/addons/onboardingapp/templates/index.html
@@ -50,6 +50,11 @@
         <li><code>mv mitmproxy-ca-cert.pem /usr/local/share/ca-certificates/mitmproxy.crt</code></li>
         <li><code>sudo update-ca-certificates</code></li>
     </ol>
+    <h5>Fedora</h5>
+    <ol>
+        <li><code>mv mitmproxy-ca-cert.pem /etc/pki/ca-trust/source/anchors/</code></li>
+        <li><code>sudo update-ca-trust</code></li>
+    </ol>
     {% endcall %}
     {% call entry('macOS', 'apple') %}
     <h5>Manual Installation</h5>


### PR DESCRIPTION
#### Description

Added instructions to install mitmproxy-ca-cert.pem on fedora.

#### Checklist

 - [x] I have updated tests where applicable.
 - [ ] I have added an entry to the CHANGELOG.
