### PR TITLE
Allow runtime modifications of HTTP flow filters for server replays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * Add `content_view_lines_cutoff` option to mitmdump
   ([#6692](https://github.com/mitmproxy/mitmproxy/pull/6692), @errorxyz)
 * Allow runtime modifications of HTTP flow filters for server replays
+  ([#6695](https://github.com/mitmproxy/mitmproxy/pull/6695), @errorxyz)
 
 
 ## 21 January 2024: mitmproxy 10.2.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
   ([#6666](https://github.com/mitmproxy/mitmproxy/pull/6666), @manselmi)
 * Add `content_view_lines_cutoff` option to mitmdump
   ([#6692](https://github.com/mitmproxy/mitmproxy/pull/6692), @errorxyz)
+* Allow runtime modifications of HTTP flow filters for server replays
 
 
 ## 21 January 2024: mitmproxy 10.2.2

--- a/mitmproxy/addons/serverplayback.py
+++ b/mitmproxy/addons/serverplayback.py
@@ -20,7 +20,8 @@ HASH_OPTIONS = [
     "server_replay_ignore_content",
     "server_replay_ignore_host",
     "server_replay_ignore_params",
-    "server_replay_ignore_payload_params" "server_replay_ignore_port",
+    "server_replay_ignore_payload_params",
+    "server_replay_ignore_port",
     "server_replay_use_headers",
 ]
 

--- a/mitmproxy/addons/serverplayback.py
+++ b/mitmproxy/addons/serverplayback.py
@@ -16,6 +16,12 @@ from mitmproxy import io
 
 logger = logging.getLogger(__name__)
 
+HASH_OPTIONS = ['server_replay_ignore_content',
+                'server_replay_ignore_host',
+                'server_replay_ignore_params',
+                'server_replay_ignore_payload_params'
+                'server_replay_ignore_port',
+                'server_replay_use_headers']
 
 class ServerPlayback:
     flowmap: dict[Hashable, list[http.HTTPFlow]]
@@ -255,6 +261,15 @@ class ServerPlayback:
             except exceptions.FlowReadException as e:
                 raise exceptions.OptionsError(str(e))
             self.load_flows(flows)
+        if any(option in updated for option in HASH_OPTIONS):
+            self.recompute_hashes()
+
+    def recompute_hashes(self) -> None:
+        flows = []
+        for _, fs in self.flowmap.items():
+            for f in fs:
+                flows.append(f)
+        self.load_flows(flows)
 
     def request(self, f: http.HTTPFlow) -> None:
         if self.flowmap:

--- a/mitmproxy/addons/serverplayback.py
+++ b/mitmproxy/addons/serverplayback.py
@@ -268,10 +268,15 @@ class ServerPlayback:
             self.recompute_hashes()
 
     def recompute_hashes(self) -> None:
-        flows = []
-        for _, fs in self.flowmap.items():
-            for f in fs:
-                flows.append(f)
+        """
+        Rebuild flowmap if the hashing method has changed during execution,
+        see https://github.com/mitmproxy/mitmproxy/issues/4506
+        """
+        flows = [
+            flow
+            for lst in self.flowmap.values()
+            for flow in lst
+        ]
         self.load_flows(flows)
 
     def request(self, f: http.HTTPFlow) -> None:

--- a/mitmproxy/addons/serverplayback.py
+++ b/mitmproxy/addons/serverplayback.py
@@ -272,11 +272,7 @@ class ServerPlayback:
         Rebuild flowmap if the hashing method has changed during execution,
         see https://github.com/mitmproxy/mitmproxy/issues/4506
         """
-        flows = [
-            flow
-            for lst in self.flowmap.values()
-            for flow in lst
-        ]
+        flows = [flow for lst in self.flowmap.values() for flow in lst]
         self.load_flows(flows)
 
     def request(self, f: http.HTTPFlow) -> None:

--- a/mitmproxy/addons/serverplayback.py
+++ b/mitmproxy/addons/serverplayback.py
@@ -16,12 +16,14 @@ from mitmproxy import io
 
 logger = logging.getLogger(__name__)
 
-HASH_OPTIONS = ['server_replay_ignore_content',
-                'server_replay_ignore_host',
-                'server_replay_ignore_params',
-                'server_replay_ignore_payload_params'
-                'server_replay_ignore_port',
-                'server_replay_use_headers']
+HASH_OPTIONS = [
+    "server_replay_ignore_content",
+    "server_replay_ignore_host",
+    "server_replay_ignore_params",
+    "server_replay_ignore_payload_params" "server_replay_ignore_port",
+    "server_replay_use_headers",
+]
+
 
 class ServerPlayback:
     flowmap: dict[Hashable, list[http.HTTPFlow]]

--- a/test/mitmproxy/addons/test_serverplayback.py
+++ b/test/mitmproxy/addons/test_serverplayback.py
@@ -324,6 +324,7 @@ def test_ignore_payload_params():
     r2 = tflow.tflow(resp=True)
     thash(r, r2, multipart_setter)
 
+
 def test_runtime_modify_params():
     s = serverplayback.ServerPlayback()
     with taddons.context(s) as tctx:
@@ -334,12 +335,13 @@ def test_runtime_modify_params():
 
         s.load_flows([r])
         hash = next(iter(s.flowmap.keys()))
-        
+
         tctx.configure(s, server_replay_ignore_params=["param1"])
         hash_mod = next(iter(s.flowmap.keys()))
 
         assert hash != hash_mod
         assert hash_mod == s._hash(r2)
+
 
 def test_server_playback_full():
     s = serverplayback.ServerPlayback()

--- a/test/mitmproxy/addons/test_serverplayback.py
+++ b/test/mitmproxy/addons/test_serverplayback.py
@@ -324,6 +324,22 @@ def test_ignore_payload_params():
     r2 = tflow.tflow(resp=True)
     thash(r, r2, multipart_setter)
 
+def test_runtime_modify_params():
+    s = serverplayback.ServerPlayback()
+    with taddons.context(s) as tctx:
+        r = tflow.tflow(resp=True)
+        r.request.path = "/test?param1=1"
+        r2 = tflow.tflow(resp=True)
+        r2.request.path = "/test"
+
+        s.load_flows([r])
+        hash = next(iter(s.flowmap.keys()))
+        
+        tctx.configure(s, server_replay_ignore_params=["param1"])
+        hash_mod = next(iter(s.flowmap.keys()))
+
+        assert hash != hash_mod
+        assert hash_mod == s._hash(r2)
 
 def test_server_playback_full():
     s = serverplayback.ServerPlayback()


### PR DESCRIPTION
#### Description
Fixes #4506
`mitmproxy` during server-replay mode, calculates the hashes of flows from input files based on user defined filters and uses them to compare against hashes of incoming requests to serve the corresponding stored response by matching the hash. However, during runtime, if the user changes any of the filters, `mitmproxy` fails to recalculate the hashes of input flows and hence doesn't return the intended response. This PR fixes this issue by recomputing the hashes for every flow whenever a filter(option) used for computing hashes is changed.

#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.