### PR TITLE
Certstore option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
   ([#5084](https://github.com/mitmproxy/mitmproxy/pull/5084), @Speedlulu)
 * Scripts with relative paths are now loaded relative to the config file and not where the command is ran
   ([#4860](https://github.com/mitmproxy/mitmproxy/pull/4860), @Speedlulu)
+* Add certstore option to store mitmproxy CA certs somewhere other than confdir
 
 
 ## 14 November 2023: mitmproxy 10.1.5

--- a/mitmproxy/addons/tlsconfig.py
+++ b/mitmproxy/addons/tlsconfig.py
@@ -4,6 +4,8 @@ import os
 import ssl
 from pathlib import Path
 from typing import Any
+from typing import Literal
+from typing import Sequence
 from typing import TypedDict
 
 from aioquic.h3.connection import H3_ALPN
@@ -421,9 +423,21 @@ class TlsConfig:
     def running(self):
         # FIXME: We have a weird bug where the contract for configure is not followed and it is never called with
         # confdir or command_history as updated.
-        self.configure("confdir")  # pragma: no cover
+        self.configure(("confdir", ))  # pragma: no cover
 
-    def configure(self, updated):
+    def configure(
+        self,
+        updated: Sequence[
+            Literal[
+                "certs",
+                "confdir",
+                "key_size",
+                "cert_passphrase",
+                "tls_ecdh_curve_client",
+                "tls_ecdh_curve_server",
+            ]
+        ],
+    ):
         if (
             "certs" in updated
             or "confdir" in updated

--- a/mitmproxy/addons/tlsconfig.py
+++ b/mitmproxy/addons/tlsconfig.py
@@ -159,6 +159,13 @@ class TlsConfig:
             help="Use a specific elliptic curve for ECDHE key exchange on server connections. "
             'OpenSSL syntax, for example "prime256v1" (see `openssl ecparam -list_curves`).',
         )
+        loader.add_option(
+            name="certstore",
+            typespec=str | None,
+            default=None,
+            help="Path to certstore"
+            "Specify to store your certificates somewhere other than your confdir",
+        )
 
     def tls_clienthello(self, tls_clienthello: tls.ClientHelloData):
         conn_context = tls_clienthello.context
@@ -435,6 +442,7 @@ class TlsConfig:
                 "cert_passphrase",
                 "tls_ecdh_curve_client",
                 "tls_ecdh_curve_server",
+                "certstore",
             ]
         ],
     ):
@@ -443,8 +451,10 @@ class TlsConfig:
             or "confdir" in updated
             or "key_size" in updated
             or "cert_passphrase" in updated
+            or "certstore" in updated
         ):
-            certstore_path = os.path.expanduser(ctx.options.confdir)
+            certstore_path = ctx.options.certstore or ctx.options.confdir
+            certstore_path = os.path.expanduser(certstore_path)
             self.certstore = certs.CertStore.from_store(
                 path=certstore_path,
                 basename=CONF_BASENAME,

--- a/mitmproxy/options.py
+++ b/mitmproxy/options.py
@@ -221,5 +221,12 @@ class Options(optmanager.OptManager):
             TLS key size for certificates and CA.
             """,
         )
+        self.add_option(
+            name="certstore",
+            typespec=str | None,
+            default=None,
+            help="Path to certstore"
+            "Specify to store your certificates somewhere other than your confdir",
+        )
 
         self.update(**kwargs)

--- a/mitmproxy/utils/magisk.py
+++ b/mitmproxy/utils/magisk.py
@@ -73,7 +73,7 @@ exit 0
 
 def get_ca_from_files() -> x509.Certificate:
     # Borrowed from tlsconfig
-    certstore_path = os.path.expanduser(ctx.options.confdir)
+    certstore_path = os.path.expanduser(ctx.options.certstore or ctx.options.confdir)
     certstore = certs.CertStore.from_store(
         path=certstore_path,
         basename=CONF_BASENAME,

--- a/test/mitmproxy/addons/test_tlsconfig.py
+++ b/test/mitmproxy/addons/test_tlsconfig.py
@@ -106,6 +106,34 @@ class TestTlsConfig:
             )
             assert ta.certstore.certs
 
+    def test_configure_confdir(self, tmp_path):
+        confdir = tmp_path / 'confdir'
+
+        ta = tlsconfig.TlsConfig()
+        with taddons.context(ta) as tctx:
+            tctx.configure(ta, confdir=str(confdir))
+            assert confdir.exists() and confdir.is_dir()
+
+    def test_configure_certstore(self, tmp_path):
+        confdir = tmp_path / 'confdir'
+        certstore = tmp_path / 'certstore'
+
+        ta = tlsconfig.TlsConfig()
+        with taddons.context(ta) as tctx:
+            tctx.configure(ta, certstore=str(certstore))
+            assert certstore.exists() and certstore.is_dir()
+            assert not confdir.exists()
+
+    def test_configure_confdir_certstore(self, tmp_path):
+        confdir = tmp_path / 'confdir'
+        certstore = tmp_path / 'certstore'
+
+        ta = tlsconfig.TlsConfig()
+        with taddons.context(ta) as tctx:
+            tctx.configure(ta, certstore=str(certstore), confdir=str(confdir))
+            assert certstore.exists() and certstore.is_dir()
+            assert not confdir.exists()
+
     def test_get_cert(self, tdata):
         """Test that we generate a certificate matching the connection's context."""
         ta = tlsconfig.TlsConfig()

--- a/test/mitmproxy/utils/test_magisk.py
+++ b/test/mitmproxy/utils/test_magisk.py
@@ -1,15 +1,30 @@
-import os
-
 from cryptography import x509
 
 from mitmproxy.test import taddons
 from mitmproxy.utils import magisk
 
 
-def test_get_ca(tdata):
+def test_get_ca_confdir(tdata):
     with taddons.context() as tctx:
         tctx.options.confdir = tdata.path("mitmproxy/data/confdir")
         ca = magisk.get_ca_from_files()
+        assert isinstance(ca, x509.Certificate)
+
+
+def test_get_ca_certstore(tdata):
+    with taddons.context() as tctx:
+        tctx.options.certstore = tdata.path("mitmproxy/data/confdir")
+        ca = magisk.get_ca_from_files()
+        assert isinstance(ca, x509.Certificate)
+
+
+def test_get_ca_confdir_certstore(tdata, tmp_path):
+    with taddons.context() as tctx:
+        confdir = tmp_path / 'confdir'
+        tctx.options.confdir = str(confdir)
+        tctx.options.certstore = tdata.path("mitmproxy/data/confdir")
+        ca = magisk.get_ca_from_files()
+        assert not confdir.exists()
         assert isinstance(ca, x509.Certificate)
 
 
@@ -29,4 +44,4 @@ def test_magisk_write(tdata, tmp_path):
         magisk_path = tmp_path / "mitmproxy-magisk-module.zip"
         magisk.write_magisk_module(magisk_path)
 
-        assert os.path.exists(magisk_path)
+        assert magisk_path.exists()


### PR DESCRIPTION
#### Description

Add a new option: `certstore`, to store the CA certs somewhere other than `confir`
If the option is not passed the behaviour stays the same and the CA certs is created in `confdir`

#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
