### PR TITLE
fix: save failed connect request urls to har files correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 * Fix bug where insecure HTTP requests are saved incorrectly when exporting to HAR files.
   ([#6578](https://github.com/mitmproxy/mitmproxy/pull/6578), @DaniElectra)
+* Fix bug where failed CONNECT request URLs are saved to HAR files incorrectly.
+  ([#6599](https://github.com/mitmproxy/mitmproxy/pull/6599), @basedBaba)
 
 
 ## 06 January 2024: mitmproxy 10.2.1

--- a/mitmproxy/addons/savehar.py
+++ b/mitmproxy/addons/savehar.py
@@ -227,6 +227,11 @@ class SaveHar:
             if flow.error:
                 response["_error"] = flow.error.msg
 
+        if flow.request.method == "CONNECT":
+            url = f"https://{flow.request.pretty_url}/"
+        else:
+            url = flow.request.pretty_url
+
         entry: dict[str, Any] = {
             "startedDateTime": datetime.fromtimestamp(
                 flow.request.timestamp_start, timezone.utc
@@ -234,7 +239,7 @@ class SaveHar:
             "time": sum(v for v in timings.values() if v is not None and v >= 0),
             "request": {
                 "method": flow.request.method,
-                "url": flow.request.pretty_url,
+                "url": url,
                 "httpVersion": flow.request.http_version,
                 "cookies": self.format_multidict(flow.request.cookies),
                 "headers": self.format_multidict(flow.request.headers),

--- a/mitmproxy/test/tflow.py
+++ b/mitmproxy/test/tflow.py
@@ -64,15 +64,15 @@ def tudpflow(
 
 
 def twebsocketflow(
-    messages=True, err=None, close_code=None, close_reason=""
+    messages=True, err=None, close_code=None, close_reason="", method="GET", host="example.com", port=80, scheme="http"
 ) -> http.HTTPFlow:
     flow = http.HTTPFlow(tclient_conn(), tserver_conn())
     flow.request = http.Request(
-        "example.com",
-        80,
-        b"GET",
-        b"http",
-        b"example.com",
+        host,
+        port,
+        method.encode("utf-8"),
+        scheme.encode("utf-8"),
+        host.encode("utf-8"),
         b"/ws",
         b"HTTP/1.1",
         headers=http.Headers(

--- a/mitmproxy/test/tflow.py
+++ b/mitmproxy/test/tflow.py
@@ -64,22 +64,15 @@ def tudpflow(
 
 
 def twebsocketflow(
-    messages=True,
-    err=None,
-    close_code=None,
-    close_reason="",
-    method="GET",
-    host="example.com",
-    port=80,
-    scheme="http",
+    messages=True, err=None, close_code=None, close_reason=""
 ) -> http.HTTPFlow:
     flow = http.HTTPFlow(tclient_conn(), tserver_conn())
     flow.request = http.Request(
-        host,
-        port,
-        method.encode("utf-8"),
-        scheme.encode("utf-8"),
-        host.encode("utf-8"),
+        "example.com",
+        80,
+        b"GET",
+        b"http",
+        b"example.com",
         b"/ws",
         b"HTTP/1.1",
         headers=http.Headers(

--- a/mitmproxy/test/tflow.py
+++ b/mitmproxy/test/tflow.py
@@ -64,7 +64,14 @@ def tudpflow(
 
 
 def twebsocketflow(
-    messages=True, err=None, close_code=None, close_reason="", method="GET", host="example.com", port=80, scheme="http"
+    messages=True,
+    err=None,
+    close_code=None,
+    close_reason="",
+    method="GET",
+    host="example.com",
+    port=80,
+    scheme="http",
 ) -> http.HTTPFlow:
     flow = http.HTTPFlow(tclient_conn(), tserver_conn())
     flow.request = http.Request(

--- a/test/mitmproxy/addons/test_savehar.py
+++ b/test/mitmproxy/addons/test_savehar.py
@@ -175,7 +175,9 @@ def test_savehar(log_file: Path, tmp_path: Path, monkeypatch):
 
 def test_flow_entry():
     s = SaveHar()
-    flow = tflow.twebsocketflow(method="CONNECT", host="test.test", port=443, scheme="https")
+    flow = tflow.twebsocketflow(
+        method="CONNECT", host="test.test", port=443, scheme="https"
+    )
     servers_seen: set[Server] = set()
 
     flow_entry = s.flow_entry(flow, servers_seen)

--- a/test/mitmproxy/addons/test_savehar.py
+++ b/test/mitmproxy/addons/test_savehar.py
@@ -174,6 +174,7 @@ def test_savehar(log_file: Path, tmp_path: Path, monkeypatch):
 
 
 def test_flow_entry():
+    """https://github.com/mitmproxy/mitmproxy/issues/6579"""
     s = SaveHar()
     req = Request.make("CONNECT", "https://test.test/")
     flow = tflow.tflow(req=req)

--- a/test/mitmproxy/addons/test_savehar.py
+++ b/test/mitmproxy/addons/test_savehar.py
@@ -173,6 +173,17 @@ def test_savehar(log_file: Path, tmp_path: Path, monkeypatch):
     assert actual_har == expected_har
 
 
+def test_flow_entry():
+    s = SaveHar()
+    flow = tflow.twebsocketflow(method="CONNECT", host="test.test", port=443, scheme="https")
+    servers_seen: set[Server] = set()
+
+    flow_entry = s.flow_entry(flow, servers_seen)
+
+    if flow_entry["request"]["method"] == "CONNECT":
+        assert flow_entry["request"]["url"].startswith("https")
+
+
 class TestHardumpOption:
     def test_simple(self, capsys):
         s = SaveHar()

--- a/test/mitmproxy/addons/test_savehar.py
+++ b/test/mitmproxy/addons/test_savehar.py
@@ -175,9 +175,8 @@ def test_savehar(log_file: Path, tmp_path: Path, monkeypatch):
 
 def test_flow_entry():
     s = SaveHar()
-    flow = tflow.twebsocketflow(
-        method="CONNECT", host="test.test", port=443, scheme="https"
-    )
+    req = Request.make("CONNECT", "https://test.test/")
+    flow = tflow.tflow(req=req)
     servers_seen: set[Server] = set()
 
     flow_entry = s.flow_entry(flow, servers_seen)

--- a/test/mitmproxy/addons/test_savehar.py
+++ b/test/mitmproxy/addons/test_savehar.py
@@ -182,8 +182,7 @@ def test_flow_entry():
 
     flow_entry = s.flow_entry(flow, servers_seen)
 
-    if flow_entry["request"]["method"] == "CONNECT":
-        assert flow_entry["request"]["url"].startswith("https")
+    assert flow_entry["request"]["url"].startswith("https")
 
 
 class TestHardumpOption:


### PR DESCRIPTION
#### Description
Fix issue #6579

This saves failed CONNECT request URLs to HAR files correctly.

#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
