### PR TITLE
Allow --allow-hosts and --ignore-hosts to work together

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * Allow runtime modifications of HTTP flow filters for server replays
   ([#6695](https://github.com/mitmproxy/mitmproxy/pull/6695), @errorxyz)
 * Allow --allow-hosts and --ignore-hosts to work together
+  ([#6711](https://github.com/mitmproxy/mitmproxy/pull/6711), @dstd)
 
 
 ## 21 January 2024: mitmproxy 10.2.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
   ([#6692](https://github.com/mitmproxy/mitmproxy/pull/6692), @errorxyz)
 * Allow runtime modifications of HTTP flow filters for server replays
   ([#6695](https://github.com/mitmproxy/mitmproxy/pull/6695), @errorxyz)
+* Allow --allow-hosts and --ignore-hosts to work together
 
 
 ## 21 January 2024: mitmproxy 10.2.2

--- a/mitmproxy/addons/next_layer.py
+++ b/mitmproxy/addons/next_layer.py
@@ -27,7 +27,6 @@ from typing import cast
 
 from mitmproxy import ctx
 from mitmproxy import dns
-from mitmproxy import exceptions
 from mitmproxy.net.tls import starts_like_dtls_record
 from mitmproxy.net.tls import starts_like_tls_record
 from mitmproxy.proxy import layer

--- a/mitmproxy/addons/next_layer.py
+++ b/mitmproxy/addons/next_layer.py
@@ -235,24 +235,25 @@ class NextLayer:
         if not hostnames:
             return False
 
-        is_allowed = True
         if ctx.options.allow_hosts:
-            is_allowed = any(
+            not_allowed = not any(
                 re.search(rex, host, re.IGNORECASE)
                 for host in hostnames
                 for rex in ctx.options.allow_hosts
             )
+            if not_allowed:
+                return True
 
         if ctx.options.ignore_hosts:
-            return not is_allowed or any(
+            ignored = any(
                 re.search(rex, host, re.IGNORECASE)
                 for host in hostnames
                 for rex in ctx.options.ignore_hosts
             )
-        elif ctx.options.allow_hosts:
-            return not is_allowed
-        else:  # pragma: no cover
-            raise AssertionError()
+            if ignored:
+                return True
+
+        return False
 
     @staticmethod
     def _get_host_header(

--- a/test/mitmproxy/addons/test_next_layer.py
+++ b/test/mitmproxy/addons/test_next_layer.py
@@ -98,14 +98,6 @@ http_connect = b"CONNECT example.com:443 HTTP/1.1\r\nHost: example.com:443\r\n\r
 
 
 class TestNextLayer:
-    def test_configure(self):
-        nl = NextLayer()
-        with taddons.context(nl) as tctx:
-            with pytest.raises(Exception, match="mutually exclusive"):
-                tctx.configure(
-                    nl, allow_hosts=["example.org"], ignore_hosts=["example.com"]
-                )
-
     @pytest.mark.parametrize(
         "ignore, allow, transport_protocol, server_address, data_client, result",
         [
@@ -299,6 +291,25 @@ class TestNextLayer:
                 client_hello_with_extensions,
                 False,
                 id="allow: sni mismatch",
+            ),
+            # allow with ignore
+            pytest.param(
+                ["binary.example.com"],
+                ["example.com"],
+                "tcp",
+                "example.com",
+                b"",
+                False,
+                id="allow+ignore: allowed and not ignored",
+            ),
+            pytest.param(
+                ["binary.example.com"],
+                ["example.com"],
+                "tcp",
+                "binary.example.org",
+                b"",
+                True,
+                id="allow+ignore: allowed but ignored",
             ),
         ],
     )


### PR DESCRIPTION
#### Description

The mutual exclusivity of the allow-hosts and ignore-hosts parameters looks like an unnecessary obstacle and does not make much sense.

It is very convenient to use a proxy only for the domain of your service, but at the same time ignore some subdomains, especially when they serve some kind of CDNs with a large amount of data.

Although this filtering could be implemented using regexp with negative lookahead, but it complicates configuration and is not as clear as conjuction of allow and deny filters.

#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
