### PR TITLE
Optimize tnet parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ## Unreleased: mitmproxy next
 
 - Fix endless tnetstring parsing in case of very large tnetstring
+  ([#7121](https://github.com/mitmproxy/mitmproxy/pull/7121), @mik1904)
 - Tighten HTTP detection heuristic to better support custom TCP-based protocols.
   ([#7087](https://github.com/mitmproxy/mitmproxy/pull/7087))
 - Improve the error message when users specify the `certs` option without a matching private key.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ## Unreleased: mitmproxy next
 
+- Fix endless tnetstring parsing in case of very large tnetstring
 - Tighten HTTP detection heuristic to better support custom TCP-based protocols.
   ([#7087](https://github.com/mitmproxy/mitmproxy/pull/7087))
 - Improve the error message when users specify the `certs` option without a matching private key.

--- a/mitmproxy/io/tnetstring.py
+++ b/mitmproxy/io/tnetstring.py
@@ -229,7 +229,8 @@ def parse(data_type: int, data: memoryview) -> TSerializable:
 def split(data: memoryview, sep: bytes) -> tuple[int, memoryview]:
     i = 0
     try:
-        while data[i] != ord(sep):
+        ord_sep = ord(sep)
+        while data[i] != ord_sep:
             i += 1
         # here i is the position of b":" in the memoryview
         return int(data[:i]), data[i + 1 :]

--- a/mitmproxy/io/tnetstring.py
+++ b/mitmproxy/io/tnetstring.py
@@ -237,12 +237,14 @@ def split(data: memoryview, sep: bytes) -> tuple[int, memoryview]:
 
 
 
-def pop(data: memoryview) -> tuple[TSerializable, memoryview]:
+def pop(data: memoryview | bytes) -> tuple[TSerializable, memoryview]:
     """
     This function parses a tnetstring into a python object.
     It returns a tuple giving the parsed object and a string
     containing any unparsed data from the end of the string.
     """
+    if isinstance(data, bytes):
+        data = memoryview(data)
     #  Parse out data length, type and remaining string.
     length, data = split(data, b":")
     try:

--- a/mitmproxy/io/tnetstring.py
+++ b/mitmproxy/io/tnetstring.py
@@ -202,7 +202,7 @@ def parse(data_type: int, data: memoryview) -> TSerializable:
     if data_type == ord(b"!"):
         if data == b"true":
             return True
-        if data == b"false":
+        elif data == b"false":
             return False
         else:
             raise ValueError(f"not a tnetstring: invalid boolean literal: {data!r}")

--- a/mitmproxy/io/tnetstring.py
+++ b/mitmproxy/io/tnetstring.py
@@ -154,7 +154,7 @@ def loads(string: bytes) -> TSerializable:
     """
     This function parses a tnetstring into a python object.
     """
-    return pop(string)[0]
+    return pop(memoryview(string))[0]
 
 
 def load(file_handle: BinaryIO) -> TSerializable:
@@ -178,17 +178,17 @@ def load(file_handle: BinaryIO) -> TSerializable:
     if c != b":":
         raise ValueError("not a tnetstring: missing or invalid length prefix")
 
-    data = file_handle.read(int(data_length))
+    data = memoryview(file_handle.read(int(data_length)))
     data_type = file_handle.read(1)[0]
 
     return parse(data_type, data)
 
 
-def parse(data_type: int, data: bytes) -> TSerializable:
+def parse(data_type: int, data: memoryview) -> TSerializable:
     if data_type == ord(b","):
-        return data
+        return data.tobytes()
     if data_type == ord(b";"):
-        return data.decode("utf8")
+        return data.tobytes().decode("utf8")
     if data_type == ord(b"#"):
         try:
             return int(data)
@@ -202,7 +202,7 @@ def parse(data_type: int, data: bytes) -> TSerializable:
     if data_type == ord(b"!"):
         if data == b"true":
             return True
-        elif data == b"false":
+        if data == b"false":
             return False
         else:
             raise ValueError(f"not a tnetstring: invalid boolean literal: {data!r}")
@@ -225,21 +225,26 @@ def parse(data_type: int, data: bytes) -> TSerializable:
         return d
     raise ValueError(f"unknown type tag: {data_type}")
 
+def split(data: memoryview, sep: bytes) -> tuple[int, memoryview]:
+    i = 0
+    try:
+        while data[i] != ord(sep):
+            i += 1
+        # here i is the position of b":" in the memoryview
+        return int(data[:i]), data[i+1:]
+    except (IndexError, ValueError):
+        raise ValueError(f"not a tnetstring: missing or invalid length prefix: {data.tobytes()!r}")
 
-def pop(data: bytes) -> tuple[TSerializable, bytes]:
+
+
+def pop(data: memoryview) -> tuple[TSerializable, memoryview]:
     """
     This function parses a tnetstring into a python object.
     It returns a tuple giving the parsed object and a string
     containing any unparsed data from the end of the string.
     """
     #  Parse out data length, type and remaining string.
-    try:
-        blength, data = data.split(b":", 1)
-        length = int(blength)
-    except ValueError:
-        raise ValueError(
-            f"not a tnetstring: missing or invalid length prefix: {data!r}"
-        )
+    length, data = split(data, b":")
     try:
         data, data_type, remain = data[:length], data[length], data[length + 1 :]
     except IndexError:

--- a/mitmproxy/io/tnetstring.py
+++ b/mitmproxy/io/tnetstring.py
@@ -239,15 +239,13 @@ def split(data: memoryview, sep: bytes) -> tuple[int, memoryview]:
         )
 
 
-def pop(data: memoryview | bytes) -> tuple[TSerializable, memoryview]:
+def pop(data: memoryview) -> tuple[TSerializable, memoryview]:
     """
     This function parses a tnetstring into a python object.
     It returns a tuple giving the parsed object and a string
     containing any unparsed data from the end of the string.
     """
-    if isinstance(data, bytes):
-        data = memoryview(data)
-    #  Parse out data length, type and remaining string.
+    # Parse out data length, type and remaining string.
     length, data = split(data, b":")
     try:
         data, data_type, remain = data[:length], data[length], data[length + 1 :]

--- a/mitmproxy/io/tnetstring.py
+++ b/mitmproxy/io/tnetstring.py
@@ -188,7 +188,7 @@ def parse(data_type: int, data: memoryview) -> TSerializable:
     if data_type == ord(b","):
         return data.tobytes()
     if data_type == ord(b";"):
-        return data.tobytes().decode("utf8")
+        return str(data, "utf8")
     if data_type == ord(b"#"):
         try:
             return int(data)

--- a/mitmproxy/io/tnetstring.py
+++ b/mitmproxy/io/tnetstring.py
@@ -225,16 +225,18 @@ def parse(data_type: int, data: memoryview) -> TSerializable:
         return d
     raise ValueError(f"unknown type tag: {data_type}")
 
+
 def split(data: memoryview, sep: bytes) -> tuple[int, memoryview]:
     i = 0
     try:
         while data[i] != ord(sep):
             i += 1
         # here i is the position of b":" in the memoryview
-        return int(data[:i]), data[i+1:]
+        return int(data[:i]), data[i + 1 :]
     except (IndexError, ValueError):
-        raise ValueError(f"not a tnetstring: missing or invalid length prefix: {data.tobytes()!r}")
-
+        raise ValueError(
+            f"not a tnetstring: missing or invalid length prefix: {data.tobytes()!r}"
+        )
 
 
 def pop(data: memoryview | bytes) -> tuple[TSerializable, memoryview]:

--- a/test/mitmproxy/io/test_tnetstring.py
+++ b/test/mitmproxy/io/test_tnetstring.py
@@ -72,19 +72,19 @@ class Test_Format(unittest.TestCase):
         for data, expect in FORMAT_EXAMPLES.items():
             self.assertEqual(expect, tnetstring.loads(data))
             self.assertEqual(expect, tnetstring.loads(tnetstring.dumps(expect)))
-            self.assertEqual((expect, b""), tnetstring.pop(data))
+            self.assertEqual((expect, b""), tnetstring.pop(memoryview(data)))
 
     def test_roundtrip_format_random(self):
         for _ in range(10):
             v = get_random_object()
             self.assertEqual(v, tnetstring.loads(tnetstring.dumps(v)))
-            self.assertEqual((v, b""), tnetstring.pop(tnetstring.dumps(v)))
+            self.assertEqual((v, b""), tnetstring.pop(memoryview(tnetstring.dumps(v))))
 
     def test_roundtrip_format_unicode(self):
         for _ in range(10):
             v = get_random_object()
             self.assertEqual(v, tnetstring.loads(tnetstring.dumps(v)))
-            self.assertEqual((v, b""), tnetstring.pop(tnetstring.dumps(v)))
+            self.assertEqual((v, b""), tnetstring.pop(memoryview(tnetstring.dumps(v))))
 
     def test_roundtrip_big_integer(self):
         # Recent Python versions do not like ints above 4300 digits, https://github.com/python/cpython/issues/95778


### PR DESCRIPTION
#### Description

Fix #7120

**Note to reviewers:** I had to add commit 5a67118a37e811c3fe8c402f835547aef1a381a3 to accomodate the existing pytest. The reason is that in `test/mitmproxy/io/test_tnetstring.py` the function `tnetstring.pop` is called directly and bytes are passed as `data` argument. However, as far as I can tell, `pop` is never called directly in mitmproxy main code but only indirectly through the `tnetstring.parse` and `tnetstring.loads` functions. I let you decided whether it is better to modify calls to `pop` in `test_tnetstring.py` and discard commit 5a67118a37e811c3fe8c402f835547aef1a381a3 or keep it as it is.

#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
