### PR TITLE
Feature/regular mode port

### DIFF
--- a/web/src/css/mode.less
+++ b/web/src/css/mode.less
@@ -60,6 +60,14 @@
         height: 25px;
     }
 
+    .mode-regular-input {
+        border: 1px solid #ccc;
+        margin-left: 10px;
+        border-radius: 4px;
+        min-width: 70px;
+        height: 25px;
+    }
+
     .mode-reverse-dropdown {
         margin: 0 5px;
     }

--- a/web/src/js/__tests__/ducks/modes/regularSpec.tsx
+++ b/web/src/js/__tests__/ducks/modes/regularSpec.tsx
@@ -2,6 +2,7 @@ import regularReducer, {
     toggleRegular,
     getMode,
     initialState,
+    setPort,
 } from "./../../../ducks/modes/regular";
 import * as options from "../../../ducks/options";
 import { TStore } from "../tutils";
@@ -21,6 +22,17 @@ describe("regularReducer", () => {
         expect(store.getState().modes.regular.active).toBe(true);
         await store.dispatch(toggleRegular());
         expect(store.getState().modes.regular.active).toBe(false);
+        expect(fetchMock).toHaveBeenCalled();
+    });
+
+    it("should dispatch MODE_REGULAR_SET_PORT and updateMode", async () => {
+        enableFetchMocks();
+        const store = TStore();
+
+        await store.dispatch(setPort("8082"));
+
+        const state = store.getState().modes.regular;
+        expect(state.listen_port).toEqual("8082");
         expect(fetchMock).toHaveBeenCalled();
     });
 

--- a/web/src/js/__tests__/ducks/modes/regularSpec.tsx
+++ b/web/src/js/__tests__/ducks/modes/regularSpec.tsx
@@ -56,7 +56,7 @@ describe("regularReducer", () => {
         const newState = regularReducer(initialState, action);
         expect(newState.active).toBe(true);
         expect(newState.listen_host).toBe("");
-        expect(newState.listen_port).toBe("");
+        expect(newState.listen_port).toBe(8080);
     });
 
     it("should handle RECEIVE_OPTIONS action with data.mode containing another mode", () => {

--- a/web/src/js/components/Modes/Regular.tsx
+++ b/web/src/js/components/Modes/Regular.tsx
@@ -11,10 +11,6 @@ export default function Regular() {
         (state) => state.modes.regular,
     );
 
-    React.useEffect(()=> {
-        console.log(listen_port)
-    },[])
-
     return (
         <div>
             <h4 className="mode-title">Explicit HTTP(S) Proxy</h4>

--- a/web/src/js/components/Modes/Regular.tsx
+++ b/web/src/js/components/Modes/Regular.tsx
@@ -2,11 +2,18 @@ import * as React from "react";
 import { ModeToggle } from "./ModeToggle";
 import { useAppDispatch, useAppSelector } from "../../ducks";
 import { toggleRegular } from "../../ducks/modes/regular";
+import ValueEditor from "../editors/ValueEditor";
 
 export default function Regular() {
-    const dispatch = useAppDispatch(),
-        active = useAppSelector((state) => state.modes.regular.active),
-        error = useAppSelector((state) => state.modes.regular.error);
+    const dispatch = useAppDispatch();
+
+    const { active, error, listen_port } = useAppSelector(
+        (state) => state.modes.regular,
+    );
+
+    React.useEffect(()=> {
+        console.log(listen_port)
+    },[])
 
     return (
         <div>
@@ -19,7 +26,12 @@ export default function Regular() {
                 value={active}
                 onChange={() => dispatch(toggleRegular())}
             >
-                Run HTTP/S Proxy
+                Run HTTP/S Proxy on port{" "}
+                <ValueEditor
+                    className="mode-regular-input"
+                    content={listen_port?.toString() || ""}
+                    onEditDone={(port) => console.log(port)}
+                />
             </ModeToggle>
             {error && <div className="mode-error text-danger">{error}</div>}
         </div>

--- a/web/src/js/components/Modes/Regular.tsx
+++ b/web/src/js/components/Modes/Regular.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { ModeToggle } from "./ModeToggle";
 import { useAppDispatch, useAppSelector } from "../../ducks";
-import { toggleRegular } from "../../ducks/modes/regular";
+import { setPort, toggleRegular } from "../../ducks/modes/regular";
 import ValueEditor from "../editors/ValueEditor";
 
 export default function Regular() {
@@ -10,6 +10,10 @@ export default function Regular() {
     const { active, error, listen_port } = useAppSelector(
         (state) => state.modes.regular,
     );
+
+    const handlePortChange = (port: string) => {
+        dispatch(setPort(port));
+    };
 
     return (
         <div>
@@ -26,7 +30,7 @@ export default function Regular() {
                 <ValueEditor
                     className="mode-regular-input"
                     content={listen_port?.toString() || ""}
-                    onEditDone={(port) => console.log(port)}
+                    onEditDone={(port) => handlePortChange(port)}
                 />
             </ModeToggle>
             {error && <div className="mode-error text-danger">{error}</div>}

--- a/web/src/js/ducks/modes.ts
+++ b/web/src/js/ducks/modes.ts
@@ -3,8 +3,6 @@ import regularReducer from "./modes/regular";
 import localReducer from "./modes/local";
 import wireguardReducer from "./modes/wireguard";
 
-export const DEFAULT_PORT = 8080;
-
 const modes = combineReducers({
     regular: regularReducer,
     local: localReducer,

--- a/web/src/js/ducks/modes.ts
+++ b/web/src/js/ducks/modes.ts
@@ -3,6 +3,8 @@ import regularReducer from "./modes/regular";
 import localReducer from "./modes/local";
 import wireguardReducer from "./modes/wireguard";
 
+export const DEFAULT_PORT = 8080;
+
 const modes = combineReducers({
     regular: regularReducer,
     local: localReducer,

--- a/web/src/js/ducks/modes/regular.ts
+++ b/web/src/js/ducks/modes/regular.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_PORT } from "../modes";
 import {
     RECEIVE as RECEIVE_OPTIONS,
     UPDATE as UPDATE_OPTIONS,
@@ -6,12 +7,13 @@ import { ModeState, updateMode } from "./utils";
 import { includeModeState, getModesOfType } from "./utils";
 
 export const MODE_REGULAR_TOGGLE = "MODE_REGULAR_TOGGLE";
+export const MODE_REGULAR_SET_PORT = "MODE_REGULAR_SET_PORT";
 
 interface RegularState extends ModeState {}
 
 export const initialState: RegularState = {
     active: true,
-    listen_port: 8080,
+    listen_port: DEFAULT_PORT,
 };
 
 export const getMode = (modes) => {
@@ -31,12 +33,29 @@ export const toggleRegular =
         }
     };
 
+export const setPort =
+    (port: string, updateModeFunc = updateMode) =>
+    async (dispatch) => {
+        dispatch({ type: MODE_REGULAR_SET_PORT, port });
+
+        const result = await dispatch(updateModeFunc());
+
+        if (!result.success) {
+            //TODO: handle error
+        }
+    };
+
 const regularReducer = (state = initialState, action): RegularState => {
     switch (action.type) {
         case MODE_REGULAR_TOGGLE:
             return {
                 ...state,
                 active: !state.active,
+            };
+        case MODE_REGULAR_SET_PORT:
+            return {
+                ...state,
+                listen_port: action.port as number,
             };
         case UPDATE_OPTIONS:
         case RECEIVE_OPTIONS:
@@ -53,7 +72,7 @@ const regularReducer = (state = initialState, action): RegularState => {
                         ? currentModeConfig.listen_host
                         : state.listen_host,
                     listen_port: isActive
-                        ? (currentModeConfig.listen_port as number) || 8080
+                        ? (currentModeConfig.listen_port as number) || DEFAULT_PORT
                         : state.listen_port,
                 };
             }

--- a/web/src/js/ducks/modes/regular.ts
+++ b/web/src/js/ducks/modes/regular.ts
@@ -11,6 +11,7 @@ interface RegularState extends ModeState {}
 
 export const initialState: RegularState = {
     active: true,
+    listen_port: 8080,
 };
 
 export const getMode = (modes) => {
@@ -52,7 +53,7 @@ const regularReducer = (state = initialState, action): RegularState => {
                         ? currentModeConfig.listen_host
                         : state.listen_host,
                     listen_port: isActive
-                        ? (currentModeConfig.listen_port as number)
+                        ? (currentModeConfig.listen_port as number) || 8080
                         : state.listen_port,
                 };
             }

--- a/web/src/js/ducks/modes/regular.ts
+++ b/web/src/js/ducks/modes/regular.ts
@@ -1,4 +1,3 @@
-import { DEFAULT_PORT } from "../modes";
 import {
     RECEIVE as RECEIVE_OPTIONS,
     UPDATE as UPDATE_OPTIONS,
@@ -9,11 +8,12 @@ import { includeModeState, getModesOfType } from "./utils";
 export const MODE_REGULAR_TOGGLE = "MODE_REGULAR_TOGGLE";
 export const MODE_REGULAR_SET_PORT = "MODE_REGULAR_SET_PORT";
 
+export const DEFAULT_PORT = 8080;
+
 interface RegularState extends ModeState {}
 
 export const initialState: RegularState = {
     active: true,
-    listen_port: DEFAULT_PORT,
 };
 
 export const getMode = (modes) => {

--- a/web/src/js/ducks/modes/regular.ts
+++ b/web/src/js/ducks/modes/regular.ts
@@ -72,7 +72,8 @@ const regularReducer = (state = initialState, action): RegularState => {
                         ? currentModeConfig.listen_host
                         : state.listen_host,
                     listen_port: isActive
-                        ? (currentModeConfig.listen_port as number) || DEFAULT_PORT
+                        ? (currentModeConfig.listen_port as number) ||
+                          DEFAULT_PORT
                         : state.listen_port,
                 };
             }


### PR DESCRIPTION
#### Description

In this PR, I added an input field to the `Regular Mode` in order to change the `listen_port` on-the-fly.

<img width="1512" alt="Screenshot 2024-06-27 at 07 27 50" src="https://github.com/mitmproxy/mitmproxy/assets/100372313/75490cf9-972d-46f0-9d97-ad5b2753d815">

#### Checklist

 - [x] I have updated tests where applicable.
 - [ ] I have added an entry to the CHANGELOG.
