### PR TITLE
Fix issue when trying to reply a request with different via

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Release History
 
-## Unreleased: mitmproxy next
+## XX March 2023: mitmproxy 9.0.2
 
-
+* Fix a bugwhen using replying flow with upstream mode enabled
+  ([#5241](https://github.com/mitmproxy/mitmproxy/issues/5241), @raphaelts3))
 
 ## 02 November 2022: mitmproxy 9.0.1
 

--- a/mitmproxy/connection.py
+++ b/mitmproxy/connection.py
@@ -407,6 +407,7 @@ class Server(Connection):
         self.timestamp_tcp_setup = state["timestamp_tcp_setup"]
         self.timestamp_tls_setup = state["timestamp_tls_setup"]
         self.tls_version = state["tls_version"]
+        self.via = state["via2"]
         self.state = ConnectionState(state["state"])
         self.error = state["error"]
         self.tls = state["tls"]
@@ -416,7 +417,6 @@ class Server(Connection):
         self.alpn_offers = state["alpn_offers"]
         self.cipher = state["cipher_name"]
         self.cipher_list = state["cipher_list"]
-        self.via = state["via2"]
 
     @property
     def ip_address(self) -> Optional[Address]:  # pragma: no cover


### PR DESCRIPTION
#### Description

This is supposed to be a 9.0.2 patch and close https://github.com/mitmproxy/mitmproxy/issues/5241, I did realize that in the recent versions, the issue is no longer there, but I've been manually fixing it since 8.X, and today I've decided to PR the fix here, unfortunately, it's no longer a bug, because it's fixed with the main branch changes, but in case you want to release the 9.0.2, here it's my small contribution. 

To add a bit more context on how I was bumping into this:
- set upstream;
- save a flow;
- try to load the flow in another instance with a different upstream;

PS: I've tried to open this PR to 9.0.1, but there is only a tag, not a branch, so I couldn't :-(

#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
