### PR TITLE
fix: OSError raised when ipv6 is disabled

### DIFF
--- a/mitmproxy/net/local_ip.py
+++ b/mitmproxy/net/local_ip.py
@@ -10,14 +10,16 @@ def get_local_ip(reachable: str = "8.8.8.8") -> str | None:
     We use Google DNS's IPv4 address as the default.
     """
     # https://stackoverflow.com/questions/166506/finding-local-ip-addresses-using-pythons-stdlib
-    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    s = None
     try:
+        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         s.connect((reachable, 80))
         return s.getsockname()[0]  # pragma: no cover
     except OSError:
         return None  # pragma: no cover
     finally:
-        s.close()
+        if s is not None:
+            s.close()
 
 
 def get_local_ip6(reachable: str = "2001:4860:4860::8888") -> str | None:
@@ -26,11 +28,13 @@ def get_local_ip6(reachable: str = "2001:4860:4860::8888") -> str | None:
     This will fail if the target address is known to be unreachable.
     We use Google DNS's IPv6 address as the default.
     """
-    s = socket.socket(socket.AF_INET6, socket.SOCK_DGRAM)
+    s = None
     try:
+        s = socket.socket(socket.AF_INET6, socket.SOCK_DGRAM)
         s.connect((reachable, 80))
         return s.getsockname()[0]  # pragma: no cover
     except OSError:
         return None  # pragma: no cover
     finally:
-        s.close()
+        if s is not None:
+            s.close()


### PR DESCRIPTION
#### Description

When ipv6 is disabled completed (e.g, in grub), _socket.socket_ throws OSError exception.

The _get_local_ipv6_ function should return None in this case

#### Checklist

 - [x] I have updated tests where applicable.
 - [ ] I have added an entry to the CHANGELOG.
