### PR TITLE
options: add request_client_cert to enable mutual TLS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@
   ([#7130](https://github.com/mitmproxy/mitmproxy/pull/7130), @catap)
 - Fix of measurement unit in HAR import, duration is in milliseconds
   ([#7179](https://github.com/mitmproxy/mitmproxy/pull/7179), @dstd)
+- Add support for full mTLS with client certs between client and mitmproxy.
+  ([#7175](https://github.com/mitmproxy/mitmproxy/pull/7175), @Kriechi)
 
 ## 02 August 2024: mitmproxy 10.4.2
 

--- a/docs/src/content/concepts-certificates.md
+++ b/docs/src/content/concepts-certificates.md
@@ -214,6 +214,19 @@ client then provides its certificate and proves ownership of the private key
 with a matching signature. This part works just like server authentication, only
 the other way around.
 
+### mTLS between mitmproxy and upstream server
+
+You can use a client certificate by passing the `--set client_certs=DIRECTORY|FILE`
+option to mitmproxy. Using a directory allows certs to be selected based on
+hostname, while using a filename allows a single specific certificate to be used
+for all TLS connections. Certificate files must be in the PEM format and should
+contain both the unencrypted private key and the certificate.
+
+You can specify a directory to `--set client_certs=DIRECTORY`, in which case the matching
+certificate is looked up by filename. So, if you visit example.org, mitmproxy
+looks for a file named `example.org.pem` in the specified directory and uses
+this as the client cert.
+
 ### mTLS between client and mitmproxy
 
 By default, mitmproxy does not send the `CertificateRequest` TLS handshake
@@ -231,15 +244,8 @@ of testing and developing client and server software, this is typically not an
 issue. If you operate mitmproxy in an environment where untrusted clients might
 connect, you need to safeguard against them.
 
-### mTLS between mitmproxy and upstream server
+The `request_client_cert` option is typically paired with `client_certs` like so:
 
-You can use a client certificate by passing the `--set client_certs=DIRECTORY|FILE`
-option to mitmproxy. Using a directory allows certs to be selected based on
-hostname, while using a filename allows a single specific certificate to be used
-for all TLS connections. Certificate files must be in the PEM format and should
-contain both the unencrypted private key and the certificate.
-
-You can specify a directory to `--set client_certs=DIRECTORY`, in which case the matching
-certificate is looked up by filename. So, if you visit example.org, mitmproxy
-looks for a file named `example.org.pem` in the specified directory and uses
-this as the client cert.
+```bash
+mitmproxy --set request_client_cert=True --set client_certs=client-cert.pem
+```

--- a/mitmproxy/addons/tlsconfig.py
+++ b/mitmproxy/addons/tlsconfig.py
@@ -160,6 +160,12 @@ class TlsConfig:
             help="Use a specific elliptic curve for ECDHE key exchange on server connections. "
             'OpenSSL syntax, for example "prime256v1" (see `openssl ecparam -list_curves`).',
         )
+        loader.add_option(
+            name="request_client_cert",
+            typespec=bool,
+            default=False,
+            help=f"Requests a client certificate (TLS message 'CertificateRequest') to establish a mutual TLS connection between client and mitmproxy (combined with 'client_certs' option for mitmproxy and upstream).",
+        )
 
     def tls_clienthello(self, tls_clienthello: tls.ClientHelloData):
         conn_context = tls_clienthello.context
@@ -199,7 +205,7 @@ class TlsConfig:
             cipher_list=tuple(cipher_list),
             ecdh_curve=ctx.options.tls_ecdh_curve_client,
             chain_file=entry.chain_file,
-            request_client_cert=False,
+            request_client_cert=ctx.options.request_client_cert,
             alpn_select_callback=alpn_select_callback,
             extra_chain_certs=tuple(extra_chain_certs),
             dhparams=self.certstore.dhparams,

--- a/web/src/js/ducks/_options_gen.ts
+++ b/web/src/js/ducks/_options_gen.ts
@@ -50,6 +50,7 @@ export interface OptionsState {
     proxyauth: string | undefined;
     rawtcp: boolean;
     readfile_filter: string | undefined;
+    request_client_cert: boolean;
     rfile: string | undefined;
     save_stream_file: string | undefined;
     save_stream_filter: string | undefined;
@@ -152,6 +153,7 @@ export const defaultState: OptionsState = {
     proxyauth: undefined,
     rawtcp: true,
     readfile_filter: undefined,
+    request_client_cert: false,
     rfile: undefined,
     save_stream_file: undefined,
     save_stream_filter: undefined,


### PR DESCRIPTION
This capability was already built-in but hard-coded to be disabled. Making it configurable as option (defaulting to off) enables mTLS connections between clients and mitmproxy. If true, mitmproxy will send a TLS `CertificateRequest` message to the client during the TLS handshake, upon which a client needs to present a client certificate to mitmproxy to successfully establish an mTLS connection.

This option can be used together with the `client_certs` option to also establish an mTLS connection between mitmproxy and the upstream server. In this case, mitmproxy needs to have a full client cert, including matching private key, that is trusted and accepted by the upstream server. This is a common scenario with MQTT or IoT connections.

Example usage:
$ mitmproxy --set request_client_cert=True --set client_certs=some_directory/

With `some_directory/` containing a `mqtt.example.com.pem` x509 certificate file (including private key).

This allows a client connecting using mTLS, to be intercepted by mitmproxy, which is itself establishing an mTLS connection to the `mqtt.example.com` upstream server. Restricting the client_certs using a directory and PEM files named after the upstream domain, narrows down the mTLS requirement to this single domain, while leaving all other traffic through mitmproxy untouched (normal TLS without client certs).

#### Description

<!-- describe your changes here -->

#### Checklist

 - [ ] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
