### PR TITLE
Fix path() docstring per #6345

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
   ([#6389](https://github.com/mitmproxy/mitmproxy/pull/6389), @mhils)
 * Fix certificate generation to work with strict mode OpenSSL 3.x clients
   ([#6410](https://github.com/mitmproxy/mitmproxy/pull/6410), @mmaxim)
+* Fix path() documentation that the return value might include the query string
+  ([#6412](https://github.com/mitmproxy/mitmproxy/pull/6412), @tddschn)
 
 
 ## 27 September 2023: mitmproxy 10.1.1

--- a/mitmproxy/http.py
+++ b/mitmproxy/http.py
@@ -807,7 +807,7 @@ class Request(Message):
         HTTP request path, e.g. "/index.html" or "/index.html?a=b".
         Usually starts with a slash, except for OPTIONS requests, which may just be "*".
 
-        Note: This may differ from the standard definition of a path in RFC 3986 and Python's urllib.parse, 
+        Note: This may differ from the standard definition of a path in RFC 3986 and Python's urllib.parse,
         where the path and query string are separate components.
         """
         return self.data.path.decode("utf-8", "surrogateescape")

--- a/mitmproxy/http.py
+++ b/mitmproxy/http.py
@@ -807,8 +807,8 @@ class Request(Message):
         HTTP request path, e.g. "/index.html" or "/index.html?a=b".
         Usually starts with a slash, except for OPTIONS requests, which may just be "*".
 
-        Note: This may differ from the standard definition of a path in RFC 3986 and Python's urllib.parse,
-        where the path and query string are separate components.
+        This attribute includes both path and query parts of the target URI 
+        (see Sections 3.3 and 3.4 of [RFC3986](https://datatracker.ietf.org/doc/html/rfc3986)).
         """
         return self.data.path.decode("utf-8", "surrogateescape")
 

--- a/mitmproxy/http.py
+++ b/mitmproxy/http.py
@@ -804,8 +804,10 @@ class Request(Message):
     @property
     def path(self) -> str:
         """
-        HTTP request path, e.g. "/index.html".
+        HTTP request path, e.g. "/index.html" or "/index.html?a=b".
         Usually starts with a slash, except for OPTIONS requests, which may just be "*".
+
+        Note: This may differ from the standard definition of a path in RFC 3986 and Python's urllib.parse, where the path and query string are separate components.
         """
         return self.data.path.decode("utf-8", "surrogateescape")
 

--- a/mitmproxy/http.py
+++ b/mitmproxy/http.py
@@ -807,7 +807,7 @@ class Request(Message):
         HTTP request path, e.g. "/index.html" or "/index.html?a=b".
         Usually starts with a slash, except for OPTIONS requests, which may just be "*".
 
-        This attribute includes both path and query parts of the target URI 
+        This attribute includes both path and query parts of the target URI
         (see Sections 3.3 and 3.4 of [RFC3986](https://datatracker.ietf.org/doc/html/rfc3986)).
         """
         return self.data.path.decode("utf-8", "surrogateescape")

--- a/mitmproxy/http.py
+++ b/mitmproxy/http.py
@@ -807,7 +807,8 @@ class Request(Message):
         HTTP request path, e.g. "/index.html" or "/index.html?a=b".
         Usually starts with a slash, except for OPTIONS requests, which may just be "*".
 
-        Note: This may differ from the standard definition of a path in RFC 3986 and Python's urllib.parse, where the path and query string are separate components.
+        Note: This may differ from the standard definition of a path in RFC 3986 and Python's urllib.parse, 
+        where the path and query string are separate components.
         """
         return self.data.path.decode("utf-8", "surrogateescape")
 


### PR DESCRIPTION
#### Description

<!-- describe your changes here -->

Fix path() docstring per #6345

Before:

https://docs.mitmproxy.org/stable/api/mitmproxy/http.html#Request.path

![CleanShot-2023-10-19T09-41-04@2x](https://github.com/mitmproxy/mitmproxy/assets/45612704/ea8302b1-fbf7-44c7-91df-6e78d9c0f75b)

After:

![CleanShot-2023-10-19T09-39-07@2x](https://github.com/mitmproxy/mitmproxy/assets/45612704/54cdaf55-4f27-4ff1-9796-256207c8ce07)


#### Checklist

 - [ ] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
