### PR TITLE
fix: anatomy.py should set basic config log level to info to show logs

### DIFF
--- a/examples/addons/anatomy.py
+++ b/examples/addons/anatomy.py
@@ -4,6 +4,8 @@ Basic skeleton of a mitmproxy addon.
 Run as follows: mitmproxy -s anatomy.py
 """
 import logging
+logging.basicConfig(level=logging.INFO)
+
 
 
 class Counter:

--- a/examples/addons/anatomy.py
+++ b/examples/addons/anatomy.py
@@ -4,8 +4,8 @@ Basic skeleton of a mitmproxy addon.
 Run as follows: mitmproxy -s anatomy.py
 """
 import logging
-logging.basicConfig(level=logging.INFO)
 
+logging.basicConfig(level=logging.INFO)
 
 
 class Counter:


### PR DESCRIPTION
#### Description

Changed the anatomy.py example in order to show the logs when the script is executed.

- Expected behavior: the mitmdump script should show the flow logging output. 
- Current behavior: it does not show the flow output as the default settings is not configured. 
Tested python version:  3.10.8

