### PR TITLE
fix: add the architecture determination when running the wireguard test

### DIFF
--- a/test/mitmproxy/proxy/test_mode_servers.py
+++ b/test/mitmproxy/proxy/test_mode_servers.py
@@ -150,6 +150,10 @@ async def test_wireguard(tdata, monkeypatch, caplog):
     else:
         return pytest.skip("Unsupported platform for wg-test-client.")
 
+    arch = platform.machine()
+    if arch != "AMD64" and arch != "x86_64":
+        return pytest.skip("Unsupported architecture for wg-test-client.")
+
     test_client_path = tdata.path(f"wg-test-client/{test_client_name}")
     test_conf = tdata.path(f"wg-test-client/test.conf")
 


### PR DESCRIPTION
#### Description

The wireguard test only check the system but didn't check the architecture.

For example, a non-x86 machine running Linux will fail the test.

Because the binary file is hardcoded in the test, I added the architecture check to skip the wireguard test on non-x86 machine.

#### Checklist

 - [ ] I have updated tests where applicable.
 - [ ] I have added an entry to the CHANGELOG.
