### PR TITLE
Fix Multipart content view parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
 
 ## Unreleased: mitmproxy next
 
-
+* Fix multipart form content view being unusable.
+  ([#6653](https://github.com/mitmproxy/mitmproxy/pull/6653), @DaniElectra)
 
 ## 07 March 2024: mitmproxy 10.2.4
 

--- a/mitmproxy/contentviews/__init__.py
+++ b/mitmproxy/contentviews/__init__.py
@@ -130,8 +130,8 @@ def get_message_content_view(
     if isinstance(message, http.Message):
         http_message = message
         if ctype := message.headers.get("content-type"):
-            if ct := http.parse_content_type(ctype):
-                content_type = f"{ct[0]}/{ct[1]}"
+            if http.parse_content_type(ctype):
+                content_type = ctype
 
     tcp_message = None
     if isinstance(message, TCPMessage):

--- a/mitmproxy/contentviews/__init__.py
+++ b/mitmproxy/contentviews/__init__.py
@@ -130,8 +130,8 @@ def get_message_content_view(
     if isinstance(message, http.Message):
         http_message = message
         if ctype := message.headers.get("content-type"):
-            if http.parse_content_type(ctype):
-                content_type = ctype
+            if ct := http.parse_content_type(ctype):
+                content_type = f"{ct[0]}/{ct[1]}"
 
     tcp_message = None
     if isinstance(message, TCPMessage):

--- a/mitmproxy/contentviews/multipart.py
+++ b/mitmproxy/contentviews/multipart.py
@@ -13,7 +13,11 @@ class ViewMultipart(base.View):
         yield from base.format_dict(multidict.MultiDict(v))
 
     def __call__(
-        self, data: bytes, content_type: str | None = None, http_message: http.Message | None = None, **metadata
+        self,
+        data: bytes,
+        content_type: str | None = None,
+        http_message: http.Message | None = None,
+        **metadata,
     ):
         # The content_type doesn't have the boundary, so we get it from the header again
         headers = getattr(http_message, "headers", None)

--- a/mitmproxy/contentviews/multipart.py
+++ b/mitmproxy/contentviews/multipart.py
@@ -12,6 +12,9 @@ class ViewMultipart(base.View):
         yield from base.format_dict(multidict.MultiDict(v))
 
     def __call__(self, data: bytes, content_type: str | None = None, **metadata):
+        # The content_type doesn't have the boundary, so we get it from the header again
+        if http_message := metadata.get("http_message"):
+            content_type = http_message.headers.get("content-type")
         if content_type is None:
             return
         v = multipart.decode_multipart(content_type, data)

--- a/mitmproxy/contentviews/multipart.py
+++ b/mitmproxy/contentviews/multipart.py
@@ -1,3 +1,4 @@
+from .. import http
 from . import base
 from mitmproxy.coretypes import multidict
 from mitmproxy.net.http import multipart
@@ -11,10 +12,13 @@ class ViewMultipart(base.View):
         yield [("highlight", "Form data:\n")]
         yield from base.format_dict(multidict.MultiDict(v))
 
-    def __call__(self, data: bytes, content_type: str | None = None, **metadata):
+    def __call__(
+        self, data: bytes, content_type: str | None = None, http_message: http.Message | None = None, **metadata
+    ):
         # The content_type doesn't have the boundary, so we get it from the header again
-        if http_message := metadata.get("http_message"):
-            content_type = http_message.headers.get("content-type")
+        headers = getattr(http_message, "headers", None)
+        if headers:
+            content_type = headers.get("content-type")
         if content_type is None:
             return
         v = multipart.decode_multipart(content_type, data)

--- a/test/mitmproxy/contentviews/test_api.py
+++ b/test/mitmproxy/contentviews/test_api.py
@@ -81,6 +81,18 @@ def test_get_message_content_view():
     desc, lines, err = contentviews.get_message_content_view("raw", r, f)
     assert desc == "[cannot decode] Raw"
 
+    del r.headers["content-encoding"]
+    r.headers["content-type"] = "multipart/form-data; boundary=AaB03x"
+    r.content = b"""
+--AaB03x
+Content-Disposition: form-data; name="submit-name"
+
+Larry
+--AaB03x
+        """.strip()
+    desc, lines, err = contentviews.get_message_content_view("multipart form", r, f)
+    assert desc == "Multipart form"
+
     r.content = None
     desc, lines, err = contentviews.get_message_content_view("raw", r, f)
     assert list(lines) == [[("error", "content missing")]]

--- a/test/mitmproxy/contentviews/test_multipart.py
+++ b/test/mitmproxy/contentviews/test_multipart.py
@@ -1,5 +1,6 @@
 from . import full_eval
 from mitmproxy.contentviews import multipart
+from mitmproxy.test import tutils
 
 
 def test_view_multipart():
@@ -12,6 +13,12 @@ Larry
 --AaB03x
         """.strip()
     assert view(v, content_type="multipart/form-data; boundary=AaB03x")
+
+    req = tutils.treq()
+    req.headers["content-type"] = "multipart/form-data; boundary=AaB03x"
+    req.content = v
+
+    assert view(v, content_type="multipart/form-data; boundary=AaB03x", http_message=req)
 
     assert not view(v)
 

--- a/test/mitmproxy/contentviews/test_multipart.py
+++ b/test/mitmproxy/contentviews/test_multipart.py
@@ -18,7 +18,9 @@ Larry
     req.headers["content-type"] = "multipart/form-data; boundary=AaB03x"
     req.content = v
 
-    assert view(v, content_type="multipart/form-data; boundary=AaB03x", http_message=req)
+    assert view(
+        v, content_type="multipart/form-data; boundary=AaB03x", http_message=req
+    )
 
     assert not view(v)
 


### PR DESCRIPTION
#### Description

On get_message_content_view, the content type wasn't including the boundary, and was only setting the MIME type. This made the multipart content view unusable, as the boundary was required on parsing. To fix the issue, we assign the full content type instead.

This wasn't triggered by any previous tests because they would test against the multipart parser directly, and not the generic parser.

#### Checklist

 - [X] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
