### PR TITLE
Make `DnsResolver.resolver` and `DnsResolver.name_servers` as cached functions instead of cached properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ## Unreleased: mitmproxy next
 
 - Fix a crash on startup when mitmproxy is unable to determine the OS' DNS servers
+  ([#7066](https://github.com/mitmproxy/mitmproxy/pull/7066), @errorxyz)
 
 ## 29 July 2024: mitmproxy 10.4.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ## Unreleased: mitmproxy next
 
+- Fix a crash on startup when mitmproxy is unable to determine the OS' DNS servers
 
 ## 29 July 2024: mitmproxy 10.4.1
 
@@ -16,7 +17,6 @@
   ([#7045](https://github.com/mitmproxy/mitmproxy/pull/7045), @mhils)
 - Container images are now published to both Docker Hub and GitHub Container Registry.
   ([#7061](https://github.com/mitmproxy/mitmproxy/pull/7061), @mhils)
-- Make `DnsResolver.resolver` and `DnsResolver.name_servers` as cached functions instead of cached properties
 
 ## 25 July 2024: mitmproxy 10.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
   ([#7045](https://github.com/mitmproxy/mitmproxy/pull/7045), @mhils)
 - Container images are now published to both Docker Hub and GitHub Container Registry.
   ([#7061](https://github.com/mitmproxy/mitmproxy/pull/7061), @mhils)
+- Make `DnsResolver.resolver` and `DnsResolver.name_servers` as cached functions instead of cached properties
 
 ## 25 July 2024: mitmproxy 10.4.0
 

--- a/mitmproxy/addons/dns_resolver.py
+++ b/mitmproxy/addons/dns_resolver.py
@@ -51,7 +51,7 @@ class DnsResolver:
     def name_servers(self) -> list[str]:
         try:
             return ctx.options.dns_name_servers or mitmproxy_rs.get_system_dns_servers()
-        except RuntimeError as e:  # pragma: no cover
+        except RuntimeError as e:
             raise RuntimeError(
                 f"Failed to get system dns servers: {e}\nMust set dns_name_servers option to run DNS mode."
             )

--- a/mitmproxy/addons/dns_resolver.py
+++ b/mitmproxy/addons/dns_resolver.py
@@ -50,7 +50,7 @@ class DnsResolver:
     @cache
     def name_servers(self) -> list[str]:
         try:
-            ctx.options.dns_name_servers or mitmproxy_rs.get_system_dns_servers()
+            return ctx.options.dns_name_servers or mitmproxy_rs.get_system_dns_servers()
         except RuntimeError as e:  # pragma: no cover
             raise RuntimeError(
                 f"Failed to get system dns servers: {e}\nMust set dns_name_servers option to run DNS mode."

--- a/mitmproxy/addons/dns_resolver.py
+++ b/mitmproxy/addons/dns_resolver.py
@@ -51,8 +51,10 @@ class DnsResolver:
     def name_servers(self) -> list[str]:
         try:
             ctx.options.dns_name_servers or mitmproxy_rs.get_system_dns_servers()
-        except RuntimeError as e: #pragma: no cover
-            raise RuntimeError(f"Failed to get system dns servers: {e}\nMust set dns_name_servers option to run DNS mode.")
+        except RuntimeError as e:  # pragma: no cover
+            raise RuntimeError(
+                f"Failed to get system dns servers: {e}\nMust set dns_name_servers option to run DNS mode."
+            )
 
     async def dns_request(self, flow: dns.DNSFlow) -> None:
         assert flow.request

--- a/mitmproxy/addons/dns_resolver.py
+++ b/mitmproxy/addons/dns_resolver.py
@@ -2,7 +2,7 @@ import ipaddress
 import socket
 from collections.abc import Iterable
 from collections.abc import Sequence
-from functools import cached_property
+from functools import cache
 
 import mitmproxy_rs
 
@@ -37,19 +37,22 @@ class DnsResolver:
 
     def configure(self, updated):
         if "dns_use_hosts_file" in updated or "dns_name_servers" in updated:
-            self.__dict__.pop("resolver", None)
-            self.__dict__.pop("name_servers", None)
+            self.resolver.cache_clear()
+            self.name_servers.cache_clear()
 
-    @cached_property
+    @cache
     def resolver(self) -> mitmproxy_rs.DnsResolver:
         return mitmproxy_rs.DnsResolver(
-            name_servers=self.name_servers,
+            name_servers=self.name_servers(),
             use_hosts_file=ctx.options.dns_use_hosts_file,
         )
 
-    @cached_property
+    @cache
     def name_servers(self) -> list[str]:
-        return ctx.options.dns_name_servers or mitmproxy_rs.get_system_dns_servers()
+        try:
+            ctx.options.dns_name_servers or mitmproxy_rs.get_system_dns_servers()
+        except RuntimeError as e: #pragma: no cover
+            raise RuntimeError(f"Failed to get system dns servers: {e}\nMust set dns_name_servers option to run DNS mode.")
 
     async def dns_request(self, flow: dns.DNSFlow) -> None:
         assert flow.request
@@ -81,7 +84,7 @@ class DnsResolver:
                 # TODO: We need to handle overly long responses here.
                 flow.response = await self.resolve_message(flow.request)
             elif not flow.server_conn.address:
-                flow.server_conn.address = (self.name_servers[0], 53)
+                flow.server_conn.address = (self.name_servers()[0], 53)
 
     async def resolve_message(self, message: dns.Message) -> dns.Message:
         try:
@@ -100,9 +103,9 @@ class DnsResolver:
 
         try:
             if question.type == dns.types.A:
-                addrinfos = await self.resolver.lookup_ipv4(question.name)
+                addrinfos = await self.resolver().lookup_ipv4(question.name)
             elif question.type == dns.types.AAAA:
-                addrinfos = await self.resolver.lookup_ipv6(question.name)
+                addrinfos = await self.resolver().lookup_ipv6(question.name)
         except socket.gaierror as e:
             # We aren't exactly following the RFC here
             # https://datatracker.ietf.org/doc/html/rfc2308#section-2

--- a/test/mitmproxy/addons/test_dns_resolver.py
+++ b/test/mitmproxy/addons/test_dns_resolver.py
@@ -1,7 +1,7 @@
-import pytest
 import socket
 
 import mitmproxy_rs
+import pytest
 
 from mitmproxy import dns
 from mitmproxy.addons import dns_resolver
@@ -48,7 +48,9 @@ async def test_resolver(monkeypatch):
             mitmproxy_rs, "get_system_dns_servers", get_system_dns_servers
         )
         tctx.options.dns_name_servers = []
-        with pytest.raises(RuntimeError, match="Must set dns_name_servers option to run DNS mode"):
+        with pytest.raises(
+            RuntimeError, match="Must set dns_name_servers option to run DNS mode"
+        ):
             dr.name_servers()
 
 

--- a/test/mitmproxy/addons/test_dns_resolver.py
+++ b/test/mitmproxy/addons/test_dns_resolver.py
@@ -27,17 +27,17 @@ async def test_ignores_reverse_mode():
 async def test_resolver():
     dr = dns_resolver.DnsResolver()
     with taddons.context(dr) as tctx:
-        assert dr.name_servers == mitmproxy_rs.get_system_dns_servers()
+        assert dr.name_servers() == mitmproxy_rs.get_system_dns_servers()
 
         tctx.options.dns_name_servers = ["1.1.1.1"]
-        assert dr.name_servers == ["1.1.1.1"]
+        assert dr.name_servers() == ["1.1.1.1"]
 
-        res_old = dr.resolver
+        res_old = dr.resolver()
         tctx.options.dns_use_hosts_file = False
-        assert dr.resolver != res_old
+        assert dr.resolver() != res_old
 
         tctx.options.dns_name_servers = ["8.8.8.8"]
-        assert dr.name_servers == ["8.8.8.8"]
+        assert dr.name_servers() == ["8.8.8.8"]
 
 
 async def lookup_ipv4(name: str):
@@ -68,14 +68,14 @@ async def test_dns_request(monkeypatch):
         flow = tflow.tdnsflow(req=req)
         flow.server_conn.address = None
         await resolver.dns_request(flow)
-        assert flow.server_conn.address[0] == resolver.name_servers[0]
+        assert flow.server_conn.address[0] == resolver.name_servers()[0]
 
         req.query = False
         req.op_code = dns.op_codes.QUERY
         flow = tflow.tdnsflow(req=req)
         flow.server_conn.address = None
         await resolver.dns_request(flow)
-        assert flow.server_conn.address[0] == resolver.name_servers[0]
+        assert flow.server_conn.address[0] == resolver.name_servers()[0]
 
         flow = await process_questions(
             [
@@ -83,7 +83,7 @@ async def test_dns_request(monkeypatch):
                 dns.Question("dns.google", dns.types.NS, dns.classes.IN),
             ]
         )
-        assert flow.server_conn.address[0] == resolver.name_servers[0]
+        assert flow.server_conn.address[0] == resolver.name_servers()[0]
 
         flow = await process_questions(
             [
@@ -119,4 +119,4 @@ async def test_dns_request(monkeypatch):
                 dns.Question("dns.google", dns.types.A, dns.classes.IN),
             ]
         )
-        assert flow.server_conn.address[0] == resolver.name_servers[0]
+        assert flow.server_conn.address[0] == resolver.name_servers()[0]


### PR DESCRIPTION
#### Description
Fixes #7064 
`mitmproxy_rs.get_system_dns_servers()` might fail with `RuntimeError`s, which would crash mitmproxy while initializing `DnsResolver`'s attributes during startup. We fix this by making `DnsResolver.resolver` and `DnsResolver.name_servers` as cached functions instead of cached properties

#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.