### PR TITLE
Revert "CONTRIBUTING.md: temporarily remove `--cov`"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,7 +78,7 @@ For speedier testing, you can also run [pytest](http://pytest.org/) directly on 
 
 ```shell
 cd test/mitmproxy/addons
-pytest --looponfail test_anticache.py
+pytest --cov mitmproxy.addons.anticache --cov-report term-missing --looponfail test_anticache.py
 ```
 
 Please ensure that all patches are accompanied by matching changes in the test suite. The project tries to maintain 100%


### PR DESCRIPTION
This reverts commit 439e5264eb8aaff74aeb80588b86e13b9f0c320e, which temporarily disabled coverage reporting to work around a PyO3 bug. We should re-add this once the following commands work again:

```
cd test/mitmproxy/addons
pytest --cov mitmproxy.addons.anticache --cov-report term-missing --looponfail test_anticache.py
```

Currently this is at least blocked on the release of cryptography 42.0. :)

refs #6515