### PR TITLE
Include sent headers with CONNECT request to upstream proxy

### DIFF
--- a/mitmproxy/addons/proxy_forward_headers.py
+++ b/mitmproxy/addons/proxy_forward_headers.py
@@ -1,0 +1,34 @@
+import weakref
+from collections.abc import MutableMapping
+
+from mitmproxy import connection
+from mitmproxy import ctx
+from mitmproxy import http
+
+
+class ProxyForwardHeaders:
+    def __init__(self) -> None:
+        self.connection_headers: MutableMapping[
+            connection.Client, tuple[str, str]
+        ] = weakref.WeakKeyDictionary()
+
+    def load(self, loader):
+        loader.add_option(
+            "proxyforwardheaders",
+            bool,
+            False,
+            """
+            Forward CONNECT headers to upstream proxy.
+            """,
+        )
+
+    def http_connect(self, f: http.HTTPFlow) -> None:
+        if ctx.options.proxyforwardheaders:
+            self.connection_headers[f.client_conn] = f.request.headers
+
+    def http_connect_upstream(self, f: http.HTTPFlow):
+        if ctx.options.proxyforwardheaders and self.connection_headers:
+            f.request.headers = self.connection_headers[f.client_conn]
+
+
+addons = [ProxyForwardHeaders()]


### PR DESCRIPTION
#### Description

Includes the request headers from the client to the upstream proxy in the CONNECT request. Looking at https://github.com/mitmproxy/mitmproxy/discussions/5802, and the relevant events, I don't believe that there is a way today to access the headers that are sent from the client and override the empty headers sent to the upstream proxy.

I don't know if this is the best way to tackle it, or if there is a reason to strip all the headers in the CONNECT request, but for my specific use case of the day, it would be nice to be able to handle the traffic differently based on the user agent of the caller.  

#### Checklist

 - [X] I have updated tests where applicable.
 - [ ] I have added an entry to the CHANGELOG.
