### PR TITLE
Make tests pass on older OpenSSL

### DIFF
--- a/mitmproxy/proxy/layers/tls.py
+++ b/mitmproxy/proxy/layers/tls.py
@@ -318,9 +318,11 @@ class TLSLayer(tunnel.TunnelLayer):
                 err = f"Certificate verify failed: {error}"
             elif last_err in [
                 ("SSL routines", "ssl3_read_bytes", "tlsv1 alert unknown ca"),
-                ("SSL routines", "ssl3_read_bytes", "ssl/tls alert bad certificate"),
+                ("SSL routines", "ssl3_read_bytes", "sslv3 alert bad certificate"),
+                ("SSL routines", "ssl3_read_bytes", "ssl/tls alert bad certificate"),  # OpenSSL 3.2+
                 ("SSL routines", "", "tlsv1 alert unknown ca"),  # OpenSSL 3+
-                ("SSL routines", "", "ssl/tls alert bad certificate"),  # OpenSSL 3+
+                ("SSL routines", "", "sslv3 alert bad certificate"),  # OpenSSL 3+
+                ("SSL routines", "", "ssl/tls alert bad certificate"),  # OpenSSL 3.2+
             ]:
                 assert isinstance(last_err, tuple)
                 err = last_err[2]

--- a/mitmproxy/proxy/layers/tls.py
+++ b/mitmproxy/proxy/layers/tls.py
@@ -319,11 +319,7 @@ class TLSLayer(tunnel.TunnelLayer):
             elif last_err in [
                 ("SSL routines", "ssl3_read_bytes", "tlsv1 alert unknown ca"),
                 ("SSL routines", "ssl3_read_bytes", "sslv3 alert bad certificate"),
-                (
-                    "SSL routines",
-                    "ssl3_read_bytes",
-                    "ssl/tls alert bad certificate",
-                ),  # OpenSSL 3.2+
+                ("SSL routines", "ssl3_read_bytes", "ssl/tls alert bad certificate"),
                 ("SSL routines", "", "tlsv1 alert unknown ca"),  # OpenSSL 3+
                 ("SSL routines", "", "sslv3 alert bad certificate"),  # OpenSSL 3+
                 ("SSL routines", "", "ssl/tls alert bad certificate"),  # OpenSSL 3.2+

--- a/mitmproxy/proxy/layers/tls.py
+++ b/mitmproxy/proxy/layers/tls.py
@@ -319,7 +319,11 @@ class TLSLayer(tunnel.TunnelLayer):
             elif last_err in [
                 ("SSL routines", "ssl3_read_bytes", "tlsv1 alert unknown ca"),
                 ("SSL routines", "ssl3_read_bytes", "sslv3 alert bad certificate"),
-                ("SSL routines", "ssl3_read_bytes", "ssl/tls alert bad certificate"),  # OpenSSL 3.2+
+                (
+                    "SSL routines",
+                    "ssl3_read_bytes",
+                    "ssl/tls alert bad certificate",
+                ),  # OpenSSL 3.2+
                 ("SSL routines", "", "tlsv1 alert unknown ca"),  # OpenSSL 3+
                 ("SSL routines", "", "sslv3 alert bad certificate"),  # OpenSSL 3+
                 ("SSL routines", "", "ssl/tls alert bad certificate"),  # OpenSSL 3.2+

--- a/test/mitmproxy/proxy/layers/test_tls.py
+++ b/test/mitmproxy/proxy/layers/test_tls.py
@@ -665,8 +665,10 @@ class TestClientTLS:
             playbook
             >> events.DataReceived(tctx.client, tssl_client.bio_read())
             << commands.Log(
-                "Client TLS handshake failed. The client does not trust the proxy's certificate "
-                "for wrong.host.mitmproxy.org (ssl/tls alert bad certificate)",
+                tutils.StrMatching(
+                    "Client TLS handshake failed. The client does not trust the proxy's certificate "
+                    "for wrong.host.mitmproxy.org"
+                ),
                 WARNING,
             )
             << tls.TlsFailedClientHook(tls_hook_data)


### PR DESCRIPTION
This re-adds some log messages adjusted in 2a82674fdc7aa1b7dde398565f6524f6dbab7828. We shouldn't fail tests for this.

refs https://github.com/pyca/cryptography/pull/10391