### PR TITLE
Update error check on test_load_script

### DIFF
--- a/test/mitmproxy/addons/test_script.py
+++ b/test/mitmproxy/addons/test_script.py
@@ -25,7 +25,7 @@ def test_load_script(tmp_path, tdata, caplog):
     assert ns.addons
 
     script.load_script("nonexistent")
-    assert "No such file or directory" in caplog.text
+    assert "FileNotFoundError" in caplog.text
 
     (tmp_path / "error.py").write_text("this is invalid syntax")
     script.load_script(str(tmp_path / "error.py"))


### PR DESCRIPTION
#### Description

This allows the "nonexistent" file error check to pass on systems that don't use English as their primary language. With this, all mitmproxy tests can pass on non-English machines.

Fixes #6723

#### Checklist

 - [X] I have updated tests where applicable.
 - [ ] I have added an entry to the CHANGELOG.
