### PR TITLE
Fix async `client_connected` handlers crashing mitmproxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
   ([#6732](https://github.com/mitmproxy/mitmproxy/pull/6732), @jaywor1)
 * Update aioquic dependency to >= 1.0.0, < 2.0.0.
   ([#6747](https://github.com/mitmproxy/mitmproxy/pull/6747), @jlaine)
+* Fix a bug where async `client_connected` handlers would crash mitmproxy.
 
 ## 07 March 2024: mitmproxy 10.2.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Update aioquic dependency to >= 1.0.0, < 2.0.0.
   ([#6747](https://github.com/mitmproxy/mitmproxy/pull/6747), @jlaine)
 * Fix a bug where async `client_connected` handlers would crash mitmproxy.
+  ([#6749](https://github.com/mitmproxy/mitmproxy/pull/6749), @mhils)
 
 ## 07 March 2024: mitmproxy 10.2.4
 

--- a/mitmproxy/proxy/server.py
+++ b/mitmproxy/proxy/server.py
@@ -144,13 +144,13 @@ class ConnectionHandler(metaclass=abc.ABCMeta):
             assert writer
             writer.close()
         else:
+            self.server_event(events.Start())
             handler = asyncio_utils.create_task(
                 self.handle_connection(self.client),
                 name=f"client connection handler",
                 client=self.client.peername,
             )
             self.transports[self.client].handler = handler
-            self.server_event(events.Start())
             await asyncio.wait([handler])
             if not handler.cancelled() and (e := handler.exception()):
                 self.log(

--- a/mitmproxy/proxy/server.py
+++ b/mitmproxy/proxy/server.py
@@ -254,7 +254,9 @@ class ConnectionHandler(metaclass=abc.ABCMeta):
                 finally:
                     self.log(f"server disconnect {addr}")
                     command.connection.timestamp_end = time.time()
-                    await self.handle_hook(server_hooks.ServerDisconnectedHook(hook_data))
+                    await self.handle_hook(
+                        server_hooks.ServerDisconnectedHook(hook_data)
+                    )
 
     async def wakeup(self, request: commands.RequestWakeup) -> None:
         await asyncio.sleep(request.delay)


### PR DESCRIPTION
fix #6745