### PR TITLE
Fixed a bug with auto scroll in mitmweb

### DIFF
--- a/web/src/js/components/helpers/AutoScroll.tsx
+++ b/web/src/js/components/helpers/AutoScroll.tsx
@@ -2,7 +2,8 @@ import React from "react";
 import ReactDOM from "react-dom";
 
 const symShouldStick = Symbol("shouldStick") as any;
-const isAtBottom = (v) => v.scrollTop + v.clientHeight === v.scrollHeight;
+const isAtBottom = (v) =>
+    Math.round(v.scrollTop) + v.clientHeight === v.scrollHeight;
 
 export default (Component) =>
     Object.assign(


### PR DESCRIPTION
#### Description
Fixed a bug that could prevent mitmweb autoscroll from working properly.
This bug was caused by the fact that clientHeight and scrollHeight returned integers, but scrollTop returned a decimal number.
[https://drafts.csswg.org/cssom-view/#extension-to-the-element-interface](https://drafts.csswg.org/cssom-view/#extension-to-the-element-interface)

![screenshot-2023-04-01-143309](https://user-images.githubusercontent.com/61645319/229270445-66d8dabd-b115-41cc-a8aa-799bc0952bf0.png)

#### Checklist

 - [ ] I have updated tests where applicable.
 - [ ] I have added an entry to the CHANGELOG.
