### PR TITLE
improve UX reverse dropdown

### DIFF
--- a/web/src/css/mode.less
+++ b/web/src/css/mode.less
@@ -103,6 +103,9 @@
 
     .mode-reverse-dropdown {
         margin: 0 5px;
+        border: 1px solid #ccc;
+        border-radius: 4px;
+        height: 25px;
     }
 
     .mode-reverse-servers {

--- a/web/src/js/components/Modes/Reverse.tsx
+++ b/web/src/js/components/Modes/Reverse.tsx
@@ -93,8 +93,8 @@ function ReverseToggleRow({
                                 server,
                                 value: e.target.value as ReverseProxyProtocols,
                             }),
-                        )}
-                    }
+                        );
+                    }}
                 >
                     {protocols.map((prot) => (
                         <option key={prot} value={prot}>

--- a/web/src/js/components/Modes/Reverse.tsx
+++ b/web/src/js/components/Modes/Reverse.tsx
@@ -12,7 +12,6 @@ import {
 import { getSpec, ReverseState } from "../../modes/reverse";
 import { ReverseProxyProtocols } from "../../backends/consts";
 import { ServerInfo } from "../../ducks/backendState";
-import Dropdown, { MenuItem } from "../common/Dropdown";
 import ValueEditor from "../editors/ValueEditor";
 import { ServerStatus } from "./CaptureSetup";
 import { ModeToggle } from "./ModeToggle";
@@ -66,13 +65,6 @@ function ReverseToggleRow({
 
     const protocols = Object.values(ReverseProxyProtocols);
 
-    const inner = (
-        <span>
-            &nbsp;<b>{server.protocol} </b>
-            <span className="caret" />
-        </span>
-    );
-
     const deleteServer = async () => {
         if (server.active) {
             await dispatch(setActive({ server, value: false })).unwrap();
@@ -91,22 +83,25 @@ function ReverseToggleRow({
                     dispatch(setActive({ server, value: !server.active }));
                 }}
             >
-                <Dropdown
-                    text={inner}
-                    className="btn btn-default btn-xs mode-reverse-dropdown"
-                    options={{ placement: "bottom" }}
+                <select
+                    name="protocols"
+                    className="mode-reverse-dropdown"
+                    value={server.protocol}
+                    onChange={(e) => {
+                        dispatch(
+                            setProtocol({
+                                server,
+                                value: e.target.value as ReverseProxyProtocols,
+                            }),
+                        )}
+                    }
                 >
                     {protocols.map((prot) => (
-                        <MenuItem
-                            key={prot}
-                            onClick={() =>
-                                dispatch(setProtocol({ server, value: prot }))
-                            }
-                        >
+                        <option key={prot} value={prot}>
                             {prot}
-                        </MenuItem>
+                        </option>
                     ))}
-                </Dropdown>
+                </select>
                 traffic to
                 <ValueEditor
                     className="mode-reverse-input"


### PR DESCRIPTION
#### Description

In this PR, I've improved the UX of the dropdown when selecting the protocols for the reverse mode. Ref: #7063 

<img width="1512" alt="Screenshot 2024-09-05 at 07 42 04" src="https://github.com/user-attachments/assets/5e6651f9-338f-4f28-92ea-4e362067c63e">
<img width="1512" alt="Screenshot 2024-09-05 at 07 42 12" src="https://github.com/user-attachments/assets/1833c197-fd4a-4eba-b18b-3bf299917a94">


#### Checklist

 - [x] I have updated tests where applicable.
 - [ ] I have added an entry to the CHANGELOG.
