### PR TITLE
Flow multi select to delete

### DIFF
--- a/web/src/js/components/FlowTable.jsx
+++ b/web/src/js/components/FlowTable.jsx
@@ -141,5 +141,5 @@ export const PureFlowTable = AutoScroll(FlowTable);
 export default connect((state) => ({
     flows: state.flows.view,
     highlight: state.flows.highlight,
-    selectedRows: state.flows.selected
+    selectedRows: state.flows.selected,
 }))(PureFlowTable);

--- a/web/src/js/components/FlowTable.jsx
+++ b/web/src/js/components/FlowTable.jsx
@@ -106,7 +106,7 @@ class FlowTable extends React.Component {
 
     render() {
         const { vScroll, viewportTop } = this.state;
-        const { flows, selected, highlight } = this.props;
+        const { flows, highlight, selectedRows } = this.props;
         const isHighlighted = highlight ? Filt.parse(highlight) : () => false;
 
         return (
@@ -124,7 +124,7 @@ class FlowTable extends React.Component {
                             <FlowRow
                                 key={flow.id}
                                 flow={flow}
-                                selected={flow === selected}
+                                selected={selectedRows.includes(flow.id)}
                                 highlighted={isHighlighted(flow)}
                             />
                         ))}
@@ -141,5 +141,5 @@ export const PureFlowTable = AutoScroll(FlowTable);
 export default connect((state) => ({
     flows: state.flows.view,
     highlight: state.flows.highlight,
-    selected: state.flows.byId[state.flows.selected[0]],
+    selectedRows: state.flows.selected
 }))(PureFlowTable);

--- a/web/src/js/components/FlowTable/FlowRow.tsx
+++ b/web/src/js/components/FlowTable/FlowRow.tsx
@@ -2,7 +2,7 @@ import React, { useCallback } from "react";
 import classnames from "classnames";
 import { Flow } from "../../flow";
 import { useAppDispatch, useAppSelector } from "../../ducks";
-import { select } from "../../ducks/flows";
+import { multiSelect, select } from "../../ducks/flows";
 import * as columns from "./FlowColumns";
 
 type FlowRowProps = {
@@ -36,7 +36,12 @@ export default React.memo(function FlowRow({
                 if (node.classList.contains("col-quickactions")) return;
                 node = node.parentNode;
             }
-            dispatch(select(flow.id));
+            if (e.ctrlKey) {
+                dispatch(multiSelect(flow.id))
+            }
+            if (!e.ctrlKey) {
+                dispatch(select(flow.id));
+            }
         },
         [flow]
     );

--- a/web/src/js/components/FlowTable/FlowRow.tsx
+++ b/web/src/js/components/FlowTable/FlowRow.tsx
@@ -37,7 +37,7 @@ export default React.memo(function FlowRow({
                 node = node.parentNode;
             }
             if (e.ctrlKey) {
-                dispatch(multiSelect(flow.id))
+                dispatch(multiSelect(flow.id));
             }
             if (!e.ctrlKey) {
                 dispatch(select(flow.id));

--- a/web/src/js/components/Header/FlowMenu.tsx
+++ b/web/src/js/components/Header/FlowMenu.tsx
@@ -11,6 +11,7 @@ import {
     replay as replayFlow,
     resume as resumeFlow,
     revert as revertFlow,
+    removeMultiple as removeMultipleFlows
 } from "../../ducks/flows";
 import Dropdown, { MenuItem } from "../common/Dropdown";
 import { copy } from "../../flow/export";
@@ -23,6 +24,7 @@ export default function FlowMenu(): JSX.Element {
         flow = useAppSelector(
             (state) => state.flows.byId[state.flows.selected[0]]
         );
+    const selectedRows = useAppSelector((state) => state.flows.selected);
 
     if (!flow) return <div />;
     return (
@@ -34,7 +36,7 @@ export default function FlowMenu(): JSX.Element {
                             title="[r]eplay flow"
                             icon="fa-repeat text-primary"
                             onClick={() => dispatch(replayFlow(flow))}
-                            disabled={!canReplay(flow)}
+                            disabled={!canReplay(flow) || selectedRows.length > 1}
                         >
                             Replay
                         </Button>
@@ -42,11 +44,12 @@ export default function FlowMenu(): JSX.Element {
                             title="[D]uplicate flow"
                             icon="fa-copy text-info"
                             onClick={() => dispatch(duplicateFlow(flow))}
+                            disabled={selectedRows.length > 1}
                         >
                             Duplicate
                         </Button>
                         <Button
-                            disabled={!flow || !flow.modified}
+                            disabled={!flow || !flow.modified || selectedRows.length > 1}
                             title="revert changes to flow [V]"
                             icon="fa-history text-warning"
                             onClick={() => dispatch(revertFlow(flow))}
@@ -56,7 +59,7 @@ export default function FlowMenu(): JSX.Element {
                         <Button
                             title="[d]elete flow"
                             icon="fa-trash text-danger"
-                            onClick={() => dispatch(removeFlow(flow))}
+                            onClick={() => selectedRows.length === 1 ? dispatch(removeFlow(flow)) : dispatch(removeMultipleFlows(selectedRows))}
                         >
                             Delete
                         </Button>
@@ -78,7 +81,7 @@ export default function FlowMenu(): JSX.Element {
                 <div className="menu-group">
                     <div className="menu-content">
                         <Button
-                            disabled={!flow || !flow.intercepted}
+                            disabled={!flow || !flow.intercepted || selectedRows.length > 1}
                             title="[a]ccept intercepted flow"
                             icon="fa-play text-success"
                             onClick={() => dispatch(resumeFlow(flow))}
@@ -86,7 +89,7 @@ export default function FlowMenu(): JSX.Element {
                             Resume
                         </Button>
                         <Button
-                            disabled={!flow || !flow.intercepted}
+                            disabled={!flow || !flow.intercepted || selectedRows.length > 1}
                             title="kill intercepted flow [x]"
                             icon="fa-times text-danger"
                             onClick={() => dispatch(killFlow(flow))}

--- a/web/src/js/components/Header/FlowMenu.tsx
+++ b/web/src/js/components/Header/FlowMenu.tsx
@@ -11,7 +11,7 @@ import {
     replay as replayFlow,
     resume as resumeFlow,
     revert as revertFlow,
-    removeMultiple as removeMultipleFlows
+    removeMultiple as removeMultipleFlows,
 } from "../../ducks/flows";
 import Dropdown, { MenuItem } from "../common/Dropdown";
 import { copy } from "../../flow/export";
@@ -36,7 +36,9 @@ export default function FlowMenu(): JSX.Element {
                             title="[r]eplay flow"
                             icon="fa-repeat text-primary"
                             onClick={() => dispatch(replayFlow(flow))}
-                            disabled={!canReplay(flow) || selectedRows.length > 1}
+                            disabled={
+                                !canReplay(flow) || selectedRows.length > 1
+                            }
                         >
                             Replay
                         </Button>
@@ -49,7 +51,11 @@ export default function FlowMenu(): JSX.Element {
                             Duplicate
                         </Button>
                         <Button
-                            disabled={!flow || !flow.modified || selectedRows.length > 1}
+                            disabled={
+                                !flow ||
+                                !flow.modified ||
+                                selectedRows.length > 1
+                            }
                             title="revert changes to flow [V]"
                             icon="fa-history text-warning"
                             onClick={() => dispatch(revertFlow(flow))}
@@ -59,7 +65,13 @@ export default function FlowMenu(): JSX.Element {
                         <Button
                             title="[d]elete flow"
                             icon="fa-trash text-danger"
-                            onClick={() => selectedRows.length === 1 ? dispatch(removeFlow(flow)) : dispatch(removeMultipleFlows(selectedRows))}
+                            onClick={() =>
+                                selectedRows.length === 1
+                                    ? dispatch(removeFlow(flow))
+                                    : dispatch(
+                                          removeMultipleFlows(selectedRows)
+                                      )
+                            }
                         >
                             Delete
                         </Button>
@@ -81,7 +93,11 @@ export default function FlowMenu(): JSX.Element {
                 <div className="menu-group">
                     <div className="menu-content">
                         <Button
-                            disabled={!flow || !flow.intercepted || selectedRows.length > 1}
+                            disabled={
+                                !flow ||
+                                !flow.intercepted ||
+                                selectedRows.length > 1
+                            }
                             title="[a]ccept intercepted flow"
                             icon="fa-play text-success"
                             onClick={() => dispatch(resumeFlow(flow))}
@@ -89,7 +105,11 @@ export default function FlowMenu(): JSX.Element {
                             Resume
                         </Button>
                         <Button
-                            disabled={!flow || !flow.intercepted || selectedRows.length > 1}
+                            disabled={
+                                !flow ||
+                                !flow.intercepted ||
+                                selectedRows.length > 1
+                            }
                             title="kill intercepted flow [x]"
                             icon="fa-times text-danger"
                             onClick={() => dispatch(killFlow(flow))}

--- a/web/src/js/ducks/flows.ts
+++ b/web/src/js/ducks/flows.ts
@@ -202,6 +202,13 @@ export function remove(flow: Flow) {
     return (dispatch) => fetchApi(`/flows/${flow.id}`, { method: "DELETE" });
 }
 
+export function removeMultiple(flowIds: string[]) {
+    const promises: Promise<Response>[] = []
+    flowIds.forEach((id) => promises.push(fetchApi(`/flows/${id}`, { method: "DELETE" })))
+    return (dispatch) => Promise.all(promises)
+    // return (dispatch) => fetchApi(`/flows/${flow.id}`, { method: "DELETE" });
+}
+
 export function duplicate(flow: Flow) {
     return (dispatch) =>
         fetchApi(`/flows/${flow.id}/duplicate`, { method: "POST" });

--- a/web/src/js/ducks/flows.ts
+++ b/web/src/js/ducks/flows.ts
@@ -14,9 +14,9 @@ export const SET_FILTER = "FLOWS_SET_FILTER";
 export const SET_SORT = "FLOWS_SET_SORT";
 export const SET_HIGHLIGHT = "FLOWS_SET_HIGHLIGHT";
 
-interface FlowSortFn extends store.SortFn<Flow> { }
+interface FlowSortFn extends store.SortFn<Flow> {}
 
-interface FlowFilterFn extends store.FilterFn<Flow> { }
+interface FlowFilterFn extends store.FilterFn<Flow> {}
 
 export interface FlowsState extends store.State<Flow> {
     highlight?: string;

--- a/web/src/js/ducks/flows.ts
+++ b/web/src/js/ducks/flows.ts
@@ -9,13 +9,14 @@ export const UPDATE = "FLOWS_UPDATE";
 export const REMOVE = "FLOWS_REMOVE";
 export const RECEIVE = "FLOWS_RECEIVE";
 export const SELECT = "FLOWS_SELECT";
+export const MULTI_SELECT = "FLOWS_MULTI_SELECT";
 export const SET_FILTER = "FLOWS_SET_FILTER";
 export const SET_SORT = "FLOWS_SET_SORT";
 export const SET_HIGHLIGHT = "FLOWS_SET_HIGHLIGHT";
 
-interface FlowSortFn extends store.SortFn<Flow> {}
+interface FlowSortFn extends store.SortFn<Flow> { }
 
-interface FlowFilterFn extends store.FilterFn<Flow> {}
+interface FlowFilterFn extends store.FilterFn<Flow> { }
 
 export interface FlowsState extends store.State<Flow> {
     highlight?: string;
@@ -111,6 +112,11 @@ export default function reducer(
                 selected: action.flowIds,
             };
 
+        case MULTI_SELECT:
+            return {
+                ...state,
+                selected: [...state.selected, ...action.flowIds],
+            };
         default:
             return state;
     }
@@ -239,6 +245,13 @@ export function upload(file) {
 export function select(id?: string) {
     return {
         type: SELECT,
+        flowIds: id ? [id] : [],
+    };
+}
+
+export function multiSelect(id?: string) {
+    return {
+        type: MULTI_SELECT,
         flowIds: id ? [id] : [],
     };
 }

--- a/web/src/js/ducks/flows.ts
+++ b/web/src/js/ducks/flows.ts
@@ -203,9 +203,11 @@ export function remove(flow: Flow) {
 }
 
 export function removeMultiple(flowIds: string[]) {
-    const promises: Promise<Response>[] = []
-    flowIds.forEach((id) => promises.push(fetchApi(`/flows/${id}`, { method: "DELETE" })))
-    return (dispatch) => Promise.all(promises)
+    const promises: Promise<Response>[] = [];
+    flowIds.forEach((id) =>
+        promises.push(fetchApi(`/flows/${id}`, { method: "DELETE" }))
+    );
+    return (dispatch) => Promise.all(promises);
     // return (dispatch) => fetchApi(`/flows/${flow.id}`, { method: "DELETE" });
 }
 


### PR DESCRIPTION
#### Description
closes #3313
Added support to have multiple flows selected at the same time by pressing CTRL + onClick event on flow row

#### Checklist

 - [ ] I have updated tests where applicable.
 - [ ] I have added an entry to the CHANGELOG.
