### PR TITLE
Make mitmweb use relative paths to connect to its resources.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
   ([#6389](https://github.com/mitmproxy/mitmproxy/pull/6389), @mhils)
 * Fix certificate generation to work with strict mode OpenSSL 3.x clients
   ([#6410](https://github.com/mitmproxy/mitmproxy/pull/6410), @mmaxim)
+* Fix root-relative URLs so that mitmweb can run in subdirectories.
+  ([#6411](https://github.com/mitmproxy/mitmproxy/pull/6411), @davet2001)
 
 
 ## 27 September 2023: mitmproxy 10.1.1

--- a/mitmproxy/addons/onboardingapp/templates/layout.html
+++ b/mitmproxy/addons/onboardingapp/templates/layout.html
@@ -5,9 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
     <title>mitmproxy</title>
-    <link href="/static/bootstrap.min.css" rel="stylesheet">
-    <link href="/static/mitmproxy.css" rel="stylesheet">
-    <link rel="icon" href="/static/images/favicon.ico" type="image/x-icon"/>
+    <link href="static/bootstrap.min.css" rel="stylesheet">
+    <link href="static/mitmproxy.css" rel="stylesheet">
+    <link rel="icon" href="static/images/favicon.ico" type="image/x-icon"/>
 </head>
 
 <body>

--- a/mitmproxy/tools/web/templates/index.html
+++ b/mitmproxy/tools/web/templates/index.html
@@ -4,14 +4,14 @@
         <meta charset="UTF-8" />
         <title>mitmproxy</title>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <link rel="stylesheet" href="/static/vendor.css" />
-        <link rel="stylesheet" href="/static/app.css" />
+        <link rel="stylesheet" href="static/vendor.css" />
+        <link rel="stylesheet" href="static/app.css" />
         <link
             rel="icon"
-            href="/static/images/favicon.ico"
+            href="static/images/favicon.ico"
             type="image/x-icon"
         />
-        <script src="/static/app.js"></script>
+        <script src="static/app.js"></script>
     </head>
     <body>
         <div id="mitmproxy"></div>

--- a/test/mitmproxy/tools/web/test_app.py
+++ b/test/mitmproxy/tools/web/test_app.py
@@ -214,7 +214,11 @@ class TestApp(tornado.testing.AsyncHTTPTestCase):
         )
 
     def test_index(self):
-        assert self.fetch("/").code == 200
+        response:httpclient.HTTPResponse = self.fetch("/")
+        assert response.code == 200
+        assert '"/' not in str(response.body), \
+            "HTML content should not contain root-relative paths"
+
 
     def test_filter_help(self):
         assert self.fetch("/filter-help").code == 200

--- a/test/mitmproxy/tools/web/test_app.py
+++ b/test/mitmproxy/tools/web/test_app.py
@@ -214,11 +214,11 @@ class TestApp(tornado.testing.AsyncHTTPTestCase):
         )
 
     def test_index(self):
-        response:httpclient.HTTPResponse = self.fetch("/")
+        response: httpclient.HTTPResponse = self.fetch("/")
         assert response.code == 200
-        assert '"/' not in str(response.body), \
-            "HTML content should not contain root-relative paths"
-
+        assert '"/' not in str(
+            response.body
+        ), "HTML content should not contain root-relative paths"
 
     def test_filter_help(self):
         assert self.fetch("/filter-help").code == 200

--- a/web/src/js/backends/websocket.tsx
+++ b/web/src/js/backends/websocket.tsx
@@ -27,7 +27,7 @@ export default class WebsocketBackend {
 
     connect() {
         this.socket = new WebSocket(
-            location.origin.replace("http", "ws") + "/updates"
+            location.origin.replace("http", "ws") + location.pathname + "/updates"
         );
         this.socket.addEventListener("open", () => this.onOpen());
         this.socket.addEventListener("close", (event) => this.onClose(event));

--- a/web/src/js/backends/websocket.tsx
+++ b/web/src/js/backends/websocket.tsx
@@ -27,7 +27,9 @@ export default class WebsocketBackend {
 
     connect() {
         this.socket = new WebSocket(
-            location.origin.replace("http", "ws") + location.pathname + "/updates"
+            location.origin.replace("http", "ws") +
+                location.pathname +
+                "/updates"
         );
         this.socket.addEventListener("open", () => this.onOpen());
         this.socket.addEventListener("close", (event) => this.onClose(event));

--- a/web/src/templates/index.html
+++ b/web/src/templates/index.html
@@ -6,11 +6,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <link rel="stylesheet" href="static/vendor.css" />
         <link rel="stylesheet" href="static/app.css" />
-        <link
-            rel="icon"
-            href="static/images/favicon.ico"
-            type="image/x-icon"
-        />
+        <link rel="icon" href="static/images/favicon.ico" type="image/x-icon" />
         <script src="static/app.js"></script>
     </head>
     <body>

--- a/web/src/templates/index.html
+++ b/web/src/templates/index.html
@@ -4,14 +4,14 @@
         <meta charset="UTF-8" />
         <title>mitmproxy</title>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <link rel="stylesheet" href="/static/vendor.css" />
-        <link rel="stylesheet" href="/static/app.css" />
+        <link rel="stylesheet" href="static/vendor.css" />
+        <link rel="stylesheet" href="static/app.css" />
         <link
             rel="icon"
-            href="/static/images/favicon.ico"
+            href="static/images/favicon.ico"
             type="image/x-icon"
         />
-        <script src="/static/app.js"></script>
+        <script src="static/app.js"></script>
     </head>
     <body>
         <div id="mitmproxy"></div>


### PR DESCRIPTION
#### Description

<!-- describe your changes here -->
mitmweb currently serves up urls that are relative to the document root of the webserver, e.g. `/static/app.js`
This is fine when running mitmweb in a conventional sense, i.e. running on one machine and clients directly connecting to it.

However, if the mitmweb server is provided as part of another document tree, it may not be at the top level.  This causes connections to `/static/app.js`, as well as all other assets and the `/updates` websocket to not work correctly, as they now point to a page that does not exist on that server

For example:
Working ok:
```
https://example.com/index.html
-->https://example.com/static/app.js
```

Not working:
```
https://example.com/mysubdir/index.html
-->https://example.com/static/app.js
```
File not found.

What we need is for index.html to reference with a relative link, i.e. `static/app.js` instead of `/static/app.js`
This applies to 4 links within index.html, and part of the javascript that generates the websocket connection code that runs on the client.

Proposed fix:
```
https://example.com/mysubdir/index.html
-->https://example.com/mysubdir/static/app.js
```
Working.






#### Checklist

 - [ ] I have updated tests where applicable.
 - [ ] I have added an entry to the CHANGELOG.
