### PR TITLE
Represent SubjectAltNames as cryptography.x509.GeneralName objects, not strings.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@
   ([#4860](https://github.com/mitmproxy/mitmproxy/pull/4860), @Speedlulu)
 * Enhance documentation and add alert log messages when stream_large_bodies and modify_body are set
   ([#6514](https://github.com/mitmproxy/mitmproxy/pull/6514), @rosydawn6)
+* Subject Alternative Names are now represented as `cryptography.x509.GeneralNames` instead of `list[str]`
+  across the codebase. This fixes a regression introduced in mitmproxy 10.1.1 related to punycode domain encoding.
+  ([#6537](https://github.com/mitmproxy/mitmproxy/pull/6537), @mhils)
 
 
 ## 14 November 2023: mitmproxy 10.1.5

--- a/mitmproxy/addons/tlsconfig.py
+++ b/mitmproxy/addons/tlsconfig.py
@@ -11,7 +11,6 @@ from aioquic.tls import CipherSuite
 from cryptography import x509
 from OpenSSL import crypto
 from OpenSSL import SSL
-from cryptography import x509
 
 from mitmproxy import certs
 from mitmproxy import connection

--- a/mitmproxy/addons/tlsconfig.py
+++ b/mitmproxy/addons/tlsconfig.py
@@ -8,6 +8,7 @@ from typing import TypedDict
 
 from aioquic.h3.connection import H3_ALPN
 from aioquic.tls import CipherSuite
+from cryptography import x509
 from OpenSSL import crypto
 from OpenSSL import SSL
 

--- a/mitmproxy/certs.py
+++ b/mitmproxy/certs.py
@@ -520,16 +520,21 @@ class CertStore:
             self.certs[i] = entry
 
     @staticmethod
-    def asterisk_forms(dn: str) -> list[str]:
+    def asterisk_forms(dn: str | x509.GeneralName) -> list[str]:
         """
         Return all asterisk forms for a domain. For example, for www.example.com this will return
         [b"www.example.com", b"*.example.com", b"*.com"]. The single wildcard "*" is omitted.
         """
-        parts = dn.split(".")
-        ret = [dn]
-        for i in range(1, len(parts)):
-            ret.append("*." + ".".join(parts[i:]))
-        return ret
+        if isinstance(dn, str):
+            parts = dn.split(".")
+            ret = [dn]
+            for i in range(1, len(parts)):
+                ret.append("*." + ".".join(parts[i:]))
+            return ret
+        elif isinstance(dn, x509.DNSName):
+            return CertStore.asterisk_forms(dn.value)
+        else:
+            return [str(dn.value)]
 
     def get_cert(
         self,

--- a/mitmproxy/tools/console/flowdetailview.py
+++ b/mitmproxy/tools/console/flowdetailview.py
@@ -80,7 +80,7 @@ def flowdetails(state, flow: mitmproxy.flow.Flow):
             ]
 
             if c.altnames:
-                parts.append(("Alt names", ", ".join(c.altnames)))
+                parts.append(("Alt names", ", ".join(str(x.value) for x in c.altnames)))
             text.extend(common.format_keyvals(parts, indent=4))
 
     if cc is not None:

--- a/mitmproxy/tools/web/app.py
+++ b/mitmproxy/tools/web/app.py
@@ -50,7 +50,7 @@ def cert_to_json(certs: Sequence[certs.Cert]) -> dict | None:
         "serial": str(cert.serial),
         "subject": cert.subject,
         "issuer": cert.issuer,
-        "altnames": cert.altnames,
+        "altnames": [str(x.value) for x in cert.altnames],
     }
 
 

--- a/test/mitmproxy/test_certs.py
+++ b/test/mitmproxy/test_certs.py
@@ -74,15 +74,15 @@ class TestCertStore:
         assert len(ca.default_chain_certs) == 2
 
     def test_sans(self, tstore):
-        c1 = tstore.get_cert("foo.com", ["*.bar.com"])
+        c1 = tstore.get_cert("foo.com", [x509.DNSName("*.bar.com")])
         tstore.get_cert("foo.bar.com", [])
         # assert c1 == c2
         c3 = tstore.get_cert("bar.com", [])
         assert not c1 == c3
 
     def test_sans_change(self, tstore):
-        tstore.get_cert("foo.com", ["*.bar.com"])
-        entry = tstore.get_cert("foo.bar.com", ["*.baz.com"])
+        tstore.get_cert("foo.com", [x509.DNSName("*.bar.com")])
+        entry = tstore.get_cert("foo.bar.com", [x509.DNSName("*.baz.com")])
         assert "*.baz.com" in entry.cert.altnames
 
     def test_expire(self, tstore):
@@ -91,29 +91,29 @@ class TestCertStore:
         tstore.get_cert("two.com", [])
         tstore.get_cert("three.com", [])
 
-        assert ("one.com", ()) in tstore.certs
-        assert ("two.com", ()) in tstore.certs
-        assert ("three.com", ()) in tstore.certs
+        assert ("one.com", x509.GeneralNames([])) in tstore.certs
+        assert ("two.com", x509.GeneralNames([])) in tstore.certs
+        assert ("three.com", x509.GeneralNames([])) in tstore.certs
 
         tstore.get_cert("one.com", [])
 
-        assert ("one.com", ()) in tstore.certs
-        assert ("two.com", ()) in tstore.certs
-        assert ("three.com", ()) in tstore.certs
+        assert ("one.com", x509.GeneralNames([])) in tstore.certs
+        assert ("two.com", x509.GeneralNames([])) in tstore.certs
+        assert ("three.com", x509.GeneralNames([])) in tstore.certs
 
         tstore.get_cert("four.com", [])
 
-        assert ("one.com", ()) not in tstore.certs
-        assert ("two.com", ()) in tstore.certs
-        assert ("three.com", ()) in tstore.certs
-        assert ("four.com", ()) in tstore.certs
+        assert ("one.com", x509.GeneralNames([])) not in tstore.certs
+        assert ("two.com", x509.GeneralNames([])) in tstore.certs
+        assert ("three.com", x509.GeneralNames([])) in tstore.certs
+        assert ("four.com", x509.GeneralNames([])) in tstore.certs
 
     def test_overrides(self, tmp_path):
         ca1 = certs.CertStore.from_store(tmp_path / "ca1", "test", 2048)
         ca2 = certs.CertStore.from_store(tmp_path / "ca2", "test", 2048)
         assert not ca1.default_ca.serial == ca2.default_ca.serial
 
-        dc = ca2.get_cert("foo.com", ["sans.example.com"])
+        dc = ca2.get_cert("foo.com", [x509.DNSName("sans.example.com")])
         dcp = tmp_path / "dc"
         dcp.write_bytes(dc.cert.to_pem())
         ca1.add_cert_file("foo.com", dcp)

--- a/test/mitmproxy/test_certs.py
+++ b/test/mitmproxy/test_certs.py
@@ -83,7 +83,7 @@ class TestCertStore:
     def test_sans_change(self, tstore):
         tstore.get_cert("foo.com", [x509.DNSName("*.bar.com")])
         entry = tstore.get_cert("foo.bar.com", [x509.DNSName("*.baz.com")])
-        assert "*.baz.com" in entry.cert.altnames
+        assert x509.DNSName("*.baz.com") in entry.cert.altnames
 
     def test_expire(self, tstore):
         tstore.STORE_CAP = 3
@@ -168,13 +168,15 @@ class TestDummyCert:
             "Foo Ltd.",
         )
         assert r.cn == "foo.com"
-        assert r.altnames == [
-            "one.com",
-            "two.com",
-            "*.three.com",
-            "xn--bcher-kva.example",
-            "127.0.0.1",
-        ]
+        assert r.altnames == x509.GeneralNames(
+            [
+                x509.DNSName("one.com"),
+                x509.DNSName("two.com"),
+                x509.DNSName("*.three.com"),
+                x509.IPAddress(ipaddress.ip_address("127.0.0.1")),
+                x509.DNSName("xn--bcher-kva.example"),
+            ]
+        )
         assert r.organization == "Foo Ltd."
 
         r = certs.dummy_cert(
@@ -182,7 +184,7 @@ class TestDummyCert:
         )
         assert r.cn is None
         assert r.organization is None
-        assert r.altnames == []
+        assert r.altnames == x509.GeneralNames([])
 
 
 class TestCert:

--- a/test/mitmproxy/test_certs.py
+++ b/test/mitmproxy/test_certs.py
@@ -134,6 +134,23 @@ class TestCertStore:
         # TODO: How do we actually attempt to read that file as another user?
         assert os.stat(filename).st_mode & 0o77 == 0
 
+    @pytest.mark.parametrize(
+        "input,output",
+        [
+            (
+                "subdomain.example.com",
+                ["subdomain.example.com", "*.example.com", "*.com"],
+            ),
+            (
+                x509.DNSName("subdomain.example.com"),
+                ["subdomain.example.com", "*.example.com", "*.com"],
+            ),
+            (x509.IPAddress(ipaddress.ip_address("127.0.0.1")), ["127.0.0.1"]),
+        ],
+    )
+    def test_asterisk_forms(self, input, output):
+        assert certs.CertStore.asterisk_forms(input) == output
+
 
 class TestDummyCert:
     def test_with_ca(self, tstore):

--- a/test/mitmproxy/test_certs.py
+++ b/test/mitmproxy/test_certs.py
@@ -1,3 +1,4 @@
+import ipaddress
 import os
 from datetime import datetime
 from datetime import timezone
@@ -140,7 +141,13 @@ class TestDummyCert:
             tstore.default_privatekey,
             tstore.default_ca._cert,
             "foo.com",
-            ["one.com", "two.com", "*.three.com", "127.0.0.1", "bücher.example"],
+            [
+                x509.DNSName("one.com"),
+                x509.DNSName("two.com"),
+                x509.DNSName("*.three.com"),
+                x509.IPAddress(ipaddress.ip_address("127.0.0.1")),
+                x509.DNSName("bücher.example".encode("idna").decode("ascii")),
+            ],
             "Foo Ltd.",
         )
         assert r.cn == "foo.com"


### PR DESCRIPTION
This fixes #6536 