### PR TITLE
Improve design capture page

### DIFF
--- a/web/src/css/mode.less
+++ b/web/src/css/mode.less
@@ -10,8 +10,28 @@
     width: 100vw;
 
     h3 {
-        margin-top: 30px;
         margin-bottom: 10px;
+    }
+
+    .modes-parent {
+        display: flex;
+        flex-direction: row;
+        gap: 10px;
+    }
+
+    .green-bar {
+        background-color: #77c77a;
+        width: 10px;
+    }
+
+    .gray-bar {
+        background-color: #b2b2b2;
+        width: 10px;
+    }
+
+    .modes-type {
+        display: flex;
+        flex-direction: column;
     }
 
     .modes-container {

--- a/web/src/css/mode.less
+++ b/web/src/css/mode.less
@@ -16,15 +16,14 @@
     .modes-category {
         padding-left: 10px;
     }
-    
+
     .green-left-border {
         border-left: 10px solid #77c77a;
     }
-    
+
     .gray-left-border {
         border-left: 10px solid #b2b2b2;
     }
-    
 
     .modes-container {
         display: flex;

--- a/web/src/css/mode.less
+++ b/web/src/css/mode.less
@@ -13,26 +13,18 @@
         margin-bottom: 10px;
     }
 
-    .modes-parent {
-        display: flex;
-        flex-direction: row;
-        gap: 10px;
+    .modes-category {
+        padding-left: 10px;
     }
-
-    .green-bar {
-        background-color: #77c77a;
-        width: 10px;
+    
+    .green-left-border {
+        border-left: 10px solid #77c77a;
     }
-
-    .gray-bar {
-        background-color: #b2b2b2;
-        width: 10px;
+    
+    .gray-left-border {
+        border-left: 10px solid #b2b2b2;
     }
-
-    .modes-type {
-        display: flex;
-        flex-direction: column;
-    }
+    
 
     .modes-container {
         display: flex;

--- a/web/src/js/components/Modes.tsx
+++ b/web/src/js/components/Modes.tsx
@@ -16,30 +16,24 @@ export default function Modes() {
             <h2>Intercept Traffic</h2>
             <p>Configure how you want to intercept traffic with mitmproxy.</p>
 
-            <div className="modes-parent">
-                <div className="green-bar" />
-                <div className="modes-type">
-                    <h3>Recommended</h3>
-                    <div className="modes-container">
-                        <Regular />
-                        {!platform.startsWith("linux") ? <Local /> : undefined}
-                        <Wireguard />
-                        <Reverse />
-                    </div>
+            <div className="modes-category green-left-border">
+                <h3>Recommended</h3>
+                <div className="modes-container">
+                    <Regular />
+                    {!platform.startsWith("linux") ? <Local /> : undefined}
+                    <Wireguard />
+                    <Reverse />
                 </div>
             </div>
-            <div className="modes-parent" style={{ marginTop: "20px" }}>
-                <div className="gray-bar" />
-                <div className="modes-type">
-                    <h3>Advanced</h3>
-                    <div className="modes-container">
-                        <Socks />
-                        <Upstream />
-                        <Dns />
-                        {!platform.startsWith("win32") ? (
-                            <Transparent />
-                        ) : undefined}
-                    </div>
+            <div className="modes-category gray-left-border">
+                <h3>Advanced</h3>
+                <div className="modes-container">
+                    <Socks />
+                    <Upstream />
+                    <Dns />
+                    {!platform.startsWith("win32") ? (
+                        <Transparent />
+                    ) : undefined}
                 </div>
             </div>
         </div>

--- a/web/src/js/components/Modes.tsx
+++ b/web/src/js/components/Modes.tsx
@@ -16,19 +16,31 @@ export default function Modes() {
             <h2>Intercept Traffic</h2>
             <p>Configure how you want to intercept traffic with mitmproxy.</p>
 
-            <h3>Recommended</h3>
-            <div className="modes-container">
-                <Regular />
-                {!platform.startsWith("linux") ? <Local /> : undefined}
-                <Wireguard />
-                <Reverse />
+            <div className="modes-parent">
+                <div className="green-bar" />
+                <div className="modes-type">
+                    <h3>Recommended</h3>
+                    <div className="modes-container">
+                        <Regular />
+                        {!platform.startsWith("linux") ? <Local /> : undefined}
+                        <Wireguard />
+                        <Reverse />
+                    </div>
+                </div>
             </div>
-            <h3>Advanced</h3>
-            <div className="modes-container">
-                <Socks />
-                <Upstream />
-                <Dns />
-                {!platform.startsWith("win32") ? <Transparent /> : undefined}
+            <div className="modes-parent" style={{ marginTop: "20px" }}>
+                <div className="gray-bar" />
+                <div className="modes-type">
+                    <h3>Advanced</h3>
+                    <div className="modes-container">
+                        <Socks />
+                        <Upstream />
+                        <Dns />
+                        {!platform.startsWith("win32") ? (
+                            <Transparent />
+                        ) : undefined}
+                    </div>
+                </div>
             </div>
         </div>
     );


### PR DESCRIPTION
#### Description

In this PR, I've improve the design of the capture page by highlighting the recommended modes. Ref: #7063 

<img width="1512" alt="Screenshot 2024-09-04 at 14 35 53" src="https://github.com/user-attachments/assets/4bd39392-1e2b-4d36-8b98-de00542fab96">
<img width="1512" alt="Screenshot 2024-09-04 at 14 36 11" src="https://github.com/user-attachments/assets/6d6b60d0-251d-4dfb-832c-b5eb4c7bdae4">


#### Checklist

 - [x] I have updated tests where applicable.
 - [ ] I have added an entry to the CHANGELOG.
