### PR TITLE
hide local mode on linux in mitmweb

### DIFF
--- a/mitmproxy/tools/web/app.py
+++ b/mitmproxy/tools/web/app.py
@@ -6,6 +6,7 @@ import json
 import logging
 import os.path
 import re
+import sys
 from collections.abc import Callable
 from collections.abc import Sequence
 from io import BytesIO
@@ -646,6 +647,7 @@ class State(RequestHandler):
             "servers": {
                 s.mode.full_spec: s.to_json() for s in master.proxyserver.servers
             },
+            "platform": sys.platform,
         }
 
     def get(self):

--- a/web/gen/state_js.py
+++ b/web/gen/state_js.py
@@ -45,6 +45,7 @@ async def make() -> str:
     data.update(available=True)
     data["contentViews"] = ["Auto", "Raw"]
     data["version"] = "1.2.3"
+    data["platform"] = "win32"
 
     # language=TypeScript
     content = (

--- a/web/src/js/__tests__/ducks/_tbackendstate.ts
+++ b/web/src/js/__tests__/ducks/_tbackendstate.ts
@@ -7,6 +7,7 @@ export function TBackendState(): Required<BackendState> {
             "Auto",
             "Raw"
         ],
+        "platform": "win32",
         "servers": {
             "regular": {
                 "description": "HTTP(S) proxy",

--- a/web/src/js/components/Modes.tsx
+++ b/web/src/js/components/Modes.tsx
@@ -3,8 +3,10 @@ import Local from "./Modes/Local";
 import Regular from "./Modes/Regular";
 import Wireguard from "./Modes/Wireguard";
 import Reverse from "./Modes/Reverse";
+import { useAppSelector } from "../ducks";
 
 export default function Modes() {
+    const platform = useAppSelector((state) => state.backendState.platform);
     return (
         <div className="modes">
             <h2>Intercept Traffic</h2>
@@ -13,7 +15,7 @@ export default function Modes() {
             <h3>Recommended</h3>
             <div className="modes-container">
                 <Regular />
-                {!navigator.userAgent.includes("linux") ? <Local /> : undefined}
+                {!platform.startsWith("linux") ? <Local /> : undefined}
                 <Wireguard />
                 <Reverse />
                 <i>Remaining modes are coming soon...</i>

--- a/web/src/js/components/Modes.tsx
+++ b/web/src/js/components/Modes.tsx
@@ -13,7 +13,7 @@ export default function Modes() {
             <h3>Recommended</h3>
             <div className="modes-container">
                 <Regular />
-                <Local />
+                {!navigator.userAgent.includes("linux") ? <Local /> : undefined}
                 <Wireguard />
                 <Reverse />
                 <i>Remaining modes are coming soon...</i>

--- a/web/src/js/ducks/backendState.ts
+++ b/web/src/js/ducks/backendState.ts
@@ -23,6 +23,7 @@ export interface BackendState {
     version: string;
     contentViews: string[];
     servers: { [key: string]: ServerInfo };
+    platform: string
 }
 
 export const defaultState: BackendState = {
@@ -30,6 +31,7 @@ export const defaultState: BackendState = {
     version: "",
     contentViews: [],
     servers: {},
+    platform: ""
 };
 
 export function mockUpdate(newState: Partial<BackendState>) {

--- a/web/src/js/ducks/backendState.ts
+++ b/web/src/js/ducks/backendState.ts
@@ -23,7 +23,7 @@ export interface BackendState {
     version: string;
     contentViews: string[];
     servers: { [key: string]: ServerInfo };
-    platform: string
+    platform: string;
 }
 
 export const defaultState: BackendState = {
@@ -31,7 +31,7 @@ export const defaultState: BackendState = {
     version: "",
     contentViews: [],
     servers: {},
-    platform: ""
+    platform: "",
 };
 
 export function mockUpdate(newState: Partial<BackendState>) {


### PR DESCRIPTION
#### Description

In this PR, we hide the local mode when mitmweb is running on Linux. I chose to hide the mode entirely rather than grey it out, as the message "Remaining modes are coming soon" is already present.

#### Checklist

 - [ ] I have updated tests where applicable.
 - [ ] I have added an entry to the CHANGELOG.
