### PR TITLE
Fix file deletion crash if file is already gone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
   ([#6659](https://github.com/mitmproxy/mitmproxy/pull/6659), @basedBaba)
 * Fix a regression when leaf cert creation would fail with intermediate CAs in `ca_file`.
   ([#6666](https://github.com/mitmproxy/mitmproxy/pull/6666), @manselmi)
+* Fix exception when file deletion fails for some reason
 
 
 ## 21 January 2024: mitmproxy 10.2.2

--- a/mitmproxy/tools/console/master.py
+++ b/mitmproxy/tools/console/master.py
@@ -33,6 +33,13 @@ from mitmproxy.tools.console import window
 T = TypeVar("T", str, bytes)
 
 
+def try_unlink(name: str) -> None:
+    try:
+        os.unlink(name)
+    except:
+        return
+
+
 class ConsoleMaster(master.Master):
     def __init__(self, opts: options.Options) -> None:
         super().__init__(opts)
@@ -171,7 +178,7 @@ class ConsoleMaster(master.Master):
                     message="Can't start external viewer: %s" % " ".join(c)
                 )
         # add a small delay before deletion so that the file is not removed before being loaded by the viewer
-        t = threading.Timer(1.0, os.unlink, args=[name])
+        t = threading.Timer(1.0, try_unlink, args=[name])
         t.start()
 
     def set_palette(self, *_) -> None:

--- a/mitmproxy/tools/console/master.py
+++ b/mitmproxy/tools/console/master.py
@@ -36,7 +36,7 @@ T = TypeVar("T", str, bytes)
 def try_unlink(name: str) -> None:
     try:
         os.unlink(name)
-    except:
+    except Exception:
         return
 
 

--- a/test/mitmproxy/tools/console/test_master.py
+++ b/test/mitmproxy/tools/console/test_master.py
@@ -1,0 +1,10 @@
+import os
+import tempfile
+
+from mitmproxy.tools.console import master
+
+
+def test_try_unlink_file_not_exists():
+    path = os.path.join(tempfile.mkdtemp(), 'something')
+    assert not os.path.exists(path)
+    master.try_unlink(path)


### PR DESCRIPTION
#### Description

In the event the file is no longer present, mitmproxy raises an exception in the deleting thread which is displayed in the TUI. Update to make the `os.unlink` call tolerant to file non-existence. Based on https://github.com/mitmproxy/mitmproxy/issues/4233

#### Checklist

 - [ :green_circle: ] I have updated tests where applicable.
 - [ :green_circle: ] I have added an entry to the CHANGELOG.
