### PR TITLE
Fix IPv6 matches against the full host:port string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 ## Unreleased: mitmproxy next
 
+* Fix a regression where `allow_hosts`/`ignore_hosts` would break with IPv6 connections.
+  ([#6614](https://github.com/mitmproxy/mitmproxy/pull/6614), @dqxpb)
 
 
 ## 21 January 2024: mitmproxy 10.2.2

--- a/mitmproxy/addons/next_layer.py
+++ b/mitmproxy/addons/next_layer.py
@@ -219,7 +219,7 @@ class NextLayer:
             return False
         hostnames: list[str] = []
         if context.server.peername:
-            host, port = context.server.peername
+            host, port, *_ = context.server.peername
             hostnames.append(f"{host}:{port}")
         if context.server.address:
             host, port = context.server.address

--- a/mitmproxy/addons/next_layer.py
+++ b/mitmproxy/addons/next_layer.py
@@ -222,7 +222,7 @@ class NextLayer:
             host, port, *_ = context.server.peername
             hostnames.append(f"{host}:{port}")
         if context.server.address:
-            host, port = context.server.address
+            host, port, *_ = context.server.address
             hostnames.append(f"{host}:{port}")
 
             # We also want to check for TLS SNI and HTTP host headers, but in order to ignore connections based on that

--- a/test/mitmproxy/addons/test_next_layer.py
+++ b/test/mitmproxy/addons/test_next_layer.py
@@ -120,7 +120,13 @@ class TestNextLayer:
                 ["192.0.2.1"], [], "tcp", "example.com", b"", True, id="ip address"
             ),
             pytest.param(
-                ["2001:db8::1"], [], "tcp", "ipv6.example.com", b"", True, id="ipv6 address"
+                ["2001:db8::1"],
+                [],
+                "tcp",
+                "ipv6.example.com",
+                b"",
+                True,
+                id="ipv6 address",
             ),
             pytest.param(
                 ["example.com:443"],

--- a/test/mitmproxy/addons/test_next_layer.py
+++ b/test/mitmproxy/addons/test_next_layer.py
@@ -120,6 +120,9 @@ class TestNextLayer:
                 ["192.0.2.1"], [], "tcp", "example.com", b"", True, id="ip address"
             ),
             pytest.param(
+                ["2001:db8::1"], [], "tcp", "ipv6.example.com", b"", True, id="ipv6 address"
+            ),
+            pytest.param(
                 ["example.com:443"],
                 [],
                 "tcp",
@@ -315,7 +318,11 @@ class TestNextLayer:
             ctx.client.transport_protocol = transport_protocol
             if server_address:
                 ctx.server.address = (server_address, 443)
-                ctx.server.peername = ("192.0.2.1", 443)
+                ctx.server.peername = (
+                    ("2001:db8::1", 443, 0, 0)
+                    if server_address.startswith("ipv6")
+                    else ("192.0.2.1", 443)
+                )
             if result is NeedsMoreData:
                 with pytest.raises(NeedsMoreData):
                     nl._ignore_connection(ctx, data_client, b"")


### PR DESCRIPTION
#### Description

Regression fix: it seems that [#6594](https://github.com/mitmproxy/mitmproxy/pull/6594) has broken IPv6 connections:

```
[1]$ mitmdump --ignore-hosts mitmproxy.org
[2]$ curl -kx 'http://127.0.0.1:8080' 'https://httpbin.dmuth.org/ip/v6'
```
```
[18:18:05.571] HTTP(S) proxy listening at 127.0.0.1:8080.
[18:18:07.791][127.0.0.1:54626] client connect
[18:18:08.066][127.0.0.1:54626] server connect httpbin.dmuth.org:443 ([2a09:8280:1::6a6e]:443)
[18:18:08.405] Addon error: too many values to unpack (expected 2)
Traceback (most recent call last):
  File "/usr/lib/python3.11/site-packages/mitmproxy/addons/next_layer.py", line 111, in next_layer
    nextlayer.layer = self._next_layer(
                      ^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/mitmproxy/addons/next_layer.py", line 133, in _next_layer
    if self._ignore_connection(context, data_client, data_server):
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/mitmproxy/addons/next_layer.py", line 222, in _ignore_connection
    host, port = context.server.peername
    ^^^^^^^^^^
ValueError: too many values to unpack (expected 2)
```

`context.server.peername` is being equal to `('2a09:8280:1::6a6e', 443, 0, 0)` in this case.
Added `*_` to swallow unwanted items when unpacking tuple - not sure if this's the right fix.

Thanks for a great project!

#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
