### PR TITLE
DockerHub-README.md: reword ambiguous command

### DIFF
--- a/release/docker/DockerHub-README.md
+++ b/release/docker/DockerHub-README.md
@@ -4,9 +4,13 @@ Containerized version of [mitmproxy](https://mitmproxy.org/): an interactive, SS
 
 ## Usage
 
+To launch the terminal user interface of mitmproxy:
+
 ```sh
-$ docker run --rm -it [-v ~/.mitmproxy:/home/mitmproxy/.mitmproxy] -p 8080:8080 mitmproxy/mitmproxy
-[terminal user interface of mitmproxy is launched...]
+$ docker run --rm -it -p 8080:8080 mitmproxy/mitmproxy
+
+# or start it with the volume mounted to your home directory:
+$ docker run --rm -it -v ~/.mitmproxy:/home/mitmproxy/.mitmproxy -p 8080:8080 mitmproxy/mitmproxy
 ```
 
 The *volume mount* is optional: It's to store the generated CA certificates.

--- a/release/docker/DockerHub-README.md
+++ b/release/docker/DockerHub-README.md
@@ -7,15 +7,13 @@ Containerized version of [mitmproxy](https://mitmproxy.org/): an interactive, SS
 To launch the terminal user interface of mitmproxy:
 
 ```sh
-$ docker run --rm -it -p 8080:8080 mitmproxy/mitmproxy
-
-# or start it with the volume mounted to your home directory:
 $ docker run --rm -it -v ~/.mitmproxy:/home/mitmproxy/.mitmproxy -p 8080:8080 mitmproxy/mitmproxy
 ```
 
-The *volume mount* is optional: It's to store the generated CA certificates.
+Note: The `-v` for *volume mount* is optional. It allows to persist and reuse the generated CA certificates between runs, and for you to access them.
+Without it, a new root CA would be generated on each container restart.
 
-Once started, mitmproxy listens as a HTTP proxy on `localhost:8080`:
+Once started, mitmproxy listens as an HTTP proxy on `localhost:8080`:
 
 ```sh
 $ http_proxy=http://localhost:8080/ curl http://example.com/
@@ -50,7 +48,7 @@ Proxy server listening at http://*:8080
 ```
 
 If `~/.mitmproxy/mitmproxy-ca.pem` is present in the container, mitmproxy will assume uid and gid from the file owner.
-For further details, please consult the mitmproxy [documentation](http://docs.mitmproxy.org/en/stable/).
+For further details, please consult the mitmproxy [documentation](https://docs.mitmproxy.org/en/stable/).
 
 ## Tags
 


### PR DESCRIPTION
#### Description

Being unfamiliar with the docker options, I thought the square brackets could be part of the command.

Instead, they refer to the sentence *after* the command, that is, they meant "optionally".

To remove the ambiguity, I put it onto different lines with an explanation.

<!-- describe your changes here -->

#### Checklist

 - [ ] I have updated tests where applicable.
 - [ ] I have added an entry to the CHANGELOG.

I think neither are applicable?