### PR TITLE
Allow passing a hostname which includes authentication credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Unreleased: mitmproxy next
 
-
+* Allow passing a hostname which includes authentication credentials.
+    ([#6504](https://github.com/mitmproxy/mitmproxy/pull/6504), @seidnerj)
 
 ## 14 November 2023: mitmproxy 10.1.5
 

--- a/mitmproxy/proxy/server.py
+++ b/mitmproxy/proxy/server.py
@@ -204,16 +204,16 @@ class ConnectionHandler(metaclass=abc.ABCMeta):
             writer: asyncio.StreamWriter | udp.DatagramWriter
             try:
                 command.connection.timestamp_start = time.time()
-                if command.connection.transport_protocol == "tcp":                    
+                if command.connection.transport_protocol == "tcp":
                     host, port = command.connection.address
                     split_host = host.split("@", 1)
-                    
+
                     # this can only be 1 or 2, no other value is possible.
-                    if len(split_host) == 2: 
+                    if len(split_host) == 2:
                         host = split_host[1]
-                        
+
                     reader, writer = await asyncio.open_connection(
-                        host, 
+                        host,
                         port,
                         local_addr=command.connection.sockname,
                     )

--- a/mitmproxy/proxy/server.py
+++ b/mitmproxy/proxy/server.py
@@ -204,9 +204,17 @@ class ConnectionHandler(metaclass=abc.ABCMeta):
             writer: asyncio.StreamWriter | udp.DatagramWriter
             try:
                 command.connection.timestamp_start = time.time()
-                if command.connection.transport_protocol == "tcp":
+                if command.connection.transport_protocol == "tcp":                    
+                    host, port = command.connection.address
+                    split_host = host.split("@", 1)
+                    
+                    # this can only be 1 or 2, no other value is possible.
+                    if len(split_host) == 2: 
+                        host = split_host[1]
+                        
                     reader, writer = await asyncio.open_connection(
-                        *command.connection.address,
+                        host, 
+                        port,
                         local_addr=command.connection.sockname,
                     )
                 elif command.connection.transport_protocol == "udp":

--- a/test/mitmproxy/test_connection.py
+++ b/test/mitmproxy/test_connection.py
@@ -84,9 +84,8 @@ class TestServer:
         c.id = c2.id = "foo"
         assert c2.get_state() == c.get_state()
 
-    @pytest.mark.parametrize("address", ["address", "user:pass@address"])
-    def test_address(self, address):
-        s = Server(address=(address, 22))
+    def test_address(self):
+        s = Server(address=("address", 22))
         s.address = ("example.com", 443)
         s.state = ConnectionState.OPEN
         with pytest.raises(RuntimeError):

--- a/test/mitmproxy/test_connection.py
+++ b/test/mitmproxy/test_connection.py
@@ -84,8 +84,9 @@ class TestServer:
         c.id = c2.id = "foo"
         assert c2.get_state() == c.get_state()
 
-    def test_address(self):
-        s = Server(address=("address", 22))
+    @pytest.mark.parametrize("address", ["address", "user:pass@address"])
+    def test_address(self, address):
+        s = Server(address=(address, 22))
         s.address = ("example.com", 443)
         s.state = ConnectionState.OPEN
         with pytest.raises(RuntimeError):


### PR DESCRIPTION
#### Description

This commit allows passing a hostname with authentication credentials as an upstream proxy value (e.g. upstream:http://user:pass@default-upstream-proxy:8080/) something which thus far would result in a connection error. This allows the connection address (which includes the credentials) to be used later to and set proxy authentication headers (amongst other things).

In addition, I believe that since the credentials could now be passed as part of the address, different credentials will prevent connection reuse resulting in a new connection when different credentials are used for the same hostname/port combination. I believe this is desired behavior since a proxy server can route traffic differently depending on the provided credentials.

#### Checklist

 - [X] I have updated tests where applicable.
 - [X] I have added an entry to the CHANGELOG.
