### PR TITLE
Add support to Sequence[int] for addon commands

### DIFF
--- a/mitmproxy/types.py
+++ b/mitmproxy/types.py
@@ -266,6 +266,28 @@ class _StrSeqType(_BaseType):
         return True
 
 
+class _IntSeqType(_BaseType):
+    typ = Sequence[int]
+    display = "int[]"
+
+    def completion(self, manager: "CommandManager", t: type, s: str) -> Sequence[str]:
+        return []
+
+    def parse(self, manager: "CommandManager", t: type, s: str) -> Sequence[int]:
+        return [int(x.strip()) for x in s.split(",")]
+
+    def is_valid(self, manager: "CommandManager", typ: Any, val: Any) -> bool:
+        if isinstance(val, int) or isinstance(val, bytes):
+            return False
+        try:
+            for v in val:
+                if not isinstance(v, int):
+                    return False
+        except TypeError:
+            return False
+        return True
+
+
 class _CutSpecType(_BaseType):
     typ = CutSpec
     display = "cut[]"
@@ -489,6 +511,7 @@ CommandTypes = TypeManager(
     _FlowType,
     _FlowsType,
     _IntType,
+    _IntSeqType,
     _MarkerType,
     _PathType,
     _StrType,

--- a/test/mitmproxy/test_command.py
+++ b/test/mitmproxy/test_command.py
@@ -585,6 +585,7 @@ def test_typename():
 
     assert command.typename(flow.Flow) == "flow"
     assert command.typename(Sequence[str]) == "str[]"
+    assert command.typename(Sequence[int]) == "int[]"
 
     assert command.typename(mitmproxy.types.Choice("foo")) == "choice"
     assert command.typename(mitmproxy.types.Path) == "path"

--- a/test/mitmproxy/test_types.py
+++ b/test/mitmproxy/test_types.py
@@ -200,6 +200,19 @@ def test_strseq():
         assert b.is_valid(tctx.master.commands, Sequence[str], "foo") is False
 
 
+def test_intseq():
+    with taddons.context() as tctx:
+        b = mitmproxy.types._IntSeqType()
+        assert b.completion(tctx.master.commands, Sequence[int], "") == []
+        assert b.parse(tctx.master.commands, Sequence[int], "42") == [42]
+        assert b.parse(tctx.master.commands, Sequence[int], "42, 100, -5") == [42, 100, -5]
+        assert b.is_valid(tctx.master.commands, Sequence[int], [42]) is True
+        assert b.is_valid(tctx.master.commands, Sequence[int], [1, 2, "3"]) is False
+        assert b.is_valid(tctx.master.commands, Sequence[int], 1) is False
+        assert b.is_valid(tctx.master.commands, Sequence[int], "foo") is False
+        assert b.is_valid(tctx.master.commands, Sequence[int], b"33") is False
+
+
 class DummyConsole:
     @command.command("view.flows.resolve")
     def resolve(self, spec: str) -> Sequence[flow.Flow]:


### PR DESCRIPTION
#### Description

Addon commands can be sequences both Sequence[str] and Sequence[int] (#6660). 

#### Checklist

 - [x] I have updated tests where applicable.
 - [ ] I have added an entry to the CHANGELOG.

