### PR TITLE
Handle "path" KeyError in the savehar addon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Update savehar addon to handle scenarios where "path" key in cookie
   attrs dict is missing.
+  ([#6458](https://github.com/mitmproxy/mitmproxy/pull/6458), @pogzyb)
 
 ## 04 November 2023: mitmproxy 10.1.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Unreleased: mitmproxy next
 
-
+* Update savehar addon to handle scenarios where "path" key in cookie
+  attrs dict is missing.
 
 ## 04 November 2023: mitmproxy 10.1.3
 

--- a/mitmproxy/addons/savehar.py
+++ b/mitmproxy/addons/savehar.py
@@ -281,7 +281,7 @@ class SaveHar:
             cookie = {
                 "name": name,
                 "value": value,
-                "path": attrs["path"],
+                "path": attrs.get("path", "/"),
                 "domain": attrs.get("domain", ""),
                 "httpOnly": "httpOnly" in attrs,
                 "secure": "secure" in attrs,


### PR DESCRIPTION
Use `.get` when retrieving "path" from the `attrs` cookie dict. This avoids the occasional `KeyError`. 

#### Description

Modifies a line in the `format_response_cookies` function in the `savehar.py` addon. I'm not sure if there is another underlying issue preventing the "path" key from making it into the `attrs` dict, but either way this solved issues I was experiencing.

#### Checklist

 - [X] I have updated tests where applicable.
 - [X] I have added an entry to the CHANGELOG.
