### PR TITLE
Set `@SECLEVEL=0` if old TLS versions are requested

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
   ([#7228](https://github.com/mitmproxy/mitmproxy/pull/7228), @fatanugraha)
 - Fix a bug where mitmproxy would incorrectly report that TLS 1.0 and 1.1 are not supported
   with the current OpenSSL build.
+  ([#7241](https://github.com/mitmproxy/mitmproxy/pull/7241), @mhils)
 
 ## 02 October 2024: mitmproxy 11.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 - Tighten HTTP detection heuristic to better support custom TCP-based protocols.
   ([#7228](https://github.com/mitmproxy/mitmproxy/pull/7228), @fatanugraha)
+- Fix a bug where mitmproxy would incorrectly report that TLS 1.0 and 1.1 are not supported
+  with the current OpenSSL build.
 
 ## 02 October 2024: mitmproxy 11.0.0
 

--- a/mitmproxy/net/tls.py
+++ b/mitmproxy/net/tls.py
@@ -49,6 +49,14 @@ class Version(Enum):
     TLS1_3 = SSL.TLS1_3_VERSION
 
 
+INSECURE_TLS_MIN_VERSIONS: tuple[Version, ...] = (
+    Version.UNBOUNDED,
+    Version.SSL3,
+    Version.TLS1,
+    Version.TLS1_1,
+)
+
+
 class Verify(Enum):
     VERIFY_NONE = SSL.VERIFY_NONE
     VERIFY_PEER = SSL.VERIFY_PEER
@@ -62,6 +70,9 @@ DEFAULT_OPTIONS = SSL.OP_CIPHER_SERVER_PREFERENCE | SSL.OP_NO_COMPRESSION
 @cache
 def is_supported_version(version: Version):
     client_ctx = SSL.Context(SSL.TLS_CLIENT_METHOD)
+    # Without SECLEVEL, recent OpenSSL versions forbid old TLS versions.
+    # https://github.com/pyca/cryptography/issues/9523
+    client_ctx.set_cipher_list(b"@SECLEVEL=0:ALL")
     client_ctx.set_min_proto_version(version.value)
     client_ctx.set_max_proto_version(version.value)
     client_conn = SSL.Connection(client_ctx)

--- a/mitmproxy/options.py
+++ b/mitmproxy/options.py
@@ -73,18 +73,6 @@ class Options(optmanager.OptManager):
             """,
         )
         self.add_option(
-            "ciphers_client",
-            Optional[str],
-            None,
-            "Set supported ciphers for client <-> mitmproxy connections using OpenSSL syntax.",
-        )
-        self.add_option(
-            "ciphers_server",
-            Optional[str],
-            None,
-            "Set supported ciphers for mitmproxy <-> server connections using OpenSSL syntax.",
-        )
-        self.add_option(
             "client_certs", Optional[str], None, "Client certificate file or directory."
         )
         self.add_option(


### PR DESCRIPTION
#### Description

I was looking to make our Docker builds support older TLS versions, only to find out that the OpenSSL version is perfectly fine - we only need to set `@SECLEVEL=0`, see https://github.com/pyca/cryptography/issues/9523.

#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
