### PR TITLE
Show exception and stack trace on startup errors

### DIFF
--- a/mitmproxy/addons/errorcheck.py
+++ b/mitmproxy/addons/errorcheck.py
@@ -29,8 +29,8 @@ class ErrorCheck:
         if self.logger.has_errored:
             plural = "s" if len(self.logger.has_errored) > 1 else ""
             if self.repeat_errors_on_stderr:
-                msg = "\n".join(r.msg for r in self.logger.has_errored)
-                print(f"Error{plural} logged during startup: {msg}", file=sys.stderr)
+                msg = "\n".join(self.logger.format(r) for r in self.logger.has_errored)
+                print(f"Error{plural} logged during startup:\n{msg}", file=sys.stderr)
             else:
                 print(
                     f"Error{plural} logged during startup, exiting...", file=sys.stderr


### PR DESCRIPTION
#### Description

It's hard to debug errors raised in addon scripts during startup as only a generic message is output on the console. Using logger.format() to format errors that occurred during startup instead of only displaying the LogRecord.msg improves the output if an exception is present by showing the stack trace. An additional newline was added for better readability.

Comparison with the load_error.py test script, before:

    $ mitmproxy -s test/mitmproxy/data/addonscripts/load_error.py
    Error logged during startup: Addon error:

After:

    $ mitmproxy -s test/mitmproxy/data/addonscripts/load_error.py
    Error logged during startup:
    Addon error:
    Traceback (most recent call last):
    File "test/mitmproxy/data/addonscripts/load_error.py", line 2, in load
        raise ValueError()
    ValueError

Relates to issue #5935 and PR #6020

#### Checklist

 - [ ] I have updated tests where applicable.
   - I think the value of extending `test_errorcheck.py` for this behavior is low and tightly couples the test to `logger.format()`
 - [ ] I have added an entry to the CHANGELOG.
  - #6020 didn't introduce a changelog entry, so I figured this won't need one either