### PR TITLE
Feature/button-to-close-flow-details-view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
   ([#5370](https://github.com/mitmproxy/mitmproxy/pull/5370), @zioalex)  
 * Make it possible to read flows from stdin with mitmweb.
   ([#6732](https://github.com/mitmproxy/mitmproxy/pull/6732), @jaywor1)
+* Add button to close flow details panel
+  ([#6734](https://github.com/mitmproxy/mitmproxy/pull/6734), @lups2000)
 
 ## 07 March 2024: mitmproxy 10.2.4
 

--- a/web/src/css/flowdetail.less
+++ b/web/src/css/flowdetail.less
@@ -20,8 +20,8 @@
             height: 23px;
         }
     }
-    
-    .close-button{
+
+    .close-button {
         margin-top: 2;
         padding-left: 10px;
         padding-right: 10px;

--- a/web/src/css/flowdetail.less
+++ b/web/src/css/flowdetail.less
@@ -27,6 +27,7 @@
         padding-right: 7px;
         color: grey;
         font-weight: 500;
+        font-size: 15px;
         cursor: pointer;
         border: none;
     }

--- a/web/src/css/flowdetail.less
+++ b/web/src/css/flowdetail.less
@@ -22,7 +22,7 @@
     }
 
     .close-button {
-        margin-top: 2;
+        margin-top: 2px;
         padding-left: 10px;
         padding-right: 7px;
         color: grey;
@@ -30,6 +30,10 @@
         font-size: 15px;
         cursor: pointer;
         border: none;
+    }
+
+    .close-button:hover {
+        color: black;
     }
 
     .first-line {

--- a/web/src/css/flowdetail.less
+++ b/web/src/css/flowdetail.less
@@ -25,7 +25,7 @@
         margin-top: 2;
         padding-left: 10px;
         padding-right: 7px;
-        color: rgb(169, 68, 66);
+        color: grey;
         font-weight: 500;
         cursor: pointer;
         border: none;

--- a/web/src/css/flowdetail.less
+++ b/web/src/css/flowdetail.less
@@ -26,9 +26,7 @@
         padding-left: 10px;
         padding-right: 7px;
         color: grey;
-        font-weight: 500;
         font-size: 15px;
-        cursor: pointer;
         border: none;
     }
 

--- a/web/src/css/flowdetail.less
+++ b/web/src/css/flowdetail.less
@@ -20,6 +20,15 @@
             height: 23px;
         }
     }
+    
+    .close-button{
+        margin-top: 2;
+        padding-left: 10px;
+        padding-right: 10px;
+        color: rgb(169, 68, 66);
+        font-weight: 600;
+        cursor: pointer;
+    }
 
     .first-line {
         font-family: @font-family-monospace;

--- a/web/src/css/flowdetail.less
+++ b/web/src/css/flowdetail.less
@@ -24,9 +24,9 @@
     .close-button {
         margin-top: 2;
         padding-left: 10px;
-        padding-right: 10px;
+        padding-right: 7px;
         color: rgb(169, 68, 66);
-        font-weight: 600;
+        font-weight: 500;
         cursor: pointer;
         border: none;
     }

--- a/web/src/css/flowdetail.less
+++ b/web/src/css/flowdetail.less
@@ -28,6 +28,7 @@
         color: rgb(169, 68, 66);
         font-weight: 600;
         cursor: pointer;
+        border: none;
     }
 
     .first-line {

--- a/web/src/js/__tests__/components/FlowViewSpec.tsx
+++ b/web/src/js/__tests__/components/FlowViewSpec.tsx
@@ -69,7 +69,7 @@ test("FlowView close button", async () => {
             <FlowView />
         </Provider>
     );
-    fireEvent.click(getByText("Close"));
+    fireEvent.click(getByText("X"));
     expect(store.getActions()).toEqual([
         { flowIds: [], type: flowActions.SELECT },
     ]);

--- a/web/src/js/__tests__/components/FlowViewSpec.tsx
+++ b/web/src/js/__tests__/components/FlowViewSpec.tsx
@@ -1,10 +1,9 @@
 import * as React from "react";
 import { render, screen } from "../test-utils";
 import FlowView from "../../components/FlowView";
-import reduceFlows, * as flowActions from "../../ducks/flows";
+import * as flowActions from "../../ducks/flows";
 import fetchMock, { enableFetchMocks } from "jest-fetch-mock";
 import { fireEvent } from "@testing-library/react";
-import * as modalActions from "../../ducks/ui/modal";
 import { TStore } from "../ducks/tutils";
 import { Provider } from "react-redux";
 

--- a/web/src/js/__tests__/components/FlowViewSpec.tsx
+++ b/web/src/js/__tests__/components/FlowViewSpec.tsx
@@ -64,12 +64,12 @@ test("FlowView", async () => {
 test("FlowView close button", async () => {
     const store = TStore();
 
-    const { getByText } = render(
+    const { getByTestId } = render(
         <Provider store={store}>
             <FlowView />
         </Provider>
     );
-    fireEvent.click(getByText("X"));
+    fireEvent.click(getByTestId("close-button-id"));
     expect(store.getActions()).toEqual([
         { flowIds: [], type: flowActions.SELECT },
     ]);

--- a/web/src/js/__tests__/components/FlowViewSpec.tsx
+++ b/web/src/js/__tests__/components/FlowViewSpec.tsx
@@ -1,9 +1,12 @@
 import * as React from "react";
 import { render, screen } from "../test-utils";
 import FlowView from "../../components/FlowView";
-import * as flowActions from "../../ducks/flows";
+import reduceFlows, * as flowActions from "../../ducks/flows";
 import fetchMock, { enableFetchMocks } from "jest-fetch-mock";
 import { fireEvent } from "@testing-library/react";
+import * as modalActions from "../../ducks/ui/modal";
+import { TStore } from "../ducks/tutils";
+import { Provider } from "react-redux";
 
 enableFetchMocks();
 
@@ -57,4 +60,18 @@ test("FlowView", async () => {
 
     fireEvent.click(screen.getByText("Error"));
     expect(asFragment()).toMatchSnapshot();
+});
+
+test("FlowView close button", async () => {
+    const store = TStore();
+
+    const { getByText } = render(
+        <Provider store={store}>
+            <FlowView />
+        </Provider>
+    );
+    fireEvent.click(getByText("Close"));
+    expect(store.getActions()).toEqual([
+        { flowIds: [], type: flowActions.SELECT },
+    ]);
 });

--- a/web/src/js/__tests__/components/__snapshots__/FlowViewSpec.tsx.snap
+++ b/web/src/js/__tests__/components/__snapshots__/FlowViewSpec.tsx.snap
@@ -50,11 +50,11 @@ exports[`FlowView 1`] = `
       >
         Comment
       </a>
-      <span
+      <button
         class="close-button"
       >
         Close
-      </span>
+      </button>
     </nav>
     <section
       class="request"
@@ -239,11 +239,11 @@ exports[`FlowView 2`] = `
       >
         Comment
       </a>
-      <span
+      <button
         class="close-button"
       >
         Close
-      </span>
+      </button>
     </nav>
     <section
       class="response"
@@ -426,11 +426,11 @@ exports[`FlowView 3`] = `
       >
         Comment
       </a>
-      <span
+      <button
         class="close-button"
       >
         Close
-      </span>
+      </button>
     </nav>
     <section
       class="websocket"
@@ -533,11 +533,11 @@ exports[`FlowView 4`] = `
       >
         Comment
       </a>
-      <span
+      <button
         class="close-button"
       >
         Close
-      </span>
+      </button>
     </nav>
     <section
       class="detail"
@@ -825,11 +825,11 @@ exports[`FlowView 5`] = `
       >
         Comment
       </a>
-      <span
+      <button
         class="close-button"
       >
         Close
-      </span>
+      </button>
     </nav>
     <section
       class="timing"
@@ -1036,11 +1036,11 @@ exports[`FlowView 6`] = `
       >
         Comment
       </a>
-      <span
+      <button
         class="close-button"
       >
         Close
-      </span>
+      </button>
     </nav>
     <section
       class="timing"
@@ -1110,11 +1110,11 @@ exports[`FlowView 7`] = `
       >
         Comment
       </a>
-      <span
+      <button
         class="close-button"
       >
         Close
-      </span>
+      </button>
     </nav>
     <section
       class="error"
@@ -1172,11 +1172,11 @@ exports[`FlowView 8`] = `
       >
         Comment
       </a>
-      <span
+      <button
         class="close-button"
       >
         Close
-      </span>
+      </button>
     </nav>
     <section
       class="tcp"
@@ -1253,11 +1253,11 @@ exports[`FlowView 9`] = `
       >
         Comment
       </a>
-      <span
+      <button
         class="close-button"
       >
         Close
-      </span>
+      </button>
     </nav>
     <section
       class="error"
@@ -1321,11 +1321,11 @@ exports[`FlowView 10`] = `
       >
         Comment
       </a>
-      <span
+      <button
         class="close-button"
       >
         Close
-      </span>
+      </button>
     </nav>
     <section
       class="dns-request"
@@ -1432,11 +1432,11 @@ exports[`FlowView 11`] = `
       >
         Comment
       </a>
-      <span
+      <button
         class="close-button"
       >
         Close
-      </span>
+      </button>
     </nav>
     <section
       class="dns-response"
@@ -1599,11 +1599,11 @@ exports[`FlowView 12`] = `
       >
         Comment
       </a>
-      <span
+      <button
         class="close-button"
       >
         Close
-      </span>
+      </button>
     </nav>
     <section
       class="error"
@@ -1661,11 +1661,11 @@ exports[`FlowView 13`] = `
       >
         Comment
       </a>
-      <span
+      <button
         class="close-button"
       >
         Close
-      </span>
+      </button>
     </nav>
     <section
       class="udp"
@@ -1742,11 +1742,11 @@ exports[`FlowView 14`] = `
       >
         Comment
       </a>
-      <span
+      <button
         class="close-button"
       >
         Close
-      </span>
+      </button>
     </nav>
     <section
       class="error"

--- a/web/src/js/__tests__/components/__snapshots__/FlowViewSpec.tsx.snap
+++ b/web/src/js/__tests__/components/__snapshots__/FlowViewSpec.tsx.snap
@@ -8,6 +8,11 @@ exports[`FlowView 1`] = `
     <nav
       class="nav-tabs nav-tabs-sm"
     >
+      <button
+        class="close-button"
+      >
+        X
+      </button>
       <a
         class="active"
         href="#"
@@ -50,11 +55,6 @@ exports[`FlowView 1`] = `
       >
         Comment
       </a>
-      <button
-        class="close-button"
-      >
-        Close
-      </button>
     </nav>
     <section
       class="request"
@@ -197,6 +197,11 @@ exports[`FlowView 2`] = `
     <nav
       class="nav-tabs nav-tabs-sm"
     >
+      <button
+        class="close-button"
+      >
+        X
+      </button>
       <a
         class=""
         href="#"
@@ -239,11 +244,6 @@ exports[`FlowView 2`] = `
       >
         Comment
       </a>
-      <button
-        class="close-button"
-      >
-        Close
-      </button>
     </nav>
     <section
       class="response"
@@ -384,6 +384,11 @@ exports[`FlowView 3`] = `
     <nav
       class="nav-tabs nav-tabs-sm"
     >
+      <button
+        class="close-button"
+      >
+        X
+      </button>
       <a
         class=""
         href="#"
@@ -426,11 +431,6 @@ exports[`FlowView 3`] = `
       >
         Comment
       </a>
-      <button
-        class="close-button"
-      >
-        Close
-      </button>
     </nav>
     <section
       class="websocket"
@@ -491,6 +491,11 @@ exports[`FlowView 4`] = `
     <nav
       class="nav-tabs nav-tabs-sm"
     >
+      <button
+        class="close-button"
+      >
+        X
+      </button>
       <a
         class=""
         href="#"
@@ -533,11 +538,6 @@ exports[`FlowView 4`] = `
       >
         Comment
       </a>
-      <button
-        class="close-button"
-      >
-        Close
-      </button>
     </nav>
     <section
       class="detail"
@@ -783,6 +783,11 @@ exports[`FlowView 5`] = `
     <nav
       class="nav-tabs nav-tabs-sm"
     >
+      <button
+        class="close-button"
+      >
+        X
+      </button>
       <a
         class=""
         href="#"
@@ -825,11 +830,6 @@ exports[`FlowView 5`] = `
       >
         Comment
       </a>
-      <button
-        class="close-button"
-      >
-        Close
-      </button>
     </nav>
     <section
       class="timing"
@@ -994,6 +994,11 @@ exports[`FlowView 6`] = `
     <nav
       class="nav-tabs nav-tabs-sm"
     >
+      <button
+        class="close-button"
+      >
+        X
+      </button>
       <a
         class=""
         href="#"
@@ -1036,11 +1041,6 @@ exports[`FlowView 6`] = `
       >
         Comment
       </a>
-      <button
-        class="close-button"
-      >
-        Close
-      </button>
     </nav>
     <section
       class="timing"
@@ -1068,6 +1068,11 @@ exports[`FlowView 7`] = `
     <nav
       class="nav-tabs nav-tabs-sm"
     >
+      <button
+        class="close-button"
+      >
+        X
+      </button>
       <a
         class=""
         href="#"
@@ -1110,11 +1115,6 @@ exports[`FlowView 7`] = `
       >
         Comment
       </a>
-      <button
-        class="close-button"
-      >
-        Close
-      </button>
     </nav>
     <section
       class="error"
@@ -1142,6 +1142,11 @@ exports[`FlowView 8`] = `
     <nav
       class="nav-tabs nav-tabs-sm"
     >
+      <button
+        class="close-button"
+      >
+        X
+      </button>
       <a
         class="active"
         href="#"
@@ -1172,11 +1177,6 @@ exports[`FlowView 8`] = `
       >
         Comment
       </a>
-      <button
-        class="close-button"
-      >
-        Close
-      </button>
     </nav>
     <section
       class="tcp"
@@ -1223,6 +1223,11 @@ exports[`FlowView 9`] = `
     <nav
       class="nav-tabs nav-tabs-sm"
     >
+      <button
+        class="close-button"
+      >
+        X
+      </button>
       <a
         class=""
         href="#"
@@ -1253,11 +1258,6 @@ exports[`FlowView 9`] = `
       >
         Comment
       </a>
-      <button
-        class="close-button"
-      >
-        Close
-      </button>
     </nav>
     <section
       class="error"
@@ -1285,6 +1285,11 @@ exports[`FlowView 10`] = `
     <nav
       class="nav-tabs nav-tabs-sm"
     >
+      <button
+        class="close-button"
+      >
+        X
+      </button>
       <a
         class="active"
         href="#"
@@ -1321,11 +1326,6 @@ exports[`FlowView 10`] = `
       >
         Comment
       </a>
-      <button
-        class="close-button"
-      >
-        Close
-      </button>
     </nav>
     <section
       class="dns-request"
@@ -1396,6 +1396,11 @@ exports[`FlowView 11`] = `
     <nav
       class="nav-tabs nav-tabs-sm"
     >
+      <button
+        class="close-button"
+      >
+        X
+      </button>
       <a
         class=""
         href="#"
@@ -1432,11 +1437,6 @@ exports[`FlowView 11`] = `
       >
         Comment
       </a>
-      <button
-        class="close-button"
-      >
-        Close
-      </button>
     </nav>
     <section
       class="dns-response"
@@ -1563,6 +1563,11 @@ exports[`FlowView 12`] = `
     <nav
       class="nav-tabs nav-tabs-sm"
     >
+      <button
+        class="close-button"
+      >
+        X
+      </button>
       <a
         class=""
         href="#"
@@ -1599,11 +1604,6 @@ exports[`FlowView 12`] = `
       >
         Comment
       </a>
-      <button
-        class="close-button"
-      >
-        Close
-      </button>
     </nav>
     <section
       class="error"
@@ -1631,6 +1631,11 @@ exports[`FlowView 13`] = `
     <nav
       class="nav-tabs nav-tabs-sm"
     >
+      <button
+        class="close-button"
+      >
+        X
+      </button>
       <a
         class="active"
         href="#"
@@ -1661,11 +1666,6 @@ exports[`FlowView 13`] = `
       >
         Comment
       </a>
-      <button
-        class="close-button"
-      >
-        Close
-      </button>
     </nav>
     <section
       class="udp"
@@ -1712,6 +1712,11 @@ exports[`FlowView 14`] = `
     <nav
       class="nav-tabs nav-tabs-sm"
     >
+      <button
+        class="close-button"
+      >
+        X
+      </button>
       <a
         class=""
         href="#"
@@ -1742,11 +1747,6 @@ exports[`FlowView 14`] = `
       >
         Comment
       </a>
-      <button
-        class="close-button"
-      >
-        Close
-      </button>
     </nav>
     <section
       class="error"

--- a/web/src/js/__tests__/components/__snapshots__/FlowViewSpec.tsx.snap
+++ b/web/src/js/__tests__/components/__snapshots__/FlowViewSpec.tsx.snap
@@ -10,8 +10,11 @@ exports[`FlowView 1`] = `
     >
       <button
         class="close-button"
+        data-testid="close-button-id"
       >
-        X
+        <i
+          class="fa fa-times-circle"
+        />
       </button>
       <a
         class="active"
@@ -199,8 +202,11 @@ exports[`FlowView 2`] = `
     >
       <button
         class="close-button"
+        data-testid="close-button-id"
       >
-        X
+        <i
+          class="fa fa-times-circle"
+        />
       </button>
       <a
         class=""
@@ -386,8 +392,11 @@ exports[`FlowView 3`] = `
     >
       <button
         class="close-button"
+        data-testid="close-button-id"
       >
-        X
+        <i
+          class="fa fa-times-circle"
+        />
       </button>
       <a
         class=""
@@ -493,8 +502,11 @@ exports[`FlowView 4`] = `
     >
       <button
         class="close-button"
+        data-testid="close-button-id"
       >
-        X
+        <i
+          class="fa fa-times-circle"
+        />
       </button>
       <a
         class=""
@@ -785,8 +797,11 @@ exports[`FlowView 5`] = `
     >
       <button
         class="close-button"
+        data-testid="close-button-id"
       >
-        X
+        <i
+          class="fa fa-times-circle"
+        />
       </button>
       <a
         class=""
@@ -996,8 +1011,11 @@ exports[`FlowView 6`] = `
     >
       <button
         class="close-button"
+        data-testid="close-button-id"
       >
-        X
+        <i
+          class="fa fa-times-circle"
+        />
       </button>
       <a
         class=""
@@ -1070,8 +1088,11 @@ exports[`FlowView 7`] = `
     >
       <button
         class="close-button"
+        data-testid="close-button-id"
       >
-        X
+        <i
+          class="fa fa-times-circle"
+        />
       </button>
       <a
         class=""
@@ -1144,8 +1165,11 @@ exports[`FlowView 8`] = `
     >
       <button
         class="close-button"
+        data-testid="close-button-id"
       >
-        X
+        <i
+          class="fa fa-times-circle"
+        />
       </button>
       <a
         class="active"
@@ -1225,8 +1249,11 @@ exports[`FlowView 9`] = `
     >
       <button
         class="close-button"
+        data-testid="close-button-id"
       >
-        X
+        <i
+          class="fa fa-times-circle"
+        />
       </button>
       <a
         class=""
@@ -1287,8 +1314,11 @@ exports[`FlowView 10`] = `
     >
       <button
         class="close-button"
+        data-testid="close-button-id"
       >
-        X
+        <i
+          class="fa fa-times-circle"
+        />
       </button>
       <a
         class="active"
@@ -1398,8 +1428,11 @@ exports[`FlowView 11`] = `
     >
       <button
         class="close-button"
+        data-testid="close-button-id"
       >
-        X
+        <i
+          class="fa fa-times-circle"
+        />
       </button>
       <a
         class=""
@@ -1565,8 +1598,11 @@ exports[`FlowView 12`] = `
     >
       <button
         class="close-button"
+        data-testid="close-button-id"
       >
-        X
+        <i
+          class="fa fa-times-circle"
+        />
       </button>
       <a
         class=""
@@ -1633,8 +1669,11 @@ exports[`FlowView 13`] = `
     >
       <button
         class="close-button"
+        data-testid="close-button-id"
       >
-        X
+        <i
+          class="fa fa-times-circle"
+        />
       </button>
       <a
         class="active"
@@ -1714,8 +1753,11 @@ exports[`FlowView 14`] = `
     >
       <button
         class="close-button"
+        data-testid="close-button-id"
       >
-        X
+        <i
+          class="fa fa-times-circle"
+        />
       </button>
       <a
         class=""

--- a/web/src/js/__tests__/components/__snapshots__/FlowViewSpec.tsx.snap
+++ b/web/src/js/__tests__/components/__snapshots__/FlowViewSpec.tsx.snap
@@ -50,6 +50,11 @@ exports[`FlowView 1`] = `
       >
         Comment
       </a>
+      <span
+        class="close-button"
+      >
+        Close
+      </span>
     </nav>
     <section
       class="request"
@@ -234,6 +239,11 @@ exports[`FlowView 2`] = `
       >
         Comment
       </a>
+      <span
+        class="close-button"
+      >
+        Close
+      </span>
     </nav>
     <section
       class="response"
@@ -416,6 +426,11 @@ exports[`FlowView 3`] = `
       >
         Comment
       </a>
+      <span
+        class="close-button"
+      >
+        Close
+      </span>
     </nav>
     <section
       class="websocket"
@@ -518,6 +533,11 @@ exports[`FlowView 4`] = `
       >
         Comment
       </a>
+      <span
+        class="close-button"
+      >
+        Close
+      </span>
     </nav>
     <section
       class="detail"
@@ -805,6 +825,11 @@ exports[`FlowView 5`] = `
       >
         Comment
       </a>
+      <span
+        class="close-button"
+      >
+        Close
+      </span>
     </nav>
     <section
       class="timing"
@@ -1011,6 +1036,11 @@ exports[`FlowView 6`] = `
       >
         Comment
       </a>
+      <span
+        class="close-button"
+      >
+        Close
+      </span>
     </nav>
     <section
       class="timing"
@@ -1080,6 +1110,11 @@ exports[`FlowView 7`] = `
       >
         Comment
       </a>
+      <span
+        class="close-button"
+      >
+        Close
+      </span>
     </nav>
     <section
       class="error"
@@ -1137,6 +1172,11 @@ exports[`FlowView 8`] = `
       >
         Comment
       </a>
+      <span
+        class="close-button"
+      >
+        Close
+      </span>
     </nav>
     <section
       class="tcp"
@@ -1213,6 +1253,11 @@ exports[`FlowView 9`] = `
       >
         Comment
       </a>
+      <span
+        class="close-button"
+      >
+        Close
+      </span>
     </nav>
     <section
       class="error"
@@ -1276,6 +1321,11 @@ exports[`FlowView 10`] = `
       >
         Comment
       </a>
+      <span
+        class="close-button"
+      >
+        Close
+      </span>
     </nav>
     <section
       class="dns-request"
@@ -1382,6 +1432,11 @@ exports[`FlowView 11`] = `
       >
         Comment
       </a>
+      <span
+        class="close-button"
+      >
+        Close
+      </span>
     </nav>
     <section
       class="dns-response"
@@ -1544,6 +1599,11 @@ exports[`FlowView 12`] = `
       >
         Comment
       </a>
+      <span
+        class="close-button"
+      >
+        Close
+      </span>
     </nav>
     <section
       class="error"
@@ -1601,6 +1661,11 @@ exports[`FlowView 13`] = `
       >
         Comment
       </a>
+      <span
+        class="close-button"
+      >
+        Close
+      </span>
     </nav>
     <section
       class="udp"
@@ -1677,6 +1742,11 @@ exports[`FlowView 14`] = `
       >
         Comment
       </a>
+      <span
+        class="close-button"
+      >
+        Close
+      </span>
     </nav>
     <section
       class="error"

--- a/web/src/js/components/FlowView.tsx
+++ b/web/src/js/components/FlowView.tsx
@@ -86,6 +86,12 @@ export default function FlowView() {
     return (
         <div className="flow-detail">
             <nav className="nav-tabs nav-tabs-sm">
+                <button
+                    className="close-button"
+                    onClick={() => dispatch(flowsActions.select(undefined))}
+                >
+                    X
+                </button>
                 {tabs.map((tabId) => (
                     <a
                         key={tabId}
@@ -99,12 +105,6 @@ export default function FlowView() {
                         {allTabs[tabId].displayName}
                     </a>
                 ))}
-                <button
-                    className="close-button"
-                    onClick={() => dispatch(flowsActions.select(undefined))}
-                >
-                    Close
-                </button>
             </nav>
             <Tab flow={flow} />
         </div>

--- a/web/src/js/components/FlowView.tsx
+++ b/web/src/js/components/FlowView.tsx
@@ -99,12 +99,12 @@ export default function FlowView() {
                         {allTabs[tabId].displayName}
                     </a>
                 ))}
-                <span
+                <button
                     className="close-button"
                     onClick={() => dispatch(flowsActions.select(undefined))}
                 >
                     Close
-                </span>
+                </button>
             </nav>
             <Tab flow={flow} />
         </div>

--- a/web/src/js/components/FlowView.tsx
+++ b/web/src/js/components/FlowView.tsx
@@ -16,6 +16,7 @@ import { Flow } from "../flow";
 import classnames from "classnames";
 import TcpMessages from "./FlowView/TcpMessages";
 import UdpMessages from "./FlowView/UdpMessages";
+import * as flowsActions from "../ducks/flows";
 
 type TabProps = {
     flow: Flow;
@@ -98,6 +99,12 @@ export default function FlowView() {
                         {allTabs[tabId].displayName}
                     </a>
                 ))}
+                <span
+                    className="close-button"
+                    onClick={() => dispatch(flowsActions.select(undefined))}
+                >
+                    Close
+                </span>
             </nav>
             <Tab flow={flow} />
         </div>

--- a/web/src/js/components/FlowView.tsx
+++ b/web/src/js/components/FlowView.tsx
@@ -90,7 +90,7 @@ export default function FlowView() {
                     className="close-button"
                     onClick={() => dispatch(flowsActions.select(undefined))}
                 >
-                    X
+                    <i className="fa fa-times-circle"></i>
                 </button>
                 {tabs.map((tabId) => (
                     <a

--- a/web/src/js/components/FlowView.tsx
+++ b/web/src/js/components/FlowView.tsx
@@ -87,6 +87,7 @@ export default function FlowView() {
         <div className="flow-detail">
             <nav className="nav-tabs nav-tabs-sm">
                 <button
+                    data-testid="close-button-id"
                     className="close-button"
                     onClick={() => dispatch(flowsActions.select(undefined))}
                 >


### PR DESCRIPTION
#### Description

Added a button to close the flow details panel, as discussed in issue #6725. It could be useful to have a button to immediately close the section. This is a preliminary idea, as I didn't want to alter the design significantly. What are your thoughts?

https://github.com/mitmproxy/mitmproxy/assets/100372313/732b29ac-6fff-4eff-be7b-98e4460a93a9


#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
