### PR TITLE
Adding support to edit binary files in a hex editor if one is installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
   ([#6659](https://github.com/mitmproxy/mitmproxy/pull/6659), @basedBaba)
 * Fix a regression when leaf cert creation would fail with intermediate CAs in `ca_file`.
   ([#6666](https://github.com/mitmproxy/mitmproxy/pull/6666), @manselmi)
+* Adding support to edit binary files in a hex editor if one is installed
 
 
 ## 21 January 2024: mitmproxy 10.2.2


### PR DESCRIPTION
#### Description

Adding support to edit binary files in a console-based hex editor if one is installed, as detailed in issue 5231

#### Checklist

 - [ :green_circle: ] I have updated tests where applicable.
 - [ :green_circle: ] I have added an entry to the CHANGELOG.
