### PR TITLE
Enable unsafe legacy SSL renegotiation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@
 * For reverse proxy directly accessed via IP address, the IP address is now included
   as a subject in the generated certificate.
   ([#6202](https://github.com/mitmproxy/mitmproxy/pull/6202), @mhils)
+* Enable legacy SSL connect when connecting to server if the `ssl_insecure` flag is set.
+  ([#6281](https://github.com/mitmproxy/mitmproxy/pull/6281), @DurandA)
 
 ### Breaking Changes
 

--- a/mitmproxy/addons/tlsconfig.py
+++ b/mitmproxy/addons/tlsconfig.py
@@ -294,6 +294,7 @@ class TlsConfig:
             ca_path=ctx.options.ssl_verify_upstream_trusted_confdir,
             ca_pemfile=ctx.options.ssl_verify_upstream_trusted_ca,
             client_cert=client_cert,
+            legacy_server_connect=ctx.options.ssl_insecure,
         )
 
         tls_start.ssl_conn = SSL.Connection(ssl_ctx)

--- a/mitmproxy/net/tls.py
+++ b/mitmproxy/net/tls.py
@@ -141,6 +141,7 @@ def create_proxy_server_context(
     ca_path: str | None,
     ca_pemfile: str | None,
     client_cert: str | None,
+    legacy_server_connect: bool,
 ) -> SSL.Context:
     context: SSL.Context = _create_ssl_context(
         method=method,
@@ -167,6 +168,9 @@ def create_proxy_server_context(
             context.use_certificate_chain_file(client_cert)
         except SSL.Error as e:
             raise RuntimeError(f"Cannot load TLS client certificate: {e}") from e
+
+    if legacy_server_connect:
+        context.set_options(0x4)  # OP_LEGACY_SERVER_CONNECT
 
     return context
 

--- a/mitmproxy/net/tls.py
+++ b/mitmproxy/net/tls.py
@@ -17,7 +17,7 @@ from mitmproxy import certs
 
 # Remove once pyOpenSSL 23.3.0 is released and bump version in pyproject.toml.
 try:  # pragma: no cover
-    from OpenSSL.SSL import OP_LEGACY_SERVER_CONNECT
+    from OpenSSL.SSL import OP_LEGACY_SERVER_CONNECT  # type: ignore
 except ImportError:
     OP_LEGACY_SERVER_CONNECT = 0x4
 

--- a/mitmproxy/net/tls.py
+++ b/mitmproxy/net/tls.py
@@ -15,6 +15,12 @@ from OpenSSL.crypto import X509
 
 from mitmproxy import certs
 
+# Remove once pyOpenSSL 23.3.0 is released and bump version in pyproject.toml.
+try:  # pragma: no cover
+    from OpenSSL.SSL import OP_LEGACY_SERVER_CONNECT
+except ImportError:
+    OP_LEGACY_SERVER_CONNECT = 0x4
+
 
 # redeclared here for strict type checking
 class Method(Enum):
@@ -170,7 +176,7 @@ def create_proxy_server_context(
             raise RuntimeError(f"Cannot load TLS client certificate: {e}") from e
 
     if legacy_server_connect:
-        context.set_options(0x4)  # OP_LEGACY_SERVER_CONNECT
+        context.set_options(OP_LEGACY_SERVER_CONNECT)
 
     return context
 

--- a/test/mitmproxy/net/test_tls.py
+++ b/test/mitmproxy/net/test_tls.py
@@ -34,6 +34,7 @@ def test_sslkeylogfile(tdata, monkeypatch):
         ca_path=None,
         ca_pemfile=None,
         client_cert=None,
+        legacy_server_connect=False,
     )
     sctx = tls.create_client_proxy_context(
         method=tls.Method.TLS_SERVER_METHOD,


### PR DESCRIPTION
#### Description

This PR fixes the issue discussed in #5422 when connecting to a server with outdated/misconfigured SSL. This is a draft PR to discuss if a full PR would be accepted. A full PR would only add the `OP_LEGACY_SERVER_CONNECT` SSL context flag if the `ssl_insecure` switch is passed. 

#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
