### PR TITLE
Change Windows Installer to delete old APR entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
   ([#6875](https://github.com/mitmproxy/mitmproxy/pull/6875), @aib)
 * Add an option to strip HTTPS records from DNS responses to block encrypted ClientHellos.
   ([#6876](https://github.com/mitmproxy/mitmproxy/pull/6876), @errorxyz)
+* Update InstallBuilder for Windows to delete old ARP entries on upgrade.
 
 
 ## 17 April 2024: mitmproxy 10.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * Add an option to strip HTTPS records from DNS responses to block encrypted ClientHellos.
   ([#6876](https://github.com/mitmproxy/mitmproxy/pull/6876), @errorxyz)
 * Update InstallBuilder for Windows to delete old ARP entries on upgrade.
+  ([#6889](https://github.com/mitmproxy/mitmproxy/pull/6889), @a-mnich)
 
 
 ## 17 April 2024: mitmproxy 10.3.0

--- a/release/installbuilder/mitmproxy.xml
+++ b/release/installbuilder/mitmproxy.xml
@@ -118,8 +118,17 @@
             <width>40</width>
             <postShowPageActionList>
                 <!-- This will skip the readytoinstall page -->
-
-                <setInstallerVariable name="next_page" value="installation"/>
+                <setInstallerVariable name="next_page" value="installation" />
+                <actionGroup>
+                    <actionList>
+                        <!-- This is custom flag to set we are performing an upgrade
+                    but do not modify the 'installationType' of the project -->
+                        <setInstallerVariable name="isUpgradeMode" value="1" />
+                    </actionList>
+                    <ruleList>
+                        <fileTest condition="exists" path="${installdir}" />
+                    </ruleList>
+                </actionGroup>
             </postShowPageActionList>
             <preShowPageActionList>
                 <setInstallerVariable>
@@ -129,4 +138,32 @@
             </preShowPageActionList>
         </directoryParameter>
     </parameterList>
+    <readyToInstallActionList>
+        <actionGroup>
+            <actionList>
+                <registryFind>
+                    <rootKey>HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\</rootKey>
+                    <keyPattern>${project.fullName} \d+.\d+.\d+</keyPattern>
+                    <namePattern>DisplayVersion</namePattern>
+                    <searchDepth>1</searchDepth>
+                    <findAll>1</findAll>
+                    <variable>previouslyInstalledVersions</variable>
+                </registryFind>
+                <foreach>
+                    <values>${previouslyInstalledVersions}</values>
+                    <variables>key name value</variables>
+                    <actionList>
+                        <!-- Delete the old ARP registry keys -->
+                        <registryDelete>
+                            <key>HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\${project.fullName} ${value}</key>
+                        </registryDelete>
+                    </actionList>
+                </foreach>
+            </actionList>
+            <ruleList>
+                <platformTest type="windows" />
+                <isTrue value="${isUpgradeMode}" />
+            </ruleList>
+        </actionGroup>
+    </readyToInstallActionList>
 </project>


### PR DESCRIPTION
### Issue (#6888)
Currently upon upgrading to a newer version of mitmproxy with the MSI installer while an older mitmproxy version is already installed, the installer does not clear the old Windows ARP entries.

### PR Description
I've adapted the InstallBuilder XML configuration to check for registry entries within `Computer\HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\` that match the `mitmproxy {Version}` naming scheme and delete the old versions when the installer detects that it is in the upgrade mode based on the installdir already existing.


Alternatively it would be possible to modify the configuration to only delete the entries for the currently installed version based on the `HKEY_LOCAL_MACHINE\Software\mitmproxy.org\mitmproxy` entry. But then duplicate entries that already exist as of today would never be deleted as this registry entry only holds the currently installed version and not past ones. Therefore I've decided for the regex approach within this PR.

### Important:
As a license key is required to run the InstallBuilder, I was not able to actually test this and only changed the configuration based on the documentation. 

#### InstallBuilder documentation:
- [Updates](https://releases.installbuilder.com/installbuilder/docs/installbuilder-userguide/_updates.html)
- [Actions](https://releases.installbuilder.com/installbuilder/docs/installbuilder-userguide/_actions.html)

resolves #6888

![grafik](https://github.com/mitmproxy/mitmproxy/assets/56564725/065cd69a-e848-429a-858a-af91f3accb16)

#### Checklist

 - [ ] ~~I have updated tests where applicable.~~
 - [X] I have added an entry to the CHANGELOG.
