### PR TITLE
Improve how we log tracebacks

### DIFF
--- a/mitmproxy/addonmanager.py
+++ b/mitmproxy/addonmanager.py
@@ -51,6 +51,8 @@ def safecall():
         etype, value, tb = sys.exc_info()
         tb = cut_traceback(tb, "invoke_addon_sync")
         tb = cut_traceback(tb, "invoke_addon")
+        assert etype
+        assert value
         logger.error(
             f"Addon error: {value}",
             exc_info=(etype, value, tb),

--- a/mitmproxy/addonmanager.py
+++ b/mitmproxy/addonmanager.py
@@ -52,7 +52,8 @@ def safecall():
         tb = cut_traceback(tb, "invoke_addon_sync")
         tb = cut_traceback(tb, "invoke_addon")
         logger.error(
-            "Addon error: %s" % "".join(traceback.format_exception(etype, value, tb))
+            f"Addon error: {value}",
+            exc_info=(etype, value, tb),
         )
 
 

--- a/mitmproxy/addons/asgiapp.py
+++ b/mitmproxy/addons/asgiapp.py
@@ -1,6 +1,5 @@
 import asyncio
 import logging
-import traceback
 import urllib.parse
 
 import asgiref.compatibility

--- a/mitmproxy/addons/asgiapp.py
+++ b/mitmproxy/addons/asgiapp.py
@@ -139,7 +139,7 @@ async def serve(app, flow: http.HTTPFlow):
         if not sent_response:
             raise RuntimeError(f"no response sent.")
     except Exception as e:
-        logger.error(f"Error in asgi app: {e}", exc_info=True)
+        logger.exception(f"Error in asgi app: {e}")
         flow.response = http.Response.make(500, b"ASGI Error.")
     finally:
         done.set()

--- a/mitmproxy/addons/asgiapp.py
+++ b/mitmproxy/addons/asgiapp.py
@@ -138,8 +138,8 @@ async def serve(app, flow: http.HTTPFlow):
         await app(scope, receive, send)
         if not sent_response:
             raise RuntimeError(f"no response sent.")
-    except Exception:
-        logger.error(f"Error in asgi app:\n{traceback.format_exc(limit=-5)}")
+    except Exception as e:
+        logger.error(f"Error in asgi app: {e}", exc_info=True)
         flow.response = http.Response.make(500, b"ASGI Error.")
     finally:
         done.set()

--- a/mitmproxy/addons/clientplayback.py
+++ b/mitmproxy/addons/clientplayback.py
@@ -173,7 +173,7 @@ class ClientPlayback:
                 else:
                     await h.replay()
             except Exception:
-                logger.error(f"Client replay has crashed!\n{traceback.format_exc()}")
+                logger.error(f"Client replay has crashed!", exc_info=True)
             self.queue.task_done()
             self.inflight = None
 

--- a/mitmproxy/addons/clientplayback.py
+++ b/mitmproxy/addons/clientplayback.py
@@ -5,6 +5,8 @@ import logging
 import time
 import traceback
 from collections.abc import Sequence
+from types import TracebackType
+from typing import Literal
 from typing import cast
 
 import mitmproxy.types
@@ -112,7 +114,12 @@ class ReplayHandler(server.ConnectionHandler):
         self.server_event(events.Start())
         await self.done.wait()
 
-    def log(self, message: str, level: int = logging.INFO) -> None:
+    def log(
+        self,
+        message: str,
+        level: int = logging.INFO,
+        exc_info: Literal[True] | tuple[type[BaseException] | None, BaseException | None, TracebackType | None] | None = None
+    ) -> None:
         assert isinstance(level, int)
         logger.log(level=level, msg=f"[replay] {message}")
 

--- a/mitmproxy/addons/clientplayback.py
+++ b/mitmproxy/addons/clientplayback.py
@@ -180,7 +180,7 @@ class ClientPlayback:
                 else:
                     await h.replay()
             except Exception:
-                logger.error(f"Client replay has crashed!", exc_info=True)
+                logger.exception(f"Client replay has crashed!")
             self.queue.task_done()
             self.inflight = None
 

--- a/mitmproxy/addons/clientplayback.py
+++ b/mitmproxy/addons/clientplayback.py
@@ -3,11 +3,10 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
-import traceback
 from collections.abc import Sequence
 from types import TracebackType
-from typing import Literal
 from typing import cast
+from typing import Literal
 
 import mitmproxy.types
 from mitmproxy import command
@@ -118,7 +117,9 @@ class ReplayHandler(server.ConnectionHandler):
         self,
         message: str,
         level: int = logging.INFO,
-        exc_info: Literal[True] | tuple[type[BaseException] | None, BaseException | None, TracebackType | None] | None = None
+        exc_info: Literal[True]
+        | tuple[type[BaseException] | None, BaseException | None, TracebackType | None]
+        | None = None,
     ) -> None:
         assert isinstance(level, int)
         logger.log(level=level, msg=f"[replay] {message}")

--- a/mitmproxy/addons/script.py
+++ b/mitmproxy/addons/script.py
@@ -72,6 +72,8 @@ def script_error_handler(path, exc, msg="", tb=False):
     if tb:
         etype, value, tback = sys.exc_info()
         tback = addonmanager.cut_traceback(tback, "invoke_addon_sync")
+        assert etype
+        assert value
         logger.error(log_msg, exc_info=(etype, value, tback))
     else:
         logger.error(log_msg)

--- a/mitmproxy/addons/script.py
+++ b/mitmproxy/addons/script.py
@@ -4,7 +4,6 @@ import importlib.util
 import logging
 import os
 import sys
-import traceback
 import types
 from collections.abc import Sequence
 

--- a/mitmproxy/addons/script.py
+++ b/mitmproxy/addons/script.py
@@ -72,10 +72,9 @@ def script_error_handler(path, exc, msg="", tb=False):
     if tb:
         etype, value, tback = sys.exc_info()
         tback = addonmanager.cut_traceback(tback, "invoke_addon_sync")
-        log_msg = (
-            log_msg + "\n" + "".join(traceback.format_exception(etype, value, tback))
-        )
-    logger.error(log_msg)
+        logger.error(log_msg, exc_info=(etype, value, tback))
+    else:
+        logger.error(log_msg)
 
 
 ReloadInterval = 1

--- a/mitmproxy/log.py
+++ b/mitmproxy/log.py
@@ -49,6 +49,8 @@ class MitmFormatter(logging.Formatter):
     def format(self, record: logging.LogRecord) -> str:
         time = self.formatTime(record)
         message = record.getMessage()
+        if record.exc_info:
+            message = f"{message}\n{self.formatException(record.exc_info)}"
         if self.colorize:
             message = miniclick.style(
                 message,

--- a/mitmproxy/master.py
+++ b/mitmproxy/master.py
@@ -84,19 +84,11 @@ class Master:
         try:
             exc: Exception = context["exception"]
         except KeyError:
-            logger.error(
-                f"Unhandled asyncio error: {context}"
-                "\nPlease lodge a bug report at:"
-                + "\n\thttps://github.com/mitmproxy/mitmproxy/issues"
-            )
+            logger.error(f"Unhandled asyncio error: {context}")
         else:
             if isinstance(exc, OSError) and exc.errno == 10038:
                 return  # suppress https://bugs.python.org/issue43253
-            logger.error(
-                "\n".join(traceback.format_exception(type(exc), exc, exc.__traceback__))
-                + "\nPlease lodge a bug report at:"
-                + "\n\thttps://github.com/mitmproxy/mitmproxy/issues"
-            )
+            logger.error("Unhandled errror in task.", exc_info=(type(exc), exc, exc.__traceback__))
 
     async def load_flow(self, f):
         """

--- a/mitmproxy/master.py
+++ b/mitmproxy/master.py
@@ -1,6 +1,5 @@
 import asyncio
 import logging
-import traceback
 
 from . import ctx as mitmproxy_ctx
 from .proxy.mode_specs import ReverseMode
@@ -88,7 +87,10 @@ class Master:
         else:
             if isinstance(exc, OSError) and exc.errno == 10038:
                 return  # suppress https://bugs.python.org/issue43253
-            logger.error("Unhandled errror in task.", exc_info=(type(exc), exc, exc.__traceback__))
+            logger.error(
+                "Unhandled errror in task.",
+                exc_info=(type(exc), exc, exc.__traceback__),
+            )
 
     async def load_flow(self, f):
         """

--- a/mitmproxy/proxy/server.py
+++ b/mitmproxy/proxy/server.py
@@ -11,7 +11,6 @@ import asyncio
 import collections
 import logging
 import time
-import traceback
 from collections.abc import Awaitable
 from collections.abc import Callable
 from collections.abc import MutableMapping
@@ -356,9 +355,13 @@ class ConnectionHandler(metaclass=abc.ABCMeta):
         self,
         message: str,
         level: int = logging.INFO,
-        exc_info: Literal[True] | tuple[type[BaseException], BaseException, TracebackType | None] | None = None
+        exc_info: Literal[True]
+        | tuple[type[BaseException], BaseException, TracebackType | None]
+        | None = None,
     ) -> None:
-        logger.log(level, message, extra={"client": self.client.peername}, exc_info=exc_info)
+        logger.log(
+            level, message, extra={"client": self.client.peername}, exc_info=exc_info
+        )
 
     def server_event(self, event: events.Event) -> None:
         self.timeout_watchdog.register_activity()

--- a/mitmproxy/proxy/server.py
+++ b/mitmproxy/proxy/server.py
@@ -17,6 +17,8 @@ from collections.abc import Callable
 from collections.abc import MutableMapping
 from contextlib import contextmanager
 from dataclasses import dataclass
+from types import TracebackType
+from typing import Literal
 
 import mitmproxy_rs
 from OpenSSL import SSL
@@ -350,7 +352,12 @@ class ConnectionHandler(metaclass=abc.ABCMeta):
     async def handle_hook(self, hook: commands.StartHook) -> None:
         pass
 
-    def log(self, message: str, level: int = logging.INFO, exc_info=None) -> None:
+    def log(
+        self,
+        message: str,
+        level: int = logging.INFO,
+        exc_info: Literal[True] | tuple[type[BaseException] | None, BaseException | None, TracebackType | None] | None = None
+    ) -> None:
         logger.log(level, message, extra={"client": self.client.peername}, exc_info=exc_info)
 
     def server_event(self, event: events.Event) -> None:

--- a/mitmproxy/proxy/server.py
+++ b/mitmproxy/proxy/server.py
@@ -356,7 +356,7 @@ class ConnectionHandler(metaclass=abc.ABCMeta):
         self,
         message: str,
         level: int = logging.INFO,
-        exc_info: Literal[True] | tuple[type[BaseException] | None, BaseException | None, TracebackType | None] | None = None
+        exc_info: Literal[True] | tuple[type[BaseException], BaseException, TracebackType | None] | None = None
     ) -> None:
         logger.log(level, message, extra={"client": self.client.peername}, exc_info=exc_info)
 


### PR DESCRIPTION
Instead of formatting the traceback on site, we not pass the exception info to the logging machinery. This allows addons to hook in and for example report to Sentry.

/cc @erikshestopal @kgriffs