### PR TITLE
Support all query types in DNS mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
   ([#7001](https://github.com/mitmproxy/mitmproxy/pull/7001), @errorxyz)
 * Add Host header to CONNECT requests.
   ([#7021](https://github.com/mitmproxy/mitmproxy/pull/7021), @petsneakers)
+* Support all query types in DNS mode
 
 ## 12 June 2024: mitmproxy 10.3.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 * Add Host header to CONNECT requests.
   ([#7021](https://github.com/mitmproxy/mitmproxy/pull/7021), @petsneakers)
 * Support all query types in DNS mode
+  ([#6975](https://github.com/mitmproxy/mitmproxy/pull/6975), @errorxyz)
 
 ## 12 June 2024: mitmproxy 10.3.1
 

--- a/mitmproxy/addons/dns_resolver.py
+++ b/mitmproxy/addons/dns_resolver.py
@@ -5,6 +5,7 @@ from collections.abc import Sequence
 from functools import cached_property
 
 import mitmproxy_rs
+
 from mitmproxy import ctx
 from mitmproxy import dns
 from mitmproxy.proxy import mode_specs
@@ -106,7 +107,7 @@ class DnsResolver:
         except socket.gaierror as e:
             if e.args[0] == "NXDOMAIN":
                 raise ResolveError(dns.response_codes.NXDOMAIN)
-            else: # pragma: no cover
+            else:  # pragma: no cover
                 raise ResolveError(dns.response_codes.SERVFAIL)
 
         return map(

--- a/mitmproxy/addons/dns_resolver.py
+++ b/mitmproxy/addons/dns_resolver.py
@@ -37,8 +37,8 @@ class DnsResolver:
 
     def configure(self, updated):
         if "dns_use_hosts_file" in updated or "dns_name_servers" in updated:
-            self.__dict__.pop('resolver', None)
-            self.__dict__.pop('name_servers', None)
+            self.__dict__.pop("resolver", None)
+            self.__dict__.pop("name_servers", None)
 
     @cached_property
     def resolver(self) -> mitmproxy_rs.DnsResolver:

--- a/mitmproxy/addons/dns_resolver.py
+++ b/mitmproxy/addons/dns_resolver.py
@@ -12,8 +12,6 @@ from mitmproxy.proxy import mode_specs
 IP4_PTR_SUFFIX = ".in-addr.arpa"
 IP6_PTR_SUFFIX = ".ip6.arpa"
 
-SYSTEM_DNS_SERVERS = mitmproxy_rs.get_system_dns_servers()
-
 
 class ResolveError(Exception):
     """Exception thrown by different resolve methods."""
@@ -111,14 +109,9 @@ class DnsResolver:
             "Name servers to use for lookups. Default: operating system's name servers",
         )
 
-        self.resolver = mitmproxy_rs.DnsResolver(
-            name_servers=SYSTEM_DNS_SERVERS,
-            use_hosts_file=ctx.options.use_hosts_file,
-        )
-
     def configure(self, updated):
         if "use_hosts_file" in updated or "name_servers" in updated:
             self.resolver = mitmproxy_rs.DnsResolver(
-                name_servers=ctx.options.name_servers or SYSTEM_DNS_SERVERS,
+                name_servers=ctx.options.name_servers or mitmproxy_rs.get_system_dns_servers(),
                 use_hosts_file=ctx.options.use_hosts_file,
             )

--- a/mitmproxy/addons/dns_resolver.py
+++ b/mitmproxy/addons/dns_resolver.py
@@ -14,6 +14,7 @@ IP6_PTR_SUFFIX = ".ip6.arpa"
 
 SYSTEM_DNS_SERVERS = mitmproxy_rs.get_system_dns_servers()
 
+
 class ResolveError(Exception):
     """Exception thrown by different resolve methods."""
 

--- a/mitmproxy/addons/dns_resolver.py
+++ b/mitmproxy/addons/dns_resolver.py
@@ -45,7 +45,8 @@ class DnsResolver:
     @cached_property
     def resolver(self) -> mitmproxy_rs.DnsResolver:
         return mitmproxy_rs.DnsResolver(
-            name_servers=ctx.options.name_servers or mitmproxy_rs.get_system_dns_servers(),
+            name_servers=ctx.options.name_servers
+            or mitmproxy_rs.get_system_dns_servers(),
             use_hosts_file=ctx.options.use_hosts_file,
         )
 

--- a/mitmproxy/addons/dns_resolver.py
+++ b/mitmproxy/addons/dns_resolver.py
@@ -104,8 +104,12 @@ class DnsResolver:
             elif question.type == dns.types.AAAA:
                 addrinfos = await self.resolver.lookup_ipv6(question.name)
         except socket.gaierror as e:
+            # We aren't exactly following the RFC here
+            # https://datatracker.ietf.org/doc/html/rfc2308#section-2
             if e.args[0] == "NXDOMAIN":
                 raise ResolveError(dns.response_codes.NXDOMAIN)
+            elif e.args[0] == "NOERROR":
+                addrinfos = []
             else:  # pragma: no cover
                 raise ResolveError(dns.response_codes.SERVFAIL)
 

--- a/mitmproxy/dns.py
+++ b/mitmproxy/dns.py
@@ -247,6 +247,8 @@ class Message(serializable.SerializableDataclass):
         )
 
     def fail(self, response_code: int) -> Message:
+        if response_code == response_codes.NOERROR:
+            raise ValueError("response_code must be an error code.")
         return Message(
             timestamp=time.time(),
             id=self.id,

--- a/mitmproxy/dns.py
+++ b/mitmproxy/dns.py
@@ -247,8 +247,6 @@ class Message(serializable.SerializableDataclass):
         )
 
     def fail(self, response_code: int) -> Message:
-        if response_code == response_codes.NOERROR:
-            raise ValueError("response_code must be an error code.")
         return Message(
             timestamp=time.time(),
             id=self.id,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
     "hyperframe>=6.0,<=6.0.1",
     "kaitaistruct>=0.10,<=0.10",
     "ldap3>=2.8,<=2.9.1",
-    "mitmproxy_rs>=0.6.0,<0.7",  # relaxed upper bound here: we control this
+    "mitmproxy_rs>=0.6.1,<0.7",  # relaxed upper bound here: we control this
     "msgpack>=1.0.0,<=1.0.8",
     "passlib>=1.6.5,<=1.7.4",
     "protobuf<=5.27.2,>=5.27.2",

--- a/test/mitmproxy/addons/test_dns_resolver.py
+++ b/test/mitmproxy/addons/test_dns_resolver.py
@@ -1,4 +1,6 @@
+import asyncio
 import mitmproxy_rs
+import socket
 
 from mitmproxy import dns
 from mitmproxy.addons import dns_resolver
@@ -35,7 +37,15 @@ async def test_resolver():
         assert dr.resolver != res_old
 
 
-async def test_dns_request():
+async def lookup_ipv4(name: str):
+    if name == "not.exists":
+        raise socket.gaierror("NXDOMAIN")
+    return await asyncio.sleep(0, ["8.8.8.8"])
+
+
+async def test_dns_request(monkeypatch):
+    monkeypatch.setattr(mitmproxy_rs.DnsResolver, "lookup_ipv4", lambda _, name: lookup_ipv4(name))
+
     resolver = dns_resolver.DnsResolver()
     with taddons.context(resolver) as tctx:
 

--- a/test/mitmproxy/addons/test_dns_resolver.py
+++ b/test/mitmproxy/addons/test_dns_resolver.py
@@ -43,6 +43,8 @@ async def test_resolver():
 async def lookup_ipv4(name: str):
     if name == "not.exists":
         raise socket.gaierror("NXDOMAIN")
+    elif name == "no.records":
+        raise socket.gaierror("NOERROR")
     return ["8.8.8.8"]
 
 
@@ -102,6 +104,14 @@ async def test_dns_request(monkeypatch):
             ]
         )
         assert flow.response.response_code == dns.response_codes.NXDOMAIN
+
+        flow = await process_questions(
+            [
+                dns.Question("no.records", dns.types.A, dns.classes.IN),
+            ]
+        )
+        assert flow.response.response_code == dns.response_codes.NOERROR
+        assert not flow.response.answers
 
         tctx.options.dns_use_hosts_file = False
         flow = await process_questions(

--- a/test/mitmproxy/addons/test_dns_resolver.py
+++ b/test/mitmproxy/addons/test_dns_resolver.py
@@ -1,9 +1,4 @@
-import asyncio
-import ipaddress
-import socket
-from collections.abc import Callable
-
-import pytest
+import mitmproxy_rs
 
 from mitmproxy import dns
 from mitmproxy.addons import dns_resolver
@@ -15,11 +10,7 @@ from mitmproxy.test import tflow
 from mitmproxy.test import tutils
 
 
-async def test_simple(monkeypatch):
-    monkeypatch.setattr(
-        dns_resolver, "resolve_message", lambda _, __: asyncio.sleep(0, "resp")
-    )
-
+async def test_simple():
     dr = dns_resolver.DnsResolver()
     with taddons.context(dr, proxyserver.Proxyserver()):
         f = tflow.tdnsflow()
@@ -32,107 +23,67 @@ async def test_simple(monkeypatch):
         assert not f.response
 
 
-class DummyLoop:
-    async def getnameinfo(self, socketaddr: Address, flags: int = 0):
-        assert flags == socket.NI_NAMEREQD
-        if socketaddr[0] in ("8.8.8.8", "2001:4860:4860::8888"):
-            return ("dns.google", "")
-        e = socket.gaierror()
-        e.errno = socket.EAI_NONAME
-        raise e
+async def test_resolver():
+    dr = dns_resolver.DnsResolver()
+    with taddons.context(dr) as tctx:
+        assert dr.name_servers == mitmproxy_rs.get_system_dns_servers()
 
-    async def getaddrinfo(self, host: str, port: int, *, family: int, type: int):
-        e = socket.gaierror()
-        e.errno = socket.EAI_NONAME
-        if family == socket.AF_INET:
-            if host == "dns.google":
-                return [(socket.AF_INET, type, None, None, ("8.8.8.8", port))]
-        elif family == socket.AF_INET6:
-            if host == "dns.google":
-                return [
-                    (
-                        socket.AF_INET6,
-                        type,
-                        None,
-                        None,
-                        ("2001:4860:4860::8888", port, None, None),
-                    )
-                ]
-        else:
-            e.errno = socket.EAI_FAMILY
-        raise e
+        tctx.options.name_servers = ["1.1.1.1"]
+        assert dr.name_servers == ["1.1.1.1"]
+
+        res_old = dr.resolver
+        tctx.options.use_hosts_file = False
+        assert dr.resolver != res_old
 
 
-async def test_resolve():
-    async def fail_with(question: dns.Question, code: int):
-        with pytest.raises(dns_resolver.ResolveError) as ex:
-            await dns_resolver.resolve_question(question, DummyLoop())
-        assert ex.value.response_code == code
+async def test_dns_request():
+    resolver = dns_resolver.DnsResolver()
+    with taddons.context(resolver) as tctx:
+        async def process_questions(questions):
+            req = tutils.tdnsreq(questions=questions)
+            flow = tflow.tdnsflow(req=req)
+            flow.server_conn.address = None
+            await resolver.dns_request(flow)
+            return flow
 
-    async def succeed_with(
-        question: dns.Question, check: Callable[[dns.ResourceRecord], bool]
-    ):
-        assert any(
-            map(check, await dns_resolver.resolve_question(question, DummyLoop()))
-        )
+        req = tutils.tdnsreq()
+        req.op_code = dns.op_codes.IQUERY
+        flow = tflow.tdnsflow(req=req)
+        flow.server_conn.address = None
+        await resolver.dns_request(flow)
+        assert flow.server_conn.address[0] == resolver.name_servers[0]
 
-    await fail_with(
-        dns.Question("dns.google", dns.types.A, dns.classes.CH),
-        dns.response_codes.NOTIMP,
-    )
-    await fail_with(
-        dns.Question("not.exists", dns.types.A, dns.classes.IN),
-        dns.response_codes.NXDOMAIN,
-    )
-    await fail_with(
-        dns.Question("dns.google", dns.types.SOA, dns.classes.IN),
-        dns.response_codes.NOTIMP,
-    )
-    await fail_with(
-        dns.Question("totally.invalid", dns.types.PTR, dns.classes.IN),
-        dns.response_codes.FORMERR,
-    )
-    await fail_with(
-        dns.Question("invalid.in-addr.arpa", dns.types.PTR, dns.classes.IN),
-        dns.response_codes.FORMERR,
-    )
-    await fail_with(
-        dns.Question("0.0.0.1.in-addr.arpa", dns.types.PTR, dns.classes.IN),
-        dns.response_codes.NXDOMAIN,
-    )
+        req.query = False
+        req.op_code = dns.op_codes.QUERY
+        flow = tflow.tdnsflow(req=req)
+        flow.server_conn.address = None
+        await resolver.dns_request(flow)
+        assert flow.server_conn.address[0] == resolver.name_servers[0]
 
-    await succeed_with(
-        dns.Question("dns.google", dns.types.A, dns.classes.IN),
-        lambda rr: rr.ipv4_address == ipaddress.IPv4Address("8.8.8.8"),
-    )
-    await succeed_with(
-        dns.Question("dns.google", dns.types.AAAA, dns.classes.IN),
-        lambda rr: rr.ipv6_address == ipaddress.IPv6Address("2001:4860:4860::8888"),
-    )
-    await succeed_with(
-        dns.Question("8.8.8.8.in-addr.arpa", dns.types.PTR, dns.classes.IN),
-        lambda rr: rr.domain_name == "dns.google",
-    )
-    await succeed_with(
-        dns.Question(
-            "8.8.8.8.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.6.8.4.0.6.8.4.1.0.0.2.ip6.arpa",
-            dns.types.PTR,
-            dns.classes.IN,
-        ),
-        lambda rr: rr.domain_name == "dns.google",
-    )
+        flow = await process_questions([
+            dns.Question("dns.google", dns.types.AAAA, dns.classes.IN),
+            dns.Question("dns.google", dns.types.NS, dns.classes.IN),
+        ])
+        assert flow.server_conn.address[0] == resolver.name_servers[0]
 
-    req = tutils.tdnsreq()
-    req.query = False
-    assert (
-        await dns_resolver.resolve_message(req, DummyLoop())
-    ).response_code == dns.response_codes.REFUSED
-    req.query = True
-    req.op_code = dns.op_codes.IQUERY
-    assert (
-        await dns_resolver.resolve_message(req, DummyLoop())
-    ).response_code == dns.response_codes.NOTIMP
-    req.op_code = dns.op_codes.QUERY
-    resp = await dns_resolver.resolve_message(req, DummyLoop())
-    assert resp.response_code == dns.response_codes.NOERROR
-    assert filter(lambda rr: str(rr.ipv4_address) == "8.8.8.8", resp.answers)
+        flow = await process_questions([
+            dns.Question("dns.google", dns.types.AAAA, dns.classes.IN),
+            dns.Question("dns.google", dns.types.A, dns.classes.IN),
+        ])
+        assert flow.server_conn.address is None
+        assert flow.response
+
+        flow = tflow.tdnsflow()
+        await resolver.dns_request(flow)
+        assert flow.server_conn.address == ("address", 22)
+
+        flow = await process_questions([
+            dns.Question("not.exists", dns.types.A, dns.classes.IN),
+        ])
+        assert flow.response.response_code == dns.response_codes.NXDOMAIN
+
+        tctx.options.use_hosts_file = False
+        flow = await process_questions([
+            dns.Question("dns.google", dns.types.A, dns.classes.IN),
+        ])
+        assert flow.server_conn.address[0] == resolver.name_servers[0]

--- a/test/mitmproxy/addons/test_dns_resolver.py
+++ b/test/mitmproxy/addons/test_dns_resolver.py
@@ -1,6 +1,7 @@
 import asyncio
-import mitmproxy_rs
 import socket
+
+import mitmproxy_rs
 
 from mitmproxy import dns
 from mitmproxy.addons import dns_resolver
@@ -44,7 +45,9 @@ async def lookup_ipv4(name: str):
 
 
 async def test_dns_request(monkeypatch):
-    monkeypatch.setattr(mitmproxy_rs.DnsResolver, "lookup_ipv4", lambda _, name: lookup_ipv4(name))
+    monkeypatch.setattr(
+        mitmproxy_rs.DnsResolver, "lookup_ipv4", lambda _, name: lookup_ipv4(name)
+    )
 
     resolver = dns_resolver.DnsResolver()
     with taddons.context(resolver) as tctx:

--- a/test/mitmproxy/addons/test_dns_resolver.py
+++ b/test/mitmproxy/addons/test_dns_resolver.py
@@ -3,7 +3,6 @@ import mitmproxy_rs
 from mitmproxy import dns
 from mitmproxy.addons import dns_resolver
 from mitmproxy.addons import proxyserver
-from mitmproxy.connection import Address
 from mitmproxy.proxy.mode_specs import ProxyMode
 from mitmproxy.test import taddons
 from mitmproxy.test import tflow
@@ -39,6 +38,7 @@ async def test_resolver():
 async def test_dns_request():
     resolver = dns_resolver.DnsResolver()
     with taddons.context(resolver) as tctx:
+
         async def process_questions(questions):
             req = tutils.tdnsreq(questions=questions)
             flow = tflow.tdnsflow(req=req)
@@ -60,16 +60,20 @@ async def test_dns_request():
         await resolver.dns_request(flow)
         assert flow.server_conn.address[0] == resolver.name_servers[0]
 
-        flow = await process_questions([
-            dns.Question("dns.google", dns.types.AAAA, dns.classes.IN),
-            dns.Question("dns.google", dns.types.NS, dns.classes.IN),
-        ])
+        flow = await process_questions(
+            [
+                dns.Question("dns.google", dns.types.AAAA, dns.classes.IN),
+                dns.Question("dns.google", dns.types.NS, dns.classes.IN),
+            ]
+        )
         assert flow.server_conn.address[0] == resolver.name_servers[0]
 
-        flow = await process_questions([
-            dns.Question("dns.google", dns.types.AAAA, dns.classes.IN),
-            dns.Question("dns.google", dns.types.A, dns.classes.IN),
-        ])
+        flow = await process_questions(
+            [
+                dns.Question("dns.google", dns.types.AAAA, dns.classes.IN),
+                dns.Question("dns.google", dns.types.A, dns.classes.IN),
+            ]
+        )
         assert flow.server_conn.address is None
         assert flow.response
 
@@ -77,13 +81,17 @@ async def test_dns_request():
         await resolver.dns_request(flow)
         assert flow.server_conn.address == ("address", 22)
 
-        flow = await process_questions([
-            dns.Question("not.exists", dns.types.A, dns.classes.IN),
-        ])
+        flow = await process_questions(
+            [
+                dns.Question("not.exists", dns.types.A, dns.classes.IN),
+            ]
+        )
         assert flow.response.response_code == dns.response_codes.NXDOMAIN
 
         tctx.options.use_hosts_file = False
-        flow = await process_questions([
-            dns.Question("dns.google", dns.types.A, dns.classes.IN),
-        ])
+        flow = await process_questions(
+            [
+                dns.Question("dns.google", dns.types.A, dns.classes.IN),
+            ]
+        )
         assert flow.server_conn.address[0] == resolver.name_servers[0]

--- a/test/mitmproxy/addons/test_proxyserver.py
+++ b/test/mitmproxy/addons/test_proxyserver.py
@@ -270,7 +270,9 @@ async def lookup_ipv4():
 
 
 async def test_dns(caplog_async, monkeypatch) -> None:
-    monkeypatch.setattr(mitmproxy_rs.DnsResolver, "lookup_ipv4", lambda _, __: lookup_ipv4())
+    monkeypatch.setattr(
+        mitmproxy_rs.DnsResolver, "lookup_ipv4", lambda _, __: lookup_ipv4()
+    )
 
     caplog_async.set_level("INFO")
     ps = Proxyserver()

--- a/test/mitmproxy/addons/test_proxyserver.py
+++ b/test/mitmproxy/addons/test_proxyserver.py
@@ -266,22 +266,10 @@ async def test_shutdown_err(caplog_async) -> None:
         await _wait_for_connection_closes(ps)
 
 
-class DummyResolver:
-    async def dns_request(self, flow: dns.DNSFlow) -> None:
-        flow.response = await dns_resolver.resolve_message(flow.request, self)
-
-    async def getaddrinfo(self, host: str, port: int, *, family: int, type: int):
-        if family == socket.AF_INET and host == "dns.google":
-            return [(socket.AF_INET, type, None, None, ("8.8.8.8", port))]
-        e = socket.gaierror()
-        e.errno = socket.EAI_NONAME
-        raise e
-
-
 async def test_dns(caplog_async) -> None:
     caplog_async.set_level("INFO")
     ps = Proxyserver()
-    with taddons.context(ps, DummyResolver()) as tctx:
+    with taddons.context(ps, dns_resolver.DnsResolver()) as tctx:
         tctx.configure(
             ps,
             mode=["dns@127.0.0.1:0"],

--- a/test/mitmproxy/addons/test_proxyserver.py
+++ b/test/mitmproxy/addons/test_proxyserver.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import socket
 import ssl
 from collections.abc import AsyncGenerator
 from collections.abc import Callable

--- a/test/mitmproxy/addons/test_proxyserver.py
+++ b/test/mitmproxy/addons/test_proxyserver.py
@@ -265,7 +265,13 @@ async def test_shutdown_err(caplog_async) -> None:
         await _wait_for_connection_closes(ps)
 
 
-async def test_dns(caplog_async) -> None:
+async def lookup_ipv4():
+    return await asyncio.sleep(0, ["8.8.8.8"])
+
+
+async def test_dns(caplog_async, monkeypatch) -> None:
+    monkeypatch.setattr(mitmproxy_rs.DnsResolver, "lookup_ipv4", lambda _, __: lookup_ipv4())
+
     caplog_async.set_level("INFO")
     ps = Proxyserver()
     with taddons.context(ps, dns_resolver.DnsResolver()) as tctx:

--- a/web/src/js/ducks/_options_gen.ts
+++ b/web/src/js/ducks/_options_gen.ts
@@ -139,7 +139,7 @@ export const defaultState: OptionsState = {
     mode: ["regular"],
     modify_body: [],
     modify_headers: [],
-    name_servers: ["127.0.0.53"],
+    name_servers: [],
     normalize_outbound_headers: true,
     onboarding: true,
     onboarding_host: "mitm.it",

--- a/web/src/js/ducks/_options_gen.ts
+++ b/web/src/js/ducks/_options_gen.ts
@@ -21,6 +21,8 @@ export interface OptionsState {
     connection_strategy: string;
     console_focus_follow: boolean;
     content_view_lines_cutoff: number;
+    dns_name_servers: string[];
+    dns_use_hosts_file: boolean;
     export_preserve_original_ip: boolean;
     hardump: string;
     http2: boolean;
@@ -39,7 +41,6 @@ export interface OptionsState {
     mode: string[];
     modify_body: string[];
     modify_headers: string[];
-    name_servers: string[];
     normalize_outbound_headers: boolean;
     onboarding: boolean;
     onboarding_host: string;
@@ -83,7 +84,6 @@ export interface OptionsState {
     udp_hosts: string[];
     upstream_auth: string | undefined;
     upstream_cert: boolean;
-    use_hosts_file: boolean;
     validate_inbound_headers: boolean;
     view_filter: string | undefined;
     view_order: string;
@@ -121,6 +121,8 @@ export const defaultState: OptionsState = {
     connection_strategy: "eager",
     console_focus_follow: false,
     content_view_lines_cutoff: 512,
+    dns_name_servers: [],
+    dns_use_hosts_file: true,
     export_preserve_original_ip: false,
     hardump: "",
     http2: true,
@@ -139,7 +141,6 @@ export const defaultState: OptionsState = {
     mode: ["regular"],
     modify_body: [],
     modify_headers: [],
-    name_servers: [],
     normalize_outbound_headers: true,
     onboarding: true,
     onboarding_host: "mitm.it",
@@ -183,7 +184,6 @@ export const defaultState: OptionsState = {
     udp_hosts: [],
     upstream_auth: undefined,
     upstream_cert: true,
-    use_hosts_file: true,
     validate_inbound_headers: true,
     view_filter: undefined,
     view_order: "time",

--- a/web/src/js/ducks/_options_gen.ts
+++ b/web/src/js/ducks/_options_gen.ts
@@ -39,6 +39,7 @@ export interface OptionsState {
     mode: string[];
     modify_body: string[];
     modify_headers: string[];
+    name_servers: string[];
     normalize_outbound_headers: boolean;
     onboarding: boolean;
     onboarding_host: string;
@@ -82,6 +83,7 @@ export interface OptionsState {
     udp_hosts: string[];
     upstream_auth: string | undefined;
     upstream_cert: boolean;
+    use_hosts_file: boolean;
     validate_inbound_headers: boolean;
     view_filter: string | undefined;
     view_order: string;
@@ -137,6 +139,7 @@ export const defaultState: OptionsState = {
     mode: ["regular"],
     modify_body: [],
     modify_headers: [],
+    name_servers: ["127.0.0.53"],
     normalize_outbound_headers: true,
     onboarding: true,
     onboarding_host: "mitm.it",
@@ -180,6 +183,7 @@ export const defaultState: OptionsState = {
     udp_hosts: [],
     upstream_auth: undefined,
     upstream_cert: true,
+    use_hosts_file: true,
     validate_inbound_headers: true,
     view_filter: undefined,
     view_order: "time",


### PR DESCRIPTION
#### Description

Uses `mitmproxy_rs.DnsResolver` to resolve domain names that need to be checked in the hosts file first and forwards any other type of query to the server specified in the options
Fixes https://github.com/mitmproxy/mitmproxy/issues/6739

#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.

~TODO: check and fix tests after we release latest version of `mitmproxy_rs`~