### PR TITLE
savehar: Fix timings being set to null

### DIFF
--- a/mitmproxy/addons/savehar.py
+++ b/mitmproxy/addons/savehar.py
@@ -144,11 +144,11 @@ class SaveHar:
                     - flow.server_conn.timestamp_tcp_setup
                 )
             else:
-                ssl_time = None
+                ssl_time = -1.0
             servers_seen.add(flow.server_conn)
         else:
-            connect_time = None
-            ssl_time = None
+            connect_time = -1.0
+            ssl_time = -1.0
 
         if flow.request.timestamp_end:
             send = 1000 * (flow.request.timestamp_end - flow.request.timestamp_start)

--- a/test/mitmproxy/addons/test_savehar.py
+++ b/test/mitmproxy/addons/test_savehar.py
@@ -141,7 +141,7 @@ def test_tls_setup():
     flow = tflow.twebsocketflow()
     flow.server_conn.timestamp_tls_setup = None
 
-    assert s.flow_entry(flow, servers_seen)["timings"]["ssl"] is None
+    assert s.flow_entry(flow, servers_seen)["timings"]["ssl"] == -1.0
 
 
 def test_binary_content():

--- a/test/mitmproxy/data/flows/error_log.har
+++ b/test/mitmproxy/data/flows/error_log.har
@@ -61,8 +61,8 @@
                 },
                 "cache": {},
                 "timings": {
-                    "connect": null,
-                    "ssl": null,
+                    "connect": -1.0,
+                    "ssl": -1.0,
                     "send": 2.851247787475586,
                     "receive": 0,
                     "wait": 0

--- a/test/mitmproxy/data/flows/incomplete_log.har
+++ b/test/mitmproxy/data/flows/incomplete_log.har
@@ -45,8 +45,8 @@
                 },
                 "cache": {},
                 "timings": {
-                    "connect": null,
-                    "ssl": null,
+                    "connect": -1.0,
+                    "ssl": -1.0,
                     "send": 0.0,
                     "receive": 0,
                     "wait": 0
@@ -89,8 +89,8 @@
                 },
                 "cache": {},
                 "timings": {
-                    "connect": null,
-                    "ssl": null,
+                    "connect": -1.0,
+                    "ssl": -1.0,
                     "send": 0.00095367431640625,
                     "receive": 0,
                     "wait": 0
@@ -138,8 +138,8 @@
                 },
                 "cache": {},
                 "timings": {
-                    "connect": null,
-                    "ssl": null,
+                    "connect": -1.0,
+                    "ssl": -1.0,
                     "send": 0.0,
                     "receive": 0,
                     "wait": 0
@@ -187,8 +187,8 @@
                 },
                 "cache": {},
                 "timings": {
-                    "connect": null,
-                    "ssl": null,
+                    "connect": -1.0,
+                    "ssl": -1.0,
                     "send": 0.0,
                     "receive": 0,
                     "wait": 0


### PR DESCRIPTION
#### Description

The HAR spec says that the `connect` and `ssl` timings are set to -1 when they are not applicable. This is the case for HTTP (not HTTPS) requests and for failed CONNECT requests, which are dumped to the HAR file too.

This allows dumps with these requests to be parsed correctly on [harviewer](http://www.softwareishard.com/har/viewer/).

#### Checklist

 - [X] I have updated tests where applicable.
 - [ ] I have added an entry to the CHANGELOG.
