### PR TITLE
Separate private key used for dummy certificates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * Enhance documentation and add alert log messages when stream_large_bodies and modify_body are set
   ([#6514](https://github.com/mitmproxy/mitmproxy/pull/6514), @rosydawn6)
 * Generating separate private key for dummy certificate generation
+  ([#6546](https://github.com/mitmproxy/mitmproxy/pull/6546), @driuba)
 
 
 ## 14 November 2023: mitmproxy 10.1.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
   ([#4860](https://github.com/mitmproxy/mitmproxy/pull/4860), @Speedlulu)
 * Enhance documentation and add alert log messages when stream_large_bodies and modify_body are set
   ([#6514](https://github.com/mitmproxy/mitmproxy/pull/6514), @rosydawn6)
+* Generating separate private key for dummy certificate generation
 
 
 ## 14 November 2023: mitmproxy 10.1.5

--- a/examples/contrib/check_ssl_pinning.py
+++ b/examples/contrib/check_ssl_pinning.py
@@ -11,7 +11,7 @@ from mitmproxy.certs import Cert
 # the function to generate test cases for SSL Pinning.
 
 
-def monkey_dummy_cert(privkey, cacert, commonname, sans):
+def monkey_dummy_cert(privkey, cacert, caprivatekey, commonname, sans):
     ss = []
     for i in sans:
         try:
@@ -56,8 +56,8 @@ def monkey_dummy_cert(privkey, cacert, commonname, sans):
         cert.add_extensions(
             [OpenSSL.crypto.X509Extension(b"subjectAltName", False, ss)]
         )
-        cert.set_pubkey(cacert.get_pubkey())
-        cert.sign(privkey, "sha256")
+        cert.set_pubkey(privkey.get_pubkey())
+        cert.sign(caprivatekey, "sha256")
         return Cert(cert)
 
 

--- a/mitmproxy/certs.py
+++ b/mitmproxy/certs.py
@@ -400,9 +400,9 @@ class CertStore:
         raw = ca_file.read_bytes()
         key = load_pem_private_key(raw, passphrase)
         dh = cls.load_dhparam(dhparam_file)
-        certs = re.split(rb"(?=-----BEGIN CERTIFICATE-----)", raw)
-        ca = Cert.from_pem(certs[1])
-        if len(certs) > 2:
+        certs = x509.load_pem_x509_certificates(raw)
+        ca = Cert(certs[-1])
+        if len(certs) > 1:
             chain_file: Path | None = ca_file
         else:
             chain_file = None

--- a/mitmproxy/certs.py
+++ b/mitmproxy/certs.py
@@ -414,7 +414,7 @@ class CertStore:
             ca,
             key,
             chain_file,
-            dh
+            dh,
         )
 
     @staticmethod

--- a/test/mitmproxy/test_certs.py
+++ b/test/mitmproxy/test_certs.py
@@ -160,7 +160,7 @@ class TestDummyCert:
             tstore.default_ca_privatekey,
             None,
             [],
-            None
+            None,
         )
         assert r.cn is None
         assert r.organization is None

--- a/test/mitmproxy/test_certs.py
+++ b/test/mitmproxy/test_certs.py
@@ -139,6 +139,7 @@ class TestDummyCert:
         r = certs.dummy_cert(
             tstore.default_privatekey,
             tstore.default_ca._cert,
+            tstore.default_ca_privatekey,
             "foo.com",
             ["one.com", "two.com", "*.three.com", "127.0.0.1", "bücher.example"],
             "Foo Ltd.",
@@ -154,7 +155,12 @@ class TestDummyCert:
         assert r.organization == "Foo Ltd."
 
         r = certs.dummy_cert(
-            tstore.default_privatekey, tstore.default_ca._cert, None, [], None
+            tstore.default_privatekey,
+            tstore.default_ca._cert,
+            tstore.default_ca_privatekey,
+            None,
+            [],
+            None
         )
         assert r.cn is None
         assert r.organization is None


### PR DESCRIPTION
#### Description

Due to some Windows CryptoAPI validations same private key used in CA certificate and dummy certificate causes issues. A separate private key is generated during certificate store creation for dummy keys and CA private key is used for signing them.

This PR intends to fix [TLS issues with Windows/Schannel clients since 10.1.2](https://github.com/mitmproxy/mitmproxy/issues/6494)

#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
