### PR TITLE
console: fix bug that caused wrong direction indicators in message stream flow view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased: mitmproxy next
 
+* Fix a bug where the direction indicator in the message stream view would be in the wrong direction.
+  ([#5921](https://github.com/mitmproxy/mitmproxy/issues/5921), @konradh)
 * Fix a bug where peername would be None in tls_passthrough script, which would make it not working.
   ([#5904](https://github.com/mitmproxy/mitmproxy/pull/5904), @truebit)
 

--- a/mitmproxy/tools/console/flowview.py
+++ b/mitmproxy/tools/console/flowview.py
@@ -255,20 +255,16 @@ class FlowDetails(tabs.Tabs):
         viewmode = self.master.commands.call("console.flowview.mode")
 
         widget_lines = []
-
-        from_client = flow.messages[0].from_client
         for m in flow.messages:
             _, lines, _ = contentviews.get_message_content_view(viewmode, m, flow)
 
             for line in lines:
-                if from_client:
+                if m.from_client:
                     line.insert(0, self.FROM_CLIENT_MARKER)
                 else:
                     line.insert(0, self.TO_CLIENT_MARKER)
 
                 widget_lines.append(urwid.Text(line))
-
-            from_client = not from_client
 
         if flow.intercepted:
             markup = widget_lines[-1].get_text()[0]


### PR DESCRIPTION
#### Description

Fixes #5921. In the stream view for TCP and UDP flows in the console, the direction indicators (from client, to client) would always alternate and not represent the actual direction. This PR fixes that bug.

#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.