### PR TITLE
Prefix version tags with 'v'

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,11 +72,10 @@ jobs:
           # run tests with loopback only. We need to sudo for unshare, which means we need an absolute path for tox.
           sudo unshare --net -- sh -c "ip link set lo up; $(which tox) -e py"
         if: matrix.os == 'ubuntu-latest'
-      - uses: mhils/better-codecov-action@main
+      - uses: codecov/codecov-action@v4
         with:
-          arguments: '--file ./coverage.xml --name ${{ matrix.os }}'
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage.xml
 
   build:
     strategy:
@@ -166,11 +165,10 @@ jobs:
         run: npm ci
       - working-directory: ./web
         run: npm test
-      - uses: mhils/better-codecov-action@main
+      - uses: codecov/codecov-action@v4
         with:
-          arguments: '--file ./web/coverage/coverage-final.json'
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./web/coverage/coverage-final.json
 
   docs:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ## Unreleased: mitmproxy next
 
 * Release tags are now prefixed with `v` again to follow SemVer convention.
+  ([#6810](https://github.com/mitmproxy/mitmproxy/pull/6810), @mhils)
 
 
 ## 17 April 2024: mitmproxy 10.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ## Unreleased: mitmproxy next
 
+* Release tags are now prefixed with `v` again to follow SemVer convention.
 
 
 ## 17 April 2024: mitmproxy 10.3.0

--- a/release/build-and-deploy-docker.py
+++ b/release/build-and-deploy-docker.py
@@ -19,7 +19,9 @@ tag: str | None = None
 if ref.startswith("refs/heads/"):
     branch = ref.replace("refs/heads/", "")
 elif ref.startswith("refs/tags/"):
-    tag = ref.replace("refs/tags/", "")
+    if not ref.startswith("refs/tags/v"):
+        raise AssertionError(f"Unexpected tag: {ref}")
+    tag = ref.replace("refs/tags/v", "")
 else:
     raise AssertionError("Failed to parse $GITHUB_REF")
 

--- a/release/build.py
+++ b/release/build.py
@@ -87,11 +87,10 @@ def version() -> str:
         if ref.startswith("refs/tags/") and not ref.startswith("refs/tags/v"):
             raise AssertionError(f"Unexpected tag: {ref}")
         return (
-            ref
-                .removeprefix("refs/heads/")
-                .removeprefix("refs/pull/")
-                .removeprefix("refs/tags/v")
-                .replace("/", "-")
+            ref.removeprefix("refs/heads/")
+            .removeprefix("refs/pull/")
+            .removeprefix("refs/tags/v")
+            .replace("/", "-")
         )
     else:
         return os.environ.get("BUILD_VERSION", "dev")

--- a/release/build.py
+++ b/release/build.py
@@ -83,9 +83,18 @@ def archive(path: Path) -> tarfile.TarFile | ZipFile2:
 
 
 def version() -> str:
-    return os.environ.get("GITHUB_REF_NAME", "").replace("/", "-") or os.environ.get(
-        "BUILD_VERSION", "dev"
-    )
+    if ref := os.environ.get("GITHUB_REF", ""):
+        if ref.startswith("refs/tags/") and not ref.startswith("refs/tags/v"):
+            raise AssertionError(f"Unexpected tag: {ref}")
+        return (
+            ref
+                .removeprefix("refs/heads/")
+                .removeprefix("refs/pull/")
+                .removeprefix("refs/tags/v")
+                .replace("/", "-")
+        )
+    else:
+        return os.environ.get("BUILD_VERSION", "dev")
 
 
 def operating_system() -> str:

--- a/release/deploy.py
+++ b/release/deploy.py
@@ -14,7 +14,9 @@ if __name__ == "__main__":
     if ref.startswith("refs/heads/"):
         branch = ref.replace("refs/heads/", "")
     elif ref.startswith("refs/tags/"):
-        tag = ref.replace("refs/tags/", "")
+        if not ref.startswith("refs/tags/v"):
+            raise AssertionError(f"Unexpected tag: {ref}")
+        tag = ref.replace("refs/tags/v", "")
     else:
         raise AssertionError
 

--- a/release/release.py
+++ b/release/release.py
@@ -99,7 +99,8 @@ if __name__ == "__main__":
     subprocess.run(
         ["git", "commit", "-a", "-m", f"mitmproxy {version}"], cwd=root, check=True
     )
-    subprocess.run(["git", "tag", version], cwd=root, check=True)
+    tag_name = f"v{version}"
+    subprocess.run(["git", "tag", tag_name], cwd=root, check=True)
     release_sha = subprocess.run(
         ["git", "rev-parse", "HEAD"],
         cwd=root,
@@ -124,7 +125,7 @@ if __name__ == "__main__":
 
     print("➡️ Pushing...")
     subprocess.run(
-        ["git", "push", "--atomic", "origin", branch, version], cwd=root, check=True
+        ["git", "push", "--atomic", "origin", branch, tag_name], cwd=root, check=True
     )
 
     print("➡️ Creating release on GitHub...")
@@ -133,7 +134,7 @@ if __name__ == "__main__":
             "gh",
             "release",
             "create",
-            version,
+            tag_name,
             "--title",
             f"mitmproxy {version}",
             "--notes-file",
@@ -145,7 +146,7 @@ if __name__ == "__main__":
 
     print("➡️ Dispatching release workflow...")
     subprocess.run(
-        ["gh", "workflow", "run", "main.yml", "--ref", version], cwd=root, check=True
+        ["gh", "workflow", "run", "main.yml", "--ref", tag_name], cwd=root, check=True
     )
 
     print("")


### PR DESCRIPTION
This got lost with mitmproxy 9 somehow. the plan is to recreate those tags with 'v', and then keep using 'v' going forward.
