### PR TITLE
Note on Installation page that Rosetta is required on Apple Silicon

### DIFF
--- a/docs/src/content/overview-installation.md
+++ b/docs/src/content/overview-installation.md
@@ -21,6 +21,8 @@ brew install mitmproxy
 
 Alternatively, you can download standalone binaries on [mitmproxy.org](https://mitmproxy.org/).
 
+NOTE: For Apple Silicon, Rosetta is required.
+
 ## Linux
 
 The recommended way to install mitmproxy on Linux is to download the


### PR DESCRIPTION
#### Description

Currently Installation page doesn't mention that Rosetta is required on Apple Silicon. That is the case and might be confusing to some trying to install it on such a machine, without Rosetta, and get an error message of `bad CPU type in executable`.

Related to https://github.com/mitmproxy/mitmproxy/issues/6590.

#### Checklist

 - [x] I have updated tests where applicable.
 - [ ] I have added an entry to the CHANGELOG.
