### PR TITLE
fix certificates generated by dummy_cert on clients that require AuthorityKeyIdentifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
   ([#6389](https://github.com/mitmproxy/mitmproxy/pull/6389), @mhils)
 * Add a contentview for DNS-over-HTTPS.
   ([#6389](https://github.com/mitmproxy/mitmproxy/pull/6389), @mhils)
+* Fix certificate generation to work with strict mode OpenSSL 3.x clients
+  ([#6410](https://github.com/mitmproxy/mitmproxy/pull/6410), @mmaxim)
 
 
 ## 27 September 2023: mitmproxy 10.1.1

--- a/mitmproxy/certs.py
+++ b/mitmproxy/certs.py
@@ -278,6 +278,19 @@ def dummy_cert(
     builder = builder.add_extension(
         x509.SubjectAlternativeName(ss), critical=not is_valid_commonname
     )
+
+    # we just use the same key as the CA for these certs, so put that in the SKI extension
+    builder = builder.add_extension(
+        x509.SubjectKeyIdentifier.from_public_key(privkey.public_key()),
+        critical=False,
+    )
+    # add authority key identifier for the cacert issuing cert for greater acceptance by
+    # client TLS libraries (such as OpenSSL 3.x)
+    builder = builder.add_extension(
+        x509.AuthorityKeyIdentifier.from_issuer_public_key(cacert.public_key()),
+        critical=False,
+    )
+
     cert = builder.sign(private_key=privkey, algorithm=hashes.SHA256())  # type: ignore
     return Cert(cert)
 


### PR DESCRIPTION
#### Description

`Cert.dummy_cert` creates certificates for domains and signs them with the configured CA certificate. Currently, these certificates are generated without the `SubjectKeyIdentifier` or `AuthorityKeyIdentifier` extensions. Normally this is fine, however in OpenSSL 3.x, it is required that these extensions be present if `X509_V_FLAG_X509_STRICT` is set. For such clients, mitmproxy right now serves "broken" certificates and nothing works. With this change, we add those two extensions to get the certificates generated by `dummy_cert` in compliance with those strict checks. 

#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
