### PR TITLE
Remove duplicate answers in DNS queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
   ([#6599](https://github.com/mitmproxy/mitmproxy/pull/6599), @basedBaba)
 * Add an arm64 variant for the precompiled macOS app.
   ([#6633](https://github.com/mitmproxy/mitmproxy/pull/6633), @mhils)
+* Fix duplicate answers being returned in DNS queries.
+  ([#6648](https://github.com/mitmproxymitmproxy/pull/6648), @sujaldev)
 
 
 ## 21 January 2024: mitmproxy 10.2.2

--- a/mitmproxy/addons/dns_resolver.py
+++ b/mitmproxy/addons/dns_resolver.py
@@ -27,7 +27,7 @@ async def resolve_question_by_name(
 ) -> Iterable[dns.ResourceRecord]:
     try:
         addrinfos = await loop.getaddrinfo(
-            host=question.name, port=0, family=family, type=socket.SOCK_DGRAM
+            host=question.name, port=0, family=family, type=socket.SOCK_STREAM
         )
     except socket.gaierror as e:
         if e.errno == socket.EAI_NONAME:

--- a/mitmproxy/addons/dns_resolver.py
+++ b/mitmproxy/addons/dns_resolver.py
@@ -26,7 +26,9 @@ async def resolve_question_by_name(
     ip: Callable[[str], ipaddress.IPv4Address | ipaddress.IPv6Address],
 ) -> Iterable[dns.ResourceRecord]:
     try:
-        addrinfos = await loop.getaddrinfo(host=question.name, port=0, family=family)
+        addrinfos = await loop.getaddrinfo(
+            host=question.name, port=0, family=family, type=socket.SOCK_DGRAM
+        )
     except socket.gaierror as e:
         if e.errno == socket.EAI_NONAME:
             raise ResolveError(dns.response_codes.NXDOMAIN)

--- a/test/mitmproxy/addons/test_dns_resolver.py
+++ b/test/mitmproxy/addons/test_dns_resolver.py
@@ -41,18 +41,18 @@ class DummyLoop:
         e.errno = socket.EAI_NONAME
         raise e
 
-    async def getaddrinfo(self, host: str, port: int, *, family: int):
+    async def getaddrinfo(self, host: str, port: int, *, family: int, type: int):
         e = socket.gaierror()
         e.errno = socket.EAI_NONAME
         if family == socket.AF_INET:
             if host == "dns.google":
-                return [(socket.AF_INET, None, None, None, ("8.8.8.8", port))]
+                return [(socket.AF_INET, type, None, None, ("8.8.8.8", port))]
         elif family == socket.AF_INET6:
             if host == "dns.google":
                 return [
                     (
                         socket.AF_INET6,
-                        None,
+                        type,
                         None,
                         None,
                         ("2001:4860:4860::8888", port, None, None),

--- a/test/mitmproxy/addons/test_proxyserver.py
+++ b/test/mitmproxy/addons/test_proxyserver.py
@@ -270,9 +270,9 @@ class DummyResolver:
     async def dns_request(self, flow: dns.DNSFlow) -> None:
         flow.response = await dns_resolver.resolve_message(flow.request, self)
 
-    async def getaddrinfo(self, host: str, port: int, *, family: int):
+    async def getaddrinfo(self, host: str, port: int, *, family: int, type: int):
         if family == socket.AF_INET and host == "dns.google":
-            return [(socket.AF_INET, None, None, None, ("8.8.8.8", port))]
+            return [(socket.AF_INET, type, None, None, ("8.8.8.8", port))]
         e = socket.gaierror()
         e.errno = socket.EAI_NONAME
         raise e


### PR DESCRIPTION
#### Description

Fixes #6647 by assuming all DNS queries are made over UDP, will need to be reworked when TCP support is added.

#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
