### PR TITLE
Add escape key as another shortcut to exit current view.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@
   ([#5904](https://github.com/mitmproxy/mitmproxy/pull/5904), @truebit)
 * mitmproxy now requires Python 3.10 or above.
   ([#5954](https://github.com/mitmproxy/mitmproxy/pull/5954), @mhils)
+* the `esc` key can now be used to exit the current view
+  ([#6087](https://github.com/mitmproxy/mitmproxy/pull/6087), @sujaldev)
 
 ### Breaking Changes
 

--- a/mitmproxy/tools/console/defaultkeys.py
+++ b/mitmproxy/tools/console/defaultkeys.py
@@ -17,6 +17,7 @@ def map(km: Keymap) -> None:
     km.add("E", "console.view.eventlog", ["commonkey", "global"], "View event log")
     km.add("Q", "console.exit", ["global"], "Exit immediately")
     km.add("q", "console.view.pop", ["commonkey", "global"], "Exit the current view")
+    km.add("esc", "console.view.pop", ["commonkey", "global"], "Exit the current view")
     km.add("-", "console.layout.cycle", ["global"], "Cycle to next layout")
     km.add("ctrl right", "console.panes.next", ["global"], "Focus next layout pane")
     km.add("ctrl left", "console.panes.prev", ["global"], "Focus previous layout pane")

--- a/mitmproxy/tools/console/keymap.py
+++ b/mitmproxy/tools/console/keymap.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from collections import defaultdict
 from collections.abc import Sequence
 from functools import cache
 
@@ -71,9 +72,7 @@ class Binding:
 class Keymap:
     def __init__(self, master):
         self.executor = commandexecutor.CommandExecutor(master)
-        self.keys: dict[str, dict[str, Binding]] = {}
-        for c in Contexts:
-            self.keys[c] = {}
+        self.keys: dict[str, dict[str, Binding]] = defaultdict(dict)
         self.bindings = []
 
     def _check_contexts(self, contexts):


### PR DESCRIPTION
#### Description

The escape key can now be used to exit the current view, alongside the pre-existing `q` key. Fixes #6085.

#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
