### PR TITLE
Miscellaneous QUIC Improvements

### DIFF
--- a/mitmproxy/proxy/layers/http/_http3.py
+++ b/mitmproxy/proxy/layers/http/_http3.py
@@ -39,7 +39,7 @@ from mitmproxy.proxy import layer
 from mitmproxy.proxy.layers.quic import error_code_to_str
 from mitmproxy.proxy.layers.quic import QuicConnectionClosed
 from mitmproxy.proxy.layers.quic import QuicStreamEvent
-from mitmproxy.proxy.layers.quic import StopQuicStream
+from mitmproxy.proxy.layers.quic import StopSendingQuicStream
 from mitmproxy.proxy.utils import expect
 
 
@@ -125,7 +125,7 @@ class Http3Connection(HttpConnection):
             if event.stream_id in self._stream_protocol_errors:
                 # we already reset or ended the stream, tell the peer to stop
                 # (this is a noop if the peer already did the same)
-                yield StopQuicStream(
+                yield StopSendingQuicStream(
                     self.conn,
                     event.stream_id,
                     self._stream_protocol_errors[event.stream_id],

--- a/mitmproxy/proxy/layers/quic.py
+++ b/mitmproxy/proxy/layers/quic.py
@@ -136,7 +136,7 @@ class QuicStreamDataReceived(QuicStreamEvent):
     """Whether the STREAM frame had the FIN bit set."""
 
     def __repr__(self):
-        target = type(self.connection).__name__.lower()
+        target = repr(self.connection).partition("(")[0].lower()
         end_stream = "[end_stream] " if self.end_stream else ""
         return f"QuicStreamDataReceived({target} on {self.stream_id}, {end_stream}{self.data!r})"
 
@@ -180,7 +180,7 @@ class SendQuicStreamData(QuicStreamCommand):
         self.end_stream = end_stream
 
     def __repr__(self):
-        target = type(self.connection).__name__.lower()
+        target = repr(self.connection).partition("(")[0].lower()
         end_stream = "[end_stream] " if self.end_stream else ""
         return f"SendQuicStreamData({target} on {self.stream_id}, {end_stream}{self.data!r})"
 

--- a/mitmproxy/proxy/layers/quic.py
+++ b/mitmproxy/proxy/layers/quic.py
@@ -198,7 +198,7 @@ class ResetQuicStream(QuicStreamCommand):
         self.error_code = error_code
 
 
-class StopQuicStream(QuicStreamCommand):
+class StopSendingQuicStream(QuicStreamCommand):
     """Request termination of the receiving part of a stream."""
 
     error_code: int
@@ -769,7 +769,7 @@ class RawQuicLayer(layer.Layer):
                         if stream_is_client_initiated(
                             stream_id
                         ) == to_client or not stream_is_unidirectional(stream_id):
-                            yield StopQuicStream(
+                            yield StopSendingQuicStream(
                                 quic_conn, stream_id, QuicErrorCode.NO_ERROR
                             )
                         yield from self.close_stream_layer(child_layer, to_client)
@@ -866,7 +866,7 @@ class QuicLayer(tunnel.TunnelLayer):
                 )
             elif isinstance(command, ResetQuicStream):
                 self.quic.reset_stream(command.stream_id, command.error_code)
-            elif isinstance(command, StopQuicStream):
+            elif isinstance(command, StopSendingQuicStream):
                 # the stream might have already been closed, check before stopping
                 if command.stream_id in self.quic._streams:
                     self.quic.stop_stream(command.stream_id, command.error_code)

--- a/test/mitmproxy/proxy/layers/http/test_http3.py
+++ b/test/mitmproxy/proxy/layers/http/test_http3.py
@@ -1013,7 +1013,9 @@ class TestClient:
             )
             << frame_factory.send_reset(ErrorCode.H3_REQUEST_CANCELLED)
             >> frame_factory.receive_data(b"foo")
-            << quic.StopQuicStream(tctx.server, 0, ErrorCode.H3_REQUEST_CANCELLED)
+            << quic.StopSendingQuicStream(
+                tctx.server, 0, ErrorCode.H3_REQUEST_CANCELLED
+            )
         )  # important: no ResponseData event here!
 
         assert frame_factory.is_done

--- a/test/mitmproxy/proxy/layers/http/test_http3.py
+++ b/test/mitmproxy/proxy/layers/http/test_http3.py
@@ -1,4 +1,3 @@
-import collections.abc
 from collections.abc import Callable
 from collections.abc import Iterable
 
@@ -74,26 +73,6 @@ class DelayedPlaceholder(tutils._Placeholder[bytes]):
         if self._obj is None:
             self._obj = self._resolve()
         return super().__call__()
-
-
-class MultiPlaybook(tutils.Playbook):
-    """Playbook that allows multiple events and commands to be registered at once."""
-
-    def __lshift__(self, c):
-        if isinstance(c, collections.abc.Iterable):
-            for c_i in c:
-                super().__lshift__(c_i)
-        else:
-            super().__lshift__(c)
-        return self
-
-    def __rshift__(self, e):
-        if isinstance(e, collections.abc.Iterable):
-            for e_i in e:
-                super().__rshift__(e_i)
-        else:
-            super().__rshift__(e)
-        return self
 
 
 class FrameFactory:
@@ -367,7 +346,7 @@ def start_h3_client(tctx: context.Context) -> tuple[tutils.Playbook, FrameFactor
     tctx.client.transport_protocol = "udp"
     tctx.server.transport_protocol = "udp"
 
-    playbook = MultiPlaybook(layers.HttpLayer(tctx, layers.http.HTTPMode.regular))
+    playbook = tutils.Playbook(layers.HttpLayer(tctx, layers.http.HTTPMode.regular))
     cff = FrameFactory(conn=tctx.client, is_client=True)
     assert (
         playbook
@@ -388,7 +367,7 @@ def test_ignore_push(tctx: context.Context):
 
 
 def test_fail_without_header(tctx: context.Context):
-    playbook = MultiPlaybook(layers.http.Http3Server(tctx))
+    playbook = tutils.Playbook(layers.http.Http3Server(tctx))
     cff = FrameFactory(tctx.client, is_client=True)
     assert (
         playbook
@@ -1005,7 +984,7 @@ def test_kill_stream(tctx: context.Context):
 class TestClient:
     def test_no_data_on_closed_stream(self, tctx: context.Context):
         frame_factory = FrameFactory(tctx.server, is_client=False)
-        playbook = MultiPlaybook(Http3Client(tctx))
+        playbook = tutils.Playbook(Http3Client(tctx))
         req = Request.make("GET", "http://example.com/")
         resp = [(b":status", b"200")]
         assert (
@@ -1041,7 +1020,7 @@ class TestClient:
 
     def test_ignore_wrong_order(self, tctx: context.Context):
         frame_factory = FrameFactory(tctx.server, is_client=False)
-        playbook = MultiPlaybook(Http3Client(tctx))
+        playbook = tutils.Playbook(Http3Client(tctx))
         req = Request.make("GET", "http://example.com/")
         assert (
             playbook

--- a/test/mitmproxy/proxy/layers/http/test_http3.py
+++ b/test/mitmproxy/proxy/layers/http/test_http3.py
@@ -341,7 +341,7 @@ def open_h3_server_conn():
     return server
 
 
-def start_h3_client(tctx: context.Context) -> tuple[tutils.Playbook, FrameFactory]:
+def start_h3_proxy(tctx: context.Context) -> tuple[tutils.Playbook, FrameFactory]:
     tctx.client.alpn = b"h3"
     tctx.client.transport_protocol = "udp"
     tctx.server.transport_protocol = "udp"
@@ -363,7 +363,7 @@ def make_h3(open_connection: commands.OpenConnection) -> None:
 
 
 def test_ignore_push(tctx: context.Context):
-    playbook, cff = start_h3_client(tctx)
+    playbook, cff = start_h3_proxy(tctx)
 
 
 def test_fail_without_header(tctx: context.Context):
@@ -382,7 +382,7 @@ def test_fail_without_header(tctx: context.Context):
 
 
 def test_invalid_header(tctx: context.Context):
-    playbook, cff = start_h3_client(tctx)
+    playbook, cff = start_h3_proxy(tctx)
     assert (
         playbook
         >> cff.receive_headers(
@@ -413,7 +413,7 @@ def test_invalid_header(tctx: context.Context):
 
 
 def test_simple(tctx: context.Context):
-    playbook, cff = start_h3_client(tctx)
+    playbook, cff = start_h3_proxy(tctx)
     flow = tutils.Placeholder(HTTPFlow)
     server = tutils.Placeholder(connection.Server)
     sff = FrameFactory(server, is_client=False)
@@ -460,7 +460,7 @@ def test_response_trailers(
     open_h3_server_conn: connection.Server,
     stream: str,
 ):
-    playbook, cff = start_h3_client(tctx)
+    playbook, cff = start_h3_proxy(tctx)
     tctx.server = open_h3_server_conn
     sff = FrameFactory(tctx.server, is_client=False)
 
@@ -534,7 +534,7 @@ def test_request_trailers(
     open_h3_server_conn: connection.Server,
     stream: str,
 ):
-    playbook, cff = start_h3_client(tctx)
+    playbook, cff = start_h3_proxy(tctx)
     tctx.server = open_h3_server_conn
     sff = FrameFactory(tctx.server, is_client=False)
 
@@ -590,7 +590,7 @@ def test_request_trailers(
 
 
 def test_upstream_error(tctx: context.Context):
-    playbook, cff = start_h3_client(tctx)
+    playbook, cff = start_h3_proxy(tctx)
     flow = tutils.Placeholder(HTTPFlow)
     server = tutils.Placeholder(connection.Server)
     err = tutils.Placeholder(bytes)
@@ -641,7 +641,7 @@ def test_http3_client_aborts(tctx: context.Context, stream: str, when: str, how:
     """
     server = tutils.Placeholder(connection.Server)
     flow = tutils.Placeholder(HTTPFlow)
-    playbook, cff = start_h3_client(tctx)
+    playbook, cff = start_h3_proxy(tctx)
 
     def enable_request_streaming(flow: HTTPFlow):
         flow.request.stream = True
@@ -762,7 +762,7 @@ def test_rst_then_close(tctx):
 
     This is slightly different to H2, as QUIC will close the connection immediately.
     """
-    playbook, cff = start_h3_client(tctx)
+    playbook, cff = start_h3_proxy(tctx)
     flow = tutils.Placeholder(HTTPFlow)
     server = tutils.Placeholder(connection.Server)
     err = tutils.Placeholder(str)
@@ -806,7 +806,7 @@ def test_cancel_then_server_disconnect(tctx: context.Context):
         - server disconnects
         - error hook completes.
     """
-    playbook, cff = start_h3_client(tctx)
+    playbook, cff = start_h3_proxy(tctx)
     flow = tutils.Placeholder(HTTPFlow)
     server = tutils.Placeholder(connection.Server)
     assert (
@@ -843,7 +843,7 @@ def test_cancel_during_response_hook(tctx: context.Context):
 
     Given that we have already triggered the response hook, we don't want to trigger the error hook.
     """
-    playbook, cff = start_h3_client(tctx)
+    playbook, cff = start_h3_proxy(tctx)
     flow = tutils.Placeholder(HTTPFlow)
     server = tutils.Placeholder(connection.Server)
     assert (
@@ -874,7 +874,7 @@ def test_cancel_during_response_hook(tctx: context.Context):
 
 def test_stream_concurrency(tctx: context.Context):
     """Test that we can send an intercepted request with a lower stream id than one that has already been sent."""
-    playbook, cff = start_h3_client(tctx)
+    playbook, cff = start_h3_proxy(tctx)
     flow1 = tutils.Placeholder(HTTPFlow)
     flow2 = tutils.Placeholder(HTTPFlow)
     server = tutils.Placeholder(connection.Server)
@@ -914,7 +914,7 @@ def test_stream_concurrency(tctx: context.Context):
 
 def test_stream_concurrent_get_connection(tctx: context.Context):
     """Test that an immediate second request for the same domain does not trigger a second connection attempt."""
-    playbook, cff = start_h3_client(tctx)
+    playbook, cff = start_h3_proxy(tctx)
     playbook.hooks = False
     server = tutils.Placeholder(connection.Server)
     sff = FrameFactory(server, is_client=False)
@@ -940,7 +940,7 @@ def test_stream_concurrent_get_connection(tctx: context.Context):
 
 def test_kill_stream(tctx: context.Context):
     """Test that we can kill individual streams."""
-    playbook, cff = start_h3_client(tctx)
+    playbook, cff = start_h3_proxy(tctx)
     flow1 = tutils.Placeholder(HTTPFlow)
     flow2 = tutils.Placeholder(HTTPFlow)
     server = tutils.Placeholder(connection.Server)
@@ -1064,7 +1064,7 @@ class TestClient:
 
 
 def test_early_server_data(tctx: context.Context):
-    playbook, cff = start_h3_client(tctx)
+    playbook, cff = start_h3_proxy(tctx)
     sff = FrameFactory(tctx.server, is_client=False)
 
     tctx.server.address = ("example.com", 80)

--- a/test/mitmproxy/proxy/layers/test_quic.py
+++ b/test/mitmproxy/proxy/layers/test_quic.py
@@ -66,7 +66,7 @@ class TlsEchoLayer(tutils.EchoLayer):
         ):
             yield quic.CloseQuicConnection(event.connection, 123, None, "error")
         elif isinstance(event, events.DataReceived) and event.data == b"stop-stream":
-            yield quic.StopQuicStream(event.connection, 24, 123)
+            yield quic.StopSendingQuicStream(event.connection, 24, 123)
         elif (
             isinstance(event, events.DataReceived) and event.data == b"invalid-command"
         ):
@@ -455,7 +455,7 @@ class TestRawQuicLayer:
             >> tutils.reply_next_layer(lambda ctx: udp.UDPLayer(ctx, ignore=True))
             << quic.SendQuicStreamData(tctx.server, 0, b"msg1", end_stream=False)
             << quic.SendQuicStreamData(tctx.server, 0, b"", end_stream=True)
-            << quic.StopQuicStream(tctx.server, 0, 0)
+            << quic.StopSendingQuicStream(tctx.server, 0, 0)
         )
 
     def test_open_connection(self, tctx: context.Context):

--- a/test/mitmproxy/proxy/tutils.py
+++ b/test/mitmproxy/proxy/tutils.py
@@ -159,6 +159,10 @@ class Playbook:
 
     def __rshift__(self, e):
         """Add an event to send"""
+        if isinstance(e, collections.abc.Iterable):
+            for ev in e:
+                self.__rshift__(ev)
+            return self
         assert isinstance(e, events.Event)
         self.expected.append(e)
         return self
@@ -166,6 +170,10 @@ class Playbook:
     def __lshift__(self, c):
         """Add an expected command"""
         if c is None:
+            return self
+        if isinstance(c, collections.abc.Iterable):
+            for cmd in c:
+                self.__lshift__(cmd)
             return self
         assert isinstance(c, commands.Command)
 


### PR DESCRIPTION
#### Description

This PR fixes a bunch of smaller QUIC and HTTP/3 things. Most notably, it removes all support for PUSH_PROMISE frames. mitmproxy will not advertise PUSH_PROMISE support going forward, matching our current HTTP/2 implementation. We haven't received a single complaint or feature request after removing HTTP/2 push promise support, so we shouldn't burden ourselves with a half-completed HTTP/3 variant.

The easiest way to remove this is probably to go commit-by-commit.