### PR TITLE
Fix server addr issue in tls_passthrough example.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased: mitmproxy next
 
+* Fix a bug where peername would be None in tls_passthrough script, which would make it not working.
+  ([#5904](https://github.com/mitmproxy/mitmproxy/pull/5904), @truebit)
+
 * Add experimental QUIC support.
   ([#5435](https://github.com/mitmproxy/mitmproxy/issues/5435), @meitinger)
 * ASGI/WSGI apps can now listen on all ports for a specific hostname. 

--- a/examples/contrib/tls_passthrough.py
+++ b/examples/contrib/tls_passthrough.py
@@ -95,22 +95,26 @@ class MaybeTls:
         else:
             self.strategy = ConservativeStrategy()
 
+    @staticmethod
+    def get_addr(server: connection.Server):
+        return server.peername or server.address or server.sockname
+
     def tls_clienthello(self, data: tls.ClientHelloData):
-        server_address = data.context.server.peername
+        server_address = self.get_addr(data.context.server)
         if not self.strategy.should_intercept(server_address):
             logging.info(f"TLS passthrough: {human.format_address(server_address)}.")
             data.ignore_connection = True
             self.strategy.record_skipped(server_address)
 
     def tls_established_client(self, data: tls.TlsData):
-        server_address = data.context.server.peername
+        server_address = self.get_addr(data.context.server)
         logging.info(
             f"TLS handshake successful: {human.format_address(server_address)}"
         )
         self.strategy.record_success(server_address)
 
     def tls_failed_client(self, data: tls.TlsData):
-        server_address = data.context.server.peername
+        server_address = self.get_addr(data.context.server)
         logging.info(f"TLS handshake failed: {human.format_address(server_address)}")
         self.strategy.record_failure(server_address)
 

--- a/examples/contrib/tls_passthrough.py
+++ b/examples/contrib/tls_passthrough.py
@@ -97,7 +97,8 @@ class MaybeTls:
 
     @staticmethod
     def get_addr(server: connection.Server):
-        return server.peername or server.address or server.sockname
+        # .peername may be unset in upstream proxy mode, so we need a fallback.
+        return server.peername or server.address
 
     def tls_clienthello(self, data: tls.ClientHelloData):
         server_address = self.get_addr(data.context.server)


### PR DESCRIPTION
#### Description
when peername returned None, the script would not working. use serveral alternatives for `server_address` variable.

#### Checklist

 - [*] I have updated tests where applicable.
 - [*] I have added an entry to the CHANGELOG.
