### PR TITLE
Fix #5910 - Spoof ICMP echo replies

### DIFF
--- a/mitmproxy/proxy/mode_servers.py
+++ b/mitmproxy/proxy/mode_servers.py
@@ -258,7 +258,6 @@ class ServerInstance(Generic[M], metaclass=ABCMeta):
         src_addr: str,
         dst_addr: str,
     ) -> None:
-
         # Some apps check network connectivity by sending ICMP pings. ICMP traffic is currently
         # swallowed by mitmproxy_rs, which makes them believe that there is no network connectivity.
         # Generating fake ICMP replies as a temporary workaround.


### PR DESCRIPTION
#### Description

Important: this depends on https://github.com/mitmproxy/mitmproxy_rs/pull/28, which has to be merged first due to interface change.

Some apps check network connectivity by sending ICMP pings. Before this fix, ICMP traffic was swallowed by mitmproxy_rs, which makes them believe that there is no network connectivity. 

Mitmproxy now generates fake ICMP Echo Replies in response to ICMP Echo Requests, and transmits them back to the sender's address. 

#### Checklist

 - [ ] I have updated tests where applicable.
 - [ ] I have added an entry to the CHANGELOG.