### PR TITLE
Mode Reducer: port to redux toolkit api

### DIFF
--- a/mitmproxy/tools/web/app.py
+++ b/mitmproxy/tools/web/app.py
@@ -643,7 +643,7 @@ class State(RequestHandler):
         return {
             "version": version.VERSION,
             "contentViews": [v.name for v in contentviews.views if v.name != "Query"],
-            "servers": [s.to_json() for s in master.proxyserver.servers],
+            "servers": {s.mode.full_spec: s.to_json() for s in master.proxyserver.servers},
         }
 
     def get(self):

--- a/mitmproxy/tools/web/app.py
+++ b/mitmproxy/tools/web/app.py
@@ -643,7 +643,9 @@ class State(RequestHandler):
         return {
             "version": version.VERSION,
             "contentViews": [v.name for v in contentviews.views if v.name != "Query"],
-            "servers": {s.mode.full_spec: s.to_json() for s in master.proxyserver.servers},
+            "servers": {
+                s.mode.full_spec: s.to_json() for s in master.proxyserver.servers
+            },
         }
 
     def get(self):

--- a/mitmproxy/tools/web/master.py
+++ b/mitmproxy/tools/web/master.py
@@ -86,7 +86,11 @@ class WebMaster(master.Master):
         app.ClientConnection.broadcast(
             resource="state",
             cmd="update",
-            payload={"servers": {s.mode.full_spec: s.to_json() for s in self.proxyserver.servers}},
+            payload={
+                "servers": {
+                    s.mode.full_spec: s.to_json() for s in self.proxyserver.servers
+                }
+            },
         )
 
     async def running(self):

--- a/mitmproxy/tools/web/master.py
+++ b/mitmproxy/tools/web/master.py
@@ -86,7 +86,7 @@ class WebMaster(master.Master):
         app.ClientConnection.broadcast(
             resource="state",
             cmd="update",
-            data={"servers": [s.to_json() for s in self.proxyserver.servers]},
+            payload={"servers": {s.mode.full_spec: s.to_json() for s in self.proxyserver.servers}},
         )
 
     async def running(self):

--- a/web/src/js/__tests__/backends/websocketSpec.tsx
+++ b/web/src/js/__tests__/backends/websocketSpec.tsx
@@ -27,9 +27,7 @@ test("websocket backend", async () => {
             connectionActions.startFetching(),
             {
                 type: "STATE_RECEIVE",
-                cmd: "receive",
-                data: {},
-                resource: "state",
+                payload: {},
             },
             {
                 type: "FLOWS_RECEIVE",

--- a/web/src/js/__tests__/components/Modes/RegularSpec.tsx
+++ b/web/src/js/__tests__/components/Modes/RegularSpec.tsx
@@ -13,8 +13,8 @@ test("RegularSpec", async () => {
     act(() =>
         store.dispatch(
             backendState.mockUpdate({
-                servers: [
-                    {
+                servers: {
+                    regular: {
                         description: "Regular Mode",
                         full_spec: "regular",
                         is_running: false,
@@ -22,7 +22,7 @@ test("RegularSpec", async () => {
                         listen_addrs: [],
                         type: "regular",
                     },
-                ],
+                },
             }),
         ),
     );

--- a/web/src/js/__tests__/components/Modes/__snapshots__/RegularSpec.tsx.snap
+++ b/web/src/js/__tests__/components/Modes/__snapshots__/RegularSpec.tsx.snap
@@ -54,9 +54,7 @@ exports[`RegularSpec 2`] = `
       <span
         class="inline-input mode-regular-input"
         tabindex="0"
-      >
-        8080
-      </span>
+      />
     </div>
     <div
       class="mode-error text-danger"

--- a/web/src/js/__tests__/components/Modes/__snapshots__/RegularSpec.tsx.snap
+++ b/web/src/js/__tests__/components/Modes/__snapshots__/RegularSpec.tsx.snap
@@ -13,18 +13,21 @@ exports[`RegularSpec 1`] = `
     >
       You manually configure your client application or device to use an HTTP(S) proxy.
     </p>
-    <div
-      class="mode-entry"
-    >
-      <input
-        checked=""
-        type="checkbox"
-      />
-      Run HTTP/S Proxy on port 
-      <span
-        class="inline-input mode-regular-input"
-        tabindex="0"
-      />
+    <div>
+      <div
+        class="mode-entry"
+      >
+        <input
+          checked=""
+          type="checkbox"
+        />
+        Run HTTP/S Proxy on port 
+        <span
+          class="inline-input mode-regular-input"
+          placeholder="8080"
+          tabindex="0"
+        />
+      </div>
     </div>
   </div>
 </DocumentFragment>
@@ -43,23 +46,26 @@ exports[`RegularSpec 2`] = `
     >
       You manually configure your client application or device to use an HTTP(S) proxy.
     </p>
-    <div
-      class="mode-entry"
-    >
-      <input
-        checked=""
-        type="checkbox"
-      />
-      Run HTTP/S Proxy on port 
-      <span
-        class="inline-input mode-regular-input"
-        tabindex="0"
-      />
-    </div>
-    <div
-      class="mode-error text-danger"
-    >
-      port already in use
+    <div>
+      <div
+        class="mode-entry"
+      >
+        <input
+          checked=""
+          type="checkbox"
+        />
+        Run HTTP/S Proxy on port 
+        <span
+          class="inline-input mode-regular-input"
+          placeholder="8080"
+          tabindex="0"
+        />
+      </div>
+      <div
+        class="mode-error text-danger"
+      >
+        port already in use
+      </div>
     </div>
   </div>
 </DocumentFragment>

--- a/web/src/js/__tests__/ducks/_tbackendstate.ts
+++ b/web/src/js/__tests__/ducks/_tbackendstate.ts
@@ -7,8 +7,8 @@ export function TBackendState(): Required<BackendState> {
             "Auto",
             "Raw"
         ],
-        "servers": [
-            {
+        "servers": {
+            "regular": {
                 "description": "HTTP(S) proxy",
                 "full_spec": "regular",
                 "is_running": true,
@@ -25,7 +25,7 @@ export function TBackendState(): Required<BackendState> {
                 ],
                 "type": "regular"
             },
-            {
+            "reverse:example.com": {
                 "description": "reverse proxy to example.com",
                 "full_spec": "reverse:example.com",
                 "is_running": false,
@@ -33,7 +33,7 @@ export function TBackendState(): Required<BackendState> {
                 "listen_addrs": [],
                 "type": "reverse"
             },
-            {
+            "socks5": {
                 "description": "SOCKS v5 proxy",
                 "full_spec": "socks5",
                 "is_running": false,
@@ -41,7 +41,7 @@ export function TBackendState(): Required<BackendState> {
                 "listen_addrs": [],
                 "type": "socks5"
             }
-        ],
+        },
         "version": "1.2.3"
     }
 }

--- a/web/src/js/__tests__/ducks/modes/localSpec.tsx
+++ b/web/src/js/__tests__/ducks/modes/localSpec.tsx
@@ -5,7 +5,7 @@ import localReducer, {
     toggleLocal,
 } from "../../../ducks/modes/local";
 import { ModesState } from "../../../ducks/modes";
-import { toggleRegular } from "../../../ducks/modes/regular";
+import { setActive as setRegularActive } from "../../../ducks/modes/regular";
 import * as backendState from "../../../ducks/backendState";
 import { TStore } from "../tutils";
 import fetchMock, { enableFetchMocks } from "jest-fetch-mock";
@@ -43,7 +43,7 @@ describe("localReducer", () => {
 
         await store.dispatch(setApplications("curl"));
 
-        await store.dispatch(toggleRegular());
+        await store.dispatch(setRegularActive(false));
 
         expect(store.getState().modes.local.active).toBe(false);
         expect(store.getState().modes.regular.active).toBe(false);

--- a/web/src/js/__tests__/ducks/modes/regularSpec.tsx
+++ b/web/src/js/__tests__/ducks/modes/regularSpec.tsx
@@ -1,9 +1,9 @@
 import regularReducer, {
     getSpecs,
     initialState,
-    setHost,
-    setPort,
-    toggleRegular,
+    setListenHost,
+    setListenPort,
+    setActive,
 } from "./../../../ducks/modes/regular";
 import { ModesState } from "../../../ducks/modes";
 import * as backendState from "../../../ducks/backendState";
@@ -11,18 +11,13 @@ import { TStore } from "../tutils";
 import fetchMock, { enableFetchMocks } from "jest-fetch-mock";
 
 describe("regularReducer", () => {
-    it("should return the initial state", () => {
-        const state = regularReducer(undefined, {});
-        expect(state).toEqual(initialState);
-    });
-
     it("should dispatch MODE_REGULAR_TOGGLE and updateMode", async () => {
         enableFetchMocks();
 
         const store = TStore();
 
         expect(store.getState().modes.regular.active).toBe(true);
-        await store.dispatch(toggleRegular());
+        await store.dispatch(setActive(false));
         expect(store.getState().modes.regular.active).toBe(false);
         expect(fetchMock).toHaveBeenCalled();
     });
@@ -31,7 +26,7 @@ describe("regularReducer", () => {
         enableFetchMocks();
         const store = TStore();
 
-        await store.dispatch(setPort(8082));
+        await store.dispatch(setListenPort(8082));
 
         const state = store.getState().modes.regular;
         expect(state.listen_port).toBe(8082);
@@ -42,7 +37,7 @@ describe("regularReducer", () => {
         enableFetchMocks();
         const store = TStore();
 
-        await store.dispatch(setHost("localhost"));
+        await store.dispatch(setListenHost("localhost"));
 
         const state = store.getState().modes.regular;
         expect(state.listen_host).toBe("localhost");
@@ -101,7 +96,8 @@ describe("regularReducer", () => {
         const newState = regularReducer(initialState, action);
         expect(newState.active).toBe(true);
         expect(newState.listen_host).toBe(undefined);
-        expect(newState.listen_port).toBe(8080);
+        expect(newState.listen_port).toBe(undefined);
+
     });
 
     it("should handle RECEIVE_STATE action with data.servers containing another mode", () => {
@@ -147,24 +143,11 @@ describe("regularReducer", () => {
         expect(newState.listen_port).toBe(initialState.listen_port);
     });
 
-    it("should handle MODE_REGULAR_ERROR action", () => {
-        const initialState = {
-            active: false,
-        };
-        const action = {
-            type: "MODE_REGULAR_ERROR",
-            error: "error message",
-        };
-        const newState = regularReducer(initialState, action);
-        expect(newState.error).toBe("error message");
-        expect(newState.active).toBe(false);
-    });
-
     it("should handle error when toggling regular", async () => {
         fetchMock.mockReject(new Error("invalid spec"));
         const store = TStore();
 
-        await store.dispatch(toggleRegular());
+        await store.dispatch(setActive(false));
 
         expect(fetchMock).toHaveBeenCalled();
         expect(store.getState().modes.regular.error).toBe("invalid spec");
@@ -174,7 +157,7 @@ describe("regularReducer", () => {
         fetchMock.mockReject(new Error("invalid spec"));
         const store = TStore();
 
-        await store.dispatch(setPort(8082));
+        await store.dispatch(setListenPort(8082));
 
         expect(fetchMock).toHaveBeenCalled();
         expect(store.getState().modes.regular.error).toBe("invalid spec");
@@ -184,7 +167,7 @@ describe("regularReducer", () => {
         fetchMock.mockReject(new Error("invalid spec"));
         const store = TStore();
 
-        await store.dispatch(setHost("localhost"));
+        await store.dispatch(setListenHost("localhost"));
 
         expect(fetchMock).toHaveBeenCalled();
         expect(store.getState().modes.regular.error).toBe("invalid spec");

--- a/web/src/js/__tests__/ducks/modes/regularSpec.tsx
+++ b/web/src/js/__tests__/ducks/modes/regularSpec.tsx
@@ -97,7 +97,6 @@ describe("regularReducer", () => {
         expect(newState.active).toBe(true);
         expect(newState.listen_host).toBe(undefined);
         expect(newState.listen_port).toBe(undefined);
-
     });
 
     it("should handle RECEIVE_STATE action with data.servers containing another mode", () => {

--- a/web/src/js/__tests__/ducks/modes/reverseSpec.tsx
+++ b/web/src/js/__tests__/ducks/modes/reverseSpec.tsx
@@ -1,8 +1,8 @@
 import { enableFetchMocks } from "jest-fetch-mock";
 import reverseReducer, {
-    addReverseServer,
+    addServer,
     defaultReverseServerConfig,
-    deleteReverse,
+    removeServer,
     getSpecs,
     initialState,
     setDestination,
@@ -40,7 +40,7 @@ describe("reverseReducer", () => {
         const store = TStore();
 
         expect(store.getState().modes.reverse.length).toBe(2);
-        await store.dispatch(addReverseServer());
+        await store.dispatch(addServer());
         expect(store.getState().modes.reverse.length).toBe(3);
         expect(store.getState().modes.reverse[2]).toBe(
             defaultReverseServerConfig,
@@ -53,7 +53,7 @@ describe("reverseReducer", () => {
         const store = TStore();
 
         expect(store.getState().modes.reverse.length).toBe(2);
-        await store.dispatch(deleteReverse(0));
+        await store.dispatch(removeServer(0));
         expect(store.getState().modes.reverse.length).toBe(1);
     });
 
@@ -218,7 +218,7 @@ describe("reverseReducer", () => {
         fetchMock.mockReject(new Error("invalid spec"));
         const store = TStore();
 
-        await store.dispatch(deleteReverse(0));
+        await store.dispatch(removeServer(0));
 
         expect(fetchMock).toHaveBeenCalled();
         expect(store.getState().modes.reverse[0].error).toBe("invalid spec");

--- a/web/src/js/__tests__/ducks/modes/reverseSpec.tsx
+++ b/web/src/js/__tests__/ducks/modes/reverseSpec.tsx
@@ -1,7 +1,7 @@
 import { enableFetchMocks } from "jest-fetch-mock";
 import reverseReducer, {
     addServer,
-    defaultReverseServerConfig,
+    defaultReverseState,
     removeServer,
     getSpecs,
     initialState,
@@ -43,7 +43,7 @@ describe("reverseReducer", () => {
         await store.dispatch(addServer());
         expect(store.getState().modes.reverse.length).toBe(3);
         expect(store.getState().modes.reverse[2]).toBe(
-            defaultReverseServerConfig,
+            defaultReverseState(),
         );
     });
 

--- a/web/src/js/__tests__/ducks/modes/reverseSpec.tsx
+++ b/web/src/js/__tests__/ducks/modes/reverseSpec.tsx
@@ -42,9 +42,7 @@ describe("reverseReducer", () => {
         expect(store.getState().modes.reverse.length).toBe(2);
         await store.dispatch(addServer());
         expect(store.getState().modes.reverse.length).toBe(3);
-        expect(store.getState().modes.reverse[2]).toBe(
-            defaultReverseState(),
-        );
+        expect(store.getState().modes.reverse[2]).toBe(defaultReverseState());
     });
 
     it("should dispatch MODE_REVERSE_DELETE and updateMode", async () => {

--- a/web/src/js/__tests__/ducks/modes/utilsSpec.tsx
+++ b/web/src/js/__tests__/ducks/modes/utilsSpec.tsx
@@ -3,7 +3,7 @@ import { TStore } from "../tutils";
 import {
     includeListenAddress,
     isActiveMode,
-    parseMode,
+    parseSpec,
     updateMode,
 } from "../../../ducks/modes/utils";
 
@@ -83,7 +83,7 @@ describe("isActiveMode", () => {
 describe("parseMode", () => {
     it("should parse regular mode with host and port", () => {
         const modeConfig = "regular@localhost:8081";
-        const result = parseMode(modeConfig);
+        const result = parseSpec(modeConfig);
         expect(result).toEqual({
             name: "regular",
             full_spec: "regular@localhost:8081",
@@ -95,7 +95,7 @@ describe("parseMode", () => {
 
     it("should parse local mode with data", () => {
         const modeConfig = "local:curl,http";
-        const result = parseMode(modeConfig);
+        const result = parseSpec(modeConfig);
         expect(result).toEqual({
             name: "local",
             data: "curl,http",
@@ -107,6 +107,6 @@ describe("parseMode", () => {
 
     it("should throw an error for invalid port", () => {
         const modeConfig = "regular@99999";
-        expect(() => parseMode(modeConfig)).toThrow("invalid port: 99999");
+        expect(() => parseSpec(modeConfig)).toThrow("invalid port: 99999");
     });
 });

--- a/web/src/js/__tests__/ducks/modes/utilsSpec.tsx
+++ b/web/src/js/__tests__/ducks/modes/utilsSpec.tsx
@@ -1,11 +1,11 @@
 import fetchMock, { enableFetchMocks } from "jest-fetch-mock";
 import { TStore } from "../tutils";
 import {
-    includeListenAddress,
     isActiveMode,
     parseSpec,
     updateMode,
 } from "../../../ducks/modes/utils";
+import { includeListenAddress } from "../../../modes";
 
 enableFetchMocks();
 

--- a/web/src/js/__tests__/ducks/tutils.ts
+++ b/web/src/js/__tests__/ducks/tutils.ts
@@ -133,9 +133,9 @@ export const testState: RootState = {
         visible: false,
     },
     modes: {
-        regular: {
+        regular: [{
             active: true,
-        },
+        }],
         local: {
             active: false,
             applications: "",
@@ -150,8 +150,9 @@ export const testState: RootState = {
                 destination: "example.com",
                 listen_port: 8080,
                 listen_host: "localhost",
+                ui_id: Math.random(),
             },
-            defaultReverseServerConfig,
+            defaultReverseServerConfig(),
         ],
     },
 };

--- a/web/src/js/__tests__/ducks/tutils.ts
+++ b/web/src/js/__tests__/ducks/tutils.ts
@@ -8,7 +8,7 @@ import { TBackendState } from "./_tbackendstate";
 import { configureStore } from "@reduxjs/toolkit";
 import { Tab } from "../../ducks/ui/tabs";
 import { LogLevel } from "../../ducks/eventLog";
-import { defaultReverseServerConfig } from "../../ducks/modes/reverse";
+import { defaultReverseState } from "../../ducks/modes/reverse";
 import { ReverseProxyProtocols } from "../../backends/consts";
 
 export { THTTPFlow as TFlow, TTCPFlow, TUDPFlow };
@@ -154,7 +154,7 @@ export const testState: RootState = {
                 listen_host: "localhost",
                 ui_id: Math.random(),
             },
-            defaultReverseServerConfig(),
+            defaultReverseState(),
         ],
     },
 };

--- a/web/src/js/__tests__/ducks/tutils.ts
+++ b/web/src/js/__tests__/ducks/tutils.ts
@@ -133,9 +133,11 @@ export const testState: RootState = {
         visible: false,
     },
     modes: {
-        regular: [{
-            active: true,
-        }],
+        regular: [
+            {
+                active: true,
+            },
+        ],
         local: {
             active: false,
             applications: "",

--- a/web/src/js/backends/websocket.tsx
+++ b/web/src/js/backends/websocket.tsx
@@ -7,6 +7,8 @@ import { fetchApi } from "../utils";
 import * as connectionActions from "../ducks/connection";
 import { Store } from "redux";
 import { RootState } from "../ducks";
+import { PayloadAction } from "@reduxjs/toolkit";
+import { BackendState } from "../ducks/backendState";
 
 const CMD_RESET = "reset";
 
@@ -73,7 +75,15 @@ export default class WebsocketBackend {
 
     receive(resource, data) {
         const type = `${resource}_RECEIVE`.toUpperCase();
-        this.store.dispatch({ type, cmd: "receive", resource, data });
+        if (resource === "state") {
+            this.store.dispatch({
+                type,
+                payload: data,
+            } as PayloadAction<BackendState>);
+        } else {
+            // deprecated: these should be converted to payload actions as well.
+            this.store.dispatch({ type, cmd: "receive", resource, data });
+        }
         const queue = this.activeFetches[resource];
         delete this.activeFetches[resource];
         queue.forEach((msg) => this.onMessage(msg));

--- a/web/src/js/components/CaptureSetup.tsx
+++ b/web/src/js/components/CaptureSetup.tsx
@@ -6,7 +6,9 @@ import { formatAddress } from "../utils";
 import QRCode from "qrcode";
 
 export default function CaptureSetup() {
-    const servers = useAppSelector((state) => state.backendState.servers);
+    const servers = Object.values(
+        useAppSelector((state) => state.backendState.servers),
+    );
 
     let configure_action_text;
     if (servers.length === 0) {

--- a/web/src/js/components/Modes/Local.tsx
+++ b/web/src/js/components/Modes/Local.tsx
@@ -15,7 +15,7 @@ export default function Local() {
 
     const backend_error = useAppSelector((state) => {
         if (state.backendState.servers) {
-            for (const server of state.backendState.servers) {
+            for (const server of Object.values(state.backendState.servers)) {
                 if (server.type === "local") {
                     return server.last_exception;
                 }

--- a/web/src/js/components/Modes/Regular.tsx
+++ b/web/src/js/components/Modes/Regular.tsx
@@ -1,13 +1,9 @@
 import * as React from "react";
 import { ModeToggle } from "./ModeToggle";
 import { useAppDispatch, useAppSelector } from "../../ducks";
-import {
-    setListenPort,
-    setActive,
-    getSpec,
-    RegularState,
-} from "../../ducks/modes/regular";
+import { setListenPort, setActive } from "../../ducks/modes/regular";
 import ValueEditor from "../editors/ValueEditor";
+import { getSpec, RegularState } from "../../modes/regular";
 
 export default function Regular() {
     const serverState = useAppSelector((state) => state.modes.regular);

--- a/web/src/js/components/Modes/Regular.tsx
+++ b/web/src/js/components/Modes/Regular.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { ModeToggle } from "./ModeToggle";
 import { useAppDispatch, useAppSelector } from "../../ducks";
-import { setPort, toggleRegular } from "../../ducks/modes/regular";
+import { setListenPort, setActive } from "../../ducks/modes/regular";
 import ValueEditor from "../editors/ValueEditor";
 
 export default function Regular() {
@@ -26,7 +26,7 @@ export default function Regular() {
 
     const handlePortChange = (port: string) => {
         // FIXME: We should eventually cast to Number and validate.
-        dispatch(setPort(port as unknown as number));
+        dispatch(setListenPort(port as unknown as number));
     };
 
     /*const handleHostChange = (host: string) => {
@@ -42,7 +42,7 @@ export default function Regular() {
             </p>
             <ModeToggle
                 value={active}
-                onChange={() => dispatch(toggleRegular())}
+                onChange={() => dispatch(setActive(!active))}
             >
                 Run HTTP/S Proxy on port{" "}
                 <ValueEditor

--- a/web/src/js/components/Modes/Regular.tsx
+++ b/web/src/js/components/Modes/Regular.tsx
@@ -1,37 +1,25 @@
 import * as React from "react";
 import { ModeToggle } from "./ModeToggle";
 import { useAppDispatch, useAppSelector } from "../../ducks";
-import { setListenPort, setActive } from "../../ducks/modes/regular";
+import {
+    setListenPort,
+    setActive,
+    getSpec,
+    RegularState,
+} from "../../ducks/modes/regular";
 import ValueEditor from "../editors/ValueEditor";
 
 export default function Regular() {
-    const dispatch = useAppDispatch();
+    const serverState = useAppSelector((state) => state.modes.regular);
+    const backendState = useAppSelector((state) => state.backendState.servers);
 
-    const {
-        active,
-        error: ui_error,
-        listen_port,
-    } = useAppSelector((state) => state.modes.regular);
-
-    const backend_error = useAppSelector((state) => {
-        if (state.backendState.servers) {
-            for (const server of state.backendState.servers) {
-                if (server.type === "regular") {
-                    return server.last_exception;
-                }
-            }
-        }
-        return "";
+    const servers = serverState.map((server) => {
+        const error =
+            server.error ||
+            backendState[getSpec(server)]?.last_exception ||
+            undefined;
+        return <RegularRow key={server.ui_id} server={server} error={error} />;
     });
-
-    const handlePortChange = (port: string) => {
-        // FIXME: We should eventually cast to Number and validate.
-        dispatch(setListenPort(port as unknown as number));
-    };
-
-    /*const handleHostChange = (host: string) => {
-        dispatch(setHost(host));
-    };*/
 
     return (
         <div>
@@ -40,22 +28,46 @@ export default function Regular() {
                 You manually configure your client application or device to use
                 an HTTP(S) proxy.
             </p>
+            {servers}
+        </div>
+    );
+}
+
+function RegularRow({
+    server,
+    error,
+}: {
+    server: RegularState;
+    error?: string;
+}) {
+    const dispatch = useAppDispatch();
+
+    server.listen_host && console.warn("TODO: implement listen_host");
+
+    return (
+        <div>
             <ModeToggle
-                value={active}
-                onChange={() => dispatch(setActive(!active))}
+                value={server.active}
+                onChange={() =>
+                    dispatch(setActive({ server, value: !server.active }))
+                }
             >
                 Run HTTP/S Proxy on port{" "}
                 <ValueEditor
                     className="mode-regular-input"
-                    content={listen_port?.toString() || ""}
-                    onEditDone={(port) => handlePortChange(port)}
+                    content={server.listen_port?.toString() || ""}
+                    placeholder="8080"
+                    onEditDone={(port) =>
+                        dispatch(
+                            setListenPort({
+                                server,
+                                value: port as unknown as number,
+                            }),
+                        )
+                    }
                 />
             </ModeToggle>
-            {(ui_error || backend_error) && (
-                <div className="mode-error text-danger">
-                    {ui_error || backend_error}
-                </div>
-            )}
+            {error && <div className="mode-error text-danger">{error}</div>}
         </div>
     );
 }

--- a/web/src/js/components/Modes/Reverse.tsx
+++ b/web/src/js/components/Modes/Reverse.tsx
@@ -1,16 +1,12 @@
 import * as React from "react";
 import ReverseToggleRow from "./ReverseToggleRow";
 import { useAppDispatch, useAppSelector } from "../../ducks";
-import { addReverseServer } from "../../ducks/modes/reverse";
+import { addServer } from "../../ducks/modes/reverse";
 
 export default function Reverse() {
     const dispatch = useAppDispatch();
 
     const servers = useAppSelector((state) => state.modes.reverse);
-
-    const handleAddReverseServer = () => {
-        dispatch(addReverseServer());
-    };
 
     return (
         <div>
@@ -19,17 +15,13 @@ export default function Reverse() {
                 Requests are forwarded to a preconfigured destination.
             </p>
             <div className="mode-reverse-servers">
-                {servers.map((server, index) => (
-                    <ReverseToggleRow
-                        key={index}
-                        modeIndex={index}
-                        server={server}
-                    />
+                {servers.map((server) => (
+                    <ReverseToggleRow key={server.ui_id} server={server} />
                 ))}
             </div>
             <div
                 className="mode-reverse-add-server"
-                onClick={handleAddReverseServer}
+                onClick={() => dispatch(addServer())}
             >
                 <i className="fa fa-plus-square-o" aria-hidden="true"></i>Add
                 additional server

--- a/web/src/js/components/Modes/ReverseToggleRow.tsx
+++ b/web/src/js/components/Modes/ReverseToggleRow.tsx
@@ -5,7 +5,6 @@ import ValueEditor from "../editors/ValueEditor";
 import { useAppDispatch } from "../../ducks";
 import {
     removeServer,
-    ReverseState,
     setActive,
     setDestination,
     setListenHost,
@@ -13,6 +12,7 @@ import {
     setProtocol,
 } from "../../ducks/modes/reverse";
 import { ReverseProxyProtocols } from "../../backends/consts";
+import { ReverseState } from "../../modes/reverse";
 
 interface ReverseToggleRowProps {
     server: ReverseState;

--- a/web/src/js/components/Modes/ReverseToggleRow.tsx
+++ b/web/src/js/components/Modes/ReverseToggleRow.tsx
@@ -4,24 +4,21 @@ import Dropdown, { MenuItem } from "../common/Dropdown";
 import ValueEditor from "../editors/ValueEditor";
 import { useAppDispatch } from "../../ducks";
 import {
-    deleteReverse,
+    removeServer,
     ReverseState,
+    setActive,
     setDestination,
-    setListenConfig,
+    setListenHost,
+    setListenPort,
     setProtocol,
-    toggleReverse,
 } from "../../ducks/modes/reverse";
 import { ReverseProxyProtocols } from "../../backends/consts";
 
 interface ReverseToggleRowProps {
-    modeIndex: number;
     server: ReverseState;
 }
 
-export default function ReverseToggleRow({
-    modeIndex,
-    server,
-}: ReverseToggleRowProps) {
+export default function ReverseToggleRow({ server }: ReverseToggleRowProps) {
     const dispatch = useAppDispatch();
 
     const protocols = Object.values(ReverseProxyProtocols);
@@ -33,22 +30,11 @@ export default function ReverseToggleRow({
         </span>
     );
 
-    const handleProtocolChange = (protocol: string) => {
-        dispatch(setProtocol(protocol as ReverseProxyProtocols, modeIndex));
-    };
-
-    const handleListenHostAndPortChange = (config: string) => {
-        const [host, port] = config.split(":");
-        // FIXME: We should eventually cast to Number and validate.
-        dispatch(setListenConfig(port as unknown as number, host, modeIndex));
-    };
-
-    const handleDestinationChange = (host: string) => {
-        dispatch(setDestination(host, modeIndex));
-    };
-
-    const handleDeletionConfig = (modeIndex: number) => {
-        dispatch(deleteReverse(modeIndex));
+    const deleteServer = async () => {
+        if (server.active) {
+            await dispatch(setActive({ server, value: false })).unwrap();
+        }
+        await dispatch(removeServer(server));
     };
 
     return (
@@ -56,7 +42,7 @@ export default function ReverseToggleRow({
             <ModeToggle
                 value={server.active}
                 onChange={() => {
-                    dispatch(toggleReverse(modeIndex));
+                    dispatch(setActive({ server, value: !server.active }));
                 }}
             >
                 Forward
@@ -68,7 +54,9 @@ export default function ReverseToggleRow({
                     {protocols.map((prot) => (
                         <MenuItem
                             key={prot}
-                            onClick={() => handleProtocolChange(prot)}
+                            onClick={() =>
+                                dispatch(setProtocol({ server, value: prot }))
+                            }
                         >
                             {prot}
                         </MenuItem>
@@ -77,29 +65,38 @@ export default function ReverseToggleRow({
                 traffic from{" "}
                 <ValueEditor
                     className="mode-reverse-input"
-                    content={
-                        server.listen_host && server.listen_port
-                            ? `${server.listen_host?.toString()}:${server.listen_port?.toString()}`
-                            : ""
+                    content={server.listen_host || ""}
+                    onEditDone={(value) =>
+                        dispatch(setListenHost({ server, value }))
                     }
-                    onEditDone={(config) =>
-                        handleListenHostAndPortChange(config)
+                    placeholder="*"
+                />
+                <ValueEditor
+                    className="mode-reverse-input"
+                    content={String(server.listen_port || "")}
+                    onEditDone={(value) =>
+                        dispatch(
+                            setListenPort({
+                                server,
+                                value: value as unknown as number,
+                            }),
+                        )
                     }
-                    placeholder="*:8080"
+                    placeholder="8080"
                 />{" "}
                 to{" "}
                 <ValueEditor
                     className="mode-reverse-input"
                     content={server.destination?.toString() || ""}
-                    onEditDone={(destination) =>
-                        handleDestinationChange(destination)
+                    onEditDone={(value) =>
+                        dispatch(setDestination({ server, value }))
                     }
                     placeholder="example.com"
                 />
                 <i
                     className="fa fa-fw fa-trash fa-lg"
                     aria-hidden="true"
-                    onClick={() => handleDeletionConfig(modeIndex)}
+                    onClick={deleteServer}
                 ></i>
             </ModeToggle>
             {server.error && (

--- a/web/src/js/components/Modes/Wireguard.tsx
+++ b/web/src/js/components/Modes/Wireguard.tsx
@@ -16,7 +16,7 @@ export default function Wireguard() {
 
     const backend_error = useAppSelector((state) => {
         if (state.backendState.servers) {
-            for (const server of state.backendState.servers) {
+            for (const server of Object.values(state.backendState.servers)) {
                 if (server.type === "wireguard") {
                     return server.last_exception;
                 }

--- a/web/src/js/ducks/backendState.ts
+++ b/web/src/js/ducks/backendState.ts
@@ -3,8 +3,10 @@
  * e.g. the list of available content views or the current version.
  */
 
-export const RECEIVE = "STATE_RECEIVE";
-export const UPDATE = "STATE_UPDATE";
+import { createAction, PayloadAction } from "@reduxjs/toolkit";
+
+export const RECEIVE = createAction<Partial<BackendState>>("STATE_RECEIVE");
+export const UPDATE = createAction<Partial<BackendState>>("STATE_UPDATE");
 
 export interface ServerInfo {
     description: string;
@@ -20,31 +22,31 @@ export interface BackendState {
     available: boolean;
     version: string;
     contentViews: string[];
-    servers: ServerInfo[];
+    servers: { [key: string]: ServerInfo };
 }
 
 export const defaultState: BackendState = {
     available: false,
     version: "",
     contentViews: [],
-    servers: [],
+    servers: {},
 };
 
 export function mockUpdate(newState: Partial<BackendState>) {
     return {
         type: UPDATE,
-        data: newState,
+        payload: newState,
     };
 }
 
 export default function reducer(state = defaultState, action): BackendState {
     switch (action.type) {
-        case RECEIVE:
-        case UPDATE:
+        case RECEIVE.type:
+        case UPDATE.type:
             return {
                 ...state,
                 available: true,
-                ...action.data,
+                ...(action as PayloadAction<Partial<BackendState>>).payload,
             };
         default:
             return state;

--- a/web/src/js/ducks/backendState.ts
+++ b/web/src/js/ducks/backendState.ts
@@ -34,7 +34,7 @@ export const defaultState: BackendState = {
 
 export function mockUpdate(newState: Partial<BackendState>) {
     return {
-        type: UPDATE,
+        type: UPDATE.type,
         payload: newState,
     };
 }

--- a/web/src/js/ducks/hooks.ts
+++ b/web/src/js/ducks/hooks.ts
@@ -1,6 +1,15 @@
 import { TypedUseSelectorHook, useDispatch, useSelector } from "react-redux";
 import type { AppDispatch, RootState } from "./store";
+import { createAsyncThunk } from "@reduxjs/toolkit";
 
 // Use throughout your app instead of plain `useDispatch` and `useSelector`
 export const useAppDispatch = () => useDispatch<AppDispatch>();
 export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;
+
+export type AppAsyncThunkConfig = {
+    state: RootState;
+    dispatch: AppDispatch;
+};
+
+export const createAppAsyncThunk =
+    createAsyncThunk.withTypes<AppAsyncThunkConfig>();

--- a/web/src/js/ducks/modes/local.ts
+++ b/web/src/js/ducks/modes/local.ts
@@ -1,29 +1,17 @@
-import { getModesOfType, isActiveMode, ModeState, updateMode } from "./utils";
+import { getModesOfType, updateMode } from "./utils";
 import {
     RECEIVE as RECEIVE_STATE,
     UPDATE as UPDATE_STATE,
 } from "../backendState";
-import type { ModesState } from "../modes";
+import { LocalState } from "../../modes/local";
 
 export const MODE_LOCAL_TOGGLE = "MODE_LOCAL_TOGGLE";
 export const MODE_LOCAL_SET_APPLICATIONS = "MODE_LOCAL_SET_APPLICATIONS";
 export const MODE_LOCAL_ERROR = "MODE_LOCAL_ERROR";
 
-interface LocalState extends ModeState {
-    applications?: string;
-}
-
 export const initialState: LocalState = {
     active: false,
     applications: "",
-};
-
-export const getSpecs = ({ local }: ModesState): string[] => {
-    if (!isActiveMode(local)) {
-        return [];
-    }
-    const spec = local.applications ? `local:${local.applications}` : "local";
-    return [spec];
 };
 
 export const toggleLocal = () => async (dispatch) => {

--- a/web/src/js/ducks/modes/local.ts
+++ b/web/src/js/ducks/modes/local.ts
@@ -63,8 +63,8 @@ const localReducer = (state = initialState, action): LocalState => {
                 applications: action.applications,
                 error: undefined,
             };
-        case UPDATE_STATE:
-        case RECEIVE_STATE:
+        case UPDATE_STATE.type:
+        case RECEIVE_STATE.type:
             if (action.data && action.data.servers) {
                 const currentModeConfig = getModesOfType(
                     "local",

--- a/web/src/js/ducks/modes/regular.ts
+++ b/web/src/js/ducks/modes/regular.ts
@@ -3,20 +3,16 @@ import {
     UPDATE as UPDATE_STATE,
 } from "../backendState";
 import {
+    addSetter,
     getModesOfType,
     isActiveMode,
     includeListenAddress,
     ModeState,
-    updateMode,
+    updateModes,
 } from "./utils";
-import type { ModesState } from "../modes";
-
-export const MODE_REGULAR_TOGGLE = "MODE_REGULAR_TOGGLE";
-export const MODE_REGULAR_SET_PORT = "MODE_REGULAR_SET_PORT";
-export const MODE_REGULAR_ERROR = "MODE_REGULAR_ERROR";
-export const MODE_REGULAR_SET_HOST = "MODE_REGULAR_SET_HOST";
-
-export const DEFAULT_PORT = 8080;
+import { createSlice } from "@reduxjs/toolkit";
+import { createAppAsyncThunk } from "../hooks";
+import { ModesState } from "../modes";
 
 interface RegularState extends ModeState {}
 
@@ -31,86 +27,45 @@ export const getSpecs = ({ regular }: ModesState): string[] => {
     return [includeListenAddress("regular", regular)];
 };
 
-export const toggleRegular = () => async (dispatch) => {
-    dispatch({ type: MODE_REGULAR_TOGGLE });
+export const setActive = createAppAsyncThunk<void, boolean>(
+    "modes/regular/setActive",
+    updateModes,
+);
+export const setListenHost = createAppAsyncThunk<void, string | undefined>(
+    "modes/regular/setListenHost",
+    updateModes,
+);
+export const setListenPort = createAppAsyncThunk<void, number | undefined>(
+    "modes/regular/setListenPort",
+    updateModes,
+);
 
-    try {
-        await dispatch(updateMode());
-    } catch (e) {
-        dispatch({ type: MODE_REGULAR_ERROR, error: e.message });
-    }
-};
+export const regularSlice = createSlice({
+    name: "modes/regular",
+    initialState,
+    reducers: {},
+    extraReducers: (builder) => {
+        addSetter(builder, "active", setActive);
+        addSetter(builder, "listen_host", setListenHost);
+        addSetter(builder, "listen_port", setListenPort);
 
-export const setPort = (port: number) => async (dispatch) => {
-    dispatch({ type: MODE_REGULAR_SET_PORT, port });
-
-    try {
-        await dispatch(updateMode());
-    } catch (e) {
-        dispatch({ type: MODE_REGULAR_ERROR, error: e.message });
-    }
-};
-
-export const setHost = (host: string) => async (dispatch) => {
-    dispatch({ type: MODE_REGULAR_SET_HOST, host });
-
-    try {
-        await dispatch(updateMode());
-    } catch (e) {
-        dispatch({ type: MODE_REGULAR_ERROR, error: e.message });
-    }
-};
-
-const regularReducer = (state = initialState, action): RegularState => {
-    switch (action.type) {
-        case MODE_REGULAR_TOGGLE:
-            return {
-                ...state,
-                active: !state.active,
-                error: undefined,
-            };
-        case MODE_REGULAR_SET_PORT:
-            return {
-                ...state,
-                listen_port: action.port as number,
-                error: undefined,
-            };
-        case MODE_REGULAR_SET_HOST:
-            return {
-                ...state,
-                listen_host: action.host,
-                error: undefined,
-            };
-        case UPDATE_STATE:
-        case RECEIVE_STATE:
+        builder.addCase(UPDATE_STATE, updateState);
+        builder.addCase(RECEIVE_STATE, updateState);
+        function updateState(state: RegularState, action: any) {
             if (action.data && action.data.servers) {
                 const currentModeConfig = getModesOfType(
                     "regular",
                     action.data.servers,
                 )[0];
-                const isActive = currentModeConfig !== undefined;
-                return {
-                    ...state,
-                    active: isActive,
-                    listen_host: isActive
-                        ? currentModeConfig.listen_host
-                        : state.listen_host,
-                    listen_port: isActive
-                        ? (currentModeConfig.listen_port as number) ||
-                          DEFAULT_PORT
-                        : state.listen_port,
-                    error: isActive ? undefined : state.error,
-                };
+                state.active = currentModeConfig !== undefined;
+                if (state.active) {
+                    state.listen_host = currentModeConfig.listen_host;
+                    state.listen_port = currentModeConfig.listen_port as number;
+                    state.error = undefined;
+                }
             }
-            return state;
-        case MODE_REGULAR_ERROR:
-            return {
-                ...state,
-                error: action.error,
-            };
-        default:
-            return state;
-    }
-};
+        }
+    },
+});
 
-export default regularReducer;
+export default regularSlice.reducer;

--- a/web/src/js/ducks/modes/regular.ts
+++ b/web/src/js/ducks/modes/regular.ts
@@ -1,4 +1,5 @@
 import {
+    BackendState,
     RECEIVE as RECEIVE_STATE,
     UPDATE as UPDATE_STATE,
 } from "../backendState";

--- a/web/src/js/ducks/modes/regular.ts
+++ b/web/src/js/ducks/modes/regular.ts
@@ -3,26 +3,9 @@ import {
     RECEIVE as RECEIVE_STATE,
     UPDATE as UPDATE_STATE,
 } from "../backendState";
-import {
-    addSetter,
-    getModesOfType,
-    isActiveMode,
-    includeListenAddress,
-    ModeState as ModeState,
-    createModeUpdateThunk,
-} from "./utils";
+import { addSetter, getModesOfType, createModeUpdateThunk } from "./utils";
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
-import { ModesState } from "../modes";
-
-export interface RegularState extends ModeState {}
-
-export const getSpec = (m: RegularState): string => {
-    return includeListenAddress("regular", m);
-};
-
-export const getSpecs = ({ regular }: ModesState): string[] => {
-    return Object.values(regular).filter(isActiveMode).map(getSpec);
-};
+import { RegularState } from "../../modes/regular";
 
 export const setActive = createModeUpdateThunk<boolean>(
     "modes/regular/setActive",

--- a/web/src/js/ducks/modes/reverse.ts
+++ b/web/src/js/ducks/modes/reverse.ts
@@ -8,7 +8,7 @@ import {
 import { partition } from "../../utils";
 import { shallowEqual } from "react-redux";
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
-import { getSpec, ReverseState } from "../../modes/reverse";
+import { defaultReverseState, getSpec, ReverseState } from "../../modes/reverse";
 
 export const setActive = createModeUpdateThunk<boolean>(
     "modes/reverse/setActive",
@@ -26,21 +26,14 @@ export const setDestination = createModeUpdateThunk<string>(
     "modes/reverse/setDestination",
 );
 
-export const defaultReverseServerConfig = (): ReverseState => ({
-    active: false,
-    protocol: ReverseProxyProtocols.HTTPS,
-    destination: "",
-    ui_id: Math.random(),
-});
-
-export const initialState: ReverseState[] = [defaultReverseServerConfig()];
+export const initialState: ReverseState[] = [defaultReverseState()];
 
 export const reverseSlice = createSlice({
     name: "modes/reverse",
     initialState,
     reducers: {
         addServer: (state) => {
-            state.push(defaultReverseServerConfig());
+            state.push(defaultReverseState());
         },
         removeServer: (state, action: PayloadAction<ReverseState>) => {
             const index = state.findIndex(
@@ -122,7 +115,7 @@ export const reverseSlice = createSlice({
                             ui_id: undefined,
                         } as ReverseState,
                         {
-                            ...defaultReverseServerConfig(),
+                            ...defaultReverseState(),
                             ui_id: undefined,
                         } as ReverseState,
                     )

--- a/web/src/js/ducks/modes/reverse.ts
+++ b/web/src/js/ducks/modes/reverse.ts
@@ -8,7 +8,11 @@ import {
 import { partition } from "../../utils";
 import { shallowEqual } from "react-redux";
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
-import { defaultReverseState, getSpec, ReverseState } from "../../modes/reverse";
+import {
+    defaultReverseState,
+    getSpec,
+    ReverseState,
+} from "../../modes/reverse";
 
 export const setActive = createModeUpdateThunk<boolean>(
     "modes/reverse/setActive",

--- a/web/src/js/ducks/modes/reverse.ts
+++ b/web/src/js/ducks/modes/reverse.ts
@@ -1,41 +1,26 @@
 import {
     ModeState,
+    createModeUpdateThunk,
     getModesOfType,
     includeListenAddress,
     isActiveMode,
-    updateMode,
+    addSetter,
 } from "./utils";
 import type { ModesState } from "../modes";
 import { ReverseProxyProtocols } from "../../backends/consts";
 import {
+    BackendState,
     RECEIVE as RECEIVE_STATE,
     UPDATE as UPDATE_STATE,
 } from "../backendState";
 import { partition } from "../../utils";
 import { shallowEqual } from "react-redux";
-
-export const MODE_REVERSE_TOGGLE = "MODE_REVERSE_TOGGLE";
-export const MODE_REVERSE_SET_LISTEN_CONFIG = "MODE_REVERSE_SET_LISTEN_CONFIG";
-export const MODE_REVERSE_SET_DESTINATION = "MODE_REVERSE_SET_DESTINATION";
-export const MODE_REVERSE_SET_PROTOCOL = "MODE_REVERSE_SET_PROTOCOL";
-export const MODE_REVERSE_ERROR = "MODE_REVERSE_ERROR";
-export const MODE_REVERSE_ADD_SERVER_CONFIG = "MODE_REVERSE_ADD_SERVER_CONFIG";
-export const MODE_REVERSE_DELETE = "MODE_REVERSE_DELETE";
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 
 export interface ReverseState extends ModeState {
     protocol: ReverseProxyProtocols;
     destination: string;
 }
-
-export const defaultReverseServerConfig: ReverseState = {
-    active: false,
-    protocol: ReverseProxyProtocols.HTTPS,
-    destination: "",
-};
-
-type ReverseServersState = ReverseState[];
-
-export const initialState: ReverseServersState = [defaultReverseServerConfig];
 
 const getSpec = (state: ReverseState): string => {
     return includeListenAddress(
@@ -48,154 +33,72 @@ export const getSpecs = ({ reverse }: ModesState): string[] => {
     return reverse.filter(isActiveMode).map(getSpec);
 };
 
-export const addReverseServer = () => async (dispatch) => {
-    dispatch({ type: MODE_REVERSE_ADD_SERVER_CONFIG });
-};
+export const setActive = createModeUpdateThunk<boolean>(
+    "modes/reverse/setActive",
+);
+export const setListenHost = createModeUpdateThunk<string | undefined>(
+    "modes/reverse/setListenHost",
+);
+export const setListenPort = createModeUpdateThunk<number | undefined>(
+    "modes/reverse/setListenPort",
+);
+export const setProtocol = createModeUpdateThunk<ReverseProxyProtocols>(
+    "modes/reverse/setProtocol",
+);
+export const setDestination = createModeUpdateThunk<string>(
+    "modes/reverse/setDestination",
+);
 
-export const toggleReverse = (modeIndex: number) => async (dispatch) => {
-    dispatch({ type: MODE_REVERSE_TOGGLE, index: modeIndex });
+export const defaultReverseServerConfig = (): ReverseState => ({
+    active: false,
+    protocol: ReverseProxyProtocols.HTTPS,
+    destination: "",
+    ui_id: Math.random(),
+});
 
-    try {
-        await dispatch(updateMode());
-    } catch (e) {
-        dispatch({
-            type: MODE_REVERSE_ERROR,
-            error: e.message,
-            index: modeIndex,
-        });
-    }
-};
+export const initialState: ReverseState[] = [defaultReverseServerConfig()];
 
-export const deleteReverse = (modeIndex: number) => async (dispatch) => {
-    dispatch({ type: MODE_REVERSE_DELETE, index: modeIndex });
-
-    try {
-        await dispatch(updateMode());
-    } catch (e) {
-        dispatch({
-            type: MODE_REVERSE_ERROR,
-            error: e.message,
-            index: modeIndex,
-        });
-    }
-};
-
-export const setProtocol =
-    (protocol: ReverseProxyProtocols, modeIndex: number) =>
-    async (dispatch) => {
-        dispatch({
-            type: MODE_REVERSE_SET_PROTOCOL,
-            protocol: protocol,
-            index: modeIndex,
-        });
-
-        try {
-            await dispatch(updateMode());
-        } catch (e) {
-            dispatch({
-                type: MODE_REVERSE_ERROR,
-                error: e.message,
-                index: modeIndex,
-            });
-        }
-    };
-
-export const setListenConfig =
-    (port: number, host: string, modeIndex: number) => async (dispatch) => {
-        dispatch({
-            type: MODE_REVERSE_SET_LISTEN_CONFIG,
-            port,
-            host,
-            index: modeIndex,
-        });
-
-        try {
-            await dispatch(updateMode());
-        } catch (e) {
-            dispatch({
-                type: MODE_REVERSE_ERROR,
-                error: e.message,
-                index: modeIndex,
-            });
-        }
-    };
-
-export const setDestination =
-    (destination: string, modeIndex: number) => async (dispatch) => {
-        dispatch({
-            type: MODE_REVERSE_SET_DESTINATION,
-            destination,
-            index: modeIndex,
-        });
-        try {
-            await dispatch(updateMode());
-        } catch (e) {
-            dispatch({
-                type: MODE_REVERSE_ERROR,
-                error: e.message,
-                index: modeIndex,
-            });
-        }
-    };
-
-const reverseReducer = (state = initialState, action): ReverseServersState => {
-    switch (action.type) {
-        case MODE_REVERSE_ADD_SERVER_CONFIG:
-            return [...state, defaultReverseServerConfig];
-        case MODE_REVERSE_TOGGLE:
-            return state.map((server, index) =>
-                index === action.index
-                    ? {
-                          ...server,
-                          active: !server.active,
-                          error: undefined,
-                      }
-                    : server,
+export const reverseSlice = createSlice({
+    name: "modes/reverse",
+    initialState,
+    reducers: {
+        addServer: (state) => {
+            state.push(defaultReverseServerConfig());
+        },
+        removeServer: (state, action: PayloadAction<ReverseState>) => {
+            const index = state.findIndex(
+                (m) => m.ui_id === action.payload.ui_id,
             );
-        case MODE_REVERSE_DELETE:
-            return state.filter((_, index) => index !== action.index);
-        case MODE_REVERSE_SET_LISTEN_CONFIG:
-            return state.map((server, index) =>
-                index === action.index
-                    ? {
-                          ...server,
-                          listen_port: action.port,
-                          listen_host: action.host,
-                          error: undefined,
-                      }
-                    : server,
-            );
-        case MODE_REVERSE_SET_DESTINATION:
-            return state.map((server, index) =>
-                index === action.index
-                    ? {
-                          ...server,
-                          destination: action.destination,
-                          error: undefined,
-                      }
-                    : server,
-            );
-        case MODE_REVERSE_SET_PROTOCOL:
-            return state.map((server, index) =>
-                index === action.index
-                    ? {
-                          ...server,
-                          protocol: action.protocol,
-                          error: undefined,
-                      }
-                    : server,
-            );
-        case UPDATE_STATE:
-        case RECEIVE_STATE:
-            if (action.data && action.data.servers) {
+            if (index !== -1) {
+                if (state[index].active)
+                    console.error(
+                        "servers should be deactivated before removal",
+                    );
+                state.splice(index, 1);
+            }
+        },
+    },
+    extraReducers: (builder) => {
+        addSetter(builder, "active", setActive);
+        addSetter(builder, "listen_host", setListenHost);
+        addSetter(builder, "listen_port", setListenPort);
+        addSetter(builder, "protocol", setProtocol);
+        addSetter(builder, "destination", setDestination);
+
+        builder.addCase(RECEIVE_STATE, updateState);
+        builder.addCase(UPDATE_STATE, updateState);
+        function updateState(
+            state: ReverseState[],
+            action: PayloadAction<Partial<BackendState>>,
+        ) {
+            if (action.payload.servers) {
                 // action.data.servers does not include servers that are currently inactive,
                 // but we want to keep them in the UI. So we need to merge UI state with what we got from the server.
 
                 const activeServers = Object.fromEntries(
-                    getModesOfType("reverse", action.data.servers).map((x) => [
-                        x.full_spec,
-                        x,
-                    ]),
+                    getModesOfType("reverse", action.payload.servers).map(
+                        (x) => [x.full_spec, x],
+                    ),
                 );
 
                 const nextState: ReverseState[] = [];
@@ -229,33 +132,31 @@ const reverseReducer = (state = initialState, action): ReverseServersState => {
                         destination,
                         listen_host,
                         listen_port,
+                        ui_id: Math.random(),
                     });
                 }
 
                 // remove default config if still present.
                 if (
                     nextState.length > 1 &&
-                    shallowEqual(nextState[0], defaultReverseServerConfig)
+                    shallowEqual(
+                        {
+                            ...nextState[0],
+                            ui_id: undefined,
+                        } as ReverseState,
+                        {
+                            ...defaultReverseServerConfig(),
+                            ui_id: undefined,
+                        } as ReverseState,
+                    )
                 ) {
                     nextState.shift();
                 }
 
                 return nextState;
             }
-            return state;
-
-        case MODE_REVERSE_ERROR:
-            return state.map((server, index) =>
-                index === action.index
-                    ? {
-                          ...server,
-                          error: action.error,
-                      }
-                    : server,
-            );
-        default:
-            return state;
-    }
-};
-
-export default reverseReducer;
+        }
+    },
+});
+export const { addServer, removeServer } = reverseSlice.actions;
+export default reverseSlice.reducer;

--- a/web/src/js/ducks/modes/reverse.ts
+++ b/web/src/js/ducks/modes/reverse.ts
@@ -1,12 +1,4 @@
-import {
-    ModeState,
-    createModeUpdateThunk,
-    getModesOfType,
-    includeListenAddress,
-    isActiveMode,
-    addSetter,
-} from "./utils";
-import type { ModesState } from "../modes";
+import { createModeUpdateThunk, getModesOfType, addSetter } from "./utils";
 import { ReverseProxyProtocols } from "../../backends/consts";
 import {
     BackendState,
@@ -16,22 +8,7 @@ import {
 import { partition } from "../../utils";
 import { shallowEqual } from "react-redux";
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
-
-export interface ReverseState extends ModeState {
-    protocol: ReverseProxyProtocols;
-    destination: string;
-}
-
-const getSpec = (state: ReverseState): string => {
-    return includeListenAddress(
-        `reverse:${state.protocol}://${state.destination}`,
-        state,
-    );
-};
-
-export const getSpecs = ({ reverse }: ModesState): string[] => {
-    return reverse.filter(isActiveMode).map(getSpec);
-};
+import { getSpec, ReverseState } from "../../modes/reverse";
 
 export const setActive = createModeUpdateThunk<boolean>(
     "modes/reverse/setActive",

--- a/web/src/js/ducks/modes/utils.ts
+++ b/web/src/js/ducks/modes/utils.ts
@@ -1,21 +1,17 @@
-import { getSpecs as getRegularModeSpecs } from "./regular";
-import { getSpecs as getLocalModeSpecs } from "./local";
-import { getSpecs as getWireguardModeSpecs } from "./wireguard";
-import { getSpecs as getReverseModeSpecs } from "./reverse";
+import { getSpec as getRegularSpec } from "../../modes/regular";
+import { getSpec as getLocalSpec } from "../../modes/local";
+import { getSpec as getWireguardSpec } from "../../modes/wireguard";
+import { getSpec as getReverseSpec } from "../../modes/reverse";
 import { fetchApi, partition, rpartition } from "../../utils";
 import { ServerInfo } from "../backendState";
-import { ModesState } from "../modes";
+import type { ModesState } from "../modes";
 import { ActionReducerMapBuilder, AsyncThunk, Draft } from "@reduxjs/toolkit";
 import { AppAsyncThunkConfig, createAppAsyncThunk } from "../hooks";
+import { ModeState } from "../../modes";
 
-export interface ModeState {
-    active: boolean;
-    error?: string;
-    listen_port?: number;
-    listen_host?: string;
-    // The UI ID is used to uniquely identify the server when doing async updates with createModeUpdateThunk
-    ui_id?: number;
-}
+export const isActiveMode = (state: ModeState): boolean => {
+    return state.active && !state.error;
+};
 
 /**
  * FIXME: Remove before PR merge. This should be entirely replaced with updateModes.
@@ -37,10 +33,11 @@ async function updateModes(_, thunkAPI) {
 
 async function updateModeInner(modes: ModesState) {
     const activeModes: string[] = [
-        ...getRegularModeSpecs(modes),
-        ...getLocalModeSpecs(modes),
-        ...getWireguardModeSpecs(modes),
-        ...getReverseModeSpecs(modes),
+        ...modes.regular.filter(isActiveMode).map(getRegularSpec),
+        // FIXME: state should be an array itself
+        ...Array(modes.local).filter(isActiveMode).map(getLocalSpec),
+        ...Array(modes.wireguard).filter(isActiveMode).map(getWireguardSpec),
+        ...modes.reverse.filter(isActiveMode).map(getReverseSpec),
         //add new modes here
     ];
     const response = await fetchApi.put("/options", {
@@ -85,23 +82,6 @@ export function addSetter<M extends ModeState, Attr extends keyof Draft<M>>(
         }
     });
 }
-
-export const includeListenAddress = (
-    modeNameAndData: string,
-    state: Pick<ModeState, "listen_host" | "listen_port">,
-): string => {
-    if (state.listen_host && state.listen_port) {
-        return `${modeNameAndData}@${state.listen_host}:${state.listen_port}`;
-    } else if (state.listen_port) {
-        return `${modeNameAndData}@${state.listen_port}`;
-    } else {
-        return modeNameAndData;
-    }
-};
-
-export const isActiveMode = (state: ModeState): boolean => {
-    return state.active && !state.error;
-};
 
 interface SpecParts {
     full_spec: string;

--- a/web/src/js/ducks/modes/wireguard.ts
+++ b/web/src/js/ducks/modes/wireguard.ts
@@ -1,15 +1,9 @@
+import { WireguardState } from "../../modes/wireguard";
 import {
     RECEIVE as RECEIVE_STATE,
     UPDATE as UPDATE_STATE,
 } from "../backendState";
-import {
-    getModesOfType,
-    isActiveMode,
-    includeListenAddress,
-    ModeState,
-    updateMode,
-} from "./utils";
-import type { ModesState } from "../modes";
+import { getModesOfType, updateMode } from "./utils";
 
 export const MODE_WIREGUARD_TOGGLE = "MODE_WIREGUARD_TOGGLE";
 export const MODE_WIREGUARD_ERROR = "MODE_WIREGUARD_ERROR";
@@ -17,21 +11,10 @@ export const MODE_WIREGUARD_SET_PORT = "MODE_WIREGUARD_SET_PORT";
 export const MODE_WIREGUARD_SET_HOST = "MODE_WIREGUARD_SET_HOST";
 export const MODE_WIREGUARD_SET_FILE_PATH = "MODE_WIREGUARD_SET_FILE_PATH";
 
-interface WireguardState extends ModeState {
-    file_path?: string;
-}
-
 export const initialState: WireguardState = {
     active: false,
     file_path: "",
     listen_port: 51820,
-};
-
-export const getSpecs = ({ wireguard }: ModesState): string[] => {
-    if (!isActiveMode(wireguard)) {
-        return [];
-    }
-    return [includeListenAddress("wireguard", wireguard)];
 };
 
 export const toggleWireguard = () => async (dispatch) => {

--- a/web/src/js/ducks/modes/wireguard.ts
+++ b/web/src/js/ducks/modes/wireguard.ts
@@ -99,8 +99,8 @@ const wireguardReducer = (state = initialState, action): WireguardState => {
                 file_path: action.path,
                 error: undefined,
             };
-        case UPDATE_STATE:
-        case RECEIVE_STATE:
+        case UPDATE_STATE.type:
+        case RECEIVE_STATE.type:
             if (action.data && action.data.servers) {
                 const currentModeConfig = getModesOfType(
                     "wireguard",

--- a/web/src/js/modes/index.ts
+++ b/web/src/js/modes/index.ts
@@ -1,0 +1,21 @@
+export interface ModeState {
+    active: boolean;
+    error?: string;
+    listen_port?: number;
+    listen_host?: string;
+    // The UI ID is used to uniquely identify the server when doing async updates with createModeUpdateThunk
+    ui_id?: number;
+}
+
+export const includeListenAddress = (
+    modeNameAndData: string,
+    state: Pick<ModeState, "listen_host" | "listen_port">,
+): string => {
+    if (state.listen_host && state.listen_port) {
+        return `${modeNameAndData}@${state.listen_host}:${state.listen_port}`;
+    } else if (state.listen_port) {
+        return `${modeNameAndData}@${state.listen_port}`;
+    } else {
+        return modeNameAndData;
+    }
+};

--- a/web/src/js/modes/local.ts
+++ b/web/src/js/modes/local.ts
@@ -1,0 +1,9 @@
+import { ModeState } from ".";
+
+export interface LocalState extends ModeState {
+    applications?: string;
+}
+
+export const getSpec = (m: LocalState): string => {
+    return m.applications ? `local:${m.applications}` : "local";
+};

--- a/web/src/js/modes/regular.ts
+++ b/web/src/js/modes/regular.ts
@@ -1,0 +1,7 @@
+import { includeListenAddress, ModeState } from ".";
+
+export interface RegularState extends ModeState {}
+
+export const getSpec = (m: RegularState): string => {
+    return includeListenAddress("regular", m);
+};

--- a/web/src/js/modes/reverse.ts
+++ b/web/src/js/modes/reverse.ts
@@ -6,6 +6,13 @@ export interface ReverseState extends ModeState {
     destination: string;
 }
 
+export const defaultReverseState = (): ReverseState => ({
+    active: false,
+    protocol: ReverseProxyProtocols.HTTPS,
+    destination: "",
+    ui_id: Math.random(),
+});
+
 export const getSpec = (state: ReverseState): string => {
     return includeListenAddress(
         `reverse:${state.protocol}://${state.destination}`,

--- a/web/src/js/modes/reverse.ts
+++ b/web/src/js/modes/reverse.ts
@@ -1,0 +1,14 @@
+import { includeListenAddress, ModeState } from ".";
+import { ReverseProxyProtocols } from "../backends/consts";
+
+export interface ReverseState extends ModeState {
+    protocol: ReverseProxyProtocols;
+    destination: string;
+}
+
+export const getSpec = (state: ReverseState): string => {
+    return includeListenAddress(
+        `reverse:${state.protocol}://${state.destination}`,
+        state,
+    );
+};

--- a/web/src/js/modes/wireguard.ts
+++ b/web/src/js/modes/wireguard.ts
@@ -1,0 +1,9 @@
+import { includeListenAddress, ModeState } from ".";
+
+export interface WireguardState extends ModeState {
+    file_path?: string;
+}
+
+export const getSpec = (s: WireguardState): string => {
+    return includeListenAddress("wireguard", s);
+};


### PR DESCRIPTION
This is a proof-of-concept to move the regular mode reducer to Redux Toolkit.

We should get https://github.com/mitmproxy/mitmproxy/pull/7029 in first and then rebase this, if we decide to adopt it.