### PR TITLE
Fix issue #6944: Optimize response/request_body_buf by using list of byte chunks to avoid concatenation overhead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Add `HttpConnectedHook` and `HttpConnectErrorHook`
   ([#6930](https://github.com/mitmproxy/mitmproxy/pull/6930), @errorxyz)
 * Fix the issue of non-linear growth in processing time in mitmproxy related to packet size.
+  ([#6952](https://github.com/mitmproxy/mitmproxy/pull/6952), @jackfromeast)
 
 ## 12 June 2024: mitmproxy 10.3.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@
 * Add `HttpConnectedHook` and `HttpConnectErrorHook`
   ([#6930](https://github.com/mitmproxy/mitmproxy/pull/6930), @errorxyz)
 * Fix the issue of non-linear growth in processing time in mitmproxy related to packet size.
-  ([#6944](https://github.com/mitmproxy/mitmproxy/issues/6944), @jackfromeast)
 
 ## 12 June 2024: mitmproxy 10.3.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
   ([#6921](https://github.com/mitmproxy/mitmproxy/pull/6921), @zendai)
 * Add `HttpConnectedHook` and `HttpConnectErrorHook`
   ([#6930](https://github.com/mitmproxy/mitmproxy/pull/6930), @errorxyz)
+* Fix the issue of non-linear growth in processing time in mitmproxy related to packet size.
+  ([#6944](https://github.com/mitmproxy/mitmproxy/issues/6944), @jackfromeast)
 
 ## 12 June 2024: mitmproxy 10.3.1
 

--- a/mitmproxy/proxy/layers/http/__init__.py
+++ b/mitmproxy/proxy/layers/http/__init__.py
@@ -61,6 +61,7 @@ from mitmproxy.proxy.layers import tls
 from mitmproxy.proxy.layers import websocket
 from mitmproxy.proxy.layers.http import _upstream_proxy
 from mitmproxy.proxy.utils import expect
+from mitmproxy.proxy.utils import ReceiveBuffer
 from mitmproxy.utils import human
 from mitmproxy.websocket import WebSocketData
 
@@ -145,10 +146,8 @@ class DropStream(HttpCommand):
 
 
 class HttpStream(layer.Layer):
-    request_body_buf: list
-    response_body_buf: list
-    request_body_size: int
-    response_body_size: int
+    request_body_buf: ReceiveBuffer
+    response_body_buf: ReceiveBuffer
     flow: http.HTTPFlow
     stream_id: StreamId
     child_layer: layer.Layer | None = None
@@ -162,10 +161,8 @@ class HttpStream(layer.Layer):
 
     def __init__(self, context: Context, stream_id: int) -> None:
         super().__init__(context)
-        self.request_body_buf = []
-        self.response_body_buf = []
-        self.request_body_size = 0
-        self.response_body_size = 0
+        self.request_body_buf = ReceiveBuffer()
+        self.response_body_buf = ReceiveBuffer()
         self.client_state = self.state_uninitialized
         self.server_state = self.state_uninitialized
         self.stream_id = stream_id
@@ -351,17 +348,15 @@ class HttpStream(layer.Layer):
         self, event: events.Event
     ) -> layer.CommandGenerator[None]:
         if isinstance(event, RequestData):
-            self.request_body_buf.append(event.data)
-            self.request_body_size += len(event.data)
+            self.request_body_buf += event.data
             yield from self.check_body_size(True)
         elif isinstance(event, RequestTrailers):
             assert self.flow.request
             self.flow.request.trailers = event.trailers
         elif isinstance(event, RequestEndOfMessage):
             self.flow.request.timestamp_end = time.time()
-            self.flow.request.data.content = b"".join(self.request_body_buf)
+            self.flow.request.data.content = bytes(self.request_body_buf)
             self.request_body_buf.clear()
-            self.request_body_size = 0
             self.client_state = self.state_done
             yield HttpRequestHook(self.flow)
             if (yield from self.check_killed(True)):
@@ -460,17 +455,15 @@ class HttpStream(layer.Layer):
         self, event: events.Event
     ) -> layer.CommandGenerator[None]:
         if isinstance(event, ResponseData):
-            self.response_body_buf.append(event.data)
-            self.response_body_size += len(event.data)
+            self.response_body_buf += event.data
             yield from self.check_body_size(False)
         elif isinstance(event, ResponseTrailers):
             assert self.flow.response
             self.flow.response.trailers = event.trailers
         elif isinstance(event, ResponseEndOfMessage):
             assert self.flow.response
-            self.flow.response.data.content = b"".join(self.response_body_buf)
+            self.flow.response.data.content = bytes(self.response_body_buf)
             self.response_body_buf.clear()
-            self.response_body_size = 0
             yield from self.send_response()
 
     def send_response(self, already_streamed: bool = False):
@@ -565,9 +558,9 @@ class HttpStream(layer.Layer):
         expected_size: int | None
         # the 'late' case: we already started consuming the body
         if request and self.request_body_buf:
-            expected_size = self.request_body_size
+            expected_size = len(self.request_body_buf)
         elif response and self.response_body_buf:
-            expected_size = self.response_body_size
+            expected_size = len(self.response_body_buf)
         else:
             # the 'early' case: we have not started consuming the body
             try:
@@ -615,18 +608,16 @@ class HttpStream(layer.Layer):
                 self.flow.request.stream = True
                 if self.request_body_buf:
                     # clear buffer and then fake a DataReceived event with everything we had in the buffer so far.
-                    body_buf = b"".join(self.request_body_buf)
-                    self.request_body_buf = []
-                    self.request_body_size = 0
+                    body_buf = bytes(self.request_body_buf)
+                    self.request_body_buf.clear()
                     yield from self.start_request_stream()
                     yield from self.handle_event(RequestData(self.stream_id, body_buf))
             if response:
                 assert self.flow.response
                 self.flow.response.stream = True
                 if self.response_body_buf:
-                    body_buf = b"".join(self.response_body_buf)
-                    self.response_body_buf = []
-                    self.response_body_size = 0
+                    body_buf = bytes(self.response_body_buf)
+                    self.response_body_buf.clear()
                     yield from self.start_response_stream()
                     yield from self.handle_event(ResponseData(self.stream_id, body_buf))
         return False

--- a/mitmproxy/proxy/layers/http/__init__.py
+++ b/mitmproxy/proxy/layers/http/__init__.py
@@ -615,7 +615,7 @@ class HttpStream(layer.Layer):
                 self.flow.request.stream = True
                 if self.request_body_buf:
                     # clear buffer and then fake a DataReceived event with everything we had in the buffer so far.
-                    body_buf = b''.join(self.request_body_buf)
+                    body_buf = b"".join(self.request_body_buf)
                     self.request_body_buf = []
                     self.request_body_size = 0
                     yield from self.start_request_stream()
@@ -624,7 +624,7 @@ class HttpStream(layer.Layer):
                 assert self.flow.response
                 self.flow.response.stream = True
                 if self.response_body_buf:
-                    body_buf = b''.join(self.response_body_buf)
+                    body_buf = b"".join(self.response_body_buf)
                     self.response_body_buf = []
                     self.response_body_size = 0
                     yield from self.start_response_stream()

--- a/mitmproxy/proxy/utils.py
+++ b/mitmproxy/proxy/utils.py
@@ -40,6 +40,7 @@ class ReceiveBuffer:
     """
     A data structure to collect stream contents efficiently in O(n).
     """
+
     _chunks: list[bytes]
     _len: int
 

--- a/mitmproxy/proxy/utils.py
+++ b/mitmproxy/proxy/utils.py
@@ -34,3 +34,34 @@ def expect(*event_types):
             return f
 
     return decorator
+
+
+class ReceiveBuffer:
+    """
+    A data structure to collect stream contents efficiently in O(n).
+    """
+    _chunks: list[bytes]
+    _len: int
+
+    def __init__(self):
+        self._chunks = []
+        self._len = 0
+
+    def __iadd__(self, other: bytes):
+        assert isinstance(other, bytes)
+        self._chunks.append(other)
+        self._len += len(other)
+        return self
+
+    def __len__(self):
+        return self._len
+
+    def __bytes__(self):
+        return b"".join(self._chunks)
+
+    def __bool__(self):
+        return self._len > 0
+
+    def clear(self):
+        self._chunks.clear()
+        self._len = 0

--- a/test/mitmproxy/proxy/test_utils.py
+++ b/test/mitmproxy/proxy/test_utils.py
@@ -1,7 +1,7 @@
 import pytest
 
-from mitmproxy.proxy.utils import ReceiveBuffer
 from mitmproxy.proxy.utils import expect
+from mitmproxy.proxy.utils import ReceiveBuffer
 
 
 def test_expect():

--- a/test/mitmproxy/proxy/test_utils.py
+++ b/test/mitmproxy/proxy/test_utils.py
@@ -1,5 +1,6 @@
 import pytest
 
+from mitmproxy.proxy.utils import ReceiveBuffer
 from mitmproxy.proxy.utils import expect
 
 
@@ -19,3 +20,25 @@ def test_expect():
     assert list(f.bar("bar")) == ["rab"]
     with pytest.raises(AssertionError, match=r"Expected str\|int, got None."):
         f.foo(None)
+
+
+def test_receive_buffer():
+    buf = ReceiveBuffer()
+    assert len(buf) == 0
+    assert bytes(buf) == b""
+    assert not buf
+
+    buf += b"foo"
+    assert len(buf) == 3
+    assert bytes(buf) == b"foo"
+    assert buf
+
+    buf += b"bar"
+    assert len(buf) == 6
+    assert bytes(buf) == b"foobar"
+    assert buf
+
+    buf.clear()
+    assert len(buf) == 0
+    assert bytes(buf) == b""
+    assert not buf


### PR DESCRIPTION
#### Description

Fix issue #6944: Optimize response/request_body_buf by using a list of byte chunks to avoid concatenation overhead. 

#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
