### PR TITLE
Propogate end_stream from downstream http/2 requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
   ([#7114](https://github.com/mitmproxy/mitmproxy/pull/7114), @errorxyz)
 - Addon to update the hosts in alt-svc header in reverse mode
   ([#7093](https://github.com/mitmproxy/mitmproxy/pull/7093), @errorxyz)
+- Do not send unnecessary empty data frames when streaming HTTP/2.
 - Fix a bug where mitmproxy would ignore Ctrl+C/SIGTERM on OpenBSD.
   ([#7130](https://github.com/mitmproxy/mitmproxy/pull/7130), @catap)
 - Fix of measurement unit in HAR import, duration is in milliseconds

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - Addon to update the hosts in alt-svc header in reverse mode
   ([#7093](https://github.com/mitmproxy/mitmproxy/pull/7093), @errorxyz)
 - Do not send unnecessary empty data frames when streaming HTTP/2.
+  ([#7196](https://github.com/mitmproxy/mitmproxy/pull/7196), @rubu)
 - Fix a bug where mitmproxy would ignore Ctrl+C/SIGTERM on OpenBSD.
   ([#7130](https://github.com/mitmproxy/mitmproxy/pull/7130), @catap)
 - Fix of measurement unit in HAR import, duration is in milliseconds

--- a/mitmproxy/proxy/layers/http/__init__.py
+++ b/mitmproxy/proxy/layers/http/__init__.py
@@ -839,7 +839,9 @@ class HttpStream(layer.Layer):
         # silently consume every event.
         yield from ()
 
-    def is_websocket(self):
+    def is_websocket(self) -> bool | None:
+        if self.flow.response is None:
+            return None
         return (
             self.flow.response.status_code == 101
             and self.flow.response.headers.get("upgrade", "").lower() == "websocket"

--- a/mitmproxy/proxy/layers/http/__init__.py
+++ b/mitmproxy/proxy/layers/http/__init__.py
@@ -284,7 +284,7 @@ class HttpStream(layer.Layer):
             self.client_state = self.state_consume_request_body
         self.server_state = self.state_wait_for_response_headers
 
-    def start_request_stream(self, event = None) -> layer.CommandGenerator[None]:
+    def start_request_stream(self, event=None) -> layer.CommandGenerator[None]:
         if self.flow.response:
             raise NotImplementedError(
                 "Can't set a response and enable streaming at the same time."

--- a/mitmproxy/proxy/layers/http/__init__.py
+++ b/mitmproxy/proxy/layers/http/__init__.py
@@ -278,7 +278,7 @@ class HttpStream(layer.Layer):
             )
             self.flow.request.headers.pop("expect")
 
-        if self.flow.request.stream and not event.end_stream: 
+        if self.flow.request.stream and not event.end_stream:
             yield from self.start_request_stream()
         else:
             self.client_state = self.state_consume_request_body
@@ -406,7 +406,9 @@ class HttpStream(layer.Layer):
         if (yield from self.check_killed(True)):
             return
 
-        elif self.flow.response.stream and (self.is_websocket() or not event.end_stream):
+        elif self.flow.response.stream and (
+            self.is_websocket() or not event.end_stream
+        ):
             yield from self.start_response_stream()
         else:
             self.server_state = self.state_consume_response_body
@@ -470,7 +472,6 @@ class HttpStream(layer.Layer):
         """We have either consumed the entire response from the server or the response was set by an addon."""
         assert self.flow.response
         self.flow.response.timestamp_end = time.time()
-
 
         if self.is_websocket():
             # We need to set this before calling the response hook
@@ -839,13 +840,14 @@ class HttpStream(layer.Layer):
         yield from ()
 
     def is_websocket(self):
-       return (
+        return (
             self.flow.response.status_code == 101
             and self.flow.response.headers.get("upgrade", "").lower() == "websocket"
             and self.flow.request.headers.get("Sec-WebSocket-Version", "").encode()
             == wsproto.handshake.WEBSOCKET_VERSION
             and self.context.options.websocket
         )
+
 
 class HttpLayer(layer.Layer):
     """

--- a/test/mitmproxy/proxy/layers/http/test_http2.py
+++ b/test/mitmproxy/proxy/layers/http/test_http2.py
@@ -622,6 +622,56 @@ def test_no_normalization(tctx, normalize):
     assert flow().request.headers.fields == ((b"Should-Not-Be-Capitalized! ", b" :) "),)
     assert flow().response.headers.fields == ((b"Same", b"Here"),)
 
+@pytest.mark.parametrize("stream", ["stream", ""])
+def test_end_stream_via_headers(tctx, stream):
+    playbook, cff = start_h2_client(tctx)
+    server = Placeholder(Server)
+    flow = Placeholder(HTTPFlow)
+    request_header_frames = cff.build_headers_frame(example_request_headers, flags=["END_STREAM"]).serialize()
+    forwarded_request_header_frames = Placeholder(bytes)
+    sff = FrameFactory()
+    response_header_frames = sff.build_headers_frame(example_response_headers, flags=["END_STREAM"]).serialize()
+    forwarded_response_header_frames = Placeholder(bytes)
+
+    def enable_streaming(flow: HTTPFlow):
+        flow.request.stream = bool(stream)
+
+    assert (
+        playbook
+        >> DataReceived(
+            tctx.client,
+            request_header_frames,
+        )
+        << http.HttpRequestHeadersHook(flow)
+        >> reply(side_effect=enable_streaming)
+        << http.HttpRequestHook(flow)
+        >> reply()
+        << OpenConnection(server)
+        >> reply(None, side_effect=make_h2)
+        << SendData(server, forwarded_request_header_frames)
+        >> DataReceived(
+            server,
+            response_header_frames
+        )
+        << http.HttpResponseHeadersHook(flow)
+        >> reply()
+        << http.HttpResponseHook(flow)
+        >> reply()
+        << SendData(tctx.client, forwarded_response_header_frames)
+    )
+
+    frames = decode_frames(forwarded_request_header_frames())
+    assert [type(x) for x in frames] == [
+        hyperframe.frame.SettingsFrame,
+        hyperframe.frame.HeadersFrame,
+    ]
+    assert "END_STREAM" in frames[1].flags
+
+    frames = decode_frames(forwarded_response_header_frames())
+    assert [type(x) for x in frames] == [
+        hyperframe.frame.HeadersFrame,
+    ]
+    assert "END_STREAM" in frames[0].flags
 
 @pytest.mark.parametrize(
     "input,pseudo,headers",

--- a/test/mitmproxy/proxy/layers/http/test_http2.py
+++ b/test/mitmproxy/proxy/layers/http/test_http2.py
@@ -622,15 +622,20 @@ def test_no_normalization(tctx, normalize):
     assert flow().request.headers.fields == ((b"Should-Not-Be-Capitalized! ", b" :) "),)
     assert flow().response.headers.fields == ((b"Same", b"Here"),)
 
+
 @pytest.mark.parametrize("stream", ["stream", ""])
 def test_end_stream_via_headers(tctx, stream):
     playbook, cff = start_h2_client(tctx)
     server = Placeholder(Server)
     flow = Placeholder(HTTPFlow)
-    request_header_frames = cff.build_headers_frame(example_request_headers, flags=["END_STREAM"]).serialize()
+    request_header_frames = cff.build_headers_frame(
+        example_request_headers, flags=["END_STREAM"]
+    ).serialize()
     forwarded_request_header_frames = Placeholder(bytes)
     sff = FrameFactory()
-    response_header_frames = sff.build_headers_frame(example_response_headers, flags=["END_STREAM"]).serialize()
+    response_header_frames = sff.build_headers_frame(
+        example_response_headers, flags=["END_STREAM"]
+    ).serialize()
     forwarded_response_header_frames = Placeholder(bytes)
 
     def enable_streaming(flow: HTTPFlow):
@@ -649,10 +654,7 @@ def test_end_stream_via_headers(tctx, stream):
         << OpenConnection(server)
         >> reply(None, side_effect=make_h2)
         << SendData(server, forwarded_request_header_frames)
-        >> DataReceived(
-            server,
-            response_header_frames
-        )
+        >> DataReceived(server, response_header_frames)
         << http.HttpResponseHeadersHook(flow)
         >> reply()
         << http.HttpResponseHook(flow)
@@ -672,6 +674,7 @@ def test_end_stream_via_headers(tctx, stream):
         hyperframe.frame.HeadersFrame,
     ]
     assert "END_STREAM" in frames[0].flags
+
 
 @pytest.mark.parametrize(
     "input,pseudo,headers",


### PR DESCRIPTION
#### Description

I encountered an issue where mitmdump was failing with a request that was working in the browser. It was a GET request with no body but the server was throwing an error about GET request having a body.

After looking at packet captures the difference between mitmdump and browser was that browser was sending `END STREAM` on the `HEADERS` frame whereas mitmdump was sending an empty `DATA` frame with `END STREAM`.

I patched mitmdump to propogate `END STREAM` if it is present on the downstream `HEADERS` frame.

Tests pass and my test case works, could anyone elaborate if this can cause other issues? If so I can adjust this to get to a state where this can be merged - since this is breaking for me ill roll with a local patch now but it would be great to use an official release.

#### Checklist

 - [ ] I have updated tests where applicable.
 - [ ] I have added an entry to the CHANGELOG.
