### PR TITLE
Fix test on an ipv6 disabled host

### DIFF
--- a/test/mitmproxy/net/test_local_ip.py
+++ b/test/mitmproxy/net/test_local_ip.py
@@ -1,4 +1,5 @@
 from mitmproxy.net import local_ip
+from ...conftest import skip_no_ipv6
 
 
 def test_get_local_ip():
@@ -9,6 +10,7 @@ def test_get_local_ip():
     local_ip.get_local_ip("invalid!")
 
 
+@skip_no_ipv6
 def test_get_local_ip6():
     # should never error, but may return None depending on the host OS configuration.
     local_ip.get_local_ip6()

--- a/test/mitmproxy/net/test_local_ip.py
+++ b/test/mitmproxy/net/test_local_ip.py
@@ -1,5 +1,5 @@
-from mitmproxy.net import local_ip
 from ...conftest import skip_no_ipv6
+from mitmproxy.net import local_ip
 
 
 def test_get_local_ip():


### PR DESCRIPTION
#### Description

Skip test_get_local_ip6 on a host with ipv6 disabled

#### Checklist

 - [x] I have updated tests where applicable.
 - [ ] I have added an entry to the CHANGELOG.
