### PR TITLE
Fix error while changing string-based options

### DIFF
--- a/mitmproxy/tools/console/grideditor/col_bytes.py
+++ b/mitmproxy/tools/console/grideditor/col_bytes.py
@@ -41,7 +41,7 @@ class Edit(base.Cell):
         super().__init__(w)
 
     def get_data(self) -> bytes:
-        txt = self._w.get_text()[0].strip()
+        txt = self._w.base_widget.get_text()[0].strip()
         try:
             return strutils.escaped_str_to_bytes(txt)
         except ValueError:


### PR DESCRIPTION
#### Description

Trying to change string based options such as `mode` or `dns_name_servers` results in a `AttributeError: 'AttrMap' object has no attribute 'get_text'`.
cause: https://github.com/mitmproxy/mitmproxy/pull/7098

#### Checklist

 - [ ] I have updated tests where applicable.
 - [ ] I have added an entry to the CHANGELOG.
