### PR TITLE
Fix slowdown when sending large data over HTTP/2 (#6873)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
   ([#6821](https://github.com/mitmproxy/mitmproxy/pull/6821), @Prinzhorn)
 * Fix a bug where client replay would not work with proxyauth.
   ([#6866](https://github.com/mitmproxy/mitmproxy/pull/6866), @mhils)
+* Fix slowdown when sending large data over HTTP/2
 
 
 ## 17 April 2024: mitmproxy 10.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Fix a bug where client replay would not work with proxyauth.
   ([#6866](https://github.com/mitmproxy/mitmproxy/pull/6866), @mhils)
 * Fix slowdown when sending large data over HTTP/2
+  ([#6875](https://github.com/mitmproxy/mitmproxy/pull/6875), @aib)
 
 
 ## 17 April 2024: mitmproxy 10.3.0

--- a/mitmproxy/proxy/layers/http/_http_h2.py
+++ b/mitmproxy/proxy/layers/http/_http_h2.py
@@ -68,12 +68,12 @@ class BufferedH2Connection(h2.connection.H2Connection):
         frame_size = len(data)
         assert pad_length is None
 
-        while frame_size > self.max_outbound_frame_size:
-            chunk_data = data[: self.max_outbound_frame_size]
-            self.send_data(stream_id, chunk_data, end_stream=False)
+        if frame_size > self.max_outbound_frame_size:
+            for start in range(0, frame_size, self.max_outbound_frame_size):
+                chunk = data[start : start + self.max_outbound_frame_size]
+                self.send_data(stream_id, chunk, end_stream=False)
 
-            data = data[self.max_outbound_frame_size :]
-            frame_size -= len(chunk_data)
+            return
 
         if self.stream_buffers.get(stream_id, None):
             # We already have some data buffered, let's append.


### PR DESCRIPTION
#### Description

Do not mutate data when splitting it into outbound_frame_size-sized chunks, as discussed in #6873.

#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
