### PR TITLE
fix #6426 - Optimize LDAP Proxy Auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
   ([#6412](https://github.com/mitmproxy/mitmproxy/pull/6412), @tddschn)
 * Fix root-relative URLs so that mitmweb can run in subdirectories.
   ([#6411](https://github.com/mitmproxy/mitmproxy/pull/6411), @davet2001)
+* Add an optional parameter(ldap search filter key) to ProxyAuth-LDAP.
+  ([#6428](https://github.com/mitmproxy/mitmproxy/pull/6428), @outlaws-bai)
 
 
 ## 27 September 2023: mitmproxy 10.1.1

--- a/mitmproxy/addons/proxyauth.py
+++ b/mitmproxy/addons/proxyauth.py
@@ -40,7 +40,7 @@ class ProxyAuth:
             "username:pass",
             "any" to accept any user/pass combination,
             "@path" to use an Apache htpasswd file,
-            or "ldap[s]:url_server_ldap:port:dn_auth:password:dn_subtree:ldap_search_filter_key" for LDAP authentication.
+            or "ldap[s]:url_server_ldap[:port]:dn_auth:password:dn_subtree" for LDAP authentication.
             """,
         )
 
@@ -213,7 +213,6 @@ class Ldap(Validator):
     conn: ldap3.Connection
     server: ldap3.Server
     dn_subtree: str
-    filter_key: str
 
     def __init__(self, proxyauth: str):
         (
@@ -223,7 +222,6 @@ class Ldap(Validator):
             ldap_user,
             ldap_pass,
             self.dn_subtree,
-            self.filter_key,
         ) = self.parse_spec(proxyauth)
         server = ldap3.Server(url, port=port, use_ssl=use_ssl)
         conn = ldap3.Connection(server, ldap_user, ldap_pass, auto_bind=True)
@@ -231,18 +229,21 @@ class Ldap(Validator):
         self.server = server
 
     @staticmethod
-    def parse_spec(spec: str) -> tuple[bool, str, int, str, str, str, str]:
+    def parse_spec(spec: str) -> tuple[bool, str, int | None, str, str, str]:
         try:
-            (
-                security,
-                url,
-                port_str,
-                ldap_user,
-                ldap_pass,
-                dn_subtree,
-                filter_key,
-            ) = spec.split(":")
-            port = int(port_str)
+            if spec.count(":") > 4:
+                (
+                    security,
+                    url,
+                    port_str,
+                    ldap_user,
+                    ldap_pass,
+                    dn_subtree,
+                ) = spec.split(":")
+                port = int(port_str)
+            else:
+                security, url, ldap_user, ldap_pass, dn_subtree = spec.split(":")
+                port = None
 
             if security == "ldaps":
                 use_ssl = True
@@ -251,14 +252,14 @@ class Ldap(Validator):
             else:
                 raise ValueError
 
-            return use_ssl, url, port, ldap_user, ldap_pass, dn_subtree, filter_key
+            return use_ssl, url, port, ldap_user, ldap_pass, dn_subtree
         except ValueError:
             raise exceptions.OptionsError(f"Invalid LDAP specification: {spec}")
 
     def __call__(self, username: str, password: str) -> bool:
         if not username or not password:
             return False
-        self.conn.search(self.dn_subtree, f"({self.filter_key}={username})")
+        self.conn.search(self.dn_subtree, f"(cn={username})")
         if self.conn.response:
             c = ldap3.Connection(
                 self.server, self.conn.response[0]["dn"], password, auto_bind=True

--- a/mitmproxy/addons/proxyauth.py
+++ b/mitmproxy/addons/proxyauth.py
@@ -40,7 +40,7 @@ class ProxyAuth:
             "username:pass",
             "any" to accept any user/pass combination,
             "@path" to use an Apache htpasswd file,
-            or "ldap[s]:url_server_ldap[:port]:dn_auth:password:dn_subtree" for LDAP authentication.
+            or "ldap[s]:url_server_ldap[:port]:dn_auth:password:dn_subtree[?search_filter_key=...]" for LDAP authentication.
             """,
         )
 
@@ -213,6 +213,7 @@ class Ldap(Validator):
     conn: ldap3.Connection
     server: ldap3.Server
     dn_subtree: str
+    filter_key: str
 
     def __init__(self, proxyauth: str):
         (
@@ -222,6 +223,7 @@ class Ldap(Validator):
             ldap_user,
             ldap_pass,
             self.dn_subtree,
+            self.filter_key,
         ) = self.parse_spec(proxyauth)
         server = ldap3.Server(url, port=port, use_ssl=use_ssl)
         conn = ldap3.Connection(server, ldap_user, ldap_pass, auto_bind=True)
@@ -229,7 +231,7 @@ class Ldap(Validator):
         self.server = server
 
     @staticmethod
-    def parse_spec(spec: str) -> tuple[bool, str, int | None, str, str, str]:
+    def parse_spec(spec: str) -> tuple[bool, str, int | None, str, str, str, str]:
         try:
             if spec.count(":") > 4:
                 (
@@ -245,6 +247,16 @@ class Ldap(Validator):
                 security, url, ldap_user, ldap_pass, dn_subtree = spec.split(":")
                 port = None
 
+            if '?' in dn_subtree:
+                dn_subtree, search_str = dn_subtree.split('?')
+                key, value = search_str.split('=')
+                if key == 'search_filter_key':
+                    search_filter_key = value
+                else:
+                    raise ValueError
+            else:
+                search_filter_key = 'cn'
+
             if security == "ldaps":
                 use_ssl = True
             elif security == "ldap":
@@ -252,14 +264,22 @@ class Ldap(Validator):
             else:
                 raise ValueError
 
-            return use_ssl, url, port, ldap_user, ldap_pass, dn_subtree
+            return (
+                use_ssl,
+                url,
+                port,
+                ldap_user,
+                ldap_pass,
+                dn_subtree,
+                search_filter_key,
+            )
         except ValueError:
             raise exceptions.OptionsError(f"Invalid LDAP specification: {spec}")
 
     def __call__(self, username: str, password: str) -> bool:
         if not username or not password:
             return False
-        self.conn.search(self.dn_subtree, f"(cn={username})")
+        self.conn.search(self.dn_subtree, f"({self.filter_key}={username})")
         if self.conn.response:
             c = ldap3.Connection(
                 self.server, self.conn.response[0]["dn"], password, auto_bind=True

--- a/mitmproxy/addons/proxyauth.py
+++ b/mitmproxy/addons/proxyauth.py
@@ -247,15 +247,15 @@ class Ldap(Validator):
                 security, url, ldap_user, ldap_pass, dn_subtree = spec.split(":")
                 port = None
 
-            if '?' in dn_subtree:
-                dn_subtree, search_str = dn_subtree.split('?')
-                key, value = search_str.split('=')
-                if key == 'search_filter_key':
+            if "?" in dn_subtree:
+                dn_subtree, search_str = dn_subtree.split("?")
+                key, value = search_str.split("=")
+                if key == "search_filter_key":
                     search_filter_key = value
                 else:
                     raise ValueError
             else:
-                search_filter_key = 'cn'
+                search_filter_key = "cn"
 
             if security == "ldaps":
                 use_ssl = True

--- a/mitmproxy/utils/arg_check.py
+++ b/mitmproxy/utils/arg_check.py
@@ -127,7 +127,7 @@ def check():
                 "Please use `--proxyauth SPEC` instead.\n"
                 'SPEC Format: "username:pass", "any" to accept any user/pass combination,\n'
                 '"@path" to use an Apache htpasswd file, or\n'
-                '"ldap[s]:url_server_ldap:dn_auth:password:dn_subtree" '
+                '"ldap[s]:url_server_ldap:port:dn_auth:password:dn_subtree:ldap_search_filter_key" '
                 "for LDAP authentication.".format(option)
             )
 

--- a/mitmproxy/utils/arg_check.py
+++ b/mitmproxy/utils/arg_check.py
@@ -127,7 +127,7 @@ def check():
                 "Please use `--proxyauth SPEC` instead.\n"
                 'SPEC Format: "username:pass", "any" to accept any user/pass combination,\n'
                 '"@path" to use an Apache htpasswd file, or\n'
-                '"ldap[s]:url_server_ldap:dn_auth:password:dn_subtree" '
+                '"ldap[s]:url_server_ldap[:port]:dn_auth:password:dn_subtree[?search_filter_key=...]" '
                 "for LDAP authentication.".format(option)
             )
 

--- a/mitmproxy/utils/arg_check.py
+++ b/mitmproxy/utils/arg_check.py
@@ -127,7 +127,7 @@ def check():
                 "Please use `--proxyauth SPEC` instead.\n"
                 'SPEC Format: "username:pass", "any" to accept any user/pass combination,\n'
                 '"@path" to use an Apache htpasswd file, or\n'
-                '"ldap[s]:url_server_ldap:port:dn_auth:password:dn_subtree:ldap_search_filter_key" '
+                '"ldap[s]:url_server_ldap:dn_auth:password:dn_subtree" '
                 "for LDAP authentication.".format(option)
             )
 

--- a/test/mitmproxy/addons/test_proxyauth.py
+++ b/test/mitmproxy/addons/test_proxyauth.py
@@ -155,20 +155,20 @@ class TestProxyAuth:
 
             ctx.configure(
                 pa,
-                proxyauth="ldap:localhost:cn=default,dc=cdhdt,dc=com:password:ou=application,dc=cdhdt,dc=com",
+                proxyauth="ldap:localhost:389:cn=default,dc=cdhdt,dc=com:password:ou=application,dc=cdhdt,dc=com:cn",
             )
             assert isinstance(pa.validator, proxyauth.Ldap)
 
             ctx.configure(
                 pa,
-                proxyauth="ldap:localhost:1234:cn=default,dc=cdhdt,dc=com:password:ou=application,dc=cdhdt,dc=com",
+                proxyauth="ldap:localhost:1234:cn=default,dc=cdhdt,dc=com:password:ou=application,dc=cdhdt,dc=com:SamAccountName",
             )
             assert isinstance(pa.validator, proxyauth.Ldap)
 
             with pytest.raises(
                 exceptions.OptionsError, match="Invalid LDAP specification"
             ):
-                ctx.configure(pa, proxyauth="ldap:test:test:test")
+                ctx.configure(pa, proxyauth="ldap:test:test:test:test")
 
             with pytest.raises(
                 exceptions.OptionsError, match="Invalid LDAP specification"
@@ -229,8 +229,8 @@ class TestProxyAuth:
 @pytest.mark.parametrize(
     "spec",
     [
-        "ldaps:localhost:cn=default,dc=cdhdt,dc=com:password:ou=application,dc=cdhdt,dc=com",
-        "ldap:localhost:1234:cn=default,dc=cdhdt,dc=com:password:ou=application,dc=cdhdt,dc=com",
+        "ldaps:localhost:389:cn=default,dc=cdhdt,dc=com:password:ou=application,dc=cdhdt,dc=com:cn",
+        "ldap:localhost:1234:cn=default,dc=cdhdt,dc=com:password:ou=application,dc=cdhdt,dc=com:SamAccountName",
     ],
 )
 def test_ldap(monkeypatch, spec):

--- a/test/mitmproxy/addons/test_proxyauth.py
+++ b/test/mitmproxy/addons/test_proxyauth.py
@@ -155,20 +155,20 @@ class TestProxyAuth:
 
             ctx.configure(
                 pa,
-                proxyauth="ldap:localhost:389:cn=default,dc=cdhdt,dc=com:password:ou=application,dc=cdhdt,dc=com:cn",
+                proxyauth="ldap:localhost:cn=default,dc=cdhdt,dc=com:password:ou=application,dc=cdhdt,dc=com",
             )
             assert isinstance(pa.validator, proxyauth.Ldap)
 
             ctx.configure(
                 pa,
-                proxyauth="ldap:localhost:1234:cn=default,dc=cdhdt,dc=com:password:ou=application,dc=cdhdt,dc=com:SamAccountName",
+                proxyauth="ldap:localhost:1234:cn=default,dc=cdhdt,dc=com:password:ou=application,dc=cdhdt,dc=com",
             )
             assert isinstance(pa.validator, proxyauth.Ldap)
 
             with pytest.raises(
                 exceptions.OptionsError, match="Invalid LDAP specification"
             ):
-                ctx.configure(pa, proxyauth="ldap:test:test:test:test")
+                ctx.configure(pa, proxyauth="ldap:test:test:test")
 
             with pytest.raises(
                 exceptions.OptionsError, match="Invalid LDAP specification"
@@ -229,8 +229,8 @@ class TestProxyAuth:
 @pytest.mark.parametrize(
     "spec",
     [
-        "ldaps:localhost:389:cn=default,dc=cdhdt,dc=com:password:ou=application,dc=cdhdt,dc=com:cn",
-        "ldap:localhost:1234:cn=default,dc=cdhdt,dc=com:password:ou=application,dc=cdhdt,dc=com:SamAccountName",
+        "ldaps:localhost:cn=default,dc=cdhdt,dc=com:password:ou=application,dc=cdhdt,dc=com",
+        "ldap:localhost:1234:cn=default,dc=cdhdt,dc=com:password:ou=application,dc=cdhdt,dc=com",
     ],
 )
 def test_ldap(monkeypatch, spec):

--- a/test/mitmproxy/addons/test_proxyauth.py
+++ b/test/mitmproxy/addons/test_proxyauth.py
@@ -165,10 +165,24 @@ class TestProxyAuth:
             )
             assert isinstance(pa.validator, proxyauth.Ldap)
 
+            ctx.configure(
+                pa,
+                proxyauth="ldap:localhost:1234:cn=default,dc=cdhdt,dc=com:password:dc=cdhdt,dc=com?search_filter_key=SamAccountName",
+            )
+            assert isinstance(pa.validator, proxyauth.Ldap)
+
             with pytest.raises(
                 exceptions.OptionsError, match="Invalid LDAP specification"
             ):
                 ctx.configure(pa, proxyauth="ldap:test:test:test")
+
+            with pytest.raises(
+                exceptions.OptionsError, match="Invalid LDAP specification"
+            ):
+                ctx.configure(
+                    pa,
+                    proxyauth="ldap:localhost:1234:cn=default,dc=cdhdt,dc=com:password:ou=application,dc=cdhdt,dc=com?key=1",
+                )
 
             with pytest.raises(
                 exceptions.OptionsError, match="Invalid LDAP specification"
@@ -231,6 +245,7 @@ class TestProxyAuth:
     [
         "ldaps:localhost:cn=default,dc=cdhdt,dc=com:password:ou=application,dc=cdhdt,dc=com",
         "ldap:localhost:1234:cn=default,dc=cdhdt,dc=com:password:ou=application,dc=cdhdt,dc=com",
+        "ldap:localhost:1234:cn=default,dc=cdhdt,dc=com:password:ou=application,dc=cdhdt,dc=com?search_filter_key=cn",
     ],
 )
 def test_ldap(monkeypatch, spec):

--- a/test/mitmproxy/utils/test_arg_check.py
+++ b/test/mitmproxy/utils/test_arg_check.py
@@ -35,7 +35,7 @@ from mitmproxy.utils import arg_check
             "Please use `--proxyauth SPEC` instead.\n"
             'SPEC Format: "username:pass", "any" to accept any user/pass combination,\n'
             '"@path" to use an Apache htpasswd file, or\n'
-            '"ldap[s]:url_server_ldap:port:dn_auth:password:dn_subtree:ldap_search_filter_key" '
+            '"ldap[s]:url_server_ldap:dn_auth:password:dn_subtree" '
             "for LDAP authentication.",
         ),
         (

--- a/test/mitmproxy/utils/test_arg_check.py
+++ b/test/mitmproxy/utils/test_arg_check.py
@@ -35,7 +35,7 @@ from mitmproxy.utils import arg_check
             "Please use `--proxyauth SPEC` instead.\n"
             'SPEC Format: "username:pass", "any" to accept any user/pass combination,\n'
             '"@path" to use an Apache htpasswd file, or\n'
-            '"ldap[s]:url_server_ldap:dn_auth:password:dn_subtree" '
+            '"ldap[s]:url_server_ldap[:port]:dn_auth:password:dn_subtree[?search_filter_key=...]" '
             "for LDAP authentication.",
         ),
         (

--- a/test/mitmproxy/utils/test_arg_check.py
+++ b/test/mitmproxy/utils/test_arg_check.py
@@ -35,7 +35,7 @@ from mitmproxy.utils import arg_check
             "Please use `--proxyauth SPEC` instead.\n"
             'SPEC Format: "username:pass", "any" to accept any user/pass combination,\n'
             '"@path" to use an Apache htpasswd file, or\n'
-            '"ldap[s]:url_server_ldap:dn_auth:password:dn_subtree" '
+            '"ldap[s]:url_server_ldap:port:dn_auth:password:dn_subtree:ldap_search_filter_key" '
             "for LDAP authentication.",
         ),
         (


### PR DESCRIPTION
https://github.com/mitmproxy/mitmproxy/issues/6426

#### Description

When I used ldap as a proxy authentication method, I found that the filter key was hardcoded, so I made it possible to pass in this item.

#### Checklist

 - [ ] I enable the filter key to be accessed externally.
 - [ ] I make the port mandatory.
 - [ ] I have corrected some annotation errors in arg_check.