### PR TITLE
Add info about --allow-hosts

### DIFF
--- a/docs/src/content/concepts-options.md
+++ b/docs/src/content/concepts-options.md
@@ -38,7 +38,7 @@ command-line option. Please see the command-line help (`--help`) for usage. Exam
 ```
 mitmproxy --set anticomp=true
 mitmweb --set web_columns=path --set web_columns=status
-mitmweb --set ignore_hosts=142.250.179.100 --set ignore_hosts=2a00:1450:4007:80e::2004 --set ignore_hosts=2a00:1450:4007:819::2004
+mitmweb --set ignore_hosts=<IPv4-1> --set ignore_hosts=<IPv4-2> --set ignore_hosts=<IPv6-1> --set ignore_hosts=<IPv6-2> 
 ```
 
 ## Available Options

--- a/docs/src/content/concepts-options.md
+++ b/docs/src/content/concepts-options.md
@@ -34,7 +34,10 @@ persistent by saving the settings out to a YAML configuration file (please see
 the specific tool's interactive help for details on how to do this).
 
 For all tools, options can be set directly by name using the `--set`
-command-line option. Please see the command-line help (`--help`) for usage.
+command-line option. Please see the command-line help (`--help`) for usage. Example on Windows:
+```
+mitmdump.exe -p 8088 --set ssl_version_client=all --set ssl_version_server=all
+```
 
 ## Available Options
 

--- a/docs/src/content/concepts-options.md
+++ b/docs/src/content/concepts-options.md
@@ -34,9 +34,11 @@ persistent by saving the settings out to a YAML configuration file (please see
 the specific tool's interactive help for details on how to do this).
 
 For all tools, options can be set directly by name using the `--set`
-command-line option. Please see the command-line help (`--help`) for usage. Example on Windows:
+command-line option. Please see the command-line help (`--help`) for usage. Example:
 ```
-mitmdump.exe -p 8088 --set ssl_version_client=all --set ssl_version_server=all
+mitmproxy --set anticomp=true
+mitmweb --set web_columns=path --set web_columns=status
+mitmweb --set ignore_hosts=142.250.179.100 --set ignore_hosts=2a00:1450:4007:80e::2004 --set ignore_hosts=2a00:1450:4007:819::2004
 ```
 
 ## Available Options

--- a/docs/src/content/concepts-options.md
+++ b/docs/src/content/concepts-options.md
@@ -38,7 +38,7 @@ command-line option. Please see the command-line help (`--help`) for usage. Exam
 ```
 mitmproxy --set anticomp=true
 mitmweb --set web_columns=path --set web_columns=status
-mitmweb --set ignore_hosts=<IPv4-1> --set ignore_hosts=<IPv4-2> --set ignore_hosts=<IPv6-1> --set ignore_hosts=<IPv6-2> 
+mitmweb --set ignore_hosts=IPv4-1 --set ignore_hosts=IPv4-2 --set ignore_hosts=IPv6-1 --set ignore_hosts=IPv6-2 
 ```
 
 ## Available Options

--- a/docs/src/content/concepts-options.md
+++ b/docs/src/content/concepts-options.md
@@ -37,8 +37,7 @@ For all tools, options can be set directly by name using the `--set`
 command-line option. Please see the command-line help (`--help`) for usage. Example:
 ```
 mitmproxy --set anticomp=true
-mitmweb --set web_columns=path --set web_columns=status
-mitmweb --set ignore_hosts=IPv4-1 --set ignore_hosts=IPv4-2 --set ignore_hosts=IPv6-1 --set ignore_hosts=IPv6-2 
+mitmweb --set ignore_hosts=example.com --set ignore_hosts=example.org 
 ```
 
 ## Available Options

--- a/mitmproxy/options.py
+++ b/mitmproxy/options.py
@@ -89,7 +89,7 @@ class Options(optmanager.OptManager):
             regular expression and matched on the ip or the hostname.
             """,
         )
-        self.add_option("allow_hosts", Sequence[str], [], "Opposite of --ignore-hosts.")
+        self.add_option("allow_hosts", Sequence[str], [], "Opposite of --ignore-hosts: only https traffic to these hosts will appear. However, http traffic will always show, which can be filtered with the --view-filter option or press f in mitmproxy")
         self.add_option(
             "listen_host",
             str,


### PR DESCRIPTION
#### Description

Http traffic can be filtered with the `--view-filter` option, as discussed in https://github.com/mitmproxy/mitmproxy/issues/5156

