### PR TITLE
Removed escaping string to get real raw view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
   ([#5725](https://github.com/mitmproxy/mitmproxy/pull/5725), @mhils)
 * Add `replay.server.add` command for adding flows to server replay buffer
   ([#5851](https://github.com/mitmproxy/mitmproxy/pull/5851), @italankin)
+* Removed string escaping in raw view.
+  ([#5470](https://github.com/mitmproxy/mitmproxy/issues/5470), @stephenspol)
 
 ### Breaking Changes
 

--- a/mitmproxy/contentviews/raw.py
+++ b/mitmproxy/contentviews/raw.py
@@ -1,5 +1,4 @@
 from . import base
-from mitmproxy.utils import strutils
 
 
 class ViewRaw(base.View):

--- a/mitmproxy/contentviews/raw.py
+++ b/mitmproxy/contentviews/raw.py
@@ -6,7 +6,7 @@ class ViewRaw(base.View):
     name = "Raw"
 
     def __call__(self, data, **metadata):
-        return "Raw", base.format_text(strutils.bytes_to_escaped_str(data, True))
+        return "Raw", base.format_text(data)
 
     def render_priority(self, data: bytes, **metadata) -> float:
         return 0.1 * float(bool(data))

--- a/test/mitmproxy/contentviews/test_raw.py
+++ b/test/mitmproxy/contentviews/test_raw.py
@@ -11,7 +11,7 @@ def test_view_raw():
         [[("text", "🫠".encode())]],
     )
     # invalid utf8
-    assert v(b"\xFF".encode()) == (
+    assert v(b"\xFF") == (
         "Raw",
         [[("text", b"\xFF")]],
     )

--- a/test/mitmproxy/contentviews/test_raw.py
+++ b/test/mitmproxy/contentviews/test_raw.py
@@ -5,9 +5,15 @@ from mitmproxy.contentviews import raw
 def test_view_raw():
     v = full_eval(raw.ViewRaw())
     assert v(b"foo")
-    assert v("\\©".encode()) == (
+    # unicode
+    assert v("🫠".encode()) == (
         "Raw",
-        [[("text", "\\©".encode())]],
+        [[("text", "🫠".encode())]],
+    )
+    # invalid utf8
+    assert v(b"\xFF".encode()) == (
+        "Raw",
+        [[("text", b"\xFF")]],
     )
 
 

--- a/test/mitmproxy/contentviews/test_raw.py
+++ b/test/mitmproxy/contentviews/test_raw.py
@@ -5,6 +5,10 @@ from mitmproxy.contentviews import raw
 def test_view_raw():
     v = full_eval(raw.ViewRaw())
     assert v(b"foo")
+    assert v("\\©".encode()) == (
+        "Raw",
+        [[("text", "\\©".encode())]],
+    )
 
 
 def test_render_priority():


### PR DESCRIPTION
#### Description

Removes the extra backslash in raw views to get a true view of raw. Unprintable characters will show up as �.
Fixes #5470.

#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
