### PR TITLE
Remove Apple Silicon note

### DIFF
--- a/docs/src/content/overview-installation.md
+++ b/docs/src/content/overview-installation.md
@@ -21,8 +21,6 @@ brew install mitmproxy
 
 Alternatively, you can download standalone binaries on [mitmproxy.org](https://mitmproxy.org/).
 
-NOTE: For Apple Silicon, Rosetta is required.
-
 ## Linux
 
 The recommended way to install mitmproxy on Linux is to download the


### PR DESCRIPTION
#### Description

mitmproxy now supplies native Apple Silicon binaries, even on honebrew. this shouldn't be needed anymore