### PR TITLE
Disabling the edit options button by a cli argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 ## Unreleased: mitmproxy next
 
+* Added a cli argument that will disable the "Edit options" button.
+  ([#6568](https://github.com/mitmproxy/mitmproxy/pull/6568), @Peacexoom)
 * Fix a regression from mitmproxy 10.1.6 where `ignore_hosts` would terminate requests
   instead of forwarding them.
   ([#6559](https://github.com/mitmproxy/mitmproxy/pull/6559), @mhils)

--- a/mitmproxy/tools/cmdline.py
+++ b/mitmproxy/tools/cmdline.py
@@ -141,6 +141,7 @@ def mitmweb(opts):
     opts.make_parser(group, "web_open_browser")
     opts.make_parser(group, "web_port", metavar="PORT")
     opts.make_parser(group, "web_host", metavar="HOST")
+    opts.make_parser(group, "disable_edit_options")
 
     common_options(parser, opts)
     group = parser.add_argument_group(

--- a/mitmproxy/tools/web/webaddons.py
+++ b/mitmproxy/tools/web/webaddons.py
@@ -11,6 +11,7 @@ class WebAddon:
         loader.add_option("web_debug", bool, False, "Enable mitmweb debugging.")
         loader.add_option("web_port", int, 8081, "Web UI port.")
         loader.add_option("web_host", str, "127.0.0.1", "Web UI host.")
+        loader.add_option("disable_edit_options", bool, False, "Disable the 'Edit options' button in the Web UI.")
         loader.add_option(
             "web_columns",
             Sequence[str],

--- a/mitmproxy/tools/web/webaddons.py
+++ b/mitmproxy/tools/web/webaddons.py
@@ -11,7 +11,12 @@ class WebAddon:
         loader.add_option("web_debug", bool, False, "Enable mitmweb debugging.")
         loader.add_option("web_port", int, 8081, "Web UI port.")
         loader.add_option("web_host", str, "127.0.0.1", "Web UI host.")
-        loader.add_option("disable_edit_options", bool, False, "Disable the 'Edit options' button in the Web UI.")
+        loader.add_option(
+            "disable_edit_options",
+            bool,
+            False,
+            "Disable the 'Edit options' button in the Web UI.",
+        )
         loader.add_option(
             "web_columns",
             Sequence[str],

--- a/web/src/js/components/Header/OptionMenu.tsx
+++ b/web/src/js/components/Header/OptionMenu.tsx
@@ -4,29 +4,34 @@ import Button from "../common/Button";
 import DocsLink from "../common/DocsLink";
 import HideInStatic from "../common/HideInStatic";
 import * as modalActions from "../../ducks/ui/modal";
-import { useAppDispatch } from "../../ducks";
+import { useAppDispatch, useAppSelector } from "../../ducks";
 
 OptionMenu.title = "Options";
 
 export default function OptionMenu() {
+    const disableEditOptions = useAppSelector(
+        (state) => state.options.disable_edit_options
+    );
     const dispatch = useAppDispatch();
     const openOptions = () => modalActions.setActiveModal("OptionModal");
 
     return (
         <div>
             <HideInStatic>
-                <div className="menu-group">
-                    <div className="menu-content">
-                        <Button
-                            title="Open Options"
-                            icon="fa-cogs text-primary"
-                            onClick={() => dispatch(openOptions())}
-                        >
-                            Edit Options <sup>alpha</sup>
-                        </Button>
+                {!disableEditOptions && (
+                    <div className="menu-group">
+                        <div className="menu-content">
+                            <Button
+                                title="Open Options"
+                                icon="fa-cogs text-primary"
+                                onClick={() => dispatch(openOptions())}
+                            >
+                                Edit Options <sup>alpha</sup>
+                            </Button>
+                        </div>
+                        <div className="menu-legend">Options Editor</div>
                     </div>
-                    <div className="menu-legend">Options Editor</div>
-                </div>
+                )}
 
                 <div className="menu-group">
                     <div className="menu-content">

--- a/web/src/js/ducks/_options_gen.ts
+++ b/web/src/js/ducks/_options_gen.ts
@@ -21,6 +21,7 @@ export interface OptionsState {
     connection_strategy: string;
     console_focus_follow: boolean;
     content_view_lines_cutoff: number;
+    disable_edit_options: boolean;
     export_preserve_original_ip: boolean;
     hardump: string;
     http2: boolean;
@@ -117,6 +118,7 @@ export const defaultState: OptionsState = {
     connection_strategy: "eager",
     console_focus_follow: false,
     content_view_lines_cutoff: 512,
+    disable_edit_options: false,
     export_preserve_original_ip: false,
     hardump: "",
     http2: true,


### PR DESCRIPTION
Fixes: https://github.com/mitmproxy/mitmproxy/issues/6526

#### Description
Added a cli argument that will hide the "Edit options" button.

`
mitmweb --set disable_edit_options=true 
` 

#### Checklist

 - [ ] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
