### PR TITLE
websockets: do not process start event before redirecting event handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 * Fix a regression where clientplayback would break due to eager task execution.
   ([#6605](https://github.com/mitmproxy/mitmproxy/pull/6605), @mhils)
+* Fix a regression where WebSocket connections would break due to eager task execution.
 * Fix bug where insecure HTTP requests are saved incorrectly when exporting to HAR files.
   ([#6578](https://github.com/mitmproxy/mitmproxy/pull/6578), @DaniElectra)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Fix a regression where clientplayback would break due to eager task execution.
   ([#6605](https://github.com/mitmproxy/mitmproxy/pull/6605), @mhils)
 * Fix a regression where WebSocket connections would break due to eager task execution.
+  ([#6609](https://github.com/mitmproxy/mitmproxy/pull/6609), @mhils)
 * Fix bug where insecure HTTP requests are saved incorrectly when exporting to HAR files.
   ([#6578](https://github.com/mitmproxy/mitmproxy/pull/6578), @DaniElectra)
 

--- a/mitmproxy/proxy/layers/http/__init__.py
+++ b/mitmproxy/proxy/layers/http/__init__.py
@@ -528,8 +528,8 @@ class HttpStream(layer.Layer):
                 yield commands.Log(
                     f"{self.debug}[http] upgrading to {self.child_layer}", DEBUG
                 )
-            yield from self.child_layer.handle_event(events.Start())
             self._handle_event = self.passthrough
+            yield from self.child_layer.handle_event(events.Start())
         else:
             yield DropStream(self.stream_id)
 
@@ -749,8 +749,8 @@ class HttpStream(layer.Layer):
 
         if 200 <= self.flow.response.status_code < 300:
             self.child_layer = self.child_layer or layer.NextLayer(self.context)
-            yield from self.child_layer.handle_event(events.Start())
             self._handle_event = self.passthrough
+            yield from self.child_layer.handle_event(events.Start())
             yield SendHttp(
                 ResponseHeaders(self.stream_id, self.flow.response, True),
                 self.context.client,


### PR DESCRIPTION
fix #6608
