### PR TITLE
grpc: enable decompressing zstd responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@
   ([#6088](https://github.com/mitmproxy/mitmproxy/pull/6088), @sujaldev)
 * Fix a bug where a server connection timeout would cause requests to be issued with a wrong SNI in reverse proxy mode.
   ([#6148](https://github.com/mitmproxy/mitmproxy/pull/6148), @mhils)
+* Add zstd to valid gRPC encoding schemes.
+  ([#6188](https://github.com/mitmproxy/mitmproxy/pull/6188), @tsaaristo)
 
 ### Breaking Changes
 

--- a/mitmproxy/contentviews/grpc.py
+++ b/mitmproxy/contentviews/grpc.py
@@ -988,6 +988,7 @@ class ViewGrpcProtobuf(base.View):
         "gzip",
         "identity",
         "deflate",
+        "zstd",
     ]
 
     # allows to take external ParserOptions object. goes with defaults otherwise


### PR DESCRIPTION
#### Description

Adds zstd to valid gRPC encoding schemes. Spotted some `grpc-encoding: zstd` in the wild, and this trivial fix was found working.

#### Checklist

 - [x] I have updated tests where applicable.
   (I assume existing gzip test is acceptable, we're relying on `mitmproxy.net.encoding.decode()` anyway)
 - [x] I have added an entry to the CHANGELOG.
