### PR TITLE
Issue 6739-Added custom DNS server for hostname resolution(Needs fixing)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@
 
 * Release tags are now prefixed with `v` again to follow SemVer convention.
   ([#6810](https://github.com/mitmproxy/mitmproxy/pull/6810), @mhils)
-
+* Adds DNS client for hostname resolution
+  ([#6739](https://github.com/mitmproxy/mitmproxy/issues/6739), @smenon02)
 
 ## 17 April 2024: mitmproxy 10.3.0
 

--- a/examples/addons/dns_server.py
+++ b/examples/addons/dns_server.py
@@ -1,6 +1,7 @@
 import asyncio
 import socket
 
+
 class DNSProtocol:
     def __init__(self):
         self.response_received = asyncio.Event()
@@ -10,10 +11,11 @@ class DNSProtocol:
         self.response_data = data
         self.response_received.set()
 
+
 class DNSServer:
     async def async_getaddrinfo(self, hostname):
         try:
-            udp_server_address = 'local'
+            udp_server_address = "local"
             udp_server_port = 12234
 
             sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
@@ -35,7 +37,6 @@ class DNSServer:
             print("Error communicating with UDP server:", e)
             return None
 
-
     async def receive_from_socket(self, sock):
         try:
             data, _ = await asyncio.wait_for(sock.recvfrom(1024), timeout=5)
@@ -49,4 +50,5 @@ class DNSServer:
         finally:
             sock.close()
 
-addons=[DNSServer()]
+
+addons = [DNSServer()]

--- a/examples/addons/dns_server.py
+++ b/examples/addons/dns_server.py
@@ -1,0 +1,52 @@
+import asyncio
+import socket
+
+class DNSProtocol:
+    def __init__(self):
+        self.response_received = asyncio.Event()
+        self.response_data = None
+
+    def received(self, data):
+        self.response_data = data
+        self.response_received.set()
+
+class DNSServer:
+    async def async_getaddrinfo(self, hostname):
+        try:
+            udp_server_address = 'local'
+            udp_server_port = 12234
+
+            sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+            sock.settimeout(10)  # Set timeout threshold for socket operations
+
+            try:
+                sock.sendto(hostname.encode(), (udp_server_address, udp_server_port))
+
+                data, _ = sock.recvfrom(1024)
+
+                ip_address = data.decode()
+                return ip_address
+            finally:
+                sock.close()
+        except socket.timeout as e:
+            print("Timeout waiting for data from UDP socket:", e)
+            return None
+        except Exception as e:
+            print("Error communicating with UDP server:", e)
+            return None
+
+
+    async def receive_from_socket(self, sock):
+        try:
+            data, _ = await asyncio.wait_for(sock.recvfrom(1024), timeout=5)
+            return data
+        except asyncio.TimeoutError as e:
+            print("Timeout waiting for data from UDP socket:", e)
+            return None
+        except Exception as e:
+            print("Error receiving data from UDP socket:", e)
+            return None
+        finally:
+            sock.close()
+
+addons=[DNSServer()]

--- a/examples/addons/udp_server.py
+++ b/examples/addons/udp_server.py
@@ -1,0 +1,39 @@
+import asyncio
+import socket
+
+async def udp_server():
+    udp_server_address = 'localhost'
+    udp_server_port = 12345
+
+    udp_socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    udp_socket.bind((udp_server_address, udp_server_port))
+
+    print(f"UDP server listening on {udp_server_address}:{udp_server_port}")
+
+    try:
+        while True:
+            data, addr = udp_socket.recvfrom(1024)
+            asyncio.ensure_future(handle_dns_request(data, addr, udp_socket))
+    except asyncio.CancelledError:
+        udp_socket.close()
+
+async def handle_dns_request(data, addr, udp_socket):
+    try:
+        query = data.decode()
+        print(f"Received DNS query: {query}")
+
+        if query == "example.com":
+            response = "192.168.1.1"
+        else:
+            response = "127.0.0.1"
+
+        udp_socket.sendto(response.encode(), addr)
+        print(f"Sent DNS response: {response}")
+    except Exception as e:
+        print("Error handling DNS request:", e)
+
+async def main():
+    await udp_server()
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
- #### Description

Creates a DNSServer addon for hostname resolution. Python implementation includes an async getaddrinfo method that opens a UDP socket to send DNS queries to using hostname to resolve. Running into issues while testing as communication between UDP server and DNS client is timing out. Any assistance of this would be greatly appreciated :)
UDP server was created to test hostname resolution. DNS client is not properly talking to it, so once communication between the two is fixed, test cases can be generated. 
#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
