### PR TITLE
add popover to reverse mode

### DIFF
--- a/web/src/js/components/Modes/Reverse.tsx
+++ b/web/src/js/components/Modes/Reverse.tsx
@@ -16,6 +16,7 @@ import Dropdown, { MenuItem } from "../common/Dropdown";
 import ValueEditor from "../editors/ValueEditor";
 import { ServerStatus } from "./CaptureSetup";
 import { ModeToggle } from "./ModeToggle";
+import { Popover } from "./Popover";
 
 interface ReverseToggleRowProps {
     removable: boolean;
@@ -106,29 +107,7 @@ function ReverseToggleRow({
                         </MenuItem>
                     ))}
                 </Dropdown>{" "}
-                traffic from{" "}
-                <ValueEditor
-                    className="mode-reverse-input"
-                    content={server.listen_host || ""}
-                    onEditDone={(value) =>
-                        dispatch(setListenHost({ server, value }))
-                    }
-                    placeholder="*"
-                />
-                <ValueEditor
-                    className="mode-reverse-input"
-                    content={String(server.listen_port || "")}
-                    onEditDone={(value) =>
-                        dispatch(
-                            setListenPort({
-                                server,
-                                value: value as unknown as number,
-                            }),
-                        )
-                    }
-                    placeholder="8080"
-                />{" "}
-                to{" "}
+                traffic to
                 <ValueEditor
                     className="mode-reverse-input"
                     content={server.destination?.toString() || ""}
@@ -137,6 +116,31 @@ function ReverseToggleRow({
                     }
                     placeholder="example.com"
                 />
+                <Popover>
+                    <p>Listen Host</p>
+                    <ValueEditor
+                        className="mode-reverse-input"
+                        content={server.listen_host || ""}
+                        onEditDone={(value) =>
+                            dispatch(setListenHost({ server, value }))
+                        }
+                        placeholder="*"
+                    />
+                    <p>Listen Port</p>
+                    <ValueEditor
+                        className="mode-reverse-input"
+                        content={String(server.listen_port || "")}
+                        onEditDone={(value) =>
+                            dispatch(
+                                setListenPort({
+                                    server,
+                                    value: value as unknown as number,
+                                }),
+                            )
+                        }
+                        placeholder="8080"
+                    />
+                </Popover>
                 {removable && (
                     <i
                         className="fa fa-fw fa-trash fa-lg"


### PR DESCRIPTION
#### Description

In this PR, I'm adding a popover to the reverse mode. So now the `listen_host` and the `listen_port` are set in the popover. Ref: #7063 

<img width="1512" alt="Screenshot 2024-09-04 at 14 55 04" src="https://github.com/user-attachments/assets/bad70e70-6538-4963-915b-b4ac83693e05">

#### Checklist

 - [ ] I have updated tests where applicable.
 - [ ] I have added an entry to the CHANGELOG.
