### PR TITLE
Change default keybind to export flow to "x"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 * Fix compatibility with Windows Schannel clients, which previously got
   confused by CA and leaf certificate sharing the same Subject Key Identifier.
   ([#6549](https://github.com/mitmproxy/mitmproxy/pull/6549), @driuba and @mhils)
+* Change keybinding for exporting flow from "e" to "x" to avoid conflict with "edit" keybinding.
+  ([#6225](https://github.com/mitmproxy/mitmproxy/issues/6225), @Llama1412)
 * Fix bug where response flows from HAR files had incorrect `content-length` headers
   ([#6548](https://github.com/mitmproxy/mitmproxy/pull/6548), @zanieb)
 * Improved handling for `--allow-hosts`/`--ignore-hosts` options in WireGuard mode (#5930).

--- a/mitmproxy/tools/console/consoleaddons.py
+++ b/mitmproxy/tools/console/consoleaddons.py
@@ -375,7 +375,9 @@ class ConsoleAddon:
         flow = self.master.view.focus.flow
         focus_options = []
 
-        if isinstance(flow, tcp.TCPFlow):
+        if flow is None:
+            raise exceptions.CommandError("No flow selected.")
+        elif isinstance(flow, tcp.TCPFlow):
             focus_options = ["tcp-message"]
         elif isinstance(flow, udp.UDPFlow):
             focus_options = ["udp-message"]

--- a/mitmproxy/tools/console/defaultkeys.py
+++ b/mitmproxy/tools/console/defaultkeys.py
@@ -74,7 +74,7 @@ def map(km: Keymap) -> None:
         "D", "view.flows.duplicate @focus", ["flowlist", "flowview"], "Duplicate flow"
     )
     km.add(
-        "e",
+        "x",
         """
         console.choose.cmd Format export.formats
         console.command export.file {choice} @focus

--- a/mitmproxy/tools/console/defaultkeys.py
+++ b/mitmproxy/tools/console/defaultkeys.py
@@ -156,7 +156,7 @@ def map(km: Keymap) -> None:
         console.choose.cmd Part console.edit.focus.options
         console.edit.focus {choice}
         """,
-        ["flowview"],
+        ["flowlist", "flowview"],
         "Edit a flow component",
     )
     km.add(

--- a/mitmproxy/tools/console/quickhelp.py
+++ b/mitmproxy/tools/console/quickhelp.py
@@ -73,6 +73,7 @@ def make(
                     top_items["Unmark"] = "Toggle mark on this flow"
                 else:
                     top_items["Mark"] = "Toggle mark on this flow"
+                top_items["Edit"] = "Edit a flow component"
             if focused_flow.intercepted:
                 top_items["Resume"] = "Resume this intercepted flow"
             if focused_flow.modified():


### PR DESCRIPTION
#### Description

Changed the default keybinding for exporting flows from "e" (also used by Edit) to "x".
Resolves #6225

#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
