### PR TITLE
Use `client.id` as connection id where possible

### DIFF
--- a/mitmproxy/addons/proxyserver.py
+++ b/mitmproxy/addons/proxyserver.py
@@ -287,6 +287,7 @@ class Proxyserver(ServerManager):
         return [addr for server in self.servers for addr in server.listen_addrs]
 
     def inject_event(self, event: events.MessageInjected):
+        connection_id: str | tuple
         if event.flow.client_conn.transport_protocol != "udp":
             connection_id = event.flow.client_conn.id
         else:

--- a/mitmproxy/addons/proxyserver.py
+++ b/mitmproxy/addons/proxyserver.py
@@ -108,7 +108,7 @@ class Proxyserver(ServerManager):
     This addon runs the actual proxy server.
     """
 
-    connections: dict[tuple, ProxyConnectionHandler]
+    connections: dict[tuple | str, ProxyConnectionHandler]
     servers: Servers
 
     is_running: bool
@@ -125,7 +125,7 @@ class Proxyserver(ServerManager):
 
     @contextmanager
     def register_connection(
-        self, connection_id: tuple, handler: ProxyConnectionHandler
+        self, connection_id: tuple | str, handler: ProxyConnectionHandler
     ):
         self.connections[connection_id] = handler
         try:
@@ -278,6 +278,7 @@ class Proxyserver(ServerManager):
                 self._update_task = asyncio.create_task(self.servers.update(modes))
 
     async def setup_servers(self) -> bool:
+        """Setup proxy servers. This may take an indefinite amount of time to complete (e.g. on permission prompts)."""
         return await self.servers.update(
             [mode_specs.ProxyMode.parse(m) for m in ctx.options.mode]
         )
@@ -286,11 +287,14 @@ class Proxyserver(ServerManager):
         return [addr for server in self.servers for addr in server.listen_addrs]
 
     def inject_event(self, event: events.MessageInjected):
-        connection_id = (
-            event.flow.client_conn.transport_protocol,
-            event.flow.client_conn.peername,
-            event.flow.client_conn.sockname,
-        )
+        if event.flow.client_conn.transport_protocol != "udp":
+            connection_id = event.flow.client_conn.id
+        else:
+            # temporary workaround: for UDP we don't have persistent client IDs yet.
+            connection_id = (
+                event.flow.client_conn.peername,
+                event.flow.client_conn.sockname,
+            )
         if connection_id not in self.connections:
             raise ValueError("Flow is not from a live connection.")
         self.connections[connection_id].server_event(event)

--- a/mitmproxy/addons/proxyserver.py
+++ b/mitmproxy/addons/proxyserver.py
@@ -290,7 +290,7 @@ class Proxyserver(ServerManager):
         connection_id: str | tuple
         if event.flow.client_conn.transport_protocol != "udp":
             connection_id = event.flow.client_conn.id
-        else:
+        else:  # pragma: no cover
             # temporary workaround: for UDP we don't have persistent client IDs yet.
             connection_id = (
                 event.flow.client_conn.peername,

--- a/mitmproxy/master.py
+++ b/mitmproxy/master.py
@@ -53,10 +53,13 @@ class Master:
                 await ec.shutdown_if_errored()
             if ps := self.addons.get("proxyserver"):
                 # This may block for some proxy modes, so we also monitor should_exit.
-                await asyncio.wait([
-                    asyncio.create_task(ps.setup_servers()),
-                    asyncio.create_task(self.should_exit.wait())
-                ], return_when=asyncio.FIRST_COMPLETED)
+                await asyncio.wait(
+                    [
+                        asyncio.create_task(ps.setup_servers()),
+                        asyncio.create_task(self.should_exit.wait()),
+                    ],
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
             if ec := self.addons.get("errorcheck"):
                 await ec.shutdown_if_errored()
                 ec.finish()

--- a/mitmproxy/master.py
+++ b/mitmproxy/master.py
@@ -52,7 +52,11 @@ class Master:
             if ec := self.addons.get("errorcheck"):
                 await ec.shutdown_if_errored()
             if ps := self.addons.get("proxyserver"):
-                await ps.setup_servers()
+                # This may block for some proxy modes, so we also monitor should_exit.
+                await asyncio.wait([
+                    asyncio.create_task(ps.setup_servers()),
+                    asyncio.create_task(self.should_exit.wait())
+                ], return_when=asyncio.FIRST_COMPLETED)
             if ec := self.addons.get("errorcheck"):
                 await ec.shutdown_if_errored()
                 ec.finish()

--- a/mitmproxy/proxy/mode_servers.py
+++ b/mitmproxy/proxy/mode_servers.py
@@ -202,8 +202,7 @@ class ServerInstance(Generic[M], metaclass=ABCMeta):
                 handler.layer.context.server.address = original_dst
         elif isinstance(self.mode, (mode_specs.WireGuardMode, mode_specs.OsProxyMode)):
             handler.layer.context.server.address = writer.get_extra_info(
-                "destination_address",
-                handler.layer.context.client.sockname
+                "destination_address", handler.layer.context.client.sockname
             )
 
         with self.manager.register_connection(handler.layer.context.client.id, handler):

--- a/mitmproxy/proxy/mode_servers.py
+++ b/mitmproxy/proxy/mode_servers.py
@@ -201,7 +201,9 @@ class ServerInstance(Generic[M], metaclass=ABCMeta):
                 handler.layer.context.client.sockname = original_dst
                 handler.layer.context.server.address = original_dst
         elif isinstance(self.mode, (mode_specs.WireGuardMode, mode_specs.OsProxyMode)):
-            handler.layer.context.server.address = writer.get_extra_info("destination_address")
+            handler.layer.context.server.address = writer.get_extra_info(
+                "destination_address"
+            )
 
         with self.manager.register_connection(handler.layer.context.client.id, handler):
             await handler.handle_client()

--- a/mitmproxy/proxy/mode_servers.py
+++ b/mitmproxy/proxy/mode_servers.py
@@ -202,7 +202,8 @@ class ServerInstance(Generic[M], metaclass=ABCMeta):
                 handler.layer.context.server.address = original_dst
         elif isinstance(self.mode, (mode_specs.WireGuardMode, mode_specs.OsProxyMode)):
             handler.layer.context.server.address = writer.get_extra_info(
-                "destination_address"
+                "destination_address",
+                handler.layer.context.client.sockname
             )
 
         with self.manager.register_connection(handler.layer.context.client.id, handler):

--- a/mitmproxy/proxy/mode_servers.py
+++ b/mitmproxy/proxy/mode_servers.py
@@ -76,11 +76,12 @@ M = TypeVar("M", bound=mode_specs.ProxyMode)
 
 
 class ServerManager(typing.Protocol):
-    connections: dict[tuple, ProxyConnectionHandler]
+    # temporary workaround: for UDP, we use the 4-tuple because we don't have a uuid.
+    connections: dict[tuple | str, ProxyConnectionHandler]
 
     @contextmanager
     def register_connection(
-        self, connection_id: tuple, handler: ProxyConnectionHandler
+        self, connection_id: tuple | str, handler: ProxyConnectionHandler
     ):
         ...  # pragma: no cover
 
@@ -200,14 +201,9 @@ class ServerInstance(Generic[M], metaclass=ABCMeta):
                 handler.layer.context.client.sockname = original_dst
                 handler.layer.context.server.address = original_dst
         elif isinstance(self.mode, (mode_specs.WireGuardMode, mode_specs.OsProxyMode)):
-            handler.layer.context.server.address = handler.layer.context.client.sockname
+            handler.layer.context.server.address = writer.get_extra_info("destination_address")
 
-        connection_id = (
-            handler.layer.context.client.transport_protocol,
-            handler.layer.context.client.peername,
-            handler.layer.context.client.sockname,
-        )
-        with self.manager.register_connection(connection_id, handler):
+        with self.manager.register_connection(handler.layer.context.client.id, handler):
             await handler.handle_client()
 
     def handle_udp_datagram(
@@ -217,7 +213,8 @@ class ServerInstance(Generic[M], metaclass=ABCMeta):
         remote_addr: Address,
         local_addr: Address,
     ) -> None:
-        connection_id = ("udp", remote_addr, local_addr)
+        # temporary workaround: we don't have a client uuid here.
+        connection_id = (remote_addr, local_addr)
         if connection_id not in self.manager.connections:
             reader = udp.DatagramReader()
             writer = udp.DatagramWriter(transport, remote_addr, reader)

--- a/test/mitmproxy/addons/test_proxyserver.py
+++ b/test/mitmproxy/addons/test_proxyserver.py
@@ -302,7 +302,7 @@ async def test_dns(caplog_async) -> None:
         assert req.id == resp.id and "8.8.8.8" in str(resp)
         assert len(ps.connections) == 1
         dns_layer = ps.connections[
-            ("udp", w.get_extra_info("sockname"), dns_addr)
+            (w.get_extra_info("sockname"), dns_addr)
         ].layer
         assert isinstance(dns_layer, layers.DNSLayer)
         assert len(dns_layer.flows) == 2

--- a/test/mitmproxy/addons/test_proxyserver.py
+++ b/test/mitmproxy/addons/test_proxyserver.py
@@ -301,9 +301,7 @@ async def test_dns(caplog_async) -> None:
         resp = dns.Message.unpack(await r.read(udp.MAX_DATAGRAM_SIZE))
         assert req.id == resp.id and "8.8.8.8" in str(resp)
         assert len(ps.connections) == 1
-        dns_layer = ps.connections[
-            (w.get_extra_info("sockname"), dns_addr)
-        ].layer
+        dns_layer = ps.connections[(w.get_extra_info("sockname"), dns_addr)].layer
         assert isinstance(dns_layer, layers.DNSLayer)
         assert len(dns_layer.flows) == 2
 


### PR DESCRIPTION
This fixes compatibilit with the new macOS transparent mode, where the client's peername is unspecified (which otherwise leads to duplicates).