### PR TITLE
fix: generate wireguard config with correct endpoint when using two or more active nics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
   ([#6633](https://github.com/mitmproxy/mitmproxy/pull/6633), @mhils)
 * Fix duplicate answers being returned in DNS queries.
   ([#6648](https://github.com/mitmproxymitmproxy/pull/6648), @sujaldev)
+* Fix bug where wireguard config is generated with incorrect endpoint when two or more NICs are active.
+  ([#6659](https://github.com/mitmproxy/mitmproxy/pull/6659), @basedBaba)
 
 
 ## 21 January 2024: mitmproxy 10.2.2

--- a/mitmproxy/proxy/mode_servers.py
+++ b/mitmproxy/proxy/mode_servers.py
@@ -388,9 +388,9 @@ class WireGuardServerInstance(ServerInstance[mode_specs.WireGuardMode]):
         if not self._server:
             return None
         host = (
-            self.mode.listen_host(ctx.options.listen_host) or
-            local_ip.get_local_ip() or
-            local_ip.get_local_ip6()
+            self.mode.listen_host(ctx.options.listen_host)
+            or local_ip.get_local_ip()
+            or local_ip.get_local_ip6()
         )
         port = self.mode.listen_port(ctx.options.listen_port)
         return textwrap.dedent(

--- a/mitmproxy/proxy/mode_servers.py
+++ b/mitmproxy/proxy/mode_servers.py
@@ -387,7 +387,9 @@ class WireGuardServerInstance(ServerInstance[mode_specs.WireGuardMode]):
     def client_conf(self) -> str | None:
         if not self._server:
             return None
-        host = local_ip.get_local_ip() or local_ip.get_local_ip6()
+        host = self.mode.listen_host(ctx.options.listen_host)
+        if host == "":
+            host = local_ip.get_local_ip() or local_ip.get_local_ip6()
         port = self.mode.listen_port(ctx.options.listen_port)
         return textwrap.dedent(
             f"""

--- a/mitmproxy/proxy/mode_servers.py
+++ b/mitmproxy/proxy/mode_servers.py
@@ -387,9 +387,11 @@ class WireGuardServerInstance(ServerInstance[mode_specs.WireGuardMode]):
     def client_conf(self) -> str | None:
         if not self._server:
             return None
-        host: str | None = self.mode.listen_host(ctx.options.listen_host)
-        if host == "":
-            host = local_ip.get_local_ip() or local_ip.get_local_ip6()
+        host = (
+            self.mode.listen_host(ctx.options.listen_host) or
+            local_ip.get_local_ip() or
+            local_ip.get_local_ip6()
+        )
         port = self.mode.listen_port(ctx.options.listen_port)
         return textwrap.dedent(
             f"""

--- a/mitmproxy/proxy/mode_servers.py
+++ b/mitmproxy/proxy/mode_servers.py
@@ -387,7 +387,7 @@ class WireGuardServerInstance(ServerInstance[mode_specs.WireGuardMode]):
     def client_conf(self) -> str | None:
         if not self._server:
             return None
-        host = self.mode.listen_host(ctx.options.listen_host)
+        host: str | None = self.mode.listen_host(ctx.options.listen_host)
         if host == "":
             host = local_ip.get_local_ip() or local_ip.get_local_ip6()
         port = self.mode.listen_port(ctx.options.listen_port)


### PR DESCRIPTION
#### Description

Fix issue #6656

This generates a wireguard config with the correct endpoint when using two or more active NICs.
 
#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
