### PR TITLE
Always include either SNI or target IP address as SAN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@
   ([#6148](https://github.com/mitmproxy/mitmproxy/pull/6148), @mhils)
 * Add zstd to valid gRPC encoding schemes.
   ([#6188](https://github.com/mitmproxy/mitmproxy/pull/6188), @tsaaristo)
+* For reverse proxy directly accessed via IP address, the IP address is now included
+  as a subject in the generated certificate.
 
 ### Breaking Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
   ([#6188](https://github.com/mitmproxy/mitmproxy/pull/6188), @tsaaristo)
 * For reverse proxy directly accessed via IP address, the IP address is now included
   as a subject in the generated certificate.
+  ([#6202](https://github.com/mitmproxy/mitmproxy/pull/6202), @mhils)
 
 ### Breaking Changes
 

--- a/mitmproxy/addons/tlsconfig.py
+++ b/mitmproxy/addons/tlsconfig.py
@@ -497,16 +497,15 @@ class TlsConfig:
             if upstream_cert.organization:
                 organization = upstream_cert.organization
 
-        # Add SNI. If not available, try the server address as well.
+        # Add SNI or our local IP address.
         if conn_context.client.sni:
             altnames.append(conn_context.client.sni)
-        elif conn_context.server.address:
-            altnames.append(conn_context.server.address[0])
-
-        # As a last resort, add our local IP address. This may be necessary for HTTPS Proxies which are addressed
-        # via IP. Here we neither have an upstream cert, nor can an IP be included in the server name indication.
-        if not altnames:
+        else:
             altnames.append(conn_context.client.sockname[0])
+
+        # If we already know of a server address, include that in the SANs as well.
+        if conn_context.server.address:
+            altnames.append(conn_context.server.address[0])
 
         # only keep first occurrence of each hostname
         altnames = list(dict.fromkeys(altnames))

--- a/test/mitmproxy/addons/test_tlsconfig.py
+++ b/test/mitmproxy/addons/test_tlsconfig.py
@@ -131,12 +131,17 @@ class TestTlsConfig:
             assert entry.cert.altnames == [
                 "example.mitmproxy.org",
                 "server-address.example",
+                "127.0.0.1",
             ]
 
             # And now we also incorporate SNI.
             ctx.client.sni = "sni.example"
             entry = ta.get_cert(ctx)
-            assert entry.cert.altnames == ["example.mitmproxy.org", "sni.example"]
+            assert entry.cert.altnames == [
+                "example.mitmproxy.org",
+                "sni.example",
+                "server-address.example",
+            ]
 
             with open(tdata.path("mitmproxy/data/invalid-subject.pem"), "rb") as f:
                 ctx.server.certificate_list = [certs.Cert.from_pem(f.read())]


### PR DESCRIPTION
this unbreaks reverse proxy setups that are directly addressed by IP.
