### PR TITLE
Update change_upstream_proxy.py

### DIFF
--- a/examples/contrib/change_upstream_proxy.py
+++ b/examples/contrib/change_upstream_proxy.py
@@ -31,4 +31,4 @@ def request(flow: http.HTTPFlow) -> None:
         # server_conn already refers to an existing connection (which cannot be modified),
         # so we need to replace it with a new server connection object.
         flow.server_conn = Server(address=flow.server_conn.address)
-    flow.server_conn.via = ServerSpec("http", address)
+    flow.server_conn.via = ServerSpec(("http", address))


### PR DESCRIPTION
Script was not working as ServerSpec accepts a tuple, which was not supplied. I fixed it so a tuple is supplied to ServerSpec.
