### PR TITLE
support full alpha tcp connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 ## Unreleased: mitmproxy next
 
+- Support full alpha tcp connection.
+  ([#7087](https://github.com/mitmproxy/mitmproxy/pull/7087))
 - Improve the error message when users specify the `certs` option without a matching private key.
   ([#7073](https://github.com/mitmproxy/mitmproxy/pull/7073), @mhils)
 - Fix a bug where intermediate certificates would not be transmitted when using QUIC.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 ## Unreleased: mitmproxy next
 
-- Support full alpha tcp connection.
+- Tighten HTTP detection heuristic to better support custom TCP-based protocols.
   ([#7087](https://github.com/mitmproxy/mitmproxy/pull/7087))
 - Improve the error message when users specify the `certs` option without a matching private key.
   ([#7073](https://github.com/mitmproxy/mitmproxy/pull/7073), @mhils)

--- a/mitmproxy/addons/next_layer.py
+++ b/mitmproxy/addons/next_layer.py
@@ -184,6 +184,8 @@ class NextLayer:
         probably_no_http = (
             # the first three bytes should be the HTTP verb, so A-Za-z is expected.
             len(data_client) < 3
+            # limit first word of http request len ex. OPTIONS, CONNECT (full alpha tcp connection)
+            or not len(data_client.split(b" ")[0]) <= 7
             or not data_client[:3].isalpha()
             # a server greeting would be uncharacteristic.
             or data_server

--- a/mitmproxy/addons/next_layer.py
+++ b/mitmproxy/addons/next_layer.py
@@ -185,7 +185,9 @@ class NextLayer:
             # the first three bytes should be the HTTP verb, so A-Za-z is expected.
             len(data_client) < 3
             # limit first word of http request len ex. OPTIONS, CONNECT (full alpha tcp connection)
-            or not len(data_client.split(b" ")[0]) <= 7
+            # HTTP would require whitespace before the first newline
+            # if we have neither whitespace nor a newline, it's also unlikely to be HTTP.
+            or (data_client.find(b" ") >= data_client.find(b"\n"))
             or not data_client[:3].isalpha()
             # a server greeting would be uncharacteristic.
             or data_server

--- a/mitmproxy/addons/next_layer.py
+++ b/mitmproxy/addons/next_layer.py
@@ -184,7 +184,6 @@ class NextLayer:
         probably_no_http = (
             # the first three bytes should be the HTTP verb, so A-Za-z is expected.
             len(data_client) < 3
-            # limit first word of http request len ex. OPTIONS, CONNECT (full alpha tcp connection)
             # HTTP would require whitespace before the first newline
             # if we have neither whitespace nor a newline, it's also unlikely to be HTTP.
             or (data_client.find(b" ") >= data_client.find(b"\n"))

--- a/test/mitmproxy/addons/test_next_layer.py
+++ b/test/mitmproxy/addons/test_next_layer.py
@@ -742,7 +742,7 @@ transparent_proxy_configs = [
         TConf(
             before=[modes.TransparentProxy],
             after=[modes.TransparentProxy, TCPLayer],
-            data_client=tcp_fullalpha
+            data_client=tcp_fullalpha,
         ),
         id="transparent proxy: full alpha tcp",
     ),

--- a/test/mitmproxy/addons/test_next_layer.py
+++ b/test/mitmproxy/addons/test_next_layer.py
@@ -94,6 +94,8 @@ quic_client_hello = bytes.fromhex(
 
 dns_query = bytes.fromhex("002a01000001000000000000076578616d706c6503636f6d0000010001")
 
+tcp_fullalpha = b"AAAAAAAAAAAAAAAAAAAAAA=="
+
 http_get = b"GET / HTTP/1.1\r\nHost: example.com\r\n\r\n"
 http_get_absolute = b"GET http://example.com/ HTTP/1.1\r\n\r\n"
 
@@ -735,6 +737,14 @@ transparent_proxy_configs = [
             ignore_conn=True,
         ),
         id="transparent proxy: ignore_hosts",
+    ),
+    pytest.param(
+        TConf(
+            before=[modes.TransparentProxy],
+            after=[modes.TransparentProxy, TCPLayer],
+            data_client=tcp_fullalpha
+        ),
+        id="transparent proxy: full alpha tcp",
     ),
     pytest.param(
         udp := TConf(

--- a/test/mitmproxy/addons/test_next_layer.py
+++ b/test/mitmproxy/addons/test_next_layer.py
@@ -744,7 +744,7 @@ transparent_proxy_configs = [
         TConf(
             before=[modes.TransparentProxy],
             after=[modes.TransparentProxy, TCPLayer],
-            data_client=tcp_fullalpha,
+            data_client=custom_base64_proto,
         ),
         id="transparent proxy: full alpha tcp",
     ),

--- a/test/mitmproxy/addons/test_next_layer.py
+++ b/test/mitmproxy/addons/test_next_layer.py
@@ -94,7 +94,9 @@ quic_client_hello = bytes.fromhex(
 
 dns_query = bytes.fromhex("002a01000001000000000000076578616d706c6503636f6d0000010001")
 
-tcp_fullalpha = b"AAAAAAAAAAAAAAAAAAAAAA=="
+# Custom protocol with just base64-encoded messages
+# https://github.com/mitmproxy/mitmproxy/pull/7087
+custom_base64_proto = b"AAAAAAAAAAAAAAAAAAAAAA=="
 
 http_get = b"GET / HTTP/1.1\r\nHost: example.com\r\n\r\n"
 http_get_absolute = b"GET http://example.com/ HTTP/1.1\r\n\r\n"


### PR DESCRIPTION
#### Description

add a filter to non-tcp connections for full alphabetics tcp connection
this depends of first word in tcp payload
after split by whitespace and checking length of that

#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.