### PR TITLE
Button to copy formatted `ContentView`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@
   ([#5904](https://github.com/mitmproxy/mitmproxy/pull/5904), @truebit)
 * mitmproxy now requires Python 3.10 or above.
   ([#5954](https://github.com/mitmproxy/mitmproxy/pull/5954), @mhils)
+* Button to copy formatted ContentView
+  ([#5730](https://github.com/mitmproxy/mitmproxy/issues/5730), @RG7279805)
 
 ### Breaking Changes
 

--- a/web/src/js/__tests__/components/__snapshots__/FlowViewSpec.tsx.snap
+++ b/web/src/js/__tests__/components/__snapshots__/FlowViewSpec.tsx.snap
@@ -135,6 +135,15 @@ exports[`FlowView 1`] = `
             <i
               class="fa fa-edit"
             />
+             Copy
+          </button>
+           
+          <button
+            class="btn-xs btn btn-default"
+          >
+            <i
+              class="fa fa-edit"
+            />
              Edit
           </button>
            
@@ -305,6 +314,15 @@ exports[`FlowView 2`] = `
           <h5>
             Loading...
           </h5>
+          <button
+            class="btn-xs btn btn-default"
+          >
+            <i
+              class="fa fa-edit"
+            />
+             Copy
+          </button>
+           
           <button
             class="btn-xs btn btn-default"
           >

--- a/web/src/js/__tests__/components/contentviews/__snapshots__/HttpMessageSpec.tsx.snap
+++ b/web/src/js/__tests__/components/contentviews/__snapshots__/HttpMessageSpec.tsx.snap
@@ -17,6 +17,15 @@ exports[`HttpMessage 1`] = `
         <i
           class="fa fa-edit"
         />
+         Copy
+      </button>
+       
+      <button
+        class="btn-xs btn btn-default"
+      >
+        <i
+          class="fa fa-edit"
+        />
          Edit
       </button>
        
@@ -142,6 +151,15 @@ exports[`HttpMessage 3`] = `
       <h5>
         Raw
       </h5>
+      <button
+        class="btn-xs btn btn-default"
+      >
+        <i
+          class="fa fa-edit"
+        />
+         Copy
+      </button>
+       
       <button
         class="btn-xs btn btn-default"
       >

--- a/web/src/js/components/contentviews/HttpMessage.tsx
+++ b/web/src/js/components/contentviews/HttpMessage.tsx
@@ -97,11 +97,12 @@ export default function HttpMessage({ flow, message }: HttpMessageProps) {
                 <div className="controls">
                     <h5>{desc}</h5>
                     <Button
-                        onClick={() => copyFormattedViewContent(contentViewData)}
+                        onClick={() =>
+                            copyFormattedViewContent(contentViewData)
+                        }
                         icon="fa-edit"
                         className="btn-xs"
                     >
-
                         Copy
                     </Button>
                     &nbsp;
@@ -130,17 +131,15 @@ export default function HttpMessage({ flow, message }: HttpMessageProps) {
                         }
                     />
                 </div>
-                {
-                    ViewImage.matches(message) && (
-                        <ViewImage flow={flow} message={message} />
-                    )
-                }
+                {ViewImage.matches(message) && (
+                    <ViewImage flow={flow} message={message} />
+                )}
                 <LineRenderer
                     lines={contentViewData?.lines || []}
                     maxLines={maxLines}
                     showMore={showMore}
                 />
-            </div >
+            </div>
         );
     }
 }

--- a/web/src/js/components/contentviews/HttpMessage.tsx
+++ b/web/src/js/components/contentviews/HttpMessage.tsx
@@ -11,6 +11,7 @@ import Button from "../common/Button";
 import CodeEditor from "./CodeEditor";
 import LineRenderer from "./LineRenderer";
 import ViewSelector from "./ViewSelector";
+import { copyFormattedViewContent } from "../../contrib/clipboard";
 
 type HttpMessageProps = {
     flow: HTTPFlow;
@@ -96,6 +97,15 @@ export default function HttpMessage({ flow, message }: HttpMessageProps) {
                 <div className="controls">
                     <h5>{desc}</h5>
                     <Button
+                        onClick={() => copyFormattedViewContent(contentViewData)}
+                        icon="fa-edit"
+                        className="btn-xs"
+                    >
+
+                        Copy
+                    </Button>
+                    &nbsp;
+                    <Button
                         onClick={() => setEdit(true)}
                         icon="fa-edit"
                         className="btn-xs"
@@ -120,15 +130,17 @@ export default function HttpMessage({ flow, message }: HttpMessageProps) {
                         }
                     />
                 </div>
-                {ViewImage.matches(message) && (
-                    <ViewImage flow={flow} message={message} />
-                )}
+                {
+                    ViewImage.matches(message) && (
+                        <ViewImage flow={flow} message={message} />
+                    )
+                }
                 <LineRenderer
                     lines={contentViewData?.lines || []}
                     maxLines={maxLines}
                     showMore={showMore}
                 />
-            </div>
+            </div >
         );
     }
 }

--- a/web/src/js/contrib/clipboard.tsx
+++ b/web/src/js/contrib/clipboard.tsx
@@ -28,12 +28,13 @@ export function copyToClipboard(text: string): Promise<void> {
     }
 }
 
-
-export function copyFormattedViewContent(contentViewData: ContentViewData | undefined) {
-    let p = ""
+export function copyFormattedViewContent(
+    contentViewData: ContentViewData | undefined
+) {
+    let p = "";
     contentViewData?.lines.forEach((line) => {
-        line.forEach((el) => p = p + String(el[1]))
-        p = p + "\n"
-    })
-    copyToClipboard(p)
+        line.forEach((el) => (p = p + String(el[1])));
+        p = p + "\n";
+    });
+    copyToClipboard(p);
 }

--- a/web/src/js/contrib/clipboard.tsx
+++ b/web/src/js/contrib/clipboard.tsx
@@ -2,6 +2,8 @@
 /**
  * `navigator.clipboard.writeText()`, but with an additional fallback for non-secure contexts.
  */
+import { ContentViewData } from "../components/contentviews/useContent";
+
 export function copyToClipboard(text: string): Promise<void> {
     // navigator clipboard requires a security context such as https
     if (navigator.clipboard && window.isSecureContext) {
@@ -24,4 +26,14 @@ export function copyToClipboard(text: string): Promise<void> {
             t.remove();
         }
     }
+}
+
+
+export function copyFormattedViewContent(contentViewData: ContentViewData | undefined) {
+    let p = ""
+    contentViewData?.lines.forEach((line) => {
+        line.forEach((el) => p = p + String(el[1]))
+        p = p + "\n"
+    })
+    copyToClipboard(p)
 }


### PR DESCRIPTION
#### Description
Added Copy button in the HTTP content view that will copy formatted data to the clipboard
![image](https://user-images.githubusercontent.com/47270636/228498993-f9d495e2-018d-49ec-ada4-e0bb64d5bd37.png)

closes #5730 
#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
