### PR TITLE
Use existing API to unpack/pack domain names in HTTPS records

### DIFF
--- a/mitmproxy/net/dns/domain_names.py
+++ b/mitmproxy/net/dns/domain_names.py
@@ -28,7 +28,7 @@ def _unpack_label_into(labels: list[str], buffer: bytes, offset: int) -> int:
             labels.append(buffer[offset:end_label].decode("idna"))
         except UnicodeDecodeError:
             raise struct.error(
-                f"unpack encountered a illegal characters at offset {offset}"
+                f"unpack encountered an illegal characters at offset {offset}"
             )
         return _LABEL_SIZE.size + size
 

--- a/mitmproxy/net/dns/https_records.py
+++ b/mitmproxy/net/dns/https_records.py
@@ -1,6 +1,7 @@
 import enum
 import struct
 from dataclasses import dataclass
+
 from . import domain_names
 
 """

--- a/mitmproxy/net/dns/https_records.py
+++ b/mitmproxy/net/dns/https_records.py
@@ -1,6 +1,7 @@
 import enum
 import struct
 from dataclasses import dataclass
+from . import domain_names
 
 """
 HTTPS records are formatted as follows (as per RFC9460):
@@ -63,30 +64,6 @@ def _unpack_params(data: bytes, offset: int) -> dict[int, bytes]:
     return params
 
 
-def _unpack_target_name(data: bytes, offset: int) -> tuple[str, int]:
-    """Unpacks the DNS-encoded domain name from data starting at the given offset."""
-    labels = []
-    while True:
-        if offset >= len(data):
-            raise struct.error("unpack requires a buffer of %i bytes" % offset)
-        length = data[offset]
-        offset += 1
-        if length == 0:
-            break
-        if offset + length > len(data):
-            raise struct.error(
-                "unpack requires a buffer of %i bytes" % (offset + length)
-            )
-        try:
-            labels.append(data[offset : offset + length].decode("utf-8"))
-        except UnicodeDecodeError:
-            raise struct.error(
-                "unpack encountered illegal characters at offset %i" % (offset)
-            )
-        offset += length
-    return ".".join(labels), offset
-
-
 def unpack(data: bytes) -> HTTPSRecord:
     """
     Unpacks HTTPS RDATA from byte data.
@@ -101,7 +78,7 @@ def unpack(data: bytes) -> HTTPSRecord:
     offset += 2
 
     # TargetName (variable length)
-    target_name, offset = _unpack_target_name(data, offset)
+    target_name, offset = domain_names.unpack_from(data, offset)
 
     # Service Parameters (remaining bytes)
     params = _unpack_params(data, offset)
@@ -121,22 +98,10 @@ def _pack_params(params: dict[int, bytes]) -> bytes:
     return bytes(buffer)
 
 
-def _pack_target_name(name: str) -> bytes:
-    """Converts the target name into its DNS encoded format"""
-    buffer = bytearray()
-    for label in name.split("."):
-        if len(label) == 0:
-            break
-        buffer.extend(struct.pack("!B", len(label)))
-        buffer.extend(label.encode("utf-8"))
-    buffer.extend(struct.pack("!B", 0))
-    return bytes(buffer)
-
-
 def pack(record: HTTPSRecord) -> bytes:
     """Packs the HTTPS record into its bytes form."""
     buffer = bytearray()
     buffer.extend(struct.pack("!h", record.priority))
-    buffer.extend(_pack_target_name(record.target_name))
+    buffer.extend(domain_names.pack(record.target_name))
     buffer.extend(_pack_params(record.params))
     return bytes(buffer)

--- a/test/mitmproxy/net/dns/test_domain_names.py
+++ b/test/mitmproxy/net/dns/test_domain_names.py
@@ -47,7 +47,7 @@ def test_unpack():
         domain_names.unpack(b"\x40" + (b"a" * 64) + b"\x00")
     with pytest.raises(
         struct.error,
-        match=re.escape("unpack encountered a illegal characters at offset 1"),
+        match=re.escape("unpack encountered an illegal characters at offset 1"),
     ):
         domain_names.unpack(b"\x03\xff\xff\xff\00")
 

--- a/test/mitmproxy/net/dns/test_https_records.py
+++ b/test/mitmproxy/net/dns/test_https_records.py
@@ -42,7 +42,7 @@ class TestHTTPSRecords:
 
         with pytest.raises(
             struct.error,
-            match=re.escape("unpack encountered illegal characters at offset 3"),
+            match=re.escape("unpack encountered a illegal characters at offset 3"),
         ):
             https_records.unpack(
                 b"\x00\x01\x07exampl\x87\x03com\x00\x00\x01\x00\x06\x02h2\x02h3"
@@ -56,7 +56,7 @@ class TestHTTPSRecords:
             )
 
         with pytest.raises(
-            struct.error, match=re.escape("unpack requires a buffer of 10 bytes")
+            struct.error, match=re.escape("unpack requires a label buffer of 7 bytes")
         ):
             https_records.unpack(b"\x00\x01\x07exa")
 

--- a/test/mitmproxy/net/dns/test_https_records.py
+++ b/test/mitmproxy/net/dns/test_https_records.py
@@ -42,7 +42,7 @@ class TestHTTPSRecords:
 
         with pytest.raises(
             struct.error,
-            match=re.escape("unpack encountered a illegal characters at offset 3"),
+            match=re.escape("unpack encountered an illegal characters at offset 3"),
         ):
             https_records.unpack(
                 b"\x00\x01\x07exampl\x87\x03com\x00\x00\x01\x00\x06\x02h2\x02h3"


### PR DESCRIPTION
#### Description

Use existing API from `mitmproxy/net/dns/domain_names` to unpack/pack domain names found in HTTPS records

#### Checklist

 - [x] I have updated tests where applicable.
 - [ ] I have added an entry to the CHANGELOG.
