### PR TITLE
temporary fix for unhandled AlternativeServiceAvailable event

### DIFF
--- a/mitmproxy/proxy/layers/http/_http2.py
+++ b/mitmproxy/proxy/layers/http/_http2.py
@@ -275,6 +275,8 @@ class Http2Connection(HttpConnection):
             # https://http2.github.io/http2-spec/#rfc.section.4.1
             # Implementations MUST ignore and discard any frame that has a type that is unknown.
             yield Log(f"Ignoring unknown HTTP/2 frame type: {event.frame.type}")
+        elif isinstance(event, h2.events.AlternativeServiceAvailable):
+            yield Log("Temporarily ignoring an Alt-Svc header")
         else:
             raise AssertionError(f"Unexpected event: {event!r}")
         return False

--- a/mitmproxy/proxy/layers/http/_http2.py
+++ b/mitmproxy/proxy/layers/http/_http2.py
@@ -276,7 +276,9 @@ class Http2Connection(HttpConnection):
             # Implementations MUST ignore and discard any frame that has a type that is unknown.
             yield Log(f"Ignoring unknown HTTP/2 frame type: {event.frame.type}")
         elif isinstance(event, h2.events.AlternativeServiceAvailable):
-            yield Log("Received HTTP/2 Alt-Svc frame, which will not be forwarded.", DEBUG)
+            yield Log(
+                "Received HTTP/2 Alt-Svc frame, which will not be forwarded.", DEBUG
+            )
         else:
             raise AssertionError(f"Unexpected event: {event!r}")
         return False

--- a/mitmproxy/proxy/layers/http/_http2.py
+++ b/mitmproxy/proxy/layers/http/_http2.py
@@ -276,7 +276,7 @@ class Http2Connection(HttpConnection):
             # Implementations MUST ignore and discard any frame that has a type that is unknown.
             yield Log(f"Ignoring unknown HTTP/2 frame type: {event.frame.type}")
         elif isinstance(event, h2.events.AlternativeServiceAvailable):
-            yield Log("Temporarily ignoring an Alt-Svc header")
+            yield Log("Received HTTP/2 Alt-Svc frame, which will not be forwarded.", DEBUG)
         else:
             raise AssertionError(f"Unexpected event: {event!r}")
         return False

--- a/test/mitmproxy/proxy/layers/http/test_http2.py
+++ b/test/mitmproxy/proxy/layers/http/test_http2.py
@@ -1,4 +1,5 @@
 import time
+from logging import DEBUG
 
 import h2.settings
 import hpack
@@ -1217,5 +1218,5 @@ def test_alt_svc(tctx):
         >> DataReceived(
             server, cff.build_alt_svc_frame(0, b"example.com", b'h3=":443"').serialize()
         )
-        << Log(Placeholder(str), Placeholder(int))
+        << Log("Received HTTP/2 Alt-Svc frame, which will not be forwarded.", DEBUG)
     )

--- a/test/mitmproxy/proxy/layers/http/test_http2.py
+++ b/test/mitmproxy/proxy/layers/http/test_http2.py
@@ -1201,7 +1201,12 @@ def test_alt_svc(tctx):
 
     assert (
         playbook
-        >> DataReceived(tctx.client, cff.build_headers_frame(example_request_headers, flags=["END_STREAM"]).serialize())
+        >> DataReceived(
+            tctx.client,
+            cff.build_headers_frame(
+                example_request_headers, flags=["END_STREAM"]
+            ).serialize(),
+        )
         << http.HttpRequestHeadersHook(flow)
         >> reply()
         << http.HttpRequestHook(flow)
@@ -1210,8 +1215,7 @@ def test_alt_svc(tctx):
         >> reply(None, side_effect=make_h2)
         << SendData(server, initial)
         >> DataReceived(
-            server,
-            cff.build_alt_svc_frame(0, b"example.com", b"h3=\":443\"").serialize()
+            server, cff.build_alt_svc_frame(0, b"example.com", b'h3=":443"').serialize()
         )
         << Log(Placeholder(str), Placeholder(int))
     )


### PR DESCRIPTION
#### Description

Temporary fix for #5880. `AlternativeServiceAvailable` event will generate a log command. I'm unsure if the test I've written is correct, please suggest changes if it isn't

#### Checklist

 - [x] I have updated tests where applicable.
 - [ ] I have added an entry to the CHANGELOG.
