### PR TITLE
Improve HTTP detection heuristic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ## Unreleased: mitmproxy next
 
+- Tighten HTTP detection heuristic to better support custom TCP-based protocols.
 
 ## 02 October 2024: mitmproxy 11.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ## Unreleased: mitmproxy next
 
 - Tighten HTTP detection heuristic to better support custom TCP-based protocols.
+  ([#7228](https://github.com/mitmproxy/mitmproxy/pull/7228), @fatanugraha)
 
 ## 02 October 2024: mitmproxy 11.0.0
 

--- a/mitmproxy/addons/next_layer.py
+++ b/mitmproxy/addons/next_layer.py
@@ -184,8 +184,7 @@ class NextLayer:
             len(data_client) < 3
             # HTTP would require whitespace before the first newline
             # if we have neither whitespace nor a newline, it's also unlikely to be HTTP.
-            or (data_client.find(b" ") == -1)
-            or (data_client.find(b"\n") == -1)
+            or (b"\n" in data_client and b" " not in data_client)
             or (data_client.find(b" ") >= data_client.find(b"\n"))
             or not data_client[:3].isalpha()
             # a server greeting would be uncharacteristic.

--- a/mitmproxy/addons/next_layer.py
+++ b/mitmproxy/addons/next_layer.py
@@ -184,6 +184,8 @@ class NextLayer:
             len(data_client) < 3
             # HTTP would require whitespace before the first newline
             # if we have neither whitespace nor a newline, it's also unlikely to be HTTP.
+            or (data_client.find(b" ") == -1)
+            or (data_client.find(b"\n") == -1)
             or (data_client.find(b" ") >= data_client.find(b"\n"))
             or not data_client[:3].isalpha()
             # a server greeting would be uncharacteristic.

--- a/mitmproxy/addons/next_layer.py
+++ b/mitmproxy/addons/next_layer.py
@@ -182,10 +182,10 @@ class NextLayer:
         probably_no_http = (
             # the first three bytes should be the HTTP verb, so A-Za-z is expected.
             len(data_client) < 3
-            # HTTP would require whitespace before the first newline
-            # if we have neither whitespace nor a newline, it's also unlikely to be HTTP.
-            or (b"\n" in data_client and b" " not in data_client)
-            or (data_client.find(b" ") >= data_client.find(b"\n"))
+            # HTTP would require whitespace...
+            or b" " not in data_client
+            # ...and that whitespace needs to be in the first line.
+            or (data_client.find(b" ") > data_client.find(b"\n"))
             or not data_client[:3].isalpha()
             # a server greeting would be uncharacteristic.
             or data_server

--- a/test/mitmproxy/addons/test_next_layer.py
+++ b/test/mitmproxy/addons/test_next_layer.py
@@ -103,7 +103,7 @@ dns_query = bytes.fromhex("002a01000001000000000000076578616d706c6503636f6d00000
 
 # Custom protocol with just base64-encoded messages
 # https://github.com/mitmproxy/mitmproxy/pull/7087
-custom_base64_proto = b"AAAAAAAAAAAAAAAAAAAAAA=="
+custom_base64_proto = b"AAAAAAAAAAAAAAAAAAAAAA==\n"
 
 http_get = b"GET / HTTP/1.1\r\nHost: example.com\r\n\r\n"
 http_get_absolute = b"GET http://example.com/ HTTP/1.1\r\n\r\n"


### PR DESCRIPTION
#### Description

Improve the HTTP detection heuristic introduced in this PR: https://github.com/mitmproxy/mitmproxy/pull/7087

In my mitmproxy `transparent` mode setup, [testcontainer's](https://testcontainers.com/getting-started/) ryuk breaks because it sends the string below in raw TCP
```
label=org.testcontainers.version=0.30.0&label=org.testcontainers.sessionId=eb48d24ade2174c56e8951a306241ad68eccdd8fcb7686b62ed03e638ec73870&label=org.testcontainers=true&label=org.testcontainers.lang=go\n
```

Upon checking the proxy log, I found out that mitmproxy thinks that it's an HTTP protocol and try to parse it as such, causing the connection to appear as "stuck"

#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
