### PR TITLE
Update next layer detection, add option to block HTTP/3.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,12 @@
 
 ## Unreleased: mitmproxy next
 
-* mitmproxy now requires Python 3.10 or above.
-  ([#5954](https://github.com/mitmproxy/mitmproxy/pull/5954), @mhils)
-* Fix a bug where the direction indicator in the message stream view would be in the wrong direction.
-  ([#5921](https://github.com/mitmproxy/mitmproxy/issues/5921), @konradh)
-* Fix a bug where peername would be None in tls_passthrough script, which would make it not working.
-  ([#5904](https://github.com/mitmproxy/mitmproxy/pull/5904), @truebit)
 
-* Add experimental QUIC support.
+* Add experimental support for HTTP/3 and QUIC.
   ([#5435](https://github.com/mitmproxy/mitmproxy/issues/5435), @meitinger)
+* You can now set the `http3` to false to block all QUIC and HTTP/3 traffic
+  in transparent modes.
+  ([#5967](https://github.com/mitmproxy/mitmproxy/pull/5967), @mhils)
 * ASGI/WSGI apps can now listen on all ports for a specific hostname. 
   This makes it simpler to accept both HTTP and HTTPS.
   ([#5725](https://github.com/mitmproxy/mitmproxy/pull/5725), @mhils)
@@ -25,6 +22,12 @@
   ([#5148](https://github.com/mitmproxy/mitmproxy/issues/5148), @mhils)
 * Added documentation on using Magisk module for intercepting traffic in Android production builds.
   ([#5924](https://github.com/mitmproxy/mitmproxy/pull/5924), @Jurrie)
+* Fix a bug where the direction indicator in the message stream view would be in the wrong direction.
+  ([#5921](https://github.com/mitmproxy/mitmproxy/issues/5921), @konradh)
+* Fix a bug where peername would be None in tls_passthrough script, which would make it not working.
+  ([#5904](https://github.com/mitmproxy/mitmproxy/pull/5904), @truebit)
+* mitmproxy now requires Python 3.10 or above.
+  ([#5954](https://github.com/mitmproxy/mitmproxy/pull/5954), @mhils)
 
 ### Breaking Changes
 

--- a/mitmproxy/addons/next_layer.py
+++ b/mitmproxy/addons/next_layer.py
@@ -19,10 +19,10 @@ from __future__ import annotations
 import logging
 import re
 import struct
+import sys
 from collections.abc import Iterable
 from collections.abc import Sequence
 from typing import Any
-from typing import assert_never
 from typing import cast
 
 from mitmproxy import ctx
@@ -40,18 +40,23 @@ from mitmproxy.proxy.layers import ClientQuicLayer
 from mitmproxy.proxy.layers import ClientTLSLayer
 from mitmproxy.proxy.layers import DNSLayer
 from mitmproxy.proxy.layers import HttpLayer
+from mitmproxy.proxy.layers import modes
 from mitmproxy.proxy.layers import RawQuicLayer
 from mitmproxy.proxy.layers import ServerQuicLayer
 from mitmproxy.proxy.layers import ServerTLSLayer
 from mitmproxy.proxy.layers import TCPLayer
 from mitmproxy.proxy.layers import UDPLayer
-from mitmproxy.proxy.layers import modes
 from mitmproxy.proxy.layers.http import HTTPMode
 from mitmproxy.proxy.layers.quic import quic_parse_client_hello
-from mitmproxy.proxy.layers.tls import HTTP_ALPNS
 from mitmproxy.proxy.layers.tls import dtls_parse_client_hello
+from mitmproxy.proxy.layers.tls import HTTP_ALPNS
 from mitmproxy.proxy.layers.tls import parse_client_hello
 from mitmproxy.tls import ClientHello
+
+if sys.version_info < (3, 11):
+    from typing_extensions import assert_never
+else:
+    from typing import assert_never
 
 logger = logging.getLogger(__name__)
 
@@ -273,7 +278,7 @@ class NextLayer:
                         raise NeedsMoreData
                     return ch
                 return None
-            case _:
+            case _:  # pragma: no cover
                 assert_never(context.client.transport_protocol)
 
     def _setup_reverse_proxy(self, context: Context, data_client: bytes) -> Layer:
@@ -331,7 +336,7 @@ class NextLayer:
                 stack /= ClientQuicLayer(context)
                 stack /= RawQuicLayer(context)
 
-            case _:
+            case _:  # pragma: no cover
                 assert_never(spec.scheme)
 
         return stack[0]

--- a/mitmproxy/addons/next_layer.py
+++ b/mitmproxy/addons/next_layer.py
@@ -8,49 +8,56 @@ This addon here peeks at the incoming bytes and then makes a decision based on p
 
 For a typical HTTPS request, this addon is called a couple of times: First to determine that we start with an HTTP layer
 which processes the `CONNECT` request, a second time to determine that the client then starts negotiating TLS, and a
-third time where we check if the protocol within that TLS stream is actually HTTP or something else.
+third time when we check if the protocol within that TLS stream is actually HTTP or something else.
 
 Sometimes it's useful to hardcode specific logic in next_layer when one wants to do fancy things.
 In that case it's not necessary to modify mitmproxy's source, adding a custom addon with a next_layer event hook
 that sets nextlayer.layer works just as well.
 """
+from __future__ import annotations
+
+import logging
 import re
 import struct
-from collections.abc import Callable
 from collections.abc import Iterable
 from collections.abc import Sequence
 from typing import Any
+from typing import assert_never
 from typing import cast
-from typing import Union
 
-from mitmproxy import connection
 from mitmproxy import ctx
 from mitmproxy import dns
 from mitmproxy import exceptions
-from mitmproxy.net.tls import is_tls_record_magic
-from mitmproxy.proxy import context
+from mitmproxy.net.tls import starts_like_dtls_record
+from mitmproxy.net.tls import starts_like_tls_record
 from mitmproxy.proxy import layer
 from mitmproxy.proxy import layers
 from mitmproxy.proxy import mode_specs
+from mitmproxy.proxy import tunnel
+from mitmproxy.proxy.context import Context
+from mitmproxy.proxy.layer import Layer
+from mitmproxy.proxy.layers import ClientQuicLayer
+from mitmproxy.proxy.layers import ClientTLSLayer
+from mitmproxy.proxy.layers import DNSLayer
+from mitmproxy.proxy.layers import HttpLayer
+from mitmproxy.proxy.layers import RawQuicLayer
+from mitmproxy.proxy.layers import ServerQuicLayer
+from mitmproxy.proxy.layers import ServerTLSLayer
+from mitmproxy.proxy.layers import TCPLayer
+from mitmproxy.proxy.layers import UDPLayer
 from mitmproxy.proxy.layers import modes
 from mitmproxy.proxy.layers.http import HTTPMode
 from mitmproxy.proxy.layers.quic import quic_parse_client_hello
-from mitmproxy.proxy.layers.tls import dtls_parse_client_hello
 from mitmproxy.proxy.layers.tls import HTTP_ALPNS
+from mitmproxy.proxy.layers.tls import dtls_parse_client_hello
 from mitmproxy.proxy.layers.tls import parse_client_hello
 from mitmproxy.tls import ClientHello
 
-LayerCls = type[layer.Layer]
-ClientSecurityLayerCls = Union[
-    type[layers.ClientTLSLayer], type[layers.ClientQuicLayer]
-]
-ServerSecurityLayerCls = Union[
-    type[layers.ServerTLSLayer], type[layers.ServerQuicLayer]
-]
+logger = logging.getLogger(__name__)
 
 
 def stack_match(
-    context: context.Context, layers: Sequence[LayerCls | tuple[LayerCls, ...]]
+    context: Context, layers: Sequence[type[Layer] | tuple[type[Layer], ...]]
 ) -> bool:
     if len(context.layers) != len(layers):
         return False
@@ -60,11 +67,15 @@ def stack_match(
     )
 
 
+class NeedsMoreData(Exception):
+    """Signal that the decision on which layer to put next needs to be deferred within the NextLayer addon."""
+
+
 class NextLayer:
-    ignore_hosts: Iterable[re.Pattern] = ()
-    allow_hosts: Iterable[re.Pattern] = ()
-    tcp_hosts: Iterable[re.Pattern] = ()
-    udp_hosts: Iterable[re.Pattern] = ()
+    ignore_hosts: Sequence[re.Pattern] = ()
+    allow_hosts: Sequence[re.Pattern] = ()
+    tcp_hosts: Sequence[re.Pattern] = ()
+    udp_hosts: Sequence[re.Pattern] = ()
 
     def configure(self, updated):
         if "tcp_hosts" in updated:
@@ -87,37 +98,123 @@ class NextLayer:
                 re.compile(x, re.IGNORECASE) for x in ctx.options.allow_hosts
             ]
 
-    def ignore_connection(
+    def next_layer(self, nextlayer: layer.NextLayer):
+        if nextlayer.layer:
+            return  # do not override something another addon has set.
+        try:
+            nextlayer.layer = self._next_layer(
+                nextlayer.context,
+                nextlayer.data_client(),
+                nextlayer.data_server(),
+            )
+        except NeedsMoreData:
+            logger.info(
+                f"Deferring layer decision, not enough data: {nextlayer.data_client().hex()}"
+            )
+
+    def _next_layer(
+        self, context: Context, data_client: bytes, data_server: bytes
+    ) -> Layer | None:
+        assert context.layers
+
+        def s(*layers):
+            return stack_match(context, layers)
+
+        tcp_based = context.client.transport_protocol == "tcp"
+        udp_based = context.client.transport_protocol == "udp"
+
+        # 1)  check for --ignore/--allow
+        if self._ignore_connection(context, data_client):
+            return (
+                layers.TCPLayer(context, ignore=True)
+                if tcp_based
+                else layers.UDPLayer(context, ignore=True)
+            )
+
+        # 2)  Handle proxy modes with well-defined next protocol
+        # 2a) Reverse proxy: derive from spec
+        if s(modes.ReverseProxy):
+            return self._setup_reverse_proxy(context, data_client)
+        # 2b) Explicit HTTP proxies
+        if s((modes.HttpProxy, modes.HttpUpstreamProxy)):
+            return self._setup_explicit_http_proxy(context, data_client)
+
+        # 3)  Handle security protocols
+        # 3a) TLS/DTLS
+        is_tls_or_dtls = (
+            tcp_based
+            and starts_like_tls_record(data_client)
+            or udp_based
+            and starts_like_dtls_record(data_client)
+        )
+        if is_tls_or_dtls:
+            server_tls = ServerTLSLayer(context)
+            server_tls.child_layer = ClientTLSLayer(context)
+            return server_tls
+        # 3b) QUIC
+        if udp_based and _starts_like_quic(data_client):
+            server_quic = ServerQuicLayer(context)
+            server_quic.child_layer = ClientQuicLayer(context)
+            return server_quic
+
+        # 4)  Check for --tcp/--udp
+        if tcp_based and self._is_destination_in_hosts(context, self.tcp_hosts):
+            return layers.TCPLayer(context)
+        if udp_based and self._is_destination_in_hosts(context, self.udp_hosts):
+            return layers.UDPLayer(context)
+
+        # 5)  Handle application protocol
+        # 5a) Is it DNS?
+        if udp_based:
+            try:
+                # TODO: DNS over TCP
+                dns.Message.unpack(data_client)  # TODO: perf
+            except struct.error:
+                pass
+            else:
+                return layers.DNSLayer(context)
+        # 5b) We have no other specialized layers for UDP, so we fall back to raw forwarding.
+        if udp_based:
+            return layers.UDPLayer(context)
+        # 5b) Check for raw tcp mode.
+        very_likely_http = context.client.alpn and context.client.alpn in HTTP_ALPNS
+        probably_no_http = not very_likely_http and (
+            # the first three bytes should be the HTTP verb, so A-Za-z is expected.
+            len(data_client) < 3
+            or not data_client[:3].isalpha()
+            # a server greeting would be uncharacteristic.
+            or data_server
+        )
+        if ctx.options.rawtcp and probably_no_http:
+            return layers.TCPLayer(context)
+        # 5c) Assume HTTP by default.
+        return layers.HttpLayer(context, HTTPMode.transparent)
+
+    def _ignore_connection(
         self,
-        server_address: connection.Address | None,
+        context: Context,
         data_client: bytes,
-        *,
-        is_tls: Callable[[bytes], bool] = is_tls_record_magic,
-        client_hello: Callable[[bytes], ClientHello | None] = parse_client_hello,
     ) -> bool | None:
         """
         Returns:
             True, if the connection should be ignored.
             False, if it should not be ignored.
-            None, if we need to wait for more input data.
+
+        Raises:
+            NeedsMoreData, if we need to wait for more input data.
         """
         if not ctx.options.ignore_hosts and not ctx.options.allow_hosts:
             return False
 
         hostnames: list[str] = []
-        if server_address is not None:
-            hostnames.append(server_address[0])
-        if is_tls(data_client):
-            try:
-                ch = client_hello(data_client)
-                if ch is None:  # not complete yet
-                    return None
-                sni = ch.sni
-            except ValueError:
-                pass
-            else:
-                if sni:
-                    hostnames.append(sni)
+        if context.server.peername and (peername := context.server.peername[0]):
+            hostnames.append(peername)
+        if context.server.address and (server_address := context.server.address[0]):
+            hostnames.append(server_address)
+        if (
+            client_hello := self._get_client_hello(context, data_client)
+        ) and client_hello.sni:
+            hostnames.append(client_hello.sni)
 
         if not hostnames:
             return False
@@ -137,35 +234,122 @@ class NextLayer:
         else:  # pragma: no cover
             raise AssertionError()
 
-    def setup_tls_layer(
-        self,
-        context: context.Context,
-        client_layer_cls: ClientSecurityLayerCls = layers.ClientTLSLayer,
-        server_layer_cls: ServerSecurityLayerCls = layers.ServerTLSLayer,
-    ) -> layer.Layer:
-        def s(*layers):
-            return stack_match(context, layers)
+    def _get_client_hello(
+        self, context: Context, data_client: bytes
+    ) -> ClientHello | None:
+        """
+        Try to read a TLS/DTLS/QUIC ClientHello from data_client.
 
-        # client tls usually requires a server tls layer as parent layer, except:
-        #  - a secure web proxy doesn't have a server part.
-        #  - an upstream proxy uses the mode spec
-        #  - reverse proxy mode manages this itself.
-        if (
-            s(modes.HttpProxy)
-            or s(modes.HttpUpstreamProxy)
-            or s(modes.ReverseProxy)
-            or s(modes.ReverseProxy, server_layer_cls)
-        ):
-            return client_layer_cls(context)
-        else:
-            # We already assign the next layer here so that the server layer
-            # knows that it can safely wait for a ClientHello.
-            ret = server_layer_cls(context)
-            ret.child_layer = client_layer_cls(context)
-            return ret
+        Returns:
+            A complete ClientHello, or None, if no ClientHello was found.
 
-    def is_destination_in_hosts(
-        self, context: context.Context, hosts: Iterable[re.Pattern]
+        Raises:
+            NeedsMoreData, if the ClientHello is incomplete.
+        """
+        match context.client.transport_protocol:
+            case "tcp":
+                if starts_like_tls_record(data_client):
+                    try:
+                        ch = parse_client_hello(data_client)
+                    except ValueError:
+                        pass
+                    else:
+                        if ch is None:
+                            raise NeedsMoreData
+                        return ch
+                return None
+            case "udp":
+                try:
+                    return quic_parse_client_hello(data_client)
+                except ValueError:
+                    pass
+
+                try:
+                    ch = dtls_parse_client_hello(data_client)
+                except ValueError:
+                    pass
+                else:
+                    if ch is None:
+                        raise NeedsMoreData
+                    return ch
+                return None
+            case _:
+                assert_never(context.client.transport_protocol)
+
+    def _setup_reverse_proxy(self, context: Context, data_client: bytes) -> Layer:
+        spec = cast(mode_specs.ReverseMode, context.client.proxy_mode)
+        stack = tunnel.LayerStack()
+
+        match spec.scheme:
+            case "http":
+                if starts_like_tls_record(data_client):
+                    stack /= ClientTLSLayer(context)
+                stack /= HttpLayer(context, HTTPMode.transparent)
+            case "https":
+                stack /= ServerTLSLayer(context)
+                if starts_like_tls_record(data_client):
+                    stack /= ClientTLSLayer(context)
+                stack /= HttpLayer(context, HTTPMode.transparent)
+
+            case "tcp":
+                if starts_like_tls_record(data_client):
+                    stack /= ClientTLSLayer(context)
+                stack /= TCPLayer(context)
+            case "tls":
+                stack /= ServerTLSLayer(context)
+                if starts_like_tls_record(data_client):
+                    stack /= ClientTLSLayer(context)
+                stack /= TCPLayer(context)
+
+            case "udp":
+                if starts_like_dtls_record(data_client):
+                    stack /= ClientTLSLayer(context)
+                stack /= UDPLayer(context)
+            case "dtls":
+                stack /= ServerTLSLayer(context)
+                if starts_like_dtls_record(data_client):
+                    stack /= ClientTLSLayer(context)
+                stack /= UDPLayer(context)
+
+            case "dns":
+                # TODO: DNS-over-TLS / DNS-over-DTLS
+                # is_tls_or_dtls = (
+                #     context.client.transport_protocol == "tcp" and starts_like_tls_record(data_client)
+                #     or
+                #     context.client.transport_protocol == "udp" and starts_like_dtls_record(data_client)
+                # )
+                # if is_tls_or_dtls:
+                #     stack /= ClientTLSLayer(context)
+                stack /= DNSLayer(context)
+
+            case "http3":
+                stack /= ServerQuicLayer(context)
+                stack /= ClientQuicLayer(context)
+                stack /= HttpLayer(context, HTTPMode.transparent)
+            case "quic":
+                stack /= ServerQuicLayer(context)
+                stack /= ClientQuicLayer(context)
+                stack /= RawQuicLayer(context)
+
+            case _:
+                assert_never(spec.scheme)
+
+        return stack[0]
+
+    def _setup_explicit_http_proxy(self, context: Context, data_client: bytes) -> Layer:
+        stack = tunnel.LayerStack()
+
+        if context.client.transport_protocol == "udp":
+            stack /= layers.ClientQuicLayer(context)
+        elif starts_like_tls_record(data_client):
+            stack /= layers.ClientTLSLayer(context)
+
+        stack /= layers.HttpLayer(context, HTTPMode.regular)
+
+        return stack[0]
+
+    def _is_destination_in_hosts(
+        self, context: Context, hosts: Iterable[re.Pattern]
     ) -> bool:
         return any(
             (context.server.address and rex.search(context.server.address[0]))
@@ -173,192 +357,13 @@ class NextLayer:
             for rex in hosts
         )
 
-    def get_http_layer(self, context: context.Context) -> layers.HttpLayer | None:
-        def s(*layers):
-            return stack_match(context, layers)
 
-        # Setup the HTTP layer for a regular HTTP proxy ...
-        if (
-            s(modes.HttpProxy)
-            or
-            # or a "Secure Web Proxy", see https://www.chromium.org/developers/design-documents/secure-web-proxy
-            s(modes.HttpProxy, (layers.ClientTLSLayer, layers.ClientQuicLayer))
-        ):
-            return layers.HttpLayer(context, HTTPMode.regular)
-        # ... or an upstream proxy.
-        if s(modes.HttpUpstreamProxy) or s(
-            modes.HttpUpstreamProxy, (layers.ClientTLSLayer, layers.ClientQuicLayer)
-        ):
-            return layers.HttpLayer(context, HTTPMode.upstream)
-        return None
-
-    def detect_udp_tls(
-        self, data_client: bytes
-    ) -> tuple[ClientHello, ClientSecurityLayerCls, ServerSecurityLayerCls] | None:
-        if len(data_client) == 0:
-            return None
-
-        # first try DTLS (the parser may return None)
-        try:
-            client_hello = dtls_parse_client_hello(data_client)
-            if client_hello is not None:
-                return (client_hello, layers.ClientTLSLayer, layers.ServerTLSLayer)
-        except ValueError:
-            pass
-
-        # next try QUIC
-        try:
-            client_hello = quic_parse_client_hello(data_client)
-            return (client_hello, layers.ClientQuicLayer, layers.ServerQuicLayer)
-        except (ValueError, TypeError):
-            pass
-
-        # that's all we currently have to offer
-        return None
-
-    def raw_udp_layer(
-        self, context: context.Context, ignore: bool = False
-    ) -> layer.Layer:
-        def s(*layers):
-            return stack_match(context, layers)
-
-        # for regular and upstream HTTP3, if we already created a client QUIC layer
-        # we need a server and raw QUIC layer as well
-        if s(modes.HttpProxy, layers.ClientQuicLayer) or s(
-            modes.HttpUpstreamProxy, layers.ClientQuicLayer
-        ):
-            server_layer = layers.ServerQuicLayer(context)
-            server_layer.child_layer = layers.RawQuicLayer(context, ignore=ignore)
-            return server_layer
-
-        # for reverse HTTP3 and QUIC, we need a client and raw QUIC layer
-        elif s(modes.ReverseProxy, layers.ServerQuicLayer):
-            client_layer = layers.ClientQuicLayer(context)
-            client_layer.child_layer = layers.RawQuicLayer(context, ignore=ignore)
-            return client_layer
-
-        # in other cases we assume `setup_tls_layer` happened, so if the
-        # top layer is `ClientQuicLayer` we return a raw QUIC layer...
-        elif isinstance(context.layers[-1], layers.ClientQuicLayer):
-            return layers.RawQuicLayer(context, ignore=ignore)
-
-        # ... otherwise an UDP layer
-        else:
-            return layers.UDPLayer(context, ignore=ignore)
-
-    def next_layer(self, nextlayer: layer.NextLayer):
-        if nextlayer.layer is None:
-            nextlayer.layer = self._next_layer(
-                nextlayer.context,
-                nextlayer.data_client(),
-                nextlayer.data_server(),
-            )
-
-    def _next_layer(
-        self, context: context.Context, data_client: bytes, data_server: bytes
-    ) -> layer.Layer | None:
-        assert context.layers
-
-        if context.client.transport_protocol == "tcp":
-            is_quic_stream = isinstance(context.layers[-1], layers.QuicStreamLayer)
-            if len(data_client) < 3 and not data_server and not is_quic_stream:
-                return None  # not enough data yet to make a decision
-
-            # 1. check for --ignore/--allow
-            ignore = self.ignore_connection(context.server.address, data_client)
-            if ignore is True:
-                return layers.TCPLayer(context, ignore=True)
-            if ignore is None and not is_quic_stream:
-                return None
-
-            # 2. Check for TLS
-            if is_tls_record_magic(data_client):
-                return self.setup_tls_layer(context)
-
-            # 3. Check for HTTP
-            if http_layer := self.get_http_layer(context):
-                return http_layer
-
-            # 4. Check for --tcp
-            if self.is_destination_in_hosts(context, self.tcp_hosts):
-                return layers.TCPLayer(context)
-
-            # 5. Check for raw tcp mode.
-            very_likely_http = context.client.alpn and context.client.alpn in HTTP_ALPNS
-            probably_no_http = not very_likely_http and (
-                not data_client[
-                    :3
-                ].isalpha()  # the first three bytes should be the HTTP verb, so A-Za-z is expected.
-                or data_server  # a server greeting would be uncharacteristic.
-            )
-            if ctx.options.rawtcp and probably_no_http:
-                return layers.TCPLayer(context)
-
-            # 6. Assume HTTP by default.
-            return layers.HttpLayer(context, HTTPMode.transparent)
-
-        elif context.client.transport_protocol == "udp":
-            # unlike TCP, we make a decision immediately
-            tls = self.detect_udp_tls(data_client)
-
-            # 1. check for --ignore/--allow
-            if self.ignore_connection(
-                context.server.address,
-                data_client,
-                is_tls=lambda _: tls is not None,
-                client_hello=lambda _: None if tls is None else tls[0],
-            ):
-                return self.raw_udp_layer(context, ignore=True)
-
-            # 2. Check for DTLS/QUIC
-            if tls is not None:
-                _, client_layer_cls, server_layer_cls = tls
-                return self.setup_tls_layer(context, client_layer_cls, server_layer_cls)
-
-            # 3. Check for HTTP
-            if http_layer := self.get_http_layer(context):
-                return http_layer
-
-            # 4. Check for --udp
-            if self.is_destination_in_hosts(context, self.udp_hosts):
-                return self.raw_udp_layer(context)
-
-            # 5. Check for reverse modes
-            if isinstance(context.layers[0], modes.ReverseProxy):
-                scheme = cast(mode_specs.ReverseMode, context.client.proxy_mode).scheme
-                if scheme in ("udp", "dtls"):
-                    return layers.UDPLayer(context)
-                elif scheme == "http3":
-                    if isinstance(context.layers[-1], layers.ClientQuicLayer):
-                        return layers.HttpLayer(context, HTTPMode.transparent)
-                    else:
-                        return layers.ClientQuicLayer(context)
-                elif scheme == "quic":
-                    if isinstance(context.layers[-1], layers.ClientQuicLayer):
-                        # the client supports QUIC, use raw layer
-                        return layers.RawQuicLayer(context)
-                    elif data_client:
-                        # we have received data, which was not a handshake, use UDP
-                        # on the client, and send datagrams over QUIC to the server
-                        return layers.UDPLayer(context)
-                    else:
-                        # wait for client data to make a decision
-                        return None
-                elif scheme == "dns":
-                    return layers.DNSLayer(context)
-                else:
-                    raise AssertionError(scheme)
-
-            # 6. Check for DNS
-            try:
-                dns.Message.unpack(data_client)
-            except struct.error:
-                pass
-            else:
-                return layers.DNSLayer(context)
-
-            # 7. Use raw mode.
-            return self.raw_udp_layer(context)
-
-        else:
-            raise AssertionError(context.client.transport_protocol)
+def _starts_like_quic(data_client: bytes) -> bool:
+    # FIXME: handle clienthellos distributed over multiple packets?
+    # FIXME: perf
+    try:
+        quic_parse_client_hello(data_client)
+    except ValueError:
+        return False
+    else:
+        return True

--- a/mitmproxy/connection.py
+++ b/mitmproxy/connection.py
@@ -1,5 +1,4 @@
 import dataclasses
-import sys
 import time
 import uuid
 import warnings
@@ -259,10 +258,6 @@ class Server(Connection):
 
     address: Address | None  # type: ignore
     """The server's `(host, port)` address tuple. The host can either be a domain or a plain IP address."""
-
-    if sys.version_info < (3, 10):  # pragma: no cover
-        # no keyword-only arguments here.
-        address: Address | None = None
 
     peername: Address | None = None
     """

--- a/mitmproxy/net/tls.py
+++ b/mitmproxy/net/tls.py
@@ -233,15 +233,8 @@ def starts_like_tls_record(d: bytes) -> bool:
     # TLS ClientHello magic, works for SSLv3, TLSv1.0, TLSv1.1, TLSv1.2, and TLSv1.3
     # http://www.moserware.com/2009/06/first-few-milliseconds-of-https.html#client-hello
     # https://tls13.ulfheim.net/
-    match len(d):
-        case 0:
-            return True
-        case 1:
-            return d[0] == 0x16
-        case 2:
-            return d[0] == 0x16 and d[1] == 0x03
-        case _:
-            return d[0] == 0x16 and d[1] == 0x03 and 0x00 <= d[2] <= 0x03
+    # We assume that a client sending less than 3 bytes initially is not a TLS client.
+    return len(d) > 2 and d[0] == 0x16 and d[1] == 0x03 and 0x00 <= d[2] <= 0x03
 
 
 def starts_like_dtls_record(d: bytes) -> bool:
@@ -254,12 +247,5 @@ def starts_like_dtls_record(d: bytes) -> bool:
     # https://www.rfc-editor.org/rfc/rfc4347#section-4.1
     # https://www.rfc-editor.org/rfc/rfc6347#section-4.1
     # https://www.rfc-editor.org/rfc/rfc9147#section-4-6.2
-    match len(d):
-        case 0:
-            return True
-        case 1:
-            return d[0] == 0x16
-        case 2:
-            return d[0] == 0x16 and d[1] == 0xfe
-        case _:
-            return d[0] == 0x16 and d[1] == 0xfe and 0xfd <= d[2] <= 0xfe
+    # We assume that a client sending less than 3 bytes initially is not a DTLS client.
+    return len(d) > 2 and d[0] == 0x16 and d[1] == 0xFE and 0xFD <= d[2] <= 0xFE

--- a/mitmproxy/options.py
+++ b/mitmproxy/options.py
@@ -144,6 +144,12 @@ class Options(optmanager.OptManager):
             """,
         )
         self.add_option(
+            "http3",
+            bool,
+            True,
+            "Enable/disable support for QUIC and HTTP/3. Enabled by default.",
+        )
+        self.add_option(
             "websocket",
             bool,
             True,

--- a/mitmproxy/options.py
+++ b/mitmproxy/options.py
@@ -131,7 +131,7 @@ class Options(optmanager.OptManager):
             "http2",
             bool,
             True,
-            "Enable/disable HTTP/2 support. " "HTTP/2 support is enabled by default.",
+            "Enable/disable HTTP/2 support. HTTP/2 support is enabled by default.",
         )
         self.add_option(
             "http2_ping_keepalive",

--- a/mitmproxy/proxy/layers/modes.py
+++ b/mitmproxy/proxy/layers/modes.py
@@ -2,23 +2,23 @@ from __future__ import annotations
 
 import socket
 import struct
+import sys
 from abc import ABCMeta
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import assert_never
 
 from mitmproxy import connection
 from mitmproxy.proxy import commands
 from mitmproxy.proxy import events
 from mitmproxy.proxy import layer
-from mitmproxy.proxy import tunnel
 from mitmproxy.proxy.commands import StartHook
-from mitmproxy.proxy.layers import dns
-from mitmproxy.proxy.layers import quic
-from mitmproxy.proxy.layers import tls
-from mitmproxy.proxy.layers import http
 from mitmproxy.proxy.mode_specs import ReverseMode
 from mitmproxy.proxy.utils import expect
+
+if sys.version_info < (3, 11):
+    from typing_extensions import assert_never
+else:
+    from typing import assert_never
 
 
 class HttpProxy(layer.Layer):
@@ -78,7 +78,7 @@ class ReverseProxy(DestinationKnown):
                     self.context.server.sni = spec.address[0]
             case "tcp" | "http" | "udp" | "dns":
                 pass
-            case _:
+            case _:  # pragma: no cover
                 assert_never(spec.scheme)
 
         err = yield from self.finish_start()

--- a/mitmproxy/proxy/layers/tls.py
+++ b/mitmproxy/proxy/layers/tls.py
@@ -11,6 +11,8 @@ from OpenSSL import SSL
 
 from mitmproxy import certs
 from mitmproxy import connection
+from mitmproxy.net.tls import starts_like_dtls_record
+from mitmproxy.net.tls import starts_like_tls_record
 from mitmproxy.proxy import commands
 from mitmproxy.proxy import context
 from mitmproxy.proxy import events

--- a/mitmproxy/proxy/layers/tls.py
+++ b/mitmproxy/proxy/layers/tls.py
@@ -11,15 +11,12 @@ from OpenSSL import SSL
 
 from mitmproxy import certs
 from mitmproxy import connection
-from mitmproxy.net.tls import starts_like_dtls_record
-from mitmproxy.net.tls import starts_like_tls_record
 from mitmproxy.proxy import commands
 from mitmproxy.proxy import context
 from mitmproxy.proxy import events
 from mitmproxy.proxy import layer
 from mitmproxy.proxy import tunnel
 from mitmproxy.proxy.commands import StartHook
-from mitmproxy.proxy.layer import CommandGenerator
 from mitmproxy.proxy.layers import tcp
 from mitmproxy.proxy.layers import udp
 from mitmproxy.tls import ClientHello
@@ -529,7 +526,7 @@ class ClientTLSLayer(TLSLayer):
             context.client.cipher_list = []
 
         super().__init__(context, context.client)
-        self.server_tls_available = len(self.context.layers) > 1 and isinstance(self.context.layers[-2], ServerTLSLayer)
+        self.server_tls_available = isinstance(self.context.layers[-2], ServerTLSLayer)
         self.recv_buffer = bytearray()
 
     def start_handshake(self) -> layer.CommandGenerator[None]:
@@ -655,64 +652,6 @@ class ClientTLSLayer(TLSLayer):
             yield commands.Log(
                 f"{self.debug}[tls] Swallowing {event} as handshake failed.", DEBUG
             )
-
-
-class MaybeClientTLSLayer(ClientTLSLayer):
-    """
-    This layer is used in places where the client connection may optionally be wrapped in TLS.
-    For example, when mitmproxy is running as a reverse proxy to https://example.com, a client may
-    issue a plaintext request to mitmproxy, or may already use TLS for the client <-> proxy connection as well.
-    Of course, in both cases the proxy <-> server connection would be HTTPS.
-    """
-    def receive_handshake_data(
-        self, data: bytes
-    ) -> layer.CommandGenerator[tuple[bool, str | None]]:
-        received = bytes(self.recv_buffer + data)
-        if len(received) < 3:
-            self.recv_buffer.extend(data)
-            return False, None
-
-        is_tls = (
-            starts_like_dtls_record(received)
-            if self.is_dtls else
-            starts_like_tls_record(received)
-        )
-        if is_tls:
-            self.receive_handshake_data = super().receive_handshake_data
-            self.on_handshake_error = super().on_handshake_error
-            self._handshake_finished = super()._handshake_finished
-            self.event_to_child = super().event_to_child
-            return (yield from super().receive_handshake_data(data))
-        else:
-            self._event_queue.append(events.DataReceived(self.context.client, received))
-            return True, None
-
-    def on_handshake_error(self, err: str) -> layer.CommandGenerator[None]:
-        yield commands.CloseConnection(self.tunnel_connection)
-
-    def _handshake_finished(self, err: str | None) -> layer.CommandGenerator[None]:
-        # only invoked for non-TLS connections.
-        # We're not doing TLS, so we assign fake connection objects for the tunnel.
-        self.conn = self.tunnel_connection = connection.Client(
-            peername=("ignore-conn", 0), sockname=("ignore-conn", 0)
-        )
-        self.tunnel_state = tunnel.TunnelState.INACTIVE
-
-        assert not self.command_to_reply_to
-        for evt in self._event_queue:
-            yield from self.event_to_child(evt)
-        self._event_queue.clear()
-
-    def event_to_child(self, event: events.Event) -> CommandGenerator[None]:
-        received_server_data_while_waiting_for_client_hello = (
-           self.tunnel_state is tunnel.TunnelState.ESTABLISHING
-           and isinstance(event, events.DataReceived)
-           and event.connection != self.conn
-        )
-        if received_server_data_while_waiting_for_client_hello:
-            yield from self._handshake_finished(None)
-
-        yield from super().event_to_child(event)
 
 
 class MockTLSLayer(TLSLayer):

--- a/mitmproxy/proxy/layers/tls.py
+++ b/mitmproxy/proxy/layers/tls.py
@@ -25,18 +25,6 @@ from mitmproxy.tls import TlsData
 from mitmproxy.utils import human
 
 
-def is_tls_handshake_record(d: bytes) -> bool:
-    """
-    Returns:
-        True, if the passed bytes start with the TLS record magic bytes
-        False, otherwise.
-    """
-    # TLS ClientHello magic, works for SSLv3, TLSv1.0, TLSv1.1, TLSv1.2.
-    # TLS 1.3 mandates legacy_record_version to be 0x0301.
-    # http://www.moserware.com/2009/06/first-few-milliseconds-of-https.html#client-hello
-    return len(d) >= 3 and d[0] == 0x16 and d[1] == 0x03 and 0x0 <= d[2] <= 0x03
-
-
 def handshake_record_contents(data: bytes) -> Iterator[bytes]:
     """
     Returns a generator that yields the bytes contained in each handshake record.
@@ -48,7 +36,7 @@ def handshake_record_contents(data: bytes) -> Iterator[bytes]:
         if len(data) < offset + 5:
             return
         record_header = data[offset : offset + 5]
-        if not is_tls_handshake_record(record_header):
+        if not starts_like_tls_record(record_header):
             raise ValueError(f"Expected TLS record, got {record_header!r} instead.")
         record_size = struct.unpack("!H", record_header[3:])[0]
         if record_size == 0:
@@ -99,15 +87,6 @@ def parse_client_hello(data: bytes) -> ClientHello | None:
     return None
 
 
-def is_dtls_handshake_record(d: bytes) -> bool:
-    """
-    Returns:
-        True, if the passed bytes start with the DTLS record magic bytes
-        False, otherwise.
-    """
-    return len(d) >= 3 and d[0] == 0x16 and d[1] == 0xFE and d[2] == 0xFD
-
-
 def dtls_handshake_record_contents(data: bytes) -> Iterator[bytes]:
     """
     Returns a generator that yields the bytes contained in each handshake record.
@@ -120,7 +99,7 @@ def dtls_handshake_record_contents(data: bytes) -> Iterator[bytes]:
         if len(data) < offset + 13:
             return
         record_header = data[offset : offset + 13]
-        if not is_dtls_handshake_record(record_header):
+        if not starts_like_dtls_record(record_header):
             raise ValueError(f"Expected DTLS record, got {record_header!r} instead.")
         # Length fields starts at 11
         record_size = struct.unpack("!H", record_header[11:])[0]

--- a/mitmproxy/proxy/tunnel.py
+++ b/mitmproxy/proxy/tunnel.py
@@ -97,7 +97,7 @@ class TunnelLayer(layer.Layer):
         else:
             yield from self.event_to_child(event)
 
-    def _handshake_finished(self, err: str | None):
+    def _handshake_finished(self, err: str | None) -> layer.CommandGenerator[None]:
         if err:
             self.tunnel_state = TunnelState.CLOSED
         else:

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,7 @@ exclude_lines =
     if TYPE_CHECKING:
     @overload
     @abstractmethod
+    assert_never
     \.\.\.
 
 [mypy]

--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,7 @@ setup(
         "wsproto>=1.0,<1.3",
         "publicsuffix2>=2.20190812,<3",
         "zstandard>=0.11,<0.21",
-        "typing-extensions>=4.3,<4.5; python_version<'3.10'",
+        "typing-extensions>=4.3,<4.6; python_version<'3.11'",
     ],
     extras_require={
         ':sys_platform == "win32"': [

--- a/test/mitmproxy/addons/test_next_layer.py
+++ b/test/mitmproxy/addons/test_next_layer.py
@@ -1,28 +1,35 @@
+from __future__ import annotations
+
+import dataclasses
+import logging
+from dataclasses import dataclass
+from functools import partial
+from typing import Sequence
 from unittest.mock import MagicMock
 
 import pytest
 
-from mitmproxy import connection
+from mitmproxy.addons.next_layer import NeedsMoreData
 from mitmproxy.addons.next_layer import NextLayer
-from mitmproxy.proxy import context
-from mitmproxy.proxy import layer
-from mitmproxy.proxy import layers
+from mitmproxy.addons.next_layer import stack_match
+from mitmproxy.connection import Client
+from mitmproxy.connection import TransportProtocol
+from mitmproxy.proxy.context import Context
+from mitmproxy.proxy.layer import Layer
+from mitmproxy.proxy.layers import ClientQuicLayer
+from mitmproxy.proxy.layers import ClientTLSLayer
+from mitmproxy.proxy.layers import DNSLayer
+from mitmproxy.proxy.layers import HttpLayer
+from mitmproxy.proxy.layers import RawQuicLayer
+from mitmproxy.proxy.layers import ServerQuicLayer
+from mitmproxy.proxy.layers import ServerTLSLayer
+from mitmproxy.proxy.layers import TCPLayer
+from mitmproxy.proxy.layers import UDPLayer
+from mitmproxy.proxy.layers import modes
 from mitmproxy.proxy.layers.http import HTTPMode
+from mitmproxy.proxy.layers.http import HttpStream
+from mitmproxy.proxy.mode_specs import ProxyMode
 from mitmproxy.test import taddons
-from mitmproxy.test import tflow
-
-
-@pytest.fixture
-def tctx():
-    context.Context(
-        connection.Client(
-            peername=("client", 1234),
-            sockname=("127.0.0.1", 8080),
-            timestamp_start=1605699329,
-        ),
-        tctx.options,
-    )
-
 
 client_hello_no_extensions = bytes.fromhex(
     "1603030065"  # record header
@@ -41,7 +48,6 @@ client_hello_with_extensions = bytes.fromhex(
     "170018"
 )
 
-
 dtls_client_hello_with_extensions = bytes.fromhex(
     "16fefd00000000000000000085"  # record layer
     "010000790000000000000079"  # handshake layer
@@ -49,7 +55,6 @@ dtls_client_hello_with_extensions = bytes.fromhex(
     "3001000043000d0010000e0403050306030401050106010807ff01000100000a00080006001d00170018000b00020100001"
     "7000000000010000e00000b6578616d706c652e636f6d"
 )
-
 
 quic_client_hello = bytes.fromhex(
     "ca0000000108c0618c84b54541320823fcce946c38d8210044e6a93bbb283593f75ffb6f2696b16cfdcb5b1255"
@@ -83,6 +88,8 @@ quic_client_hello = bytes.fromhex(
     "297c0013924e88248684fe8f2098326ce51aa6e5"
 )
 
+dns_query = bytes.fromhex("002a01000001000000000000076578616d706c6503636f6d0000010001")
+
 
 class TestNextLayer:
     def test_configure(self):
@@ -93,325 +100,510 @@ class TestNextLayer:
                     nl, allow_hosts=["example.org"], ignore_hosts=["example.com"]
                 )
 
-    def test_ignore_connection(self):
-        nl = NextLayer()
-        with taddons.context(nl) as tctx:
-            assert not nl.ignore_connection(("example.com", 443), b"")
-
-            tctx.configure(nl, ignore_hosts=["example.com"])
-            assert nl.ignore_connection(("example.com", 443), b"")
-            assert nl.ignore_connection(("example.com", 1234), b"")
-            assert nl.ignore_connection(("com", 443), b"") is False
-            assert nl.ignore_connection(None, b"") is False
-            assert nl.ignore_connection(None, client_hello_no_extensions) is False
-            assert nl.ignore_connection(None, client_hello_with_extensions)
-            assert nl.ignore_connection(None, client_hello_with_extensions[:-5]) is None
-            # invalid clienthello
-            assert (
-                nl.ignore_connection(
-                    None, client_hello_no_extensions[:9] + b"\x00" * 200
-                )
-                is False
-            )
-            # different server name and SNI
-            assert nl.ignore_connection(("decoy", 1234), client_hello_with_extensions)
-
-            tctx.configure(nl, ignore_hosts=[], allow_hosts=["example.com"])
-            assert nl.ignore_connection(("example.com", 443), b"") is False
-            assert nl.ignore_connection(("example.org", 443), b"")
-            # different server name and SNI
-            assert (
-                nl.ignore_connection(("decoy", 1234), client_hello_with_extensions)
-                is False
-            )
-
-    def test_next_layer(self, monkeypatch):
-        ctx = MagicMock()
-        ctx.client.transport_protocol = "tcp"
-        nl_layer = layer.NextLayer(ctx)
-        monkeypatch.setattr(nl_layer, "data_client", lambda: b"\x16\x03\x03")
-        nl = NextLayer()
-
-        with taddons.context(nl):
-            nl.next_layer(nl_layer)
-            assert nl_layer.layer
-
-    def test_next_layer2(self):
-        nl = NextLayer()
-        ctx = MagicMock()
-        ctx.client.alpn = None
-        ctx.server.address = ("example.com", 443)
-        ctx.client.transport_protocol = "tcp"
-        with taddons.context(nl) as tctx:
-            ctx.layers = [layers.modes.HttpProxy(ctx)]
-
-            assert nl._next_layer(ctx, b"", b"") is None
-
-            tctx.configure(nl, ignore_hosts=["example.com"])
-            assert isinstance(nl._next_layer(ctx, b"123", b""), layers.TCPLayer)
-            assert nl._next_layer(ctx, client_hello_no_extensions[:10], b"") is None
-
-            tctx.configure(nl, ignore_hosts=[])
-            assert isinstance(
-                nl._next_layer(ctx, client_hello_no_extensions, b""),
-                layers.ServerTLSLayer,
-            )
-            assert isinstance(ctx.layers[-1], layers.ClientTLSLayer)
-
-            ctx.layers = [layers.modes.HttpProxy(ctx)]
-            assert isinstance(
-                nl._next_layer(ctx, client_hello_no_extensions, b""),
-                layers.ClientTLSLayer,
-            )
-
-            ctx.layers = [layers.modes.HttpProxy(ctx)]
-            assert isinstance(
-                nl._next_layer(ctx, b"GET http://example.com/ HTTP/1.1\r\n", b""),
-                layers.HttpLayer,
-            )
-            assert ctx.layers[-1].mode == HTTPMode.regular
-
-            ctx.layers = [layers.modes.HttpUpstreamProxy(ctx)]
-            assert isinstance(
-                nl._next_layer(ctx, b"GET http://example.com/ HTTP/1.1\r\n", b""),
-                layers.HttpLayer,
-            )
-            assert ctx.layers[-1].mode == HTTPMode.upstream
-
-            tctx.configure(nl, tcp_hosts=["example.com"])
-            assert isinstance(nl._next_layer(ctx, b"123", b""), layers.TCPLayer)
-
-            tctx.configure(nl, tcp_hosts=[])
-            assert isinstance(nl._next_layer(ctx, b"GET /foo", b""), layers.HttpLayer)
-            assert isinstance(nl._next_layer(ctx, b"", b"hello"), layers.TCPLayer)
-
     @pytest.mark.parametrize(
-        ("protocol", "client_layer", "server_layer"),
+        "ignore, allow, transport_protocol, server_address, data_client, result",
         [
-            ("dtls", layers.ClientTLSLayer, layers.ServerTLSLayer),
-            ("quic", layers.ClientQuicLayer, layers.ServerQuicLayer),
+            # ignore
+            pytest.param(
+                [], [], "example.com", "tcp", b"", False, id="nothing ignored"
+            ),
+            pytest.param(
+                ["example.com"], [], "tcp", "example.com", b"", True, id="address"
+            ),
+            pytest.param(
+                ["1.2.3.4"], [], "tcp", "example.com", b"", True, id="ip address"
+            ),
+            pytest.param(
+                ["example.com"],
+                [],
+                "tcp",
+                "com",
+                b"",
+                False,
+                id="partial address match",
+            ),
+            pytest.param(
+                ["example.com"], [], "tcp", None, b"", False, id="no destination info"
+            ),
+            pytest.param(
+                ["example.com"],
+                [],
+                "tcp",
+                None,
+                client_hello_no_extensions,
+                False,
+                id="no sni",
+            ),
+            pytest.param(
+                ["example.com"],
+                [],
+                "tcp",
+                None,
+                client_hello_with_extensions,
+                True,
+                id="sni",
+            ),
+            pytest.param(
+                ["example.com"],
+                [],
+                "tcp",
+                None,
+                client_hello_with_extensions[:-5],
+                NeedsMoreData,
+                id="incomplete client hello",
+            ),
+            pytest.param(
+                ["example.com"],
+                [],
+                "tcp",
+                None,
+                client_hello_no_extensions[:9] + b"\x00" * 200,
+                False,
+                id="invalid client hello",
+            ),
+            pytest.param(
+                ["example.com"],
+                [],
+                "tcp",
+                "decoy",
+                client_hello_with_extensions,
+                True,
+                id="sni mismatch",
+            ),
+            pytest.param(
+                ["example.com"],
+                [],
+                "udp",
+                None,
+                dtls_client_hello_with_extensions,
+                True,
+                id="dtls sni",
+            ),
+            pytest.param(
+                ["example.com"],
+                [],
+                "udp",
+                None,
+                dtls_client_hello_with_extensions[:-5],
+                NeedsMoreData,
+                id="incomplete dtls client hello",
+            ),
+            pytest.param(
+                ["example.com"],
+                [],
+                "udp",
+                None,
+                dtls_client_hello_with_extensions[:9] + b"\x00" * 200,
+                False,
+                id="invalid dtls client hello",
+            ),
+            pytest.param(
+                ["example.com"], [], "udp", None, quic_client_hello, True, id="quic sni"
+            ),
+            # allow
+            pytest.param(
+                [], ["example.com"], "tcp", "example.com", b"", False, id="allow: allow"
+            ),
+            pytest.param(
+                [], ["example.com"], "tcp", "example.org", b"", True, id="allow: ignore"
+            ),
+            pytest.param(
+                [],
+                ["example.com"],
+                "tcp",
+                "decoy",
+                client_hello_with_extensions,
+                False,
+                id="allow: sni mismatch",
+            ),
         ],
     )
-    def test_next_layer_udp(
+    def test_ignore_connection(
         self,
-        protocol: str,
-        client_layer: layer.Layer,
-        server_layer: layer.Layer,
+        ignore: list[str],
+        allow: list[str],
+        transport_protocol: TransportProtocol,
+        server_address: str,
+        data_client: bytes,
+        result: bool | type[NeedsMoreData],
     ):
-        def is_ignored_udp(layer: layer.Layer | None):
-            return isinstance(layer, layers.UDPLayer) and layer.flow is None
-
-        def is_intercepted_udp(layer: layer.Layer | None):
-            return isinstance(layer, layers.UDPLayer) and layer.flow is not None
-
-        def is_http(layer: layer.Layer | None, mode: HTTPMode):
-            return isinstance(layer, layers.HttpLayer) and layer.mode is mode
-
-        client_hello = {
-            "dtls": dtls_client_hello_with_extensions,
-            "quic": quic_client_hello,
-        }[protocol]
         nl = NextLayer()
-        ctx = MagicMock()
-        ctx.client.alpn = None
-        ctx.server.address = ("example.com", 443)
-        ctx.client.transport_protocol = "udp"
         with taddons.context(nl) as tctx:
-            ctx.layers = [layers.modes.HttpProxy(ctx), client_layer(ctx)]
-            assert is_http(nl._next_layer(ctx, b"", b""), HTTPMode.regular)
+            if ignore:
+                tctx.configure(nl, ignore_hosts=ignore)
+            if allow:
+                tctx.configure(nl, allow_hosts=allow)
 
-            ctx.layers = [layers.modes.HttpUpstreamProxy(ctx), client_layer(ctx)]
-            assert is_http(nl._next_layer(ctx, b"", b""), HTTPMode.upstream)
+            ctx = Context(
+                Client(peername=("192.168.0.42", 51234), sockname=("0.0.0.0", 8080)),
+                tctx.options,
+            )
+            ctx.client.transport_protocol = transport_protocol
+            if server_address:
+                ctx.server.address = (server_address, 443)
+                ctx.server.peername = ("1.2.3.4", 443)
 
-            ctx.layers = [layers.modes.TransparentProxy(ctx)]
-            is_intercepted_udp(nl._next_layer(ctx, b"", b""))
+            if result is NeedsMoreData:
+                with pytest.raises(NeedsMoreData):
+                    nl._ignore_connection(ctx, data_client)
+            else:
+                assert nl._ignore_connection(ctx, data_client) is result
 
-            ctx.layers = [layers.modes.TransparentProxy(ctx)]
-            ctx.server.address = ("nomatch.com", 443)
+    def test_next_layer(self, monkeypatch, caplog):
+        caplog.set_level(logging.INFO)
+        nl = NextLayer()
+
+        with taddons.context(nl) as tctx:
+            m = MagicMock()
+            m.context = Context(
+                Client(peername=("192.168.0.42", 51234), sockname=("0.0.0.0", 8080)),
+                tctx.options,
+            )
+            m.context.layers = [modes.TransparentProxy(m.context)]
+            m.context.server.address = ("example.com", 42)
             tctx.configure(nl, ignore_hosts=["example.com"])
-            assert is_intercepted_udp(nl._next_layer(ctx, client_hello[:50], b""))
-            assert is_ignored_udp(nl._next_layer(ctx, client_hello, b""))
 
-            ctx.layers = [layers.modes.TransparentProxy(ctx)]
-            ctx.server.address = ("example.com", 443)
-            assert is_ignored_udp(nl._next_layer(ctx, client_hello[:50], b""))
+            m.layer = preexisting = object()
+            nl.next_layer(m)
+            assert m.layer is preexisting
 
-            ctx.layers = [layers.modes.TransparentProxy(ctx)]
-            tctx.configure(nl, ignore_hosts=[])
-            decision = nl._next_layer(ctx, client_hello, b"")
-            assert isinstance(decision, server_layer)
-            assert isinstance(decision.child_layer, client_layer)
+            m.layer = None
+            nl.next_layer(m)
+            assert m.layer
 
-            ctx.layers = [layers.modes.ReverseProxy(ctx), server_layer(ctx)]
-            tctx.configure(nl, ignore_hosts=[])
-            assert isinstance(nl._next_layer(ctx, client_hello, b""), client_layer)
-
-            ctx.layers = [layers.modes.TransparentProxy(ctx)]
-            tctx.configure(nl, udp_hosts=["example.com"])
-            assert isinstance(
-                nl._next_layer(ctx, tflow.tdnsreq().packed, b""), layers.UDPLayer
+            m.layer = None
+            monkeypatch.setattr(
+                m, "data_client", lambda: client_hello_with_extensions[:-5]
             )
+            nl.next_layer(m)
+            assert not m.layer
+            assert "Deferring layer decision" in caplog.text
 
-            ctx.layers = [layers.modes.TransparentProxy(ctx)]
-            tctx.configure(nl, udp_hosts=[])
-            assert isinstance(
-                nl._next_layer(ctx, tflow.tdnsreq().packed, b""), layers.DNSLayer
-            )
 
-    def test_next_layer_reverse_raw(self):
-        nl = NextLayer()
-        with taddons.context(nl):
-            ctx = MagicMock()
-            ctx.client.alpn = None
-            ctx.server.address = ("example.com", 443)
-            ctx.client.transport_protocol = "udp"
-            with taddons.context(nl) as tctx:
-                tctx.configure(nl, ignore_hosts=["example.com"])
+@dataclass
+class TestConf:
+    before: list[type[Layer]]
+    after: list[type[Layer]]
+    proxy_mode: str = "regular"
+    transport_protocol: TransportProtocol = "tcp"
+    data_client: bytes = b""
+    data_server: bytes = b""
+    ignore_hosts: Sequence[str] = ()
+    tcp_hosts: Sequence[str] = ()
+    udp_hosts: Sequence[str] = ()
+    ignore_conn: bool = False
 
-                ctx.layers = [
-                    layers.modes.HttpProxy(ctx),
-                    layers.ClientQuicLayer(ctx),
-                ]
-                decision = nl._next_layer(ctx, b"", b"")
-                assert isinstance(decision, layers.ServerQuicLayer)
-                assert isinstance(decision.child_layer, layers.RawQuicLayer)
 
-                ctx.layers = [
-                    layers.modes.ReverseProxy(ctx),
-                    layers.ServerQuicLayer(ctx),
-                    layers.ClientQuicLayer(
-                        ctx,
-                    ),
-                ]
-                assert isinstance(nl._next_layer(ctx, b"", b""), layers.RawQuicLayer)
+explicit_proxy_configs = [
+    pytest.param(
+        TestConf(
+            before=[modes.HttpProxy],
+            after=[modes.HttpProxy, HttpLayer],
+        ),
+        id=f"explicit proxy: regular http",
+    ),
+    pytest.param(
+        TestConf(
+            before=[modes.HttpProxy],
+            after=[modes.HttpProxy, ClientTLSLayer, HttpLayer],
+            data_client=client_hello_no_extensions,
+        ),
+        id=f"explicit proxy: secure web proxy",
+    ),
+    pytest.param(
+        TestConf(
+            before=[modes.HttpUpstreamProxy],
+            after=[modes.HttpUpstreamProxy, HttpLayer],
+        ),
+        id=f"explicit proxy: upstream proxy",
+    ),
+    pytest.param(
+        TestConf(
+            before=[modes.HttpUpstreamProxy],
+            after=[modes.HttpUpstreamProxy, ClientQuicLayer, HttpLayer],
+            transport_protocol="udp",
+        ),
+        id=f"explicit proxy: experimental http3",
+    ),
+    pytest.param(
+        TestConf(
+            before=[
+                modes.HttpProxy,
+                partial(HttpLayer, mode=HTTPMode.regular),
+                partial(HttpStream, stream_id=1),
+            ],
+            after=[modes.HttpProxy, HttpLayer, HttpStream, HttpLayer],
+            data_client=b"GET / HTTP/1.1\r\n",
+        ),
+        id=f"explicit proxy: HTTP over regular proxy",
+    ),
+    pytest.param(
+        TestConf(
+            before=[
+                modes.HttpProxy,
+                partial(HttpLayer, mode=HTTPMode.regular),
+                partial(HttpStream, stream_id=1),
+            ],
+            after=[
+                modes.HttpProxy,
+                HttpLayer,
+                HttpStream,
+                ServerTLSLayer,
+                ClientTLSLayer,
+            ],
+            data_client=client_hello_with_extensions,
+        ),
+        id=f"explicit proxy: TLS over regular proxy",
+    ),
+    pytest.param(
+        TestConf(
+            before=[
+                modes.HttpProxy,
+                partial(HttpLayer, mode=HTTPMode.regular),
+                partial(HttpStream, stream_id=1),
+                ServerTLSLayer,
+                ClientTLSLayer,
+            ],
+            after=[
+                modes.HttpProxy,
+                HttpLayer,
+                HttpStream,
+                ServerTLSLayer,
+                ClientTLSLayer,
+                HttpLayer,
+            ],
+            data_client=b"GET / HTTP/1.1\r\n",
+        ),
+        id=f"explicit proxy: HTTPS over regular proxy",
+    ),
+    pytest.param(
+        TestConf(
+            before=[
+                modes.HttpProxy,
+                partial(HttpLayer, mode=HTTPMode.regular),
+                partial(HttpStream, stream_id=1),
+            ],
+            after=[modes.HttpProxy, HttpLayer, HttpStream, TCPLayer],
+            data_client=b"\xFF",
+        ),
+        id=f"explicit proxy: TCP over regular proxy",
+    ),
+]
 
-                ctx.layers = [
-                    layers.modes.ReverseProxy(ctx),
-                    layers.ServerQuicLayer(ctx),
-                ]
-                decision = nl._next_layer(ctx, b"", b"")
-                assert isinstance(decision, layers.ClientQuicLayer)
-                assert isinstance(decision.child_layer, layers.RawQuicLayer)
+reverse_proxy_configs = []
+for proto_plain, proto_enc, app_layer in [
+    ("udp", "dtls", UDPLayer),
+    ("tcp", "tls", TCPLayer),
+    ("http", "https", HttpLayer),
+]:
+    if proto_plain == "udp":
+        data_client = dtls_client_hello_with_extensions
+    else:
+        data_client = client_hello_with_extensions
 
-                tctx.configure(nl, ignore_hosts=[])
+    reverse_proxy_configs.extend(
+        [
+            pytest.param(
+                TestConf(
+                    before=[modes.ReverseProxy],
+                    after=[modes.ReverseProxy, app_layer],
+                    proxy_mode=f"reverse:{proto_plain}://example.com:42",
+                ),
+                id=f"reverse proxy: {proto_plain} -> {proto_plain}",
+            ),
+            pytest.param(
+                TestConf(
+                    before=[modes.ReverseProxy],
+                    after=[
+                        modes.ReverseProxy,
+                        ServerTLSLayer,
+                        ClientTLSLayer,
+                        app_layer,
+                    ],
+                    proxy_mode=f"reverse:{proto_enc}://example.com:42",
+                    data_client=data_client,
+                ),
+                id=f"reverse proxy: {proto_enc} -> {proto_enc}",
+            ),
+            pytest.param(
+                TestConf(
+                    before=[modes.ReverseProxy],
+                    after=[modes.ReverseProxy, ClientTLSLayer, app_layer],
+                    proxy_mode=f"reverse:{proto_plain}://example.com:42",
+                    data_client=data_client,
+                ),
+                id=f"reverse proxy: {proto_enc} -> {proto_plain}",
+            ),
+            pytest.param(
+                TestConf(
+                    before=[modes.ReverseProxy],
+                    after=[modes.ReverseProxy, ServerTLSLayer, app_layer],
+                    proxy_mode=f"reverse:{proto_enc}://example.com:42",
+                ),
+                id=f"reverse proxy: {proto_plain} -> {proto_enc}",
+            ),
+        ]
+    )
 
-    def test_next_layer_reverse_quic_mode(self):
-        nl = NextLayer()
-        with taddons.context(nl):
-            ctx = MagicMock()
-            ctx.client.alpn = None
-            ctx.server.address = ("example.com", 443)
-            ctx.client.transport_protocol = "udp"
-            ctx.client.proxy_mode.scheme = "quic"
-            ctx.layers = [
-                layers.modes.ReverseProxy(ctx),
-                layers.ServerQuicLayer(ctx),
-                layers.ClientQuicLayer(ctx),
-            ]
-            assert isinstance(nl._next_layer(ctx, b"", b""), layers.RawQuicLayer)
-            ctx.layers = [
-                layers.modes.ReverseProxy(ctx),
-                layers.ServerQuicLayer(ctx),
-            ]
-            assert nl._next_layer(ctx, b"", b"") is None
-            assert isinstance(
-                nl._next_layer(ctx, b"notahandshake", b""), layers.UDPLayer
-            )
-            ctx.layers = [
-                layers.modes.ReverseProxy(ctx),
-                layers.ServerQuicLayer(ctx),
-            ]
-            assert isinstance(
-                nl._next_layer(ctx, quic_client_hello, b""), layers.ClientQuicLayer
-            )
+reverse_proxy_configs.extend(
+    [
+        pytest.param(
+            TestConf(
+                before=[modes.ReverseProxy],
+                after=[modes.ReverseProxy, DNSLayer],
+                proxy_mode="reverse:dns://example.com:53",
+            ),
+            id="reverse proxy: dns",
+        ),
+        pytest.param(
+            TestConf(
+                before=[modes.ReverseProxy],
+                after=[modes.ReverseProxy, ServerQuicLayer, ClientQuicLayer, HttpLayer],
+                proxy_mode="reverse:http3://example.com",
+            ),
+            id="reverse proxy: http3",
+        ),
+        pytest.param(
+            TestConf(
+                before=[modes.ReverseProxy],
+                after=[
+                    modes.ReverseProxy,
+                    ServerQuicLayer,
+                    ClientQuicLayer,
+                    RawQuicLayer,
+                ],
+                proxy_mode="reverse:quic://example.com",
+            ),
+            id="reverse proxy: quic",
+        ),
+    ]
+)
 
-    def test_next_layer_reverse_http3_mode(self):
-        nl = NextLayer()
-        with taddons.context(nl):
-            ctx = MagicMock()
-            ctx.client.alpn = None
-            ctx.server.address = ("example.com", 443)
-            ctx.client.transport_protocol = "udp"
-            ctx.client.proxy_mode.scheme = "http3"
-            ctx.layers = [
-                layers.modes.ReverseProxy(ctx),
-                layers.ServerQuicLayer(ctx),
-            ]
-            assert isinstance(
-                nl._next_layer(ctx, b"notahandshakebutignore", b""),
-                layers.ClientQuicLayer,
-            )
-            assert len(ctx.layers) == 3
-            decision = nl._next_layer(ctx, b"", b"")
-            assert isinstance(decision, layers.HttpLayer)
-            assert decision.mode is HTTPMode.transparent
+transparent_proxy_configs = [
+    pytest.param(
+        TestConf(
+            before=[modes.TransparentProxy],
+            after=[modes.TransparentProxy, ServerTLSLayer, ClientTLSLayer],
+            data_client=client_hello_no_extensions,
+        ),
+        id=f"transparent proxy: tls",
+    ),
+    pytest.param(
+        TestConf(
+            before=[modes.TransparentProxy],
+            after=[modes.TransparentProxy, ServerTLSLayer, ClientTLSLayer],
+            data_client=dtls_client_hello_with_extensions,
+            transport_protocol="udp",
+        ),
+        id=f"transparent proxy: dtls",
+    ),
+    pytest.param(
+        TestConf(
+            before=[modes.TransparentProxy],
+            after=[modes.TransparentProxy, ServerQuicLayer, ClientQuicLayer],
+            data_client=quic_client_hello,
+            transport_protocol="udp",
+        ),
+        id="transparent proxy: quic",
+    ),
+    pytest.param(
+        TestConf(
+            before=[modes.TransparentProxy],
+            after=[modes.TransparentProxy, TCPLayer],
+            data_server=b"220 service ready",
+        ),
+        id="transparent proxy: raw tcp",
+    ),
+    pytest.param(
+        http := TestConf(
+            before=[modes.TransparentProxy],
+            after=[modes.TransparentProxy, HttpLayer],
+            data_client=b"GET / HTTP/1.1\r\n",
+        ),
+        id="transparent proxy: http",
+    ),
+    pytest.param(
+        dataclasses.replace(
+            http,
+            tcp_hosts=["example.com"],
+            after=[modes.TransparentProxy, TCPLayer],
+        ),
+        id="transparent proxy: tcp_hosts",
+    ),
+    pytest.param(
+        dataclasses.replace(
+            http,
+            ignore_hosts=["example.com"],
+            after=[modes.TransparentProxy, TCPLayer],
+            ignore_conn=True,
+        ),
+        id="transparent proxy: ignore_hosts",
+    ),
+    pytest.param(
+        dns := TestConf(
+            before=[modes.TransparentProxy],
+            after=[modes.TransparentProxy, DNSLayer],
+            transport_protocol="udp",
+            data_client=dns_query,
+        ),
+        id="transparent proxy: dns",
+    ),
+    pytest.param(
+        TestConf(
+            before=[modes.TransparentProxy],
+            after=[modes.TransparentProxy, UDPLayer],
+            transport_protocol="udp",
+            data_client=b"\xFF",
+        ),
+        id="transparent proxy: raw udp",
+    ),
+    pytest.param(
+        dataclasses.replace(
+            dns,
+            udp_hosts=["example.com"],
+            after=[modes.TransparentProxy, UDPLayer],
+        ),
+        id="transparent proxy: udp_hosts",
+    ),
+]
 
-    def test_next_layer_reverse_invalid_mode(self):
-        nl = NextLayer()
-        ctx = MagicMock()
-        ctx.client.alpn = None
-        ctx.server.address = ("example.com", 443)
-        ctx.client.transport_protocol = "udp"
-        ctx.client.proxy_mode.scheme = "invalidscheme"
-        ctx.layers = [layers.modes.ReverseProxy(ctx)]
-        with pytest.raises(AssertionError, match="invalidscheme"):
-            nl._next_layer(ctx, b"", b"")
 
-    def test_next_layer_reverse_dtls_mode(self):
-        nl = NextLayer()
-        ctx = MagicMock()
-        ctx.client.alpn = None
-        ctx.server.address = ("example.com", 443)
-        ctx.client.transport_protocol = "udp"
-        ctx.client.proxy_mode.scheme = "dtls"
-        ctx.layers = [layers.modes.ReverseProxy(ctx), layers.ServerTLSLayer(ctx)]
-        assert isinstance(nl._next_layer(ctx, b"", b""), layers.UDPLayer)
-        ctx.layers = [layers.modes.ReverseProxy(ctx), layers.ServerTLSLayer(ctx)]
-        assert isinstance(
-            nl._next_layer(ctx, dtls_client_hello_with_extensions, b""),
-            layers.ClientTLSLayer,
+@pytest.mark.parametrize(
+    "test_conf",
+    [
+        *explicit_proxy_configs,
+        *reverse_proxy_configs,
+        *transparent_proxy_configs,
+    ],
+)
+def test_next_layer(
+    test_conf: TestConf,
+):
+    nl = NextLayer()
+    with taddons.context(nl) as tctx:
+        tctx.configure(
+            nl,
+            ignore_hosts=test_conf.ignore_hosts,
+            tcp_hosts=test_conf.tcp_hosts,
+            udp_hosts=test_conf.udp_hosts,
         )
-        assert len(ctx.layers) == 3
-        assert isinstance(nl._next_layer(ctx, b"", b""), layers.UDPLayer)
 
-    def test_next_layer_reverse_udp_mode(self):
-        nl = NextLayer()
-        ctx = MagicMock()
-        ctx.client.alpn = None
-        ctx.server.address = ("example.com", 443)
-        ctx.client.transport_protocol = "udp"
-        ctx.client.proxy_mode.scheme = "udp"
-        ctx.layers = [layers.modes.ReverseProxy(ctx)]
-        assert isinstance(nl._next_layer(ctx, b"", b""), layers.UDPLayer)
-        ctx.layers = [layers.modes.ReverseProxy(ctx)]
-        assert isinstance(
-            nl._next_layer(ctx, dtls_client_hello_with_extensions, b""),
-            layers.ClientTLSLayer,
+        ctx = Context(
+            Client(peername=("192.168.0.42", 51234), sockname=("0.0.0.0", 8080)),
+            tctx.options,
         )
-        assert len(ctx.layers) == 2
-        assert isinstance(nl._next_layer(ctx, b"", b""), layers.UDPLayer)
-
-    def test_next_layer_reverse_dns_mode(self):
-        nl = NextLayer()
-        ctx = MagicMock()
-        ctx.client.alpn = None
-        ctx.server.address = ("example.com", 443)
-        ctx.client.transport_protocol = "udp"
-        ctx.client.proxy_mode.scheme = "dns"
-        ctx.layers = [layers.modes.ReverseProxy(ctx)]
-        assert isinstance(nl._next_layer(ctx, b"", b""), layers.DNSLayer)
-        ctx.layers = [layers.modes.ReverseProxy(ctx)]
-        assert isinstance(
-            nl._next_layer(ctx, dtls_client_hello_with_extensions, b""),
-            layers.ClientTLSLayer,
+        ctx.server.address = ("example.com", 42)
+        # these aren't properly set up, but this does not matter here.
+        ctx.client.transport_protocol = test_conf.transport_protocol
+        ctx.client.proxy_mode = ProxyMode.parse(test_conf.proxy_mode)
+        ctx.layers = [x(ctx) for x in test_conf.before]
+        nl._next_layer(
+            ctx,
+            data_client=test_conf.data_client,
+            data_server=test_conf.data_server,
         )
-        assert len(ctx.layers) == 2
-        assert isinstance(nl._next_layer(ctx, b"", b""), layers.DNSLayer)
+        assert stack_match(ctx, test_conf.after)
 
-    def test_next_layer_invalid_proto(self):
-        nl = NextLayer()
-        ctx = MagicMock()
-        ctx.client.transport_protocol = "invalid"
-        with taddons.context(nl):
-            with pytest.raises(AssertionError):
-                nl._next_layer(ctx, b"", b"")
+        last_layer = ctx.layers[-1]
+        if isinstance(last_layer, (UDPLayer, TCPLayer)):
+            assert bool(last_layer.flow) ^ test_conf.ignore_conn

--- a/test/mitmproxy/addons/test_next_layer.py
+++ b/test/mitmproxy/addons/test_next_layer.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import dataclasses
 import logging
+from collections.abc import Sequence
 from dataclasses import dataclass
 from functools import partial
-from typing import Sequence
 from unittest.mock import MagicMock
 
 import pytest
@@ -20,12 +20,12 @@ from mitmproxy.proxy.layers import ClientQuicLayer
 from mitmproxy.proxy.layers import ClientTLSLayer
 from mitmproxy.proxy.layers import DNSLayer
 from mitmproxy.proxy.layers import HttpLayer
+from mitmproxy.proxy.layers import modes
 from mitmproxy.proxy.layers import RawQuicLayer
 from mitmproxy.proxy.layers import ServerQuicLayer
 from mitmproxy.proxy.layers import ServerTLSLayer
 from mitmproxy.proxy.layers import TCPLayer
 from mitmproxy.proxy.layers import UDPLayer
-from mitmproxy.proxy.layers import modes
 from mitmproxy.proxy.layers.http import HTTPMode
 from mitmproxy.proxy.layers.http import HttpStream
 from mitmproxy.proxy.mode_specs import ProxyMode

--- a/test/mitmproxy/addons/test_proxyserver.py
+++ b/test/mitmproxy/addons/test_proxyserver.py
@@ -27,7 +27,6 @@ import mitmproxy.platform
 from mitmproxy import dns
 from mitmproxy import exceptions
 from mitmproxy.addons import dns_resolver
-from mitmproxy.addons import next_layer
 from mitmproxy.addons.next_layer import NextLayer
 from mitmproxy.addons.proxyserver import Proxyserver
 from mitmproxy.addons.tlsconfig import TlsConfig
@@ -35,8 +34,6 @@ from mitmproxy.connection import Address
 from mitmproxy.net import udp
 from mitmproxy.proxy import layers
 from mitmproxy.proxy import server_hooks
-from mitmproxy.proxy.layers import tls
-from mitmproxy.proxy.layers.http import HTTPMode
 from mitmproxy.test import taddons
 from mitmproxy.test import tflow
 from mitmproxy.test.tflow import tclient_conn

--- a/test/mitmproxy/contentviews/test_http3.py
+++ b/test/mitmproxy/contentviews/test_http3.py
@@ -5,9 +5,6 @@ from mitmproxy.contentviews import http3
 from mitmproxy.tcp import TCPMessage
 from mitmproxy.test import tflow
 
-if http3 is None:
-    pytest.skip("HTTP/3 not available.", allow_module_level=True)
-
 
 @pytest.mark.parametrize(
     "data",

--- a/test/mitmproxy/net/test_tls.py
+++ b/test/mitmproxy/net/test_tls.py
@@ -70,10 +70,23 @@ def test_sslkeylogfile(tdata, monkeypatch):
 
 
 def test_is_record_magic():
-    assert not tls.is_tls_record_magic(b"POST /")
-    assert not tls.is_tls_record_magic(b"\x16\x03")
-    assert not tls.is_tls_record_magic(b"\x16\x03\x04")
-    assert tls.is_tls_record_magic(b"\x16\x03\x00")
-    assert tls.is_tls_record_magic(b"\x16\x03\x01")
-    assert tls.is_tls_record_magic(b"\x16\x03\x02")
-    assert tls.is_tls_record_magic(b"\x16\x03\x03")
+    assert not tls.starts_like_tls_record(b"POST /")
+    assert not tls.starts_like_tls_record(b"\x16\x03\x04")
+    assert tls.starts_like_tls_record(b"")
+    assert tls.starts_like_tls_record(b"\x16")
+    assert tls.starts_like_tls_record(b"\x16\x03")
+    assert tls.starts_like_tls_record(b"\x16\x03\x00")
+    assert tls.starts_like_tls_record(b"\x16\x03\x01")
+    assert tls.starts_like_tls_record(b"\x16\x03\x02")
+    assert tls.starts_like_tls_record(b"\x16\x03\x03")
+
+
+def test_is_dtls_record_magic():
+    assert tls.starts_like_dtls_record(bytes.fromhex(""))
+    assert tls.starts_like_dtls_record(bytes.fromhex("16"))
+    assert tls.starts_like_dtls_record(bytes.fromhex("16fe"))
+    assert tls.starts_like_dtls_record(bytes.fromhex("16fefd"))
+    assert tls.starts_like_dtls_record(bytes.fromhex("16fefe"))
+    assert not tls.starts_like_dtls_record(bytes.fromhex("160300"))
+    assert not tls.starts_like_dtls_record(bytes.fromhex("160304"))
+    assert not tls.starts_like_dtls_record(bytes.fromhex("150301"))

--- a/test/mitmproxy/net/test_tls.py
+++ b/test/mitmproxy/net/test_tls.py
@@ -72,19 +72,20 @@ def test_sslkeylogfile(tdata, monkeypatch):
 def test_is_record_magic():
     assert not tls.starts_like_tls_record(b"POST /")
     assert not tls.starts_like_tls_record(b"\x16\x03\x04")
-    assert tls.starts_like_tls_record(b"")
-    assert tls.starts_like_tls_record(b"\x16")
-    assert tls.starts_like_tls_record(b"\x16\x03")
+    assert not tls.starts_like_tls_record(b"")
+    assert not tls.starts_like_tls_record(b"\x16")
+    assert not tls.starts_like_tls_record(b"\x16\x03")
     assert tls.starts_like_tls_record(b"\x16\x03\x00")
     assert tls.starts_like_tls_record(b"\x16\x03\x01")
     assert tls.starts_like_tls_record(b"\x16\x03\x02")
     assert tls.starts_like_tls_record(b"\x16\x03\x03")
+    assert not tls.starts_like_tls_record(bytes.fromhex("16fefe"))
 
 
 def test_is_dtls_record_magic():
-    assert tls.starts_like_dtls_record(bytes.fromhex(""))
-    assert tls.starts_like_dtls_record(bytes.fromhex("16"))
-    assert tls.starts_like_dtls_record(bytes.fromhex("16fe"))
+    assert not tls.starts_like_dtls_record(bytes.fromhex(""))
+    assert not tls.starts_like_dtls_record(bytes.fromhex("16"))
+    assert not tls.starts_like_dtls_record(bytes.fromhex("16fe"))
     assert tls.starts_like_dtls_record(bytes.fromhex("16fefd"))
     assert tls.starts_like_dtls_record(bytes.fromhex("16fefe"))
     assert not tls.starts_like_dtls_record(bytes.fromhex("160300"))

--- a/test/mitmproxy/proxy/layers/test_quic.py
+++ b/test/mitmproxy/proxy/layers/test_quic.py
@@ -889,6 +889,18 @@ def make_client_tls_layer(
 
 
 class TestClientTLS:
+    def test_http3_disabled(self, tctx: context.Context):
+        """Test that we swallow QUIC packets if QUIC and HTTP/3 are disabled."""
+        tctx.options.http3 = False
+        assert (
+            tutils.Playbook(quic.ClientQuicLayer(tctx, time=time.time), logs=True)
+            >> events.DataReceived(tctx.client, client_hello)
+            << commands.Log(
+                "Swallowing QUIC handshake because HTTP/3 is disabled.", DEBUG
+            )
+            << None
+        )
+
     def test_client_only(self, tctx: context.Context):
         """Test TLS with client only"""
         playbook, client_layer, tssl_client = make_client_tls_layer(tctx)

--- a/test/mitmproxy/proxy/layers/test_tls.py
+++ b/test/mitmproxy/proxy/layers/test_tls.py
@@ -765,15 +765,6 @@ class TestClientTLS:
         assert tls_hook_data().conn.error
 
 
-def test_is_dtls_handshake_record():
-    assert tls.is_dtls_handshake_record(bytes.fromhex("16fefd"))
-    assert not tls.is_dtls_handshake_record(bytes.fromhex("160300"))
-    assert not tls.is_dtls_handshake_record(bytes.fromhex("16fefe"))
-    assert not tls.is_dtls_handshake_record(bytes.fromhex(""))
-    assert not tls.is_dtls_handshake_record(bytes.fromhex("160304"))
-    assert not tls.is_dtls_handshake_record(bytes.fromhex("150301"))
-
-
 def test_dtls_record_contents():
     data = bytes.fromhex(
         "16fefd00000000000000000002beef" "16fefd00000000000000000001ff"

--- a/test/mitmproxy/proxy/layers/test_tls.py
+++ b/test/mitmproxy/proxy/layers/test_tls.py
@@ -24,17 +24,6 @@ from test.mitmproxy.proxy.tutils import StrMatching
 tlsdata = data.Data(__name__)
 
 
-def test_is_tls_handshake_record():
-    assert tls.is_tls_handshake_record(bytes.fromhex("160300"))
-    assert tls.is_tls_handshake_record(bytes.fromhex("160301"))
-    assert tls.is_tls_handshake_record(bytes.fromhex("160302"))
-    assert tls.is_tls_handshake_record(bytes.fromhex("160303"))
-    assert not tls.is_tls_handshake_record(bytes.fromhex("ffffff"))
-    assert not tls.is_tls_handshake_record(bytes.fromhex(""))
-    assert not tls.is_tls_handshake_record(bytes.fromhex("160304"))
-    assert not tls.is_tls_handshake_record(bytes.fromhex("150301"))
-
-
 def test_record_contents():
     data = bytes.fromhex("1603010002beef" "1603010001ff")
     assert list(tls.handshake_record_contents(data)) == [b"\xbe\xef", b"\xff"]

--- a/test/mitmproxy/proxy/layers/test_tls.py
+++ b/test/mitmproxy/proxy/layers/test_tls.py
@@ -765,13 +765,69 @@ class TestClientTLS:
         assert tls_hook_data().conn.error
 
 
-def test_is_dtls_handshake_record():
-    assert tls.is_dtls_handshake_record(bytes.fromhex("16fefd"))
-    assert not tls.is_dtls_handshake_record(bytes.fromhex("160300"))
-    assert not tls.is_dtls_handshake_record(bytes.fromhex("16fefe"))
-    assert not tls.is_dtls_handshake_record(bytes.fromhex(""))
-    assert not tls.is_dtls_handshake_record(bytes.fromhex("160304"))
-    assert not tls.is_dtls_handshake_record(bytes.fromhex("150301"))
+class TestMaybeClientTLS:
+    @pytest.mark.parametrize("trickle", ["trickle", "full"])
+    def test_no_tls(self, tctx: context.Context, trickle: bool):
+        layer = tls.MaybeClientTLSLayer(tctx)
+        layer.child_layer = tutils.EchoLayer(tctx)
+        playbook = tutils.Playbook(layer)
+
+        if trickle == "trickle":
+            playbook >> events.DataReceived(tctx.client, b"ABC")
+        else:
+            playbook >> events.DataReceived(tctx.client, b"A")
+            playbook >> events.DataReceived(tctx.client, b"B")
+            playbook >> events.DataReceived(tctx.client, b"C")
+
+        assert (
+            playbook
+            << commands.SendData(tctx.client, b'abc')
+            >> events.ConnectionClosed(tctx.client)
+            << commands.CloseConnection(tctx.client)
+        )
+
+    @pytest.mark.parametrize("trickle", ["trickle", "full"])
+    def test_tls(self, tctx: context.Context, trickle):
+        layer = tls.MaybeClientTLSLayer(tctx)
+        layer.child_layer = tutils.EchoLayer(tctx)
+        data = tutils.Placeholder(bytes)
+        playbook = tutils.Playbook(layer)
+
+        if trickle == "trickle":
+            for d in client_hello_tls_1_3:
+                playbook >> events.DataReceived(tctx.client, bytes([d]))
+        else:
+            playbook >> events.DataReceived(tctx.client, client_hello_tls_1_3)
+        assert (
+            playbook
+            << tls.TlsClienthelloHook(tutils.Placeholder())
+            >> tutils.reply()
+            << tls.TlsStartClientHook(tutils.Placeholder())
+            >> reply_tls_start_client()
+            << commands.SendData(tctx.client, data)
+        )
+        assert data().startswith(b"\x16\x03\x03")
+
+    def test_close_early(self, tctx: context.Context):
+        layer = tls.MaybeClientTLSLayer(tctx)
+        layer.child_layer = tutils.EchoLayer(tctx)
+
+        assert (
+            tutils.Playbook(layer)
+            >> events.DataReceived(tctx.client, b"A")
+            >> events.ConnectionClosed(tctx.client)
+            << commands.CloseConnection(tctx.client)
+        )
+
+    def test_no_side_effects(self, tctx: context.Context):
+        layer = tls.MaybeClientTLSLayer(tctx)
+        layer.child_layer = tutils.EchoLayer(tctx)
+
+        assert (
+            tutils.Playbook(layer)
+            >> events.DataReceived(tctx.server, b"A")
+            << commands.SendData(tctx.server, b"a")
+        )
 
 
 def test_dtls_record_contents():

--- a/web/src/js/ducks/_options_gen.ts
+++ b/web/src/js/ducks/_options_gen.ts
@@ -24,6 +24,7 @@ export interface OptionsState {
     export_preserve_original_ip: boolean
     http2: boolean
     http2_ping_keepalive: number
+    http3: boolean
     ignore_hosts: string[]
     intercept: string | undefined
     intercept_active: boolean
@@ -114,6 +115,7 @@ export const defaultState: OptionsState = {
     export_preserve_original_ip: false,
     http2: true,
     http2_ping_keepalive: 58,
+    http3: true,
     ignore_hosts: [],
     intercept: undefined,
     intercept_active: false,


### PR DESCRIPTION
This PR makes our logic to determine the next protocol layer more explicit, and handles UDP and TCP in a uniform way. We also now make heavy use of `match` statements combined with `typing.assert_never`, which allows us to assert that we exhaust all options in many cases. Finally, I'm adding an `http3` option which can be used to block QUIC traffic in transparent mode. 🎉 