### PR TITLE
Fixed typo in `__init__.py`

### DIFF
--- a/mitmproxy/proxy/__init__.py
+++ b/mitmproxy/proxy/__init__.py
@@ -6,12 +6,12 @@ The most important primitives are:
     - Layers: represent protocol layers, e.g. one for TCP, TLS, and so on. Layers are nested, so
       a typical configuration might be ReverseProxy/TLS/TCP.
       Most importantly, layers are implemented using the sans-io pattern (https://sans-io.readthedocs.io/).
-      This means that calls return immediately, their is no blocking sync or async code.
-    - Server: the proxy server handles all I/O. This is implemented using asyncio, but could be done any other way.
-      The ConnectionHandler is subclassed in the Proxyserver addon, which handles the communication with the
+      This means that calls return immediately, there is no blocking sync or async code.
+    - Server: the proxy server handles all I/O. This is implemented using `asyncio`, but could be done any other way.
+      The `ConnectionHandler` is subclassed in the `Proxyserver` addon, which handles the communication with the
       rest of mitmproxy.
     - Events: When I/O actions occur at the proxy server, they are passed to the outermost layer as events,
-      e.g. "DataReceived" or "ConnectionClosed".
+      e.g. `DataReceived` or `ConnectionClosed`.
     - Commands: In the other direction, layers can emit commands to higher layers or the proxy server.
       This is used to e.g. send data, request for new connections to be opened, or to call mitmproxy's
       event hooks.


### PR DESCRIPTION
#### Description

Fixed a small typo in `__init__.py`.

#### Checklist

 - [x] I have updated tests where applicable.
 - [ ] I have added an entry to the CHANGELOG.
