### PR TITLE
Remove Links to Slack Workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,3 @@ use GitHub Discussions!
 As an open source project, mitmproxy welcomes contributions of all forms.
 
 [![Dev Guide](https://shields.mitmproxy.org/badge/dev_docs-CONTRIBUTING.md-blue)](./CONTRIBUTING.md)
-
-Also, please feel free to join our developer Slack! However, please note that the primary purpose of our Slack is direct communication between maintainers and contributors. **If you have questions where the answer might be valuable to others, please use [GitHub Discussions](https://github.com/mitmproxy/mitmproxy/discussions) and not Slack.**
-
-[![Slack Developer Chat](https://shields.mitmproxy.org/badge/slack-mitmproxy-E01563.svg)](http://slack.mitmproxy.org/)

--- a/docs/src/content/overview-getting-started.md
+++ b/docs/src/content/overview-getting-started.md
@@ -49,4 +49,3 @@ new flow and you can inspect it.
 
 * [**GitHub**](https://github.com/mitmproxy/mitmproxy): If you want to ask usage questions, contribute
   to mitmproxy, or submit a bug report, please use GitHub.
-* [**Slack**](https://mitmproxy.slack.com): For ephemeral development questions/coordination, please use our Slack channel.


### PR DESCRIPTION
We want to focus on GitHub Discussions going forward. 