### PR TITLE
Incorporate existing SNI into allow/ignore decision, fix #5064

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
   ([#6935](https://github.com/mitmproxy/mitmproxy/pull/6935), @errorxyz)
 * Fix non-linear growth in processing time for large HTTP bodies.
   ([#6952](https://github.com/mitmproxy/mitmproxy/pull/6952), @jackfromeast)
+* Fix a bug where connections would be incorrectly ignored with `allow_hosts`
+  ([#7002](https://github.com/mitmproxy/mitmproxy/pull/7002), @JarLob, @mhils)
 * Fix zstd decompression to read across frames.
   ([#6921](https://github.com/mitmproxy/mitmproxy/pull/6921), @zendai)
 * Add `HttpConnectedHook` and `HttpConnectErrorHook`.

--- a/mitmproxy/addons/next_layer.py
+++ b/mitmproxy/addons/next_layer.py
@@ -225,6 +225,9 @@ class NextLayer:
                 client_hello := self._get_client_hello(context, data_client)
             ) and client_hello.sni:
                 hostnames.append(f"{client_hello.sni}:{port}")
+            if context.client.sni:
+                # Hostname may be allowed, TLS is already established, and we have another next layer decision.
+                hostnames.append(f"{context.client.sni}:{port}")
 
         if not hostnames:
             return False

--- a/test/helper_tools/loggrep.py
+++ b/test/helper_tools/loggrep.py
@@ -11,7 +11,7 @@ if __name__ == "__main__":
     port = sys.argv[1]
     matches = False
     for line in fileinput.input(sys.argv[2:]):
-        if re.match(r"^\[|(\d+\.){3}", line):
+        if re.search(r"^\[|(\d+\.){3}", line):
             matches = port in line
         if matches:
             print(line, end="")

--- a/test/mitmproxy/addons/test_next_layer.py
+++ b/test/mitmproxy/addons/test_next_layer.py
@@ -347,7 +347,11 @@ class TestNextLayer:
             if allow:
                 tctx.configure(nl, allow_hosts=allow)
             ctx = Context(
-                Client(peername=("192.168.0.42", 51234), sockname=("0.0.0.0", 8080), sni="existing-sni.example"),
+                Client(
+                    peername=("192.168.0.42", 51234),
+                    sockname=("0.0.0.0", 8080),
+                    sni="existing-sni.example",
+                ),
                 tctx.options,
             )
             ctx.client.transport_protocol = transport_protocol

--- a/test/mitmproxy/addons/test_next_layer.py
+++ b/test/mitmproxy/addons/test_next_layer.py
@@ -287,6 +287,24 @@ class TestNextLayer:
                 [],
                 ["example.com"],
                 "tcp",
+                "192.0.2.1",
+                client_hello_with_extensions,
+                False,
+                id="allow: sni",
+            ),
+            pytest.param(
+                [],
+                ["existing-sni.example"],
+                "tcp",
+                "192.0.2.1",
+                b"",
+                False,
+                id="allow: sni from parent layer",
+            ),
+            pytest.param(
+                [],
+                ["example.com"],
+                "tcp",
                 "decoy",
                 client_hello_with_extensions,
                 False,
@@ -329,7 +347,7 @@ class TestNextLayer:
             if allow:
                 tctx.configure(nl, allow_hosts=allow)
             ctx = Context(
-                Client(peername=("192.168.0.42", 51234), sockname=("0.0.0.0", 8080)),
+                Client(peername=("192.168.0.42", 51234), sockname=("0.0.0.0", 8080), sni="existing-sni.example"),
                 tctx.options,
             )
             ctx.client.transport_protocol = transport_protocol


### PR DESCRIPTION
#### Description

This PR fixes the issue reported by @JarLob in https://github.com/mitmproxy/mitmproxy/issues/5064#issuecomment-2211403259. The problem here was that we did not take an already-parsed SNI into account, but were only looking at TLS handshakes that were happening _just now_.

#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
