### PR TITLE
Add primitive websocket interception and modification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
   ([#6749](https://github.com/mitmproxy/mitmproxy/pull/6749), @mhils)
   * Add button to close flow details panel
   ([#6734](https://github.com/mitmproxy/mitmproxy/pull/6734), @lups2000)
+* Add primitive websocket interception and modification
 
 ## 07 March 2024: mitmproxy 10.2.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
   * Add button to close flow details panel
   ([#6734](https://github.com/mitmproxy/mitmproxy/pull/6734), @lups2000)
 * Add primitive websocket interception and modification
+  ([#6766](https://github.com/mitmproxy/mitmproxy/pull/6766), @errorxyz)
 
 ## 07 March 2024: mitmproxy 10.2.4
 

--- a/mitmproxy/addons/intercept.py
+++ b/mitmproxy/addons/intercept.py
@@ -58,3 +58,6 @@ class Intercept:
 
     def dns_response(self, f):
         self.process_flow(f)
+
+    def websocket_message(self, f):
+        self.process_flow(f)

--- a/mitmproxy/tools/console/consoleaddons.py
+++ b/mitmproxy/tools/console/consoleaddons.py
@@ -398,6 +398,8 @@ class ConsoleAddon:
                 "set-cookies",
                 "url",
             ]
+            if flow.websocket:
+                focus_options.append("websocket-message")
         elif isinstance(flow, dns.DNSFlow):
             raise exceptions.CommandError(
                 "Cannot edit DNS flows yet, please submit a patch."
@@ -467,6 +469,10 @@ class ConsoleAddon:
             )
         elif flow_part in ["tcp-message", "udp-message"]:
             message = flow.messages[-1]
+            c = self.master.spawn_editor(message.content or b"")
+            message.content = c.rstrip(b"\n")
+        elif flow_part == "websocket-message":
+            message = flow.websocket.messages[-1]
             c = self.master.spawn_editor(message.content or b"")
             message.content = c.rstrip(b"\n")
 

--- a/mitmproxy/tools/console/flowview.py
+++ b/mitmproxy/tools/console/flowview.py
@@ -119,7 +119,7 @@ class FlowDetails(tabs.Tabs):
         assert isinstance(flow, http.HTTPFlow)
 
         # prevent renaming when websocket messages are intercepted
-        if self.flow.intercepted and flow.response and not flow.websocket:
+        if self.flow.intercepted and flow.response and (not flow.websocket or len(flow.websocket.messages) == 0):
             return "Response intercepted"
         else:
             return "Response"
@@ -147,7 +147,14 @@ class FlowDetails(tabs.Tabs):
         return "UDP Stream"
 
     def tab_websocket_messages(self):
-        return "WebSocket Messages"
+        flow = self.flow
+        assert isinstance(flow, http.HTTPFlow)
+        assert flow.websocket
+
+        if self.flow.intercepted and len(flow.websocket.messages) != 0:
+            return "WebSocket Messages intercepted"
+        else:
+            return "WebSocket Messages"
 
     def tab_details(self):
         return "Detail"

--- a/mitmproxy/tools/console/flowview.py
+++ b/mitmproxy/tools/console/flowview.py
@@ -117,7 +117,9 @@ class FlowDetails(tabs.Tabs):
     def tab_http_response(self):
         flow = self.flow
         assert isinstance(flow, http.HTTPFlow)
-        if self.flow.intercepted and flow.response:
+
+        # prevent renaming when websocket messages are intercepted
+        if self.flow.intercepted and flow.response and not flow.websocket:
             return "Response intercepted"
         else:
             return "Response"

--- a/mitmproxy/tools/console/flowview.py
+++ b/mitmproxy/tools/console/flowview.py
@@ -118,7 +118,7 @@ class FlowDetails(tabs.Tabs):
         flow = self.flow
         assert isinstance(flow, http.HTTPFlow)
 
-        # currently we cant check whether HTTP response is intercepted or websocket message
+        # there is no good way to detect what part of the flow is intercepted,
         # so we apply some heuristics to see if it's the HTTP response.
         websocket_started = flow.websocket and len(flow.websocket.messages) != 0
         response_is_intercepted = (

--- a/mitmproxy/tools/console/flowview.py
+++ b/mitmproxy/tools/console/flowview.py
@@ -119,7 +119,11 @@ class FlowDetails(tabs.Tabs):
         assert isinstance(flow, http.HTTPFlow)
 
         # prevent renaming when websocket messages are intercepted
-        if self.flow.intercepted and flow.response and (not flow.websocket or len(flow.websocket.messages) == 0):
+        if (
+            self.flow.intercepted
+            and flow.response
+            and (not flow.websocket or len(flow.websocket.messages) == 0)
+        ):
             return "Response intercepted"
         else:
             return "Response"

--- a/mitmproxy/tools/console/flowview.py
+++ b/mitmproxy/tools/console/flowview.py
@@ -121,7 +121,8 @@ class FlowDetails(tabs.Tabs):
         # currently we cant check whether HTTP response is intercepted or websocket message
         # so we apply some heuristics to see if it's the HTTP response.
         websocket_started = flow.websocket and len(flow.websocket.messages) != 0
-        if self.flow.intercepted and flow.response and not websocket_started:
+        response_is_intercepted = self.flow.intercepted and flow.response and not websocket_started
+        if response_is_intercepted:
             return "Response intercepted"
         else:
             return "Response"

--- a/mitmproxy/tools/console/flowview.py
+++ b/mitmproxy/tools/console/flowview.py
@@ -121,11 +121,7 @@ class FlowDetails(tabs.Tabs):
         # currently we cant check whether HTTP response is intercepted or websocket message
         # so we apply some heuristics to see if it's the HTTP response.
         websocket_started = flow.websocket and len(flow.websocket.messages) != 0
-        if (
-            self.flow.intercepted
-            and flow.response
-            and not websocket_started
-        ):
+        if self.flow.intercepted and flow.response and not websocket_started:
             return "Response intercepted"
         else:
             return "Response"

--- a/mitmproxy/tools/console/flowview.py
+++ b/mitmproxy/tools/console/flowview.py
@@ -118,11 +118,13 @@ class FlowDetails(tabs.Tabs):
         flow = self.flow
         assert isinstance(flow, http.HTTPFlow)
 
-        # prevent renaming when websocket messages are intercepted
+        # currently we cant check whether HTTP response is intercepted or websocket message
+        # so we apply some heuristics to see if it's the HTTP response.
+        websocket_started = flow.websocket and len(flow.websocket.messages) != 0
         if (
             self.flow.intercepted
             and flow.response
-            and (not flow.websocket or len(flow.websocket.messages) == 0)
+            and not websocket_started
         ):
             return "Response intercepted"
         else:

--- a/mitmproxy/tools/console/flowview.py
+++ b/mitmproxy/tools/console/flowview.py
@@ -121,7 +121,9 @@ class FlowDetails(tabs.Tabs):
         # currently we cant check whether HTTP response is intercepted or websocket message
         # so we apply some heuristics to see if it's the HTTP response.
         websocket_started = flow.websocket and len(flow.websocket.messages) != 0
-        response_is_intercepted = self.flow.intercepted and flow.response and not websocket_started
+        response_is_intercepted = (
+            self.flow.intercepted and flow.response and not websocket_started
+        )
         if response_is_intercepted:
             return "Response intercepted"
         else:

--- a/test/mitmproxy/addons/test_intercept.py
+++ b/test/mitmproxy/addons/test_intercept.py
@@ -90,10 +90,11 @@ async def test_udp():
         await tctx.cycle(r, f)
         assert not f.intercepted
 
+
 async def test_websocket_message():
     r = intercept.Intercept()
     with taddons.context(r) as tctx:
-        tctx.configure(r, intercept="~b \"hello binary\"")
+        tctx.configure(r, intercept='~b "hello binary"')
         f = tflow.twebsocketflow()
         await tctx.cycle(r, f)
         assert f.intercepted

--- a/test/mitmproxy/addons/test_intercept.py
+++ b/test/mitmproxy/addons/test_intercept.py
@@ -89,3 +89,16 @@ async def test_udp():
         f = tflow.tudpflow()
         await tctx.cycle(r, f)
         assert not f.intercepted
+
+async def test_websocket_message():
+    r = intercept.Intercept()
+    with taddons.context(r) as tctx:
+        tctx.configure(r, intercept="~b \"hello binary\"")
+        f = tflow.twebsocketflow()
+        await tctx.cycle(r, f)
+        assert f.intercepted
+
+        tctx.configure(r, intercept_active=False)
+        f = tflow.twebsocketflow()
+        await tctx.cycle(r, f)
+        assert not f.intercepted


### PR DESCRIPTION
#### Description

This PR adds a feature(MVP) to allow for websocket interception and modification one at a time per flow. On the mitmweb side of things, the UI shows that websocket messages are being intercepted but there's no option to edit (yet?).
Websockets are intercepted by default if interception is on, to prevent websocket interception use `!~websocket`

#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
