### PR TITLE
Use dynamic port assignment to resolve collision issue between mitmweb and web UI

### DIFF
--- a/mitmproxy/tools/web/webaddons.py
+++ b/mitmproxy/tools/web/webaddons.py
@@ -1,12 +1,9 @@
-from errno import EADDRINUSE
 import logging
 import webbrowser
 import socket
 from collections.abc import Sequence
 
 from mitmproxy import ctx
-from pprint import pprint
-
 
 
 class WebAddon:

--- a/mitmproxy/tools/web/webaddons.py
+++ b/mitmproxy/tools/web/webaddons.py
@@ -1,15 +1,26 @@
+from errno import EADDRINUSE
 import logging
 import webbrowser
+import socket
 from collections.abc import Sequence
 
 from mitmproxy import ctx
+from pprint import pprint
+
 
 
 class WebAddon:
+    def get_free_port(self):
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.bind(("", 0))
+        _, port = sock.getsockname()
+        sock.close()
+        return port
+    
     def load(self, loader):
         loader.add_option("web_open_browser", bool, True, "Start a browser.")
         loader.add_option("web_debug", bool, False, "Enable mitmweb debugging.")
-        loader.add_option("web_port", int, 8081, "Web UI port.")
+        loader.add_option("web_port", int, self.get_free_port(), "Web UI port.")
         loader.add_option("web_host", str, "127.0.0.1", "Web UI host.")
         loader.add_option(
             "web_columns",

--- a/mitmproxy/tools/web/webaddons.py
+++ b/mitmproxy/tools/web/webaddons.py
@@ -1,6 +1,6 @@
 import logging
-import webbrowser
 import socket
+import webbrowser
 from collections.abc import Sequence
 
 from mitmproxy import ctx
@@ -13,7 +13,7 @@ class WebAddon:
         _, port = sock.getsockname()
         sock.close()
         return port
-    
+
     def load(self, loader):
         loader.add_option("web_open_browser", bool, True, "Start a browser.")
         loader.add_option("web_debug", bool, False, "Enable mitmweb debugging.")


### PR DESCRIPTION
#### Description

To solve #5891, the fix introduces dynamic port assignment by specifying port 0. When mitmweb is started without specifying a port, it uses
```python
socket.bind(('', 0))
```
which allows the operating system to assign an available port.

#### Checklist

 - [x] I have updated tests where applicable.
 - [ ] I have added an entry to the CHANGELOG.
