### PR TITLE
Add experimental option for HTTP/3 in transparent mode

### DIFF
--- a/mitmproxy/addons/next_layer.py
+++ b/mitmproxy/addons/next_layer.py
@@ -39,7 +39,6 @@ from mitmproxy.proxy.layers import ClientTLSLayer
 from mitmproxy.proxy.layers import DNSLayer
 from mitmproxy.proxy.layers import HttpLayer
 from mitmproxy.proxy.layers import modes
-from mitmproxy.proxy.layers import QuicStreamLayer
 from mitmproxy.proxy.layers import RawQuicLayer
 from mitmproxy.proxy.layers import ServerQuicLayer
 from mitmproxy.proxy.layers import ServerTLSLayer
@@ -171,8 +170,11 @@ class NextLayer:
 
         # 5b) Do we have a known ALPN negotiation?
         if context.client.alpn in HTTP_ALPNS:
-            is_explicitly_quic_and_not_h3 = s(modes.ReverseProxy, ServerQuicLayer, ClientQuicLayer, RawQuicLayer, QuicStreamLayer)
-            if not is_explicitly_quic_and_not_h3:
+            explicit_quic_proxy = (
+                isinstance(context.client.proxy_mode, modes.ReverseMode)
+                and context.client.proxy_mode.scheme == "quic"
+            )
+            if not explicit_quic_proxy:
                 return layers.HttpLayer(context, HTTPMode.transparent)
 
         # 5c) We have no other specialized layers for UDP, so we fall back to raw forwarding.

--- a/mitmproxy/addons/next_layer.py
+++ b/mitmproxy/addons/next_layer.py
@@ -39,6 +39,7 @@ from mitmproxy.proxy.layers import ClientTLSLayer
 from mitmproxy.proxy.layers import DNSLayer
 from mitmproxy.proxy.layers import HttpLayer
 from mitmproxy.proxy.layers import modes
+from mitmproxy.proxy.layers import QuicStreamLayer
 from mitmproxy.proxy.layers import RawQuicLayer
 from mitmproxy.proxy.layers import ServerQuicLayer
 from mitmproxy.proxy.layers import ServerTLSLayer
@@ -170,7 +171,9 @@ class NextLayer:
 
         # 5b) Do we have a known ALPN negotiation?
         if context.client.alpn in HTTP_ALPNS:
-            return layers.HttpLayer(context, HTTPMode.transparent)
+            is_explicitly_quic_and_not_h3 = s(modes.ReverseProxy, ServerQuicLayer, ClientQuicLayer, RawQuicLayer, QuicStreamLayer)
+            if not is_explicitly_quic_and_not_h3:
+                return layers.HttpLayer(context, HTTPMode.transparent)
 
         # 5c) We have no other specialized layers for UDP, so we fall back to raw forwarding.
         if udp_based:

--- a/mitmproxy/addons/next_layer.py
+++ b/mitmproxy/addons/next_layer.py
@@ -168,12 +168,15 @@ class NextLayer:
         if context.server.address and context.server.address[1] in (53, 5353):
             return layers.DNSLayer(context)
 
-        # 5b) We have no other specialized layers for UDP, so we fall back to raw forwarding.
+        # 5b) Do we have a known ALPN negotiation?
+        if context.client.alpn in HTTP_ALPNS:
+            return layers.HttpLayer(context, HTTPMode.transparent)
+
+        # 5c) We have no other specialized layers for UDP, so we fall back to raw forwarding.
         if udp_based:
             return layers.UDPLayer(context)
-        # 5b) Check for raw tcp mode.
-        very_likely_http = context.client.alpn in HTTP_ALPNS
-        probably_no_http = not very_likely_http and (
+        # 5d) Check for raw tcp mode.
+        probably_no_http = (
             # the first three bytes should be the HTTP verb, so A-Za-z is expected.
             len(data_client) < 3
             or not data_client[:3].isalpha()

--- a/mitmproxy/options.py
+++ b/mitmproxy/options.py
@@ -150,6 +150,12 @@ class Options(optmanager.OptManager):
             "Enable/disable support for QUIC and HTTP/3. Enabled by default.",
         )
         self.add_option(
+            "experimental_transparent_http3",
+            bool,
+            False,
+            "Experimental support for QUIC in transparent mode. This option is for development only and will be removed soon.",
+        )
+        self.add_option(
             "http_connect_send_host_header",
             bool,
             True,

--- a/mitmproxy/proxy/layers/quic.py
+++ b/mitmproxy/proxy/layers/quic.py
@@ -1148,7 +1148,10 @@ class ClientQuicLayer(QuicLayer):
     def receive_handshake_data(
         self, data: bytes
     ) -> layer.CommandGenerator[tuple[bool, str | None]]:
-        if isinstance(self.context.layers[0], TransparentProxy):  # pragma: no cover
+        if (
+            isinstance(self.context.layers[0], TransparentProxy)
+            and not self.context.options.experimental_transparent_http3
+        ):  # pragma: no cover
             yield commands.Log(
                 f"Swallowing QUIC handshake because HTTP/3 does not support transparent mode yet.",
                 DEBUG,

--- a/mitmproxy/proxy/layers/tls.py
+++ b/mitmproxy/proxy/layers/tls.py
@@ -157,7 +157,10 @@ def dtls_parse_client_hello(data: bytes) -> ClientHello | None:
 
 
 HTTP1_ALPNS = (b"http/1.1", b"http/1.0", b"http/0.9")
-HTTP_ALPNS = (b"h2",) + HTTP1_ALPNS
+HTTP_ALPNS = (
+    b"h3",
+    b"h2",
+) + HTTP1_ALPNS
 
 
 # We need these classes as hooks can only have one argument at the moment.

--- a/mitmproxy/proxy/layers/tls.py
+++ b/mitmproxy/proxy/layers/tls.py
@@ -157,10 +157,9 @@ def dtls_parse_client_hello(data: bytes) -> ClientHello | None:
 
 
 HTTP1_ALPNS = (b"http/1.1", b"http/1.0", b"http/0.9")
-HTTP_ALPNS = (
-    b"h3",
-    b"h2",
-) + HTTP1_ALPNS
+HTTP2_ALPN = b"h2"
+HTTP3_ALPN = b"h3"
+HTTP_ALPNS = (HTTP3_ALPN, HTTP2_ALPN, *HTTP1_ALPNS)
 
 
 # We need these classes as hooks can only have one argument at the moment.

--- a/test/mitmproxy/addons/test_next_layer.py
+++ b/test/mitmproxy/addons/test_next_layer.py
@@ -99,8 +99,6 @@ http_get_absolute = b"GET http://example.com/ HTTP/1.1\r\n\r\n"
 
 http_connect = b"CONNECT example.com:443 HTTP/1.1\r\nHost: example.com:443\r\n\r\n"
 
-http2_preface = b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n"
-
 
 class TestNextLayer:
     @pytest.mark.parametrize(

--- a/test/mitmproxy/addons/test_next_layer.py
+++ b/test/mitmproxy/addons/test_next_layer.py
@@ -22,6 +22,7 @@ from mitmproxy.proxy.layers import ClientTLSLayer
 from mitmproxy.proxy.layers import DNSLayer
 from mitmproxy.proxy.layers import HttpLayer
 from mitmproxy.proxy.layers import modes
+from mitmproxy.proxy.layers import QuicStreamLayer
 from mitmproxy.proxy.layers import RawQuicLayer
 from mitmproxy.proxy.layers import ServerQuicLayer
 from mitmproxy.proxy.layers import ServerTLSLayer
@@ -29,6 +30,8 @@ from mitmproxy.proxy.layers import TCPLayer
 from mitmproxy.proxy.layers import UDPLayer
 from mitmproxy.proxy.layers.http import HTTPMode
 from mitmproxy.proxy.layers.http import HttpStream
+from mitmproxy.proxy.layers.tls import HTTP1_ALPNS
+from mitmproxy.proxy.layers.tls import HTTP3_ALPN
 from mitmproxy.proxy.mode_specs import ProxyMode
 from mitmproxy.test import taddons
 
@@ -95,6 +98,8 @@ http_get = b"GET / HTTP/1.1\r\nHost: example.com\r\n\r\n"
 http_get_absolute = b"GET http://example.com/ HTTP/1.1\r\n\r\n"
 
 http_connect = b"CONNECT example.com:443 HTTP/1.1\r\nHost: example.com:443\r\n\r\n"
+
+http2_preface = b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n"
 
 
 class TestNextLayer:
@@ -413,6 +418,7 @@ class TConf:
     udp_hosts: Sequence[str] = ()
     ignore_conn: bool = False
     server_address: Address | None = None
+    alpn: bytes | None = None
 
 
 explicit_proxy_configs = [
@@ -618,6 +624,28 @@ reverse_proxy_configs.extend(
         ),
         pytest.param(
             TConf(
+                before=[
+                    modes.ReverseProxy,
+                    ServerQuicLayer,
+                    ClientQuicLayer,
+                    RawQuicLayer,
+                    lambda ctx: QuicStreamLayer(ctx, False, 0),
+                ],
+                after=[
+                    modes.ReverseProxy,
+                    ServerQuicLayer,
+                    ClientQuicLayer,
+                    RawQuicLayer,
+                    QuicStreamLayer,
+                    TCPLayer,
+                ],
+                proxy_mode="reverse:quic://example.com",
+                alpn=HTTP3_ALPN,
+            ),
+            id="reverse proxy: quic",
+        ),
+        pytest.param(
+            TConf(
                 before=[modes.ReverseProxy],
                 after=[modes.ReverseProxy, TCPLayer],
                 proxy_mode=f"reverse:http://example.com",
@@ -674,6 +702,15 @@ transparent_proxy_configs = [
             data_client=http_get,
         ),
         id="transparent proxy: http",
+    ),
+    pytest.param(
+        TConf(
+            before=[modes.TransparentProxy, ServerTLSLayer, ClientTLSLayer],
+            after=[modes.TransparentProxy, ServerTLSLayer, ClientTLSLayer, HttpLayer],
+            data_client=b"GO /method-too-short-for-heuristic HTTP/1.1\r\n",
+            alpn=HTTP1_ALPNS[0],
+        ),
+        id=f"transparent proxy: http via ALPN",
     ),
     pytest.param(
         dataclasses.replace(
@@ -762,7 +799,11 @@ def test_next_layer(
         )
 
         ctx = Context(
-            Client(peername=("192.168.0.42", 51234), sockname=("0.0.0.0", 8080)),
+            Client(
+                peername=("192.168.0.42", 51234),
+                sockname=("0.0.0.0", 8080),
+                alpn=test_conf.alpn,
+            ),
             tctx.options,
         )
         ctx.server.address = test_conf.server_address

--- a/test/mitmproxy/addons/test_tlsconfig.py
+++ b/test/mitmproxy/addons/test_tlsconfig.py
@@ -387,12 +387,14 @@ class TestTlsConfig:
                 assert ctx.server.alpn_offers == expected
 
             assert_alpn(
-                True, proxy_tls.HTTP_ALPNS + (b"foo",), proxy_tls.HTTP_ALPNS + (b"foo",)
+                True,
+                (proxy_tls.HTTP2_ALPN, *proxy_tls.HTTP1_ALPNS, b"foo"),
+                (proxy_tls.HTTP2_ALPN, *proxy_tls.HTTP1_ALPNS, b"foo"),
             )
             assert_alpn(
                 False,
-                proxy_tls.HTTP_ALPNS + (b"foo",),
-                proxy_tls.HTTP1_ALPNS + (b"foo",),
+                (proxy_tls.HTTP2_ALPN, *proxy_tls.HTTP1_ALPNS, b"foo"),
+                (*proxy_tls.HTTP1_ALPNS, b"foo"),
             )
             assert_alpn(True, [], [])
             assert_alpn(False, [], [])

--- a/web/src/js/ducks/_options_gen.ts
+++ b/web/src/js/ducks/_options_gen.ts
@@ -23,6 +23,7 @@ export interface OptionsState {
     content_view_lines_cutoff: number;
     dns_name_servers: string[];
     dns_use_hosts_file: boolean;
+    experimental_transparent_http3: boolean;
     export_preserve_original_ip: boolean;
     hardump: string;
     http2: boolean;
@@ -123,6 +124,7 @@ export const defaultState: OptionsState = {
     content_view_lines_cutoff: 512,
     dns_name_servers: [],
     dns_use_hosts_file: true,
+    experimental_transparent_http3: false,
     export_preserve_original_ip: false,
     hardump: "",
     http2: true,


### PR DESCRIPTION
With these changes I can get (static-curl, macOS, local mode) to work. 🎉 

Does that help with any of the other entries on our matrix?