### PR TITLE
Addon to update the ports in alt-svc header in reverse mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
   ([#7067](https://github.com/mitmproxy/mitmproxy/pull/7067), @errorxyz)
 - mitmproxy now officially supports Python 3.13.
   ([#6934](https://github.com/mitmproxy/mitmproxy/pull/6934), @mhils)
+- Addon to update the hosts in alt-svc header in reverse mode
 
 ## 02 August 2024: mitmproxy 10.4.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - mitmproxy now officially supports Python 3.13.
   ([#6934](https://github.com/mitmproxy/mitmproxy/pull/6934), @mhils)
 - Addon to update the hosts in alt-svc header in reverse mode
+  ([#7093](https://github.com/mitmproxy/mitmproxy/pull/7093), @errorxyz)
 
 ## 02 August 2024: mitmproxy 10.4.2
 

--- a/mitmproxy/addons/__init__.py
+++ b/mitmproxy/addons/__init__.py
@@ -28,6 +28,7 @@ from mitmproxy.addons import stickycookie
 from mitmproxy.addons import strip_ech
 from mitmproxy.addons import tlsconfig
 from mitmproxy.addons import upstream_auth
+from mitmproxy.addons import update_alt_svc
 
 
 def default_addons():
@@ -62,4 +63,5 @@ def default_addons():
         savehar.SaveHar(),
         tlsconfig.TlsConfig(),
         upstream_auth.UpstreamAuth(),
+        update_alt_svc.UpdateAltSvc(),
     ]

--- a/mitmproxy/addons/__init__.py
+++ b/mitmproxy/addons/__init__.py
@@ -27,8 +27,8 @@ from mitmproxy.addons import stickyauth
 from mitmproxy.addons import stickycookie
 from mitmproxy.addons import strip_ech
 from mitmproxy.addons import tlsconfig
-from mitmproxy.addons import upstream_auth
 from mitmproxy.addons import update_alt_svc
+from mitmproxy.addons import upstream_auth
 
 
 def default_addons():

--- a/mitmproxy/addons/update_alt_svc.py
+++ b/mitmproxy/addons/update_alt_svc.py
@@ -1,22 +1,30 @@
-from mitmproxy.http import HTTPFlow
 import re
+
 from mitmproxy import ctx
+from mitmproxy.http import HTTPFlow
 from mitmproxy.proxy import mode_specs
 
-ALT_SVC = 'alt-svc'
+ALT_SVC = "alt-svc"
 PORT_PATTERN = r'(?<=:)\d{1,5}(?=")'
 
 
 def update_alt_svc_port(data: str, port: int) -> str:
-    return re.sub(PORT_PATTERN, f'{port}', data)
+    return re.sub(PORT_PATTERN, f"{port}", data)
 
 
 class UpdateAltSvc:
     def load(self, loader):
-        loader.add_option("update_alt_svc", bool, True, "Update the ports in alt-svc header to the port that we are listening on in reverse mode")
+        loader.add_option(
+            "update_alt_svc",
+            bool,
+            True,
+            "Update the ports in alt-svc header to the port that we are listening on in reverse mode",
+        )
 
     def responseheaders(self, flow: HTTPFlow):
-        if ctx.options.update_alt_svc and isinstance(flow.client_conn.proxy_mode, mode_specs.ReverseMode):
+        if ctx.options.update_alt_svc and isinstance(
+            flow.client_conn.proxy_mode, mode_specs.ReverseMode
+        ):
             listen_port = flow.client_conn.sockname[1]
             headers = flow.response.headers
             if ALT_SVC in headers:

--- a/mitmproxy/addons/update_alt_svc.py
+++ b/mitmproxy/addons/update_alt_svc.py
@@ -18,12 +18,11 @@ class UpdateAltSvc:
             "keep_alt_svc_header",
             bool,
             False,
-            "Keep the original alt-svc header instead of updating as per the reverse proxy target.",
+            "Keep the original alt-svc header instead of updating it based on the reverse proxy target.",
         )
 
     def responseheaders(self, flow: HTTPFlow):
         assert flow.response
-        assert flow.response.headers
         if not ctx.options.keep_alt_svc_header and isinstance(
             flow.client_conn.proxy_mode, mode_specs.ReverseMode
         ):

--- a/mitmproxy/addons/update_alt_svc.py
+++ b/mitmproxy/addons/update_alt_svc.py
@@ -18,7 +18,7 @@ class UpdateAltSvc:
             "keep_alt_svc_header",
             bool,
             False,
-            "Keep the original alt-svc header instead of updating it based on the reverse proxy target.",
+            "Reverse Proxy: Keep Alt-Svc headers as-is, even if they do not point to mitmproxy. Enabling this option may cause clients to bypass the proxy.",
         )
 
     def responseheaders(self, flow: HTTPFlow):

--- a/mitmproxy/addons/update_alt_svc.py
+++ b/mitmproxy/addons/update_alt_svc.py
@@ -18,14 +18,14 @@ class UpdateAltSvc:
             "keep_alt_svc_header",
             bool,
             False,
-            "Keep the original alt-svc header instead of updating it to the reverse proxy target.",
+            "Keep the original alt-svc header instead of updating as per the reverse proxy target.",
         )
 
     def responseheaders(self, flow: HTTPFlow):
         if not ctx.options.keep_alt_svc_header and isinstance(
             flow.client_conn.proxy_mode, mode_specs.ReverseMode
         ):
-            listen_port = flow.client_conn.sockname[1]
+            (_, listen_port) = flow.client_conn.sockname
             headers = flow.response.headers
             if ALT_SVC in headers:
                 headers[ALT_SVC] = update_alt_svc_header(headers[ALT_SVC], listen_port)

--- a/mitmproxy/addons/update_alt_svc.py
+++ b/mitmproxy/addons/update_alt_svc.py
@@ -23,9 +23,11 @@ class UpdateAltSvc:
 
     def responseheaders(self, flow: HTTPFlow):
         assert flow.response
-        if not ctx.options.keep_alt_svc_header and isinstance(
-            flow.client_conn.proxy_mode, mode_specs.ReverseMode
-        ) and ALT_SVC in flow.response.headers:
+        if (
+            not ctx.options.keep_alt_svc_header
+            and isinstance(flow.client_conn.proxy_mode, mode_specs.ReverseMode)
+            and ALT_SVC in flow.response.headers
+        ):
             _, listen_port, *_ = flow.client_conn.sockname
             headers = flow.response.headers
             headers[ALT_SVC] = update_alt_svc_header(headers[ALT_SVC], listen_port)

--- a/mitmproxy/addons/update_alt_svc.py
+++ b/mitmproxy/addons/update_alt_svc.py
@@ -1,0 +1,23 @@
+from mitmproxy.http import HTTPFlow
+import re
+from mitmproxy import ctx
+from mitmproxy.proxy import mode_specs
+
+ALT_SVC = 'alt-svc'
+PORT_PATTERN = r'(?<=:)\d{1,5}(?=")'
+
+
+def update_alt_svc_port(data: str, port: int) -> str:
+    return re.sub(PORT_PATTERN, f'{port}', data)
+
+
+class UpdateAltSvc:
+    def load(self, loader):
+        loader.add_option("update_alt_svc", bool, True, "Update the ports in alt-svc header to the port that we are listening on in reverse mode")
+
+    def responseheaders(self, flow: HTTPFlow):
+        if ctx.options.update_alt_svc and isinstance(flow.client_conn.proxy_mode, mode_specs.ReverseMode):
+            listen_port = flow.client_conn.sockname[1]
+            headers = flow.response.headers
+            if ALT_SVC in headers:
+                headers[ALT_SVC] = update_alt_svc_port(headers[ALT_SVC], listen_port)

--- a/mitmproxy/addons/update_alt_svc.py
+++ b/mitmproxy/addons/update_alt_svc.py
@@ -22,6 +22,8 @@ class UpdateAltSvc:
         )
 
     def responseheaders(self, flow: HTTPFlow):
+        assert flow.response
+        assert flow.response.headers
         if not ctx.options.keep_alt_svc_header and isinstance(
             flow.client_conn.proxy_mode, mode_specs.ReverseMode
         ):

--- a/mitmproxy/addons/update_alt_svc.py
+++ b/mitmproxy/addons/update_alt_svc.py
@@ -5,27 +5,27 @@ from mitmproxy.http import HTTPFlow
 from mitmproxy.proxy import mode_specs
 
 ALT_SVC = "alt-svc"
-PORT_PATTERN = r'(?<=:)\d{1,5}(?=")'
+HOST_PATTERN = r'([a-zA-Z0-9.-]*:\d{1,5})'
 
 
-def update_alt_svc_port(data: str, port: int) -> str:
-    return re.sub(PORT_PATTERN, f"{port}", data)
+def update_alt_svc_header(header: str, port: int) -> str:
+    return re.sub(HOST_PATTERN, f":{port}", header)
 
 
 class UpdateAltSvc:
     def load(self, loader):
         loader.add_option(
-            "update_alt_svc",
+            "keep_alt_svc_header",
             bool,
-            True,
-            "Update the ports in alt-svc header to the port that we are listening on in reverse mode",
+            False,
+            "Keep the original alt-svc header instead of updating it to the reverse proxy target.",
         )
 
     def responseheaders(self, flow: HTTPFlow):
-        if ctx.options.update_alt_svc and isinstance(
+        if not ctx.options.keep_alt_svc_header and isinstance(
             flow.client_conn.proxy_mode, mode_specs.ReverseMode
         ):
             listen_port = flow.client_conn.sockname[1]
             headers = flow.response.headers
             if ALT_SVC in headers:
-                headers[ALT_SVC] = update_alt_svc_port(headers[ALT_SVC], listen_port)
+                headers[ALT_SVC] = update_alt_svc_header(headers[ALT_SVC], listen_port)

--- a/mitmproxy/addons/update_alt_svc.py
+++ b/mitmproxy/addons/update_alt_svc.py
@@ -11,7 +11,7 @@ HOST_PATTERN = r"([a-zA-Z0-9.-]*:\d{1,5})"
 def update_alt_svc_header(header: str, port: int) -> str:
     return re.sub(HOST_PATTERN, f":{port}", header)
 
-import logging
+
 class UpdateAltSvc:
     def load(self, loader):
         loader.add_option(
@@ -27,7 +27,7 @@ class UpdateAltSvc:
         if not ctx.options.keep_alt_svc_header and isinstance(
             flow.client_conn.proxy_mode, mode_specs.ReverseMode
         ):
-            _, listen_port, *_  = flow.client_conn.sockname
+            _, listen_port, *_ = flow.client_conn.sockname
             headers = flow.response.headers
             if ALT_SVC in headers:
                 headers[ALT_SVC] = update_alt_svc_header(headers[ALT_SVC], listen_port)

--- a/mitmproxy/addons/update_alt_svc.py
+++ b/mitmproxy/addons/update_alt_svc.py
@@ -25,8 +25,7 @@ class UpdateAltSvc:
         assert flow.response
         if not ctx.options.keep_alt_svc_header and isinstance(
             flow.client_conn.proxy_mode, mode_specs.ReverseMode
-        ):
+        ) and ALT_SVC in flow.response.headers:
             _, listen_port, *_ = flow.client_conn.sockname
             headers = flow.response.headers
-            if ALT_SVC in headers:
-                headers[ALT_SVC] = update_alt_svc_header(headers[ALT_SVC], listen_port)
+            headers[ALT_SVC] = update_alt_svc_header(headers[ALT_SVC], listen_port)

--- a/mitmproxy/addons/update_alt_svc.py
+++ b/mitmproxy/addons/update_alt_svc.py
@@ -5,7 +5,7 @@ from mitmproxy.http import HTTPFlow
 from mitmproxy.proxy import mode_specs
 
 ALT_SVC = "alt-svc"
-HOST_PATTERN = r'([a-zA-Z0-9.-]*:\d{1,5})'
+HOST_PATTERN = r"([a-zA-Z0-9.-]*:\d{1,5})"
 
 
 def update_alt_svc_header(header: str, port: int) -> str:

--- a/mitmproxy/addons/update_alt_svc.py
+++ b/mitmproxy/addons/update_alt_svc.py
@@ -11,7 +11,7 @@ HOST_PATTERN = r"([a-zA-Z0-9.-]*:\d{1,5})"
 def update_alt_svc_header(header: str, port: int) -> str:
     return re.sub(HOST_PATTERN, f":{port}", header)
 
-
+import logging
 class UpdateAltSvc:
     def load(self, loader):
         loader.add_option(
@@ -27,7 +27,7 @@ class UpdateAltSvc:
         if not ctx.options.keep_alt_svc_header and isinstance(
             flow.client_conn.proxy_mode, mode_specs.ReverseMode
         ):
-            (_, listen_port) = flow.client_conn.sockname
+            _, listen_port, *_  = flow.client_conn.sockname
             headers = flow.response.headers
             if ALT_SVC in headers:
                 headers[ALT_SVC] = update_alt_svc_header(headers[ALT_SVC], listen_port)

--- a/test/mitmproxy/addons/test_update_alt_svc.py
+++ b/test/mitmproxy/addons/test_update_alt_svc.py
@@ -1,8 +1,8 @@
+from mitmproxy import http
 from mitmproxy.addons import update_alt_svc
+from mitmproxy.proxy.mode_specs import ProxyMode
 from mitmproxy.test import taddons
 from mitmproxy.test import tflow
-from mitmproxy import http
-from mitmproxy.proxy.mode_specs import ProxyMode
 
 
 def test_simple():
@@ -14,22 +14,31 @@ def test_simple():
 def test_updates_alt_svc_header():
     upd = update_alt_svc.UpdateAltSvc()
     with taddons.context(upd) as ctx:
-        headers = http.Headers(host="example.com", content_type="application/xml", alt_svc='h3="example.com:443"; ma=3600, h2=":443"; ma=3600')
+        headers = http.Headers(
+            host="example.com",
+            content_type="application/xml",
+            alt_svc='h3="example.com:443"; ma=3600, h2=":443"; ma=3600',
+        )
         resp = tflow.tresp(headers=headers)
         f = tflow.tflow(resp=resp)
         f.client_conn.sockname = ("", 1234)
 
         ctx.options.keep_alt_svc_header = True
         upd.responseheaders(f)
-        assert f.response.headers["alt-svc"] == 'h3="example.com:443"; ma=3600, h2=":443"; ma=3600'
+        assert (
+            f.response.headers["alt-svc"]
+            == 'h3="example.com:443"; ma=3600, h2=":443"; ma=3600'
+        )
 
         f.client_conn.proxy_mode = ProxyMode.parse("reverse:https://example.com")
         upd.responseheaders(f)
-        assert f.response.headers["alt-svc"] == 'h3="example.com:443"; ma=3600, h2=":443"; ma=3600'
+        assert (
+            f.response.headers["alt-svc"]
+            == 'h3="example.com:443"; ma=3600, h2=":443"; ma=3600'
+        )
 
         ctx.options.keep_alt_svc_header = False
         upd.responseheaders(f)
-        assert f.response.headers["alt-svc"] == 'h3=":1234"; ma=3600, h2=":1234"; ma=3600'
-
-
-
+        assert (
+            f.response.headers["alt-svc"] == 'h3=":1234"; ma=3600, h2=":1234"; ma=3600'
+        )

--- a/test/mitmproxy/addons/test_update_alt_svc.py
+++ b/test/mitmproxy/addons/test_update_alt_svc.py
@@ -23,13 +23,13 @@ def test_updates_alt_svc_header():
         f = tflow.tflow(resp=resp)
         f.client_conn.sockname = ("", 1234)
 
-        ctx.options.keep_alt_svc_header = True
         upd.responseheaders(f)
         assert (
             f.response.headers["alt-svc"]
             == 'h3="example.com:443"; ma=3600, h2=":443"; ma=3600'
         )
 
+        ctx.options.keep_alt_svc_header = True
         f.client_conn.proxy_mode = ProxyMode.parse("reverse:https://example.com")
         upd.responseheaders(f)
         assert (

--- a/test/mitmproxy/addons/test_update_alt_svc.py
+++ b/test/mitmproxy/addons/test_update_alt_svc.py
@@ -1,0 +1,35 @@
+from mitmproxy.addons import update_alt_svc
+from mitmproxy.test import taddons
+from mitmproxy.test import tflow
+from mitmproxy import http
+from mitmproxy.proxy.mode_specs import ProxyMode
+
+
+def test_simple():
+    header = 'h3="example.com:443"; ma=3600, h2=":443"; ma=3600'
+    modified = update_alt_svc.update_alt_svc_header(header, 1234)
+    assert modified == 'h3=":1234"; ma=3600, h2=":1234"; ma=3600'
+
+
+def test_updates_alt_svc_header():
+    upd = update_alt_svc.UpdateAltSvc()
+    with taddons.context(upd) as ctx:
+        headers = http.Headers(host="example.com", content_type="application/xml", alt_svc='h3="example.com:443"; ma=3600, h2=":443"; ma=3600')
+        resp = tflow.tresp(headers=headers)
+        f = tflow.tflow(resp=resp)
+        f.client_conn.sockname = ("", 1234)
+
+        ctx.options.keep_alt_svc_header = True
+        upd.responseheaders(f)
+        assert f.response.headers["alt-svc"] == 'h3="example.com:443"; ma=3600, h2=":443"; ma=3600'
+
+        f.client_conn.proxy_mode = ProxyMode.parse("reverse:https://example.com")
+        upd.responseheaders(f)
+        assert f.response.headers["alt-svc"] == 'h3="example.com:443"; ma=3600, h2=":443"; ma=3600'
+
+        ctx.options.keep_alt_svc_header = False
+        upd.responseheaders(f)
+        assert f.response.headers["alt-svc"] == 'h3=":1234"; ma=3600, h2=":1234"; ma=3600'
+
+
+

--- a/web/src/js/ducks/_options_gen.ts
+++ b/web/src/js/ducks/_options_gen.ts
@@ -83,6 +83,7 @@ export interface OptionsState {
     tls_version_server_max: string;
     tls_version_server_min: string;
     udp_hosts: string[];
+    update_alt_svc: boolean;
     upstream_auth: string | undefined;
     upstream_cert: boolean;
     validate_inbound_headers: boolean;
@@ -184,6 +185,7 @@ export const defaultState: OptionsState = {
     tls_version_server_max: "UNBOUNDED",
     tls_version_server_min: "TLS1_2",
     udp_hosts: [],
+    update_alt_svc: true,
     upstream_auth: undefined,
     upstream_cert: true,
     validate_inbound_headers: true,

--- a/web/src/js/ducks/_options_gen.ts
+++ b/web/src/js/ducks/_options_gen.ts
@@ -33,6 +33,7 @@ export interface OptionsState {
     ignore_hosts: string[];
     intercept: string | undefined;
     intercept_active: boolean;
+    keep_alt_svc_header: boolean;
     keep_host_header: boolean;
     key_size: number;
     listen_host: string;
@@ -83,7 +84,6 @@ export interface OptionsState {
     tls_version_server_max: string;
     tls_version_server_min: string;
     udp_hosts: string[];
-    update_alt_svc: boolean;
     upstream_auth: string | undefined;
     upstream_cert: boolean;
     validate_inbound_headers: boolean;
@@ -135,6 +135,7 @@ export const defaultState: OptionsState = {
     ignore_hosts: [],
     intercept: undefined,
     intercept_active: false,
+    keep_alt_svc_header: false,
     keep_host_header: false,
     key_size: 2048,
     listen_host: "",
@@ -185,7 +186,6 @@ export const defaultState: OptionsState = {
     tls_version_server_max: "UNBOUNDED",
     tls_version_server_min: "TLS1_2",
     udp_hosts: [],
-    update_alt_svc: true,
     upstream_auth: undefined,
     upstream_cert: true,
     validate_inbound_headers: true,


### PR DESCRIPTION
#### Description

Alt-Svc headers in HTTP responses advertise the host to use while migrating from HTTP1/2 to HTTP3 (amongst other information). This addon modifies the hosts specified in this header to our reverse proxy target.
refs #7025 

#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.