### PR TITLE
Support empty string as marker in flow.mark

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Fix a bug where mitmproxy would crash when receiving `STOP_SENDING` QUIC frames.
   ([#7119](https://github.com/mitmproxy/mitmproxy/pull/7119), @mhils)
 - Fix error when unmarking all flows.
+  ([#7192](https://github.com/mitmproxy/mitmproxy/pull/7192), @bburky)
 - mitmproxy now officially supports Python 3.13.
   ([#6934](https://github.com/mitmproxy/mitmproxy/pull/6934), @mhils)
 - Add HTTP3 support in HTTPS reverse-proxy mode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
   ([#7139](https://github.com/mitmproxy/mitmproxy/pull/7139), @mhils)
 - Fix a bug where mitmproxy would crash when receiving `STOP_SENDING` QUIC frames.
   ([#7119](https://github.com/mitmproxy/mitmproxy/pull/7119), @mhils)
+- Fix error when unmarking all flows.
 - mitmproxy now officially supports Python 3.13.
   ([#6934](https://github.com/mitmproxy/mitmproxy/pull/6934), @mhils)
 - Add HTTP3 support in HTTPS reverse-proxy mode

--- a/mitmproxy/addons/core.py
+++ b/mitmproxy/addons/core.py
@@ -68,7 +68,7 @@ class Core:
         Mark flows.
         """
         updated = []
-        if marker not in emoji.emoji:
+        if not (marker == "" or marker in emoji.emoji):
             raise exceptions.CommandError(f"invalid marker value")
 
         for i in flows:


### PR DESCRIPTION
#### Description

"Un-set all marks" is implemented as `flow.mark @all false`

`_MarkerType()` coerces `False` into `""`, but this was previously unsupported by `flow.mark`. This previously caused `flow.mark` to error with "invalid marker value".
https://github.com/mitmproxy/mitmproxy/blob/2c1802692ddb99b8d02a353d8382772029168616/mitmproxy/types.py#L457-L464

Add a check for the empty string to `flow.mark` to fix this.

I assume this previously worked, but the error checking got too strict at some point.

#### Checklist

 - [ ] I have updated tests where applicable.
 - [ ] I have added an entry to the CHANGELOG.
