### PR TITLE
Issue2936

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
   ([#6790](https://github.com/mitmproxy/mitmproxy/pull/6790), @mhils)
 * Fix a bug when proxying unicode domains.
   ([#6796](https://github.com/mitmproxy/mitmproxy/pull/6796), @mhils)
+* Update header name line-wrapping according to unused console columns.
 
 
 ## 07 March 2024: mitmproxy 10.2.4

--- a/mitmproxy/tools/console/common.py
+++ b/mitmproxy/tools/console/common.py
@@ -67,6 +67,20 @@ def format_keyvals(
     if indent > 2:
         indent -= 2  # We use dividechars=2 below, which already adds two empty spaces
 
+    cols,_ = urwid.raw_display.Screen().get_cols_rows()
+    available_cols = cols - (indent + 2*COL_GAP) # total console columns minus the indent whitespace and the column gaps
+    key_lengths = []
+    val_lengths = []
+    for k,v in entries:
+        if k is not None:
+            key_lengths.append(len(k))
+            if v is not None and isinstance(v, str):
+                val_lengths.append(len(v))
+    max_entry_key_len = max(key_lengths, default=0)
+    max_entry_val_len = max(val_lengths, default=0)
+    unused_cols = available_cols - (max_entry_key_len + max_entry_val_len)
+    max_key_len = max(KEY_MAX, available_cols - max_entry_val_len) if unused_cols < 0 else max_entry_key_len
+
     ret = []
     for k, v in entries:
         if v is None:

--- a/mitmproxy/tools/console/common.py
+++ b/mitmproxy/tools/console/common.py
@@ -43,7 +43,7 @@ def highlight_key(text, key, textattr="text", keyattr="key"):
 
 
 KEY_MAX = 30
-
+COL_GAP = 2
 
 def format_keyvals(
     entries: Iterable[tuple[str, None | str | urwid.Widget]],
@@ -80,7 +80,7 @@ def format_keyvals(
                     ("fixed", max_key_len, urwid.Text([(key_format, k)])),
                     v,
                 ],
-                dividechars=2,
+                dividechars=COL_GAP,
             )
         )
     return ret


### PR DESCRIPTION
#### Description

My attempt at increasing header name line-wrap length according to unused console columns. Specifically:
* line-wrap length is never lower than 30 columns.
* it is increased to use as many unused columns as possible, as long as this does not cause the longest amongst the header values to be wrapped.
* column gaps and indentation whitespace are accounted for when calculating unused columns.

Fixes #2936 .

#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
