### PR TITLE
Temporarily disable half-broken HTTP/3 modes

### DIFF
--- a/mitmproxy/proxy/layers/quic.py
+++ b/mitmproxy/proxy/layers/quic.py
@@ -1130,7 +1130,7 @@ class ClientQuicLayer(QuicLayer):
     def receive_handshake_data(
         self, data: bytes
     ) -> layer.CommandGenerator[tuple[bool, str | None]]:
-        if isinstance(self.context.layers[0], TransparentProxy):
+        if isinstance(self.context.layers[0], TransparentProxy):  # pragma: no cover
             yield commands.Log(
                 f"Swallowing QUIC handshake because HTTP/3 does not support transparent mode yet.",
                 DEBUG,

--- a/mitmproxy/proxy/layers/quic.py
+++ b/mitmproxy/proxy/layers/quic.py
@@ -39,6 +39,7 @@ from mitmproxy.proxy import context
 from mitmproxy.proxy import events
 from mitmproxy.proxy import layer
 from mitmproxy.proxy import tunnel
+from mitmproxy.proxy.layers.modes import TransparentProxy
 from mitmproxy.proxy.layers.tcp import TCPLayer
 from mitmproxy.proxy.layers.tls import TlsClienthelloHook
 from mitmproxy.proxy.layers.tls import TlsEstablishedClientHook
@@ -1129,6 +1130,11 @@ class ClientQuicLayer(QuicLayer):
     def receive_handshake_data(
         self, data: bytes
     ) -> layer.CommandGenerator[tuple[bool, str | None]]:
+        if isinstance(self.context.layers[0], TransparentProxy):
+            yield commands.Log(
+                f"Swallowing QUIC handshake because HTTP/3 does not support transparent mode yet.", DEBUG
+            )
+            return False, None
         if not self.context.options.http3:
             yield commands.Log(
                 f"Swallowing QUIC handshake because HTTP/3 is disabled.", DEBUG

--- a/mitmproxy/proxy/layers/quic.py
+++ b/mitmproxy/proxy/layers/quic.py
@@ -1132,7 +1132,8 @@ class ClientQuicLayer(QuicLayer):
     ) -> layer.CommandGenerator[tuple[bool, str | None]]:
         if isinstance(self.context.layers[0], TransparentProxy):
             yield commands.Log(
-                f"Swallowing QUIC handshake because HTTP/3 does not support transparent mode yet.", DEBUG
+                f"Swallowing QUIC handshake because HTTP/3 does not support transparent mode yet.",
+                DEBUG,
             )
             return False, None
         if not self.context.options.http3:

--- a/mitmproxy/proxy/mode_servers.py
+++ b/mitmproxy/proxy/mode_servers.py
@@ -519,6 +519,6 @@ class DnsInstance(AsyncioServerInstance[mode_specs.DnsMode]):
         return layers.DNSLayer(context)
 
 
-class Http3Instance(AsyncioServerInstance[mode_specs.Http3Mode]):
-    def make_top_layer(self, context: Context) -> Layer:
-        return layers.modes.HttpProxy(context)
+# class Http3Instance(AsyncioServerInstance[mode_specs.Http3Mode]):
+#     def make_top_layer(self, context: Context) -> Layer:
+#         return layers.modes.HttpProxy(context)

--- a/mitmproxy/proxy/mode_specs.py
+++ b/mitmproxy/proxy/mode_specs.py
@@ -262,17 +262,17 @@ class DnsMode(ProxyMode):
         _check_empty(self.data)
 
 
-class Http3Mode(ProxyMode):
-    """
-    A regular HTTP3 proxy that is interfaced with absolute-form HTTP requests.
-    (This class will be merged into `RegularMode` once the UDP implementation is deemed stable enough.)
-    """
-
-    description = "HTTP3 proxy"
-    transport_protocol = UDP
-
-    def __post_init__(self) -> None:
-        _check_empty(self.data)
+# class Http3Mode(ProxyMode):
+#     """
+#     A regular HTTP3 proxy that is interfaced with absolute-form HTTP requests.
+#     (This class will be merged into `RegularMode` once the UDP implementation is deemed stable enough.)
+#     """
+#
+#     description = "HTTP3 proxy"
+#     transport_protocol = UDP
+#
+#     def __post_init__(self) -> None:
+#         _check_empty(self.data)
 
 
 class WireGuardMode(ProxyMode):

--- a/test/mitmproxy/addons/test_proxyserver.py
+++ b/test/mitmproxy/addons/test_proxyserver.py
@@ -820,6 +820,7 @@ async def test_reverse_quic_datagram(caplog_async, connection_strategy: str) -> 
             await caplog_async.await_log("stopped")
 
 
+@pytest.mark.skip("HTTP/3 for regular mode is not fully supported yet")
 async def test_regular_http3(caplog_async, monkeypatch) -> None:
     caplog_async.set_level("INFO")
     ps = Proxyserver()

--- a/test/mitmproxy/proxy/test_mode_servers.py
+++ b/test/mitmproxy/proxy/test_mode_servers.py
@@ -26,7 +26,7 @@ def test_make():
 
     for mode in [
         "regular",
-        "http3",
+        # "http3",
         "upstream:example.com",
         "transparent",
         "reverse:example.com",

--- a/test/mitmproxy/proxy/test_mode_specs.py
+++ b/test/mitmproxy/proxy/test_mode_specs.py
@@ -57,7 +57,7 @@ def test_listen_addr():
 
 def test_parse_specific_modes():
     assert ProxyMode.parse("regular")
-    assert ProxyMode.parse("http3")
+    # assert ProxyMode.parse("http3")
     assert ProxyMode.parse("transparent")
     assert ProxyMode.parse("upstream:https://proxy")
     assert ProxyMode.parse("reverse:https://host@443")
@@ -78,8 +78,8 @@ def test_parse_specific_modes():
     with pytest.raises(ValueError, match="takes no arguments"):
         ProxyMode.parse("regular:configuration")
 
-    with pytest.raises(ValueError, match="takes no arguments"):
-        ProxyMode.parse("http3:configuration")
+    # with pytest.raises(ValueError, match="takes no arguments"):
+    #     ProxyMode.parse("http3:configuration")
 
     with pytest.raises(ValueError, match="invalid upstream proxy scheme"):
         ProxyMode.parse("upstream:dns://example.com")


### PR DESCRIPTION
Those will come back after shipping a reverse-proxy MVP.