### PR TITLE
do not include subject key identifier in leaf certificates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 
 ## Unreleased: mitmproxy next
 
+* Fix compatibility with Windows Schannel clients, which previously got
+  confused by CA and leaf certificate sharing the same Subject Key Identifier.
+  ([#6549](https://github.com/mitmproxy/mitmproxy/pull/6549), @driuba and @mhils)
 * Fix bug where response flows from HAR files had incorrect `content-length` headers
   ([#6548](https://github.com/mitmproxy/mitmproxy/pull/6548), @zanieb)
 * Improved handling for `--allow-hosts`/`--ignore-hosts` options in WireGuard mode (#5930).


### PR DESCRIPTION
This fixes #6494: if CA and leaf share the same Subject Key Identifier, SChannel gets confused. So we just skip the SKI for leafs, which is still fine with OpenSSL 3.x (this was previously fixed by @mmaxim) and RFC 5280.

@driuba did the hard work of nailing down the issue, this here is a slightly simpler (and more performant) fix for the problem.

closes #6546