### PR TITLE
Setting SIG_IGN for SIGPIPE errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * Ignore SIGPIPE signals when there is lots of traffic.
   Socket errors are handled directly and do not require extra signals
   that generate noise.
+  ([#6764](https://github.com/mitmproxy/mitmproxy/pull/6764), @changsin)
 
 ## 07 March 2024: mitmproxy 10.2.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,11 @@
   ([#6747](https://github.com/mitmproxy/mitmproxy/pull/6747), @jlaine)
 * Fix a bug where async `client_connected` handlers would crash mitmproxy.
   ([#6749](https://github.com/mitmproxy/mitmproxy/pull/6749), @mhils)
-  * Add button to close flow details panel
+* Add button to close flow details panel
   ([#6734](https://github.com/mitmproxy/mitmproxy/pull/6734), @lups2000)
+* Ignore SIGPIPE signals when there is lots of traffic.
+  Socket errors are handled directly and do not require extra signals
+  that generate noise.
 
 ## 07 March 2024: mitmproxy 10.2.4
 

--- a/mitmproxy/tools/main.py
+++ b/mitmproxy/tools/main.py
@@ -122,7 +122,8 @@ def run(
         signal.signal(signal.SIGTERM, _sigterm)
         # to fix the issue mentioned https://github.com/mitmproxy/mitmproxy/issues/6744
         # by setting SIGPIPE to SIG_IGN, the process will not terminate and continue to run
-        signal.signal(signal.SIGPIPE, signal.SIG_IGN)
+        if sys.platform != 'win32':
+            signal.signal(signal.SIGPIPE, signal.SIG_IGN)
 
         await master.run()
         return master

--- a/mitmproxy/tools/main.py
+++ b/mitmproxy/tools/main.py
@@ -122,7 +122,7 @@ def run(
         signal.signal(signal.SIGTERM, _sigterm)
         # to fix the issue mentioned https://github.com/mitmproxy/mitmproxy/issues/6744
         # by setting SIGPIPE to SIG_IGN, the process will not terminate and continue to run
-        if sys.platform != "win32":
+        if hasattr(signal, "SIGPIPE"):
             signal.signal(signal.SIGPIPE, signal.SIG_IGN)
 
         await master.run()

--- a/mitmproxy/tools/main.py
+++ b/mitmproxy/tools/main.py
@@ -120,6 +120,9 @@ def run(
         # but signal.signal just works fine for our purposes.
         signal.signal(signal.SIGINT, _sigint)
         signal.signal(signal.SIGTERM, _sigterm)
+        # to fix the issue mentioned https://github.com/mitmproxy/mitmproxy/issues/6744
+        # by setting SIGPIPE to SIG_IGN, the process will not terminate and continue to run
+        signal.signal(signal.SIGPIPE, signal.SIG_IGN)
 
         await master.run()
         return master

--- a/mitmproxy/tools/main.py
+++ b/mitmproxy/tools/main.py
@@ -122,7 +122,7 @@ def run(
         signal.signal(signal.SIGTERM, _sigterm)
         # to fix the issue mentioned https://github.com/mitmproxy/mitmproxy/issues/6744
         # by setting SIGPIPE to SIG_IGN, the process will not terminate and continue to run
-        if sys.platform != 'win32':
+        if sys.platform != "win32":
             signal.signal(signal.SIGPIPE, signal.SIG_IGN)
 
         await master.run()


### PR DESCRIPTION
    The issue was reported in https://github.com/mitmproxy/mitmproxy/issues/6744

    Problem description:
    When there is a sudden surge of requests, mitmproxy will hit SIGPIPE (broken pipe) errors because it was trying to write to a closed socket. The stacktrace is:
    File "asyncio/runners.py", line 44, in run
    File "asyncio/base_events.py", line 636, in run_until_complete
    File "asyncio/base_events.py", line 603, in run_forever
    File "asyncio/base_events.py", line 1909, in _run_once
    File "asyncio/events.py", line 80, in _run
    File "mitmproxy/proxy/server.py", line 294, in handle_connection
    File "mitmproxy/proxy/server.py", line 407, in server_event
    File "asyncio/streams.py", line 325, in write
    File "asyncio/selector_events.py", line 924, in write

    When this happens, the process terminates unless handled
    The fix will allow the process to continue to run.

#### Description

<!-- describe your changes here -->

#### Checklist

 - [ ] I have updated tests where applicable.
 - [ ] I have added an entry to the CHANGELOG.
