### PR TITLE
Add `--show-ignored-hosts`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
 
 ## Unreleased: mitmproxy next
 
-- Add parameter `--show-ignored-hosts` for showing SNI for ignored hosts.
+- Add `show_ignored_hosts` option to display ignored flows in the UI.
+  This option is implemented as a temporary workaround and will be removed in the future.
   ([#6720](https://github.com/mitmproxy/mitmproxy/pull/6720), @NicolaiSoeborg)
 - mitmproxy now supports transparent HTTP/3 proxying.
   ([#7202](https://github.com/mitmproxy/mitmproxy/pull/7202), @errorxyz, @meitinger, @mhils)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ## Unreleased: mitmproxy next
 
 - Add parameter `--show-ignored-hosts` for showing SNI for ignored hosts.
+  ([#6720](https://github.com/mitmproxy/mitmproxy/pull/6720), @NicolaiSoeborg)
 - mitmproxy now supports transparent HTTP/3 proxying.
   ([#7202](https://github.com/mitmproxy/mitmproxy/pull/7202), @errorxyz, @meitinger, @mhils)
 - Fix endless tnetstring parsing in case of very large tnetstring

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ## Unreleased: mitmproxy next
 
+- Add parameter `--show-ignored-hosts` for showing SNI for ignored hosts.
 - mitmproxy now supports transparent HTTP/3 proxying.
   ([#7202](https://github.com/mitmproxy/mitmproxy/pull/7202), @errorxyz, @meitinger, @mhils)
 - Fix endless tnetstring parsing in case of very large tnetstring

--- a/mitmproxy/addons/next_layer.py
+++ b/mitmproxy/addons/next_layer.py
@@ -81,7 +81,6 @@ class NextLayer:
     allow_hosts: Sequence[re.Pattern] = ()
     tcp_hosts: Sequence[re.Pattern] = ()
     udp_hosts: Sequence[re.Pattern] = ()
-    hide_ignored_hosts: bool = True
 
     def configure(self, updated):
         if "tcp_hosts" in updated:
@@ -99,8 +98,6 @@ class NextLayer:
             self.allow_hosts = [
                 re.compile(x, re.IGNORECASE) for x in ctx.options.allow_hosts
             ]
-        if "show_ignored_hosts" in updated:
-            self.hide_ignored_hosts = not ctx.options.show_ignored_hosts
 
     def next_layer(self, nextlayer: layer.NextLayer):
         if nextlayer.layer:
@@ -129,12 +126,10 @@ class NextLayer:
 
         # 1)  check for --ignore/--allow
         if self._ignore_connection(context, data_client, data_server):
-            # By returning now, we will not MITM the connection
-            # If `--show-ignored-hosts` is set, we still show the TCP/UDP-connection in the UI
             return (
-                layers.TCPLayer(context, ignore=self.hide_ignored_hosts)
+                layers.TCPLayer(context, ignore=not ctx.options.show_ignored_hosts)
                 if tcp_based
-                else layers.UDPLayer(context, ignore=self.hide_ignored_hosts)
+                else layers.UDPLayer(context, ignore=not ctx.options.show_ignored_hosts)
             )
 
         # 2)  Handle proxy modes with well-defined next protocol

--- a/mitmproxy/options.py
+++ b/mitmproxy/options.py
@@ -26,9 +26,9 @@ class Options(optmanager.OptManager):
             bool,
             False,
             """
-            Show ignored (i.e. non-MITM'ed) hosts.
-            This option is useful together with `--ignore-hosts` or `--allow-hosts`.
-            To turn mitmproxy into a regular proxy you can use: `--ignore-hosts '.*' --show-ignored-hosts`
+            Record ignored flows in the UI even if we do not perform TLS interception.
+            This option will keep ignored flows' contents in memory, which can greatly increase memory usage.
+            A future release will fix this issue, record ignored flows by default, and remove this option.
             """,
         )
 

--- a/mitmproxy/options.py
+++ b/mitmproxy/options.py
@@ -21,6 +21,16 @@ class Options(optmanager.OptManager):
             False,
             "Use the Host header to construct URLs for display.",
         )
+        self.add_option(
+            "show_ignored_hosts",
+            bool,
+            False,
+            """
+            Show ignored (i.e. non-MITM'ed) hosts.
+            This option is useful together with `--ignore-hosts` or `--allow-hosts`.
+            To turn mitmproxy into a regular proxy you can use: `--ignore-hosts '.*' --show-ignored-hosts`
+            """,
+        )
 
         # Proxy options
         self.add_option(

--- a/mitmproxy/tools/cmdline.py
+++ b/mitmproxy/tools/cmdline.py
@@ -49,6 +49,7 @@ def common_options(parser, opts):
     opts.make_parser(parser, "mode", short="m")
     opts.make_parser(parser, "anticache")
     opts.make_parser(parser, "showhost")
+    opts.make_parser(parser, "show_ignored_hosts")
     opts.make_parser(parser, "rfile", metavar="PATH", short="r")
     opts.make_parser(parser, "scripts", metavar="SCRIPT", short="s")
     opts.make_parser(parser, "stickycookie", metavar="FILTER")

--- a/web/src/js/ducks/_options_gen.ts
+++ b/web/src/js/ducks/_options_gen.ts
@@ -67,6 +67,7 @@ export interface OptionsState {
     server_replay_refresh: boolean;
     server_replay_reuse: boolean;
     server_replay_use_headers: string[];
+    show_ignored_hosts: boolean;
     showhost: boolean;
     ssl_insecure: boolean;
     ssl_verify_upstream_trusted_ca: string | undefined;
@@ -169,6 +170,7 @@ export const defaultState: OptionsState = {
     server_replay_refresh: true,
     server_replay_reuse: false,
     server_replay_use_headers: [],
+    show_ignored_hosts: false,
     showhost: false,
     ssl_insecure: false,
     ssl_verify_upstream_trusted_ca: undefined,


### PR DESCRIPTION
#### Description

Maybe a bit counterintuitive, but mitmproxy is very nice even without the MITM part.  When doing `--ignore-hosts '.*'` it is not possible to see SNI's, so add new flag to show the raw TCP/UDP streams.

Fixes #6421

Running `mitmproxy --ignore-hosts '.*' --show-ignored-hosts`:

![image](https://github.com/mitmproxy/mitmproxy/assets/8722223/043eb0a9-3d0e-480e-99ec-3c34469008e1)

#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
