### PR TITLE
Add support for starting a preconfigured Firefox instance via `browser.start` command.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
   with the current OpenSSL build.
   ([#7241](https://github.com/mitmproxy/mitmproxy/pull/7241), @mhils)
 - `browser.start` command now supports Firefox.
+  ([#7239](https://github.com/mitmproxy/mitmproxy/pull/7239), @sujaldev)
 
 ## 02 October 2024: mitmproxy 11.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 - Tighten HTTP detection heuristic to better support custom TCP-based protocols.
   ([#7228](https://github.com/mitmproxy/mitmproxy/pull/7228), @fatanugraha)
+- `browser.start` command now supports Firefox.
 
 ## 02 October 2024: mitmproxy 11.0.0
 

--- a/mitmproxy/addons/browser.py
+++ b/mitmproxy/addons/browser.py
@@ -2,14 +2,13 @@ import logging
 import shutil
 import subprocess
 import tempfile
-from typing import List
 
 from mitmproxy import command
 from mitmproxy import ctx
 from mitmproxy.log import ALERT
 
 
-def find_executable_cmd(*search_paths) -> List[str] | None:
+def find_executable_cmd(*search_paths) -> list[str] | None:
     for browser in search_paths:
         if shutil.which(browser):
             return [browser]
@@ -17,7 +16,7 @@ def find_executable_cmd(*search_paths) -> List[str] | None:
     return None
 
 
-def find_flatpak_cmd(*search_paths) -> List[str] | None:
+def find_flatpak_cmd(*search_paths) -> list[str] | None:
     if shutil.which("flatpak"):
         for browser in search_paths:
             if (

--- a/mitmproxy/addons/browser.py
+++ b/mitmproxy/addons/browser.py
@@ -108,9 +108,7 @@ class Browser:
             "firefox",
             "mozilla-firefox",
             "mozilla",
-        ) or find_flatpak_cmd(
-            "org.mozilla.firefox"
-        )
+        ) or find_flatpak_cmd("org.mozilla.firefox")
 
         if not cmd:
             logging.log(
@@ -129,7 +127,7 @@ class Browser:
             for service in ("http", "ssl", "socks", "ftp"):
                 prefs += [
                     f'user_pref("network.proxy.{service}", "{host}");',
-                    f'user_pref("network.proxy.{service}_port", {port});'
+                    f'user_pref("network.proxy.{service}_port", {port});',
                 ]
             return prefs
 

--- a/mitmproxy/addons/browser.py
+++ b/mitmproxy/addons/browser.py
@@ -116,26 +116,23 @@ class Browser:
             )
             return
 
-        def generate_user_prefs():
-            host = ctx.options.listen_host or "127.0.0.1"
-            port = ctx.options.listen_port or "8080"
-            prefs = [
-                f'user_pref("datareporting.policy.firstRunURL", "");',
-                'user_pref("network.proxy.type", 1);',
-                'user_pref("network.proxy.share_proxy_settings", true);',
+        host = ctx.options.listen_host or "127.0.0.1"
+        port = ctx.options.listen_port or 8080
+        prefs = [
+            'user_pref("datareporting.policy.firstRunURL", "");',
+            'user_pref("network.proxy.type", 1);',
+            'user_pref("network.proxy.share_proxy_settings", true);',
+        ]
+        for service in ("http", "ssl", "socks", "ftp"):
+            prefs += [
+                f'user_pref("network.proxy.{service}", "{host}");',
+                f'user_pref("network.proxy.{service}_port", {port});',
             ]
-            for service in ("http", "ssl", "socks", "ftp"):
-                prefs += [
-                    f'user_pref("network.proxy.{service}", "{host}");',
-                    f'user_pref("network.proxy.{service}_port", {port});',
-                ]
-            return prefs
 
         tdir = tempfile.TemporaryDirectory()
 
-        # Configure proxy via prefs.js
         with open(tdir.name + "/prefs.js", "w") as file:
-            file.writelines(generate_user_prefs())
+            file.writelines(prefs)
 
         self.tdir.append(tdir)
         self.browser.append(

--- a/mitmproxy/addons/browser.py
+++ b/mitmproxy/addons/browser.py
@@ -126,7 +126,7 @@ class Browser:
             'user_pref("network.proxy.type", 1);',
             'user_pref("network.proxy.share_proxy_settings", true);',
         ]
-        for service in ("http", "ssl", "socks", "ftp"):
+        for service in ("http", "ssl"):
             prefs += [
                 f'user_pref("network.proxy.{service}", "{host}");',
                 f'user_pref("network.proxy.{service}_port", {port});',

--- a/mitmproxy/addons/browser.py
+++ b/mitmproxy/addons/browser.py
@@ -130,6 +130,7 @@ class Browser:
             'user_pref("app.update.auto", false);',
             'user_pref("app.update.enabled", false);',
             'user_pref("app.update.autoInstallEnabled", false);',
+            'user_pref("app.shield.optoutstudies.enabled", false);'
             'user_pref("extensions.blocklist.enabled", false);',
             'user_pref("browser.safebrowsing.downloads.remote.enabled", false);',
             'user_pref("browser.region.network.url", "");',

--- a/mitmproxy/addons/browser.py
+++ b/mitmproxy/addons/browser.py
@@ -2,7 +2,6 @@ import logging
 import shutil
 import subprocess
 import tempfile
-import time
 
 from mitmproxy import command
 from mitmproxy import ctx

--- a/mitmproxy/addons/browser.py
+++ b/mitmproxy/addons/browser.py
@@ -105,6 +105,7 @@ class Browser:
         """
         cmd = find_executable_cmd(
             "/Applications/Firefox.app/Contents/MacOS/firefox",
+            r"C:\Program Files\Mozilla Firefox\firefox.exe",
             "firefox",
             "mozilla-firefox",
             "mozilla",

--- a/mitmproxy/addons/browser.py
+++ b/mitmproxy/addons/browser.py
@@ -45,6 +45,8 @@ class Browser:
             self.launch_chrome()
         elif browser == "firefox":
             self.launch_firefox()
+        else:
+            logging.log(ALERT, "Invalid browser name.")
 
     def launch_chrome(self) -> None:
         """

--- a/mitmproxy/addons/browser.py
+++ b/mitmproxy/addons/browser.py
@@ -148,6 +148,8 @@ class Browser:
             'user_pref("browser.newtabpage.activity-stream.feeds.topsites", false);',
             'user_pref("browser.newtabpage.activity-stream.default.sites", "");',
             'user_pref("browser.newtabpage.activity-stream.showSponsoredTopSites", false);',
+            'user_pref("browser.bookmarks.restore_default_bookmarks", false);',
+            'user_pref("browser.bookmarks.file", "");',
         ]
         for service in ("http", "ssl"):
             prefs += [

--- a/mitmproxy/addons/browser.py
+++ b/mitmproxy/addons/browser.py
@@ -144,7 +144,6 @@ class Browser:
                     *cmd,
                     "--profile",
                     str(tdir.name),
-                    "--safe-mode",
                     "--new-window",
                     "about:blank",
                 ],

--- a/mitmproxy/addons/browser.py
+++ b/mitmproxy/addons/browser.py
@@ -46,7 +46,7 @@ class Browser:
         elif browser == "firefox":
             self.launch_firefox()
 
-    def launch_chrome(self):
+    def launch_chrome(self) -> None:
         """
         Start an isolated instance of Chrome that points to the currently
         running proxy.

--- a/mitmproxy/addons/browser.py
+++ b/mitmproxy/addons/browser.py
@@ -2,6 +2,7 @@ import logging
 import shutil
 import subprocess
 import tempfile
+import time
 
 from mitmproxy import command
 from mitmproxy import ctx
@@ -125,6 +126,28 @@ class Browser:
             'user_pref("datareporting.policy.firstRunURL", "");',
             'user_pref("network.proxy.type", 1);',
             'user_pref("network.proxy.share_proxy_settings", true);',
+            'user_pref("datareporting.healthreport.uploadEnabled", false);',
+            'user_pref("app.normandy.enabled", false);',
+            'user_pref("app.update.auto", false);',
+            'user_pref("app.update.enabled", false);',
+            'user_pref("app.update.autoInstallEnabled", false);',
+            'user_pref("extensions.blocklist.enabled", false);',
+            'user_pref("browser.safebrowsing.downloads.remote.enabled", false);',
+            'user_pref("browser.region.network.url", "");',
+            'user_pref("browser.region.update.enabled", false);',
+            'user_pref("browser.region.local-geocoding", false);',
+            'user_pref("extensions.pocket.enabled", false);',
+            'user_pref("network.captive-portal-service.enabled", false);',
+            'user_pref("network.connectivity-service.enabled", false);',
+            'user_pref("toolkit.telemetry.server", "");',
+            'user_pref("dom.push.serverURL", "");',
+            'user_pref("services.settings.enabled", false);',
+            'user_pref("browser.newtab.preload", false);',
+            'user_pref("browser.safebrowsing.provider.google4.updateURL", "");',
+            'user_pref("browser.safebrowsing.provider.mozilla.updateURL", "");',
+            'user_pref("browser.newtabpage.activity-stream.feeds.topsites", false);',
+            'user_pref("browser.newtabpage.activity-stream.default.sites", "");',
+            'user_pref("browser.newtabpage.activity-stream.showSponsoredTopSites", false);',
         ]
         for service in ("http", "ssl"):
             prefs += [

--- a/mitmproxy/addons/browser.py
+++ b/mitmproxy/addons/browser.py
@@ -105,6 +105,7 @@ class Browser:
         running proxy.
         """
         cmd = find_executable_cmd(
+            "/Applications/Firefox.app/Contents/MacOS/firefox",
             "firefox",
             "mozilla-firefox",
             "mozilla",

--- a/mitmproxy/addons/browser.py
+++ b/mitmproxy/addons/browser.py
@@ -2,40 +2,24 @@ import logging
 import shutil
 import subprocess
 import tempfile
+from typing import List
 
 from mitmproxy import command
 from mitmproxy import ctx
 from mitmproxy.log import ALERT
 
 
-def get_chrome_executable() -> str | None:
-    for browser in (
-        "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
-        # https://stackoverflow.com/questions/40674914/google-chrome-path-in-windows-10
-        r"C:\Program Files (x86)\Google\Chrome\Application\chrome.exe",
-        r"C:\Program Files (x86)\Google\Application\chrome.exe",
-        # Linux binary names from Python's webbrowser module.
-        "google-chrome",
-        "google-chrome-stable",
-        "chrome",
-        "chromium",
-        "chromium-browser",
-        "google-chrome-unstable",
-    ):
+def find_executable_cmd(*search_paths) -> List[str] | None:
+    for browser in search_paths:
         if shutil.which(browser):
-            return browser
+            return [browser]
 
     return None
 
 
-def get_chrome_flatpak() -> str | None:
+def find_flatpak_cmd(*search_paths) -> List[str] | None:
     if shutil.which("flatpak"):
-        for browser in (
-            "com.google.Chrome",
-            "org.chromium.Chromium",
-            "com.github.Eloston.UngoogledChromium",
-            "com.google.ChromeDev",
-        ):
+        for browser in search_paths:
             if (
                 subprocess.run(
                     ["flatpak", "info", browser],
@@ -44,16 +28,7 @@ def get_chrome_flatpak() -> str | None:
                 ).returncode
                 == 0
             ):
-                return browser
-
-    return None
-
-
-def get_browser_cmd() -> list[str] | None:
-    if browser := get_chrome_executable():
-        return [browser]
-    elif browser := get_chrome_flatpak():
-        return ["flatpak", "run", "-p", browser]
+                return ["flatpak", "run", "-p", browser]
 
     return None
 
@@ -63,15 +38,39 @@ class Browser:
     tdir: list[tempfile.TemporaryDirectory] = []
 
     @command.command("browser.start")
-    def start(self) -> None:
+    def start(self, browser: str = "chrome") -> None:
+        if len(self.browser) > 0:
+            logging.log(ALERT, "Starting additional browser")
+
+        if browser in ("chrome", "chromium"):
+            self.launch_chrome()
+        elif browser == "firefox":
+            self.launch_firefox()
+
+    def launch_chrome(self):
         """
         Start an isolated instance of Chrome that points to the currently
         running proxy.
         """
-        if len(self.browser) > 0:
-            logging.log(ALERT, "Starting additional browser")
+        cmd = find_executable_cmd(
+            "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+            # https://stackoverflow.com/questions/40674914/google-chrome-path-in-windows-10
+            r"C:\Program Files (x86)\Google\Chrome\Application\chrome.exe",
+            r"C:\Program Files (x86)\Google\Application\chrome.exe",
+            # Linux binary names from Python's webbrowser module.
+            "google-chrome",
+            "google-chrome-stable",
+            "chrome",
+            "chromium",
+            "chromium-browser",
+            "google-chrome-unstable",
+        ) or find_flatpak_cmd(
+            "com.google.Chrome",
+            "org.chromium.Chromium",
+            "com.github.Eloston.UngoogledChromium",
+            "com.google.ChromeDev",
+        )
 
-        cmd = get_browser_cmd()
         if not cmd:
             logging.log(
                 ALERT, "Your platform is not supported yet - please submit a patch."
@@ -93,6 +92,62 @@ class Browser:
                     "--no-default-browser-check",
                     "--no-first-run",
                     "--disable-extensions",
+                    "about:blank",
+                ],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+        )
+
+    def launch_firefox(self) -> None:
+        """
+        Start an isolated instance of Firefox that points to the currently
+        running proxy.
+        """
+        cmd = find_executable_cmd(
+            "firefox",
+            "mozilla-firefox",
+            "mozilla",
+        ) or find_flatpak_cmd(
+            "org.mozilla.firefox"
+        )
+
+        if not cmd:
+            logging.log(
+                ALERT, "Your platform is not supported yet - please submit a patch."
+            )
+            return
+
+        def generate_user_prefs():
+            host = ctx.options.listen_host or "127.0.0.1"
+            port = ctx.options.listen_port or "8080"
+            prefs = [
+                f'user_pref("datareporting.policy.firstRunURL", "");',
+                'user_pref("network.proxy.type", 1);',
+                'user_pref("network.proxy.share_proxy_settings", true);',
+            ]
+            for service in ("http", "ssl", "socks", "ftp"):
+                prefs += [
+                    f'user_pref("network.proxy.{service}", "{host}");',
+                    f'user_pref("network.proxy.{service}_port", {port});'
+                ]
+            return prefs
+
+        tdir = tempfile.TemporaryDirectory()
+
+        # Configure proxy via prefs.js
+        with open(tdir.name + "/prefs.js", "w") as file:
+            file.writelines(generate_user_prefs())
+
+        self.tdir.append(tdir)
+        self.browser.append(
+            subprocess.Popen(
+                [
+                    *cmd,
+                    "--profile",
+                    str(tdir.name),
+                    "--safe-mode",
+                    "--new-window",
                     "about:blank",
                 ],
                 stdout=subprocess.DEVNULL,

--- a/test/mitmproxy/addons/test_browser.py
+++ b/test/mitmproxy/addons/test_browser.py
@@ -19,6 +19,10 @@ def test_browser(caplog):
         b.start()
         assert "Starting additional browser" in caplog.text
         assert len(b.browser) == 2
+
+        b.start("unsupported-browser")
+        assert "Invalid browser name." in caplog.text
+        assert len(b.browser) == 2
         b.done()
         assert not b.browser
 

--- a/test/mitmproxy/addons/test_browser.py
+++ b/test/mitmproxy/addons/test_browser.py
@@ -33,19 +33,19 @@ async def test_no_browser(caplog):
         assert "platform is not supported" in caplog.text
 
 
-async def test_get_browser_cmd_executable():
+async def test_find_executable_cmd():
     with mock.patch("shutil.which") as which:
         which.side_effect = lambda cmd: cmd == "chrome"
-        assert browser.get_browser_cmd() == ["chrome"]
+        assert browser.find_executable_cmd("chrome") == ["chrome"]
 
 
-async def test_get_browser_cmd_no_executable():
+async def test_find_executable_cmd_no_executable():
     with mock.patch("shutil.which") as which:
         which.return_value = False
-        assert browser.get_browser_cmd() is None
+        assert browser.find_executable_cmd("chrome") is None
 
 
-async def test_get_browser_cmd_flatpak():
+async def test_find_flatpak_cmd():
     def subprocess_run_mock(cmd, **kwargs):
         returncode = 0 if cmd == ["flatpak", "info", "com.google.Chrome"] else 1
         return mock.Mock(returncode=returncode)
@@ -56,7 +56,7 @@ async def test_get_browser_cmd_flatpak():
     ):
         which.side_effect = lambda cmd: cmd == "flatpak"
         subprocess_run.side_effect = subprocess_run_mock
-        assert browser.get_browser_cmd() == [
+        assert browser.find_flatpak_cmd("com.google.Chrome") == [
             "flatpak",
             "run",
             "-p",
@@ -64,11 +64,11 @@ async def test_get_browser_cmd_flatpak():
         ]
 
 
-async def test_get_browser_cmd_no_flatpak():
+async def test_find_flatpak_cmd_no_flatpak():
     with (
         mock.patch("shutil.which") as which,
         mock.patch("subprocess.run") as subprocess_run,
     ):
         which.side_effect = lambda cmd: cmd == "flatpak"
         subprocess_run.return_value = mock.Mock(returncode=1)
-        assert browser.get_browser_cmd() is None
+        assert browser.find_flatpak_cmd("com.google.Chrome") is None

--- a/test/mitmproxy/addons/test_browser.py
+++ b/test/mitmproxy/addons/test_browser.py
@@ -72,3 +72,22 @@ async def test_find_flatpak_cmd_no_flatpak():
         which.side_effect = lambda cmd: cmd == "flatpak"
         subprocess_run.return_value = mock.Mock(returncode=1)
         assert browser.find_flatpak_cmd("com.google.Chrome") is None
+
+
+async def test_browser_start_firefox():
+    with (
+        mock.patch("shutil.which") as which,
+        mock.patch("subprocess.Popen") as po,
+        taddons.context(),
+    ):
+        which.return_value = "firefox"
+        browser.Browser().start("firefox")
+        assert po.called
+
+
+async def test_browser_start_firefox_not_found(caplog):
+    caplog.set_level("INFO")
+    with mock.patch("shutil.which") as which:
+        which.return_value = False
+        browser.Browser().start("firefox")
+        assert "platform is not supported" in caplog.text


### PR DESCRIPTION
#### Description

`browser.start` command will now allow for a `browser` parameter defaulting to "chrome". (Refer #5247)

#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
