### PR TITLE
mitmweb: Allow up to 4GB dump to be uploaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Add support for reading HAR files using the existing flow loading APIs, e.g. `mitmproxy -r example.har`.
   ([#6335](https://github.com/mitmproxy/mitmproxy/pull/6335), @stanleygvi)
+* Increase maximum dump file size accepted by mitmweb
 
 
 ## 04 August 2023: mitmproxy 10.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Add support for reading HAR files using the existing flow loading APIs, e.g. `mitmproxy -r example.har`.
   ([#6335](https://github.com/mitmproxy/mitmproxy/pull/6335), @stanleygvi)
 * Increase maximum dump file size accepted by mitmweb
+  ([#6373](https://github.com/mitmproxy/mitmproxy/pull/6373), @t-wy)
 
 
 ## 04 August 2023: mitmproxy 10.0.0

--- a/mitmproxy/tools/web/master.py
+++ b/mitmproxy/tools/web/master.py
@@ -97,7 +97,7 @@ class WebMaster(master.Master):
         tornado.ioloop.IOLoop.current()
 
         # Add our web app.
-        http_server = tornado.httpserver.HTTPServer(self.app)
+        http_server = tornado.httpserver.HTTPServer(self.app, max_buffer_size=2**32) # 4GB
         try:
             http_server.listen(self.options.web_port, self.options.web_host)
         except OSError as e:

--- a/mitmproxy/tools/web/master.py
+++ b/mitmproxy/tools/web/master.py
@@ -97,7 +97,9 @@ class WebMaster(master.Master):
         tornado.ioloop.IOLoop.current()
 
         # Add our web app.
-        http_server = tornado.httpserver.HTTPServer(self.app, max_buffer_size=2**32) # 4GB
+        http_server = tornado.httpserver.HTTPServer(
+            self.app, max_buffer_size=2**32
+        )  # 4GB
         try:
             http_server.listen(self.options.web_port, self.options.web_host)
         except OSError as e:


### PR DESCRIPTION
#### Description

A temporary fix to allow up to 4GB dump to be uploaded by supplying max_buffer_size of the HTTPServer constructor to be 2**32 (4GB).

(Perhaps it is better to be a configurable item, or change the post mechanism to stream instead if there ever is any security concern implied due to usage or hardware limitations)

By default, if no argument is supplied, the maximum buffer size is 100MB, which causes saved dump file to be unreadable through the web interface.

Reference Documentation: [Link](https://www.tornadoweb.org/en/stable/httpclient.html#:~:text=a%20simple%20mapping.-,max_buffer_size,-(default%20100MB)%20is)

Possibly:
Resolves #4651, resolves #5609

#### Checklist

 - [x] I have updated tests where applicable.
 - [ ] I have added an entry to the CHANGELOG.
