### PR TITLE
Temporarily prohibit pytest 8.2.0 in order to fix CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ dev = [
     "pytest-cov>=5.0.0,<5.1",
     "pytest-timeout>=2.3.1,<2.4",
     "pytest-xdist>=3.5.0,<3.7",
-    "pytest>=8.1.1,<9",
+    "pytest>=8.1.1,<9,!=8.2.0",
     "requests>=2.9.1,<3",
     "tox>=3.5,<5",
     "wheel>=0.36.2,<0.44",


### PR DESCRIPTION
See https://github.com/pytest-dev/pytest/issues/12263
