### PR TITLE
Update aioquic dependency to >= 1.0.0, < 2.0.0 (fixes: #6746)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
   ([#5370](https://github.com/mitmproxy/mitmproxy/pull/5370), @zioalex)  
 * Make it possible to read flows from stdin with mitmweb.
   ([#6732](https://github.com/mitmproxy/mitmproxy/pull/6732), @jaywor1)
+* Update aioquic dependency to >= 1.0.0, < 2.0.0.
+  ([#6747](https://github.com/mitmproxy/mitmproxy/pull/6747), @jlaine)
 
 ## 07 March 2024: mitmproxy 10.2.4
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
 # https://packaging.python.org/en/latest/discussions/install-requires-vs-requirements/#install-requires
 # It is not considered best practice to use install_requires to pin dependencies to specific versions.
 dependencies = [
-    "aioquic>=0.9.24,<0.10",
+    "aioquic>=1.0.0,<2.0.0",
     "asgiref>=3.2.10,<3.8",
     "Brotli>=1.0,<1.2",
     "certifi>=2019.9.11",  # no semver here - this should always be on the last release!


### PR DESCRIPTION
#### Description

This fixes some specification compliance issues as well as a potential DoS vulnerability.

Start with version 1.0.0, aioquic follows semantic versioning, so no breaking changes will occur before version 2.0.0.

#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
