### PR TITLE
Fix QUIC version negotiation test

### DIFF
--- a/test/mitmproxy/proxy/layers/test_quic.py
+++ b/test/mitmproxy/proxy/layers/test_quic.py
@@ -1207,7 +1207,11 @@ class TestClientQuic:
         )
 
     def test_version_negotiation(self, tctx: context.Context):
-        playbook, client_layer, tssl_client = make_client_tls_layer(tctx, version=0)
+        # To trigger a version negotiation, use one of the reserved 0x?A?A?A?A versions.
+        # https://datatracker.ietf.org/doc/html/rfc9000#section-15
+        playbook, client_layer, tssl_client = make_client_tls_layer(
+            tctx, version=0x1A2A3A4A
+        )
         assert (
             playbook
             >> events.DataReceived(tctx.client, tssl_client.read())


### PR DESCRIPTION
To exercise incompatible version negotiation, we must not use version 0, as this would cause the client's INITIAL packet to be erroneously interpreted as a VERSION_NEGOTIATION packet - but with a corrupt format.

So far this has not caused any errors, because aioquic's `pull_quic_header` did not fully parse VERSION_NEGOTIATION packets, but this will change with the next aioquic version.

Use one of the reserved version numbers of the form 0x?a?a?a?a, as defined in https://datatracker.ietf.org/doc/html/rfc9000#section-15
