### PR TITLE
Add `tun` proxy mode on Linux

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,11 +44,11 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            py: "3.13-dev"
+            py: "3.13"
           - os: windows-latest
-            py: "3.13-dev"
+            py: "3.13"
           - os: macos-latest
-            py: "3.13-dev"
+            py: "3.13"
           - os: ubuntu-latest
             py: "3.12"
           - os: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,14 +67,14 @@ jobs:
           python-version: ${{ matrix.py }}
       - run: pip install tox
       - run: tox -e py
-        if: matrix.os != 'ubuntu-latest'
+        if: matrix.os != 'ubuntu-latestFIXME'
       - name: Run tox -e py (without internet)
         run: |
           # install dependencies (requires internet connectivity)
           tox -e py --notest  
           # run tests with loopback only. We need to sudo for unshare, which means we need an absolute path for tox.
           sudo unshare --net -- sh -c "ip link set lo up; $(which tox) -e py"
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-latestFIXME'
       - uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,6 +68,9 @@ jobs:
       - run: pip install tox
       - run: tox -e py
         if: matrix.os != 'ubuntu-latest'
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+        if: matrix.os == 'ubuntu-latest' && matrix.py == '3.12'
       - name: Run tox -e py (without internet)
         run: |
           # install dependencies (requires internet connectivity)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,7 +73,7 @@ jobs:
           # install dependencies (requires internet connectivity)
           tox -e py --notest  
           # run tests with loopback only. We need to sudo for unshare, which means we need an absolute path for tox.
-          sudo unshare --map-root-user --net -- sh -c "ip link set lo up; $(which tox) -e py"
+          sudo unshare --map-root-user --net -- sh -c "ip link set lo up; sudo $(which tox) -e py"
         if: matrix.os == 'ubuntu-latest'
       - uses: codecov/codecov-action@v4
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,12 +68,15 @@ jobs:
       - run: pip install tox
       - run: tox -e py
         if: matrix.os != 'ubuntu-latest'
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+        if: matrix.os == 'ubuntu-latest' && matrix.py == '3.12'
       - name: Run tox -e py (without internet)
         run: |
           # install dependencies (requires internet connectivity)
           tox -e py --notest  
           # run tests with loopback only. We need to sudo for unshare, which means we need an absolute path for tox.
-          sudo unshare --map-root-user --net -- sh -c "ip link set lo up; sudo $(which tox) -e py"
+          sudo unshare --net -- sh -c "ip link set lo up; $(which tox) -e py"
         if: matrix.os == 'ubuntu-latest'
       - uses: codecov/codecov-action@v4
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -100,7 +100,7 @@ jobs:
         include:
           - image: macos-14
             platform: macos-arm64
-          - image: macos-12
+          - image: macos-13
             platform: macos-x86_64
           - image: windows-2019
             platform: windows

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,9 +68,6 @@ jobs:
       - run: pip install tox
       - run: tox -e py
         if: matrix.os != 'ubuntu-latest'
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-        if: matrix.os == 'ubuntu-latest' && matrix.py == '3.12'
       - name: Run tox -e py (without internet)
         run: |
           # install dependencies (requires internet connectivity)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,14 +67,14 @@ jobs:
           python-version: ${{ matrix.py }}
       - run: pip install tox
       - run: tox -e py
-        if: matrix.os != 'ubuntu-latestFIXME'
+        if: matrix.os != 'ubuntu-latest'
       - name: Run tox -e py (without internet)
         run: |
           # install dependencies (requires internet connectivity)
           tox -e py --notest  
           # run tests with loopback only. We need to sudo for unshare, which means we need an absolute path for tox.
-          sudo unshare --net -- sh -c "ip link set lo up; $(which tox) -e py"
-        if: matrix.os == 'ubuntu-latestFIXME'
+          sudo unshare --map-root-user --net -- sh -c "ip link set lo up; $(which tox) -e py"
+        if: matrix.os == 'ubuntu-latest'
       - uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Tighten HTTP detection heuristic to better support custom TCP-based protocols.
   ([#7228](https://github.com/mitmproxy/mitmproxy/pull/7228), @fatanugraha)
 - Add a `tun` proxy mode that creates a virtual network device on Linux for transparent proxying.
+  ([#7278](https://github.com/mitmproxy/mitmproxy/pull/7278), @mhils)
 - Fix a bug where mitmproxy would incorrectly report that TLS 1.0 and 1.1 are not supported
   with the current OpenSSL build.
   ([#7241](https://github.com/mitmproxy/mitmproxy/pull/7241), @mhils)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
   ([#7242](https://github.com/mitmproxy/mitmproxy/pull/7242), @mhils)
 - Tighten HTTP detection heuristic to better support custom TCP-based protocols.
   ([#7228](https://github.com/mitmproxy/mitmproxy/pull/7228), @fatanugraha)
+- Add a `tun` proxy mode that creates a virtual network device on Linux for transparent proxying.
 - Fix a bug where mitmproxy would incorrectly report that TLS 1.0 and 1.1 are not supported
   with the current OpenSSL build.
   ([#7241](https://github.com/mitmproxy/mitmproxy/pull/7241), @mhils)

--- a/mitmproxy/proxy/mode_servers.py
+++ b/mitmproxy/proxy/mode_servers.py
@@ -530,6 +530,16 @@ class TunInstance(ServerInstance[mode_specs.TunMode]):
     def is_running(self) -> bool:
         return self._server is not None
 
+    @property
+    def tun_name(self) -> str | None:
+        if self._server:
+            return self._server.tun_name
+        else:
+            return None
+
+    def to_json(self) -> dict:
+        return {"tun_name": self.tun_name, **super().to_json()}
+
     async def _start(self) -> None:
         assert self._server is None
         self._server = await mitmproxy_rs.tun.create_tun_interface(

--- a/mitmproxy/proxy/mode_servers.py
+++ b/mitmproxy/proxy/mode_servers.py
@@ -523,7 +523,7 @@ class TunInstance(ServerInstance[mode_specs.TunMode]):
     _server: mitmproxy_rs.tun.TunInterface | None = None
     listen_addrs = ()
 
-    def make_top_layer(self, context: Context) -> Layer:
+    def make_top_layer(self, context: Context) -> Layer:  # pragma: no cover mocked in tests
         return layers.modes.TransparentProxy(context)
 
     @property

--- a/mitmproxy/proxy/mode_servers.py
+++ b/mitmproxy/proxy/mode_servers.py
@@ -533,7 +533,7 @@ class TunInstance(ServerInstance[mode_specs.TunMode]):
     @property
     def tun_name(self) -> str | None:
         if self._server:
-            return self._server.tun_name
+            return self._server.tun_name()
         else:
             return None
 

--- a/mitmproxy/proxy/mode_servers.py
+++ b/mitmproxy/proxy/mode_servers.py
@@ -523,7 +523,9 @@ class TunInstance(ServerInstance[mode_specs.TunMode]):
     _server: mitmproxy_rs.tun.TunInterface | None = None
     listen_addrs = ()
 
-    def make_top_layer(self, context: Context) -> Layer:  # pragma: no cover mocked in tests
+    def make_top_layer(
+        self, context: Context
+    ) -> Layer:  # pragma: no cover mocked in tests
         return layers.modes.TransparentProxy(context)
 
     @property

--- a/mitmproxy/proxy/mode_specs.py
+++ b/mitmproxy/proxy/mode_specs.py
@@ -23,6 +23,8 @@ Examples:
 from __future__ import annotations
 
 import dataclasses
+import platform
+import re
 import sys
 from abc import ABCMeta
 from abc import abstractmethod
@@ -300,6 +302,25 @@ class LocalMode(ProxyMode):
     def __post_init__(self) -> None:
         # should not raise
         mitmproxy_rs.local.LocalRedirector.describe_spec(self.data)
+
+
+class TunMode(ProxyMode):
+    """A Tun interface."""
+
+    description = "TUN interface"
+    default_port = None
+    transport_protocol = BOTH
+
+    def __post_init__(self) -> None:
+        invalid_tun_name = self.data and (
+            # The Rust side is Linux only for the moment, but eventually we may need this.
+            platform.system() == "Darwin" and not re.match(r"^utun\d+$", self.data)
+        )
+        if invalid_tun_name:  # pragma: no cover
+            raise ValueError(
+                f"Invalid tun name: {self.data}. "
+                f"On macOS, the tun name must be the form utunx where x is a number, such as utun3."
+            )
 
 
 class OsProxyMode(ProxyMode):  # pragma: no cover

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
     "hyperframe>=6.0,<=6.0.1",
     "kaitaistruct>=0.10,<=0.10",
     "ldap3>=2.8,<=2.9.1",
-    "mitmproxy_rs>=0.10.3,<0.11",  # relaxed upper bound here: we control this
+    "mitmproxy_rs>=0.10.4,<0.11",  # relaxed upper bound here: we control this
     "msgpack>=1.0.0,<=1.1.0",
     "passlib>=1.6.5,<=1.7.4",
     "protobuf>=5.27.2,<=5.28.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
     "hyperframe>=6.0,<=6.0.1",
     "kaitaistruct>=0.10,<=0.10",
     "ldap3>=2.8,<=2.9.1",
-    "mitmproxy_rs>=0.10.1,<0.11",  # relaxed upper bound here: we control this
+    "mitmproxy_rs>=0.10.3,<0.11",  # relaxed upper bound here: we control this
     "msgpack>=1.0.0,<=1.1.0",
     "passlib>=1.6.5,<=1.7.4",
     "protobuf>=5.27.2,<=5.28.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
     "hyperframe>=6.0,<=6.0.1",
     "kaitaistruct>=0.10,<=0.10",
     "ldap3>=2.8,<=2.9.1",
-    "mitmproxy_rs>=0.9.1,<0.10",  # relaxed upper bound here: we control this
+    "mitmproxy_rs>=0.10.0,<0.11",  # relaxed upper bound here: we control this
     "msgpack>=1.0.0,<=1.1.0",
     "passlib>=1.6.5,<=1.7.4",
     "protobuf>=5.27.2,<=5.28.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
     "hyperframe>=6.0,<=6.0.1",
     "kaitaistruct>=0.10,<=0.10",
     "ldap3>=2.8,<=2.9.1",
-    "mitmproxy_rs>=0.10.0,<0.11",  # relaxed upper bound here: we control this
+    "mitmproxy_rs>=0.10.1,<0.11",  # relaxed upper bound here: we control this
     "msgpack>=1.0.0,<=1.1.0",
     "passlib>=1.6.5,<=1.7.4",
     "protobuf>=5.27.2,<=5.28.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
     "hyperframe>=6.0,<=6.0.1",
     "kaitaistruct>=0.10,<=0.10",
     "ldap3>=2.8,<=2.9.1",
-    "mitmproxy_rs>=0.10.4,<0.11",  # relaxed upper bound here: we control this
+    "mitmproxy_rs>=0.10.7,<0.11",  # relaxed upper bound here: we control this
     "msgpack>=1.0.0,<=1.1.0",
     "passlib>=1.6.5,<=1.7.4",
     "protobuf>=5.27.2,<=5.28.2",

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+import platform
 import socket
 import sys
 
@@ -13,6 +14,10 @@ skip_windows = pytest.mark.skipif(os.name == "nt", reason="Skipping due to Windo
 
 skip_not_windows = pytest.mark.skipif(
     os.name != "nt", reason="Skipping due to not Windows"
+)
+
+skip_not_linux = pytest.mark.skipif(
+    platform.system() != "Linux", reason="Skipping due to not Linux"
 )
 
 try:

--- a/test/mitmproxy/proxy/test_mode_servers.py
+++ b/test/mitmproxy/proxy/test_mode_servers.py
@@ -386,6 +386,28 @@ async def test_tun_mode(monkeypatch, caplog):
         await inst.stop()
 
 
+async def test_tun_mode_mocked(monkeypatch):
+    tun_interface = Mock()
+    tun_interface.tun_name = lambda: "tun0"
+    tun_interface.wait_closed = AsyncMock()
+    create_tun_interface = AsyncMock(return_value=tun_interface)
+    monkeypatch.setattr(
+        mitmproxy_rs.tun, "create_tun_interface", create_tun_interface
+    )
+
+    inst = TunInstance.make(f"tun", MagicMock())
+    assert not inst.is_running
+    assert inst.tun_name is None
+
+    await inst.start()
+    assert inst.is_running
+    assert inst.tun_name == "tun0"
+    assert inst.to_json()["tun_name"] == "tun0"
+
+    await inst.stop()
+    assert not inst.is_running
+    assert inst.tun_name is None
+
 @pytest.fixture()
 def patched_local_redirector(monkeypatch):
     start_local_redirector = AsyncMock(return_value=Mock())

--- a/test/mitmproxy/proxy/test_mode_servers.py
+++ b/test/mitmproxy/proxy/test_mode_servers.py
@@ -359,7 +359,6 @@ async def test_dns_start_stop(caplog_async, transport_protocol):
 
 @skip_not_linux
 async def test_tun_mode(monkeypatch, caplog):
-    caplog.set_level("DEBUG")
     monkeypatch.setattr(ConnectionHandler, "handle_client", _echo_server)
 
     with taddons.context(Proxyserver()):

--- a/test/mitmproxy/proxy/test_mode_servers.py
+++ b/test/mitmproxy/proxy/test_mode_servers.py
@@ -381,6 +381,8 @@ async def test_tun_mode(monkeypatch, caplog):
         writer.write(b"hello")
         await writer.drain()
         assert await reader.readexactly(5) == b"HELLO"
+        writer.close()
+        await writer.wait_closed()
         await inst.stop()
 
 

--- a/test/mitmproxy/proxy/test_mode_servers.py
+++ b/test/mitmproxy/proxy/test_mode_servers.py
@@ -7,17 +7,17 @@ from unittest.mock import Mock
 
 import pytest
 
-from mitmproxy.proxy.mode_servers import TunInstance
 from ...conftest import no_ipv6
+from ...conftest import skip_not_linux
 import mitmproxy.platform
 import mitmproxy_rs
 from mitmproxy.addons.proxyserver import Proxyserver
 from mitmproxy.proxy.mode_servers import LocalRedirectorInstance
 from mitmproxy.proxy.mode_servers import ServerInstance
+from mitmproxy.proxy.mode_servers import TunInstance
 from mitmproxy.proxy.mode_servers import WireGuardServerInstance
 from mitmproxy.proxy.server import ConnectionHandler
 from mitmproxy.test import taddons
-from ...conftest import skip_not_linux
 
 
 def test_make():
@@ -132,12 +132,14 @@ async def test_transparent(failure, monkeypatch, caplog_async):
         await inst.stop()
         assert await caplog_async.await_log("stopped")
 
+
 async def _echo_server(self: ConnectionHandler):
     t = self.transports[self.client]
     data = await t.reader.read(65535)
     t.writer.write(data.upper())
     await t.writer.drain()
     t.writer.close()
+
 
 async def test_wireguard(tdata, monkeypatch, caplog):
     caplog.set_level("DEBUG")
@@ -353,7 +355,6 @@ async def test_dns_start_stop(caplog_async, transport_protocol):
 
         await inst.stop()
         assert await caplog_async.await_log("stopped")
-
 
 
 @skip_not_linux

--- a/test/mitmproxy/proxy/test_mode_servers.py
+++ b/test/mitmproxy/proxy/test_mode_servers.py
@@ -391,9 +391,7 @@ async def test_tun_mode_mocked(monkeypatch):
     tun_interface.tun_name = lambda: "tun0"
     tun_interface.wait_closed = AsyncMock()
     create_tun_interface = AsyncMock(return_value=tun_interface)
-    monkeypatch.setattr(
-        mitmproxy_rs.tun, "create_tun_interface", create_tun_interface
-    )
+    monkeypatch.setattr(mitmproxy_rs.tun, "create_tun_interface", create_tun_interface)
 
     inst = TunInstance.make(f"tun", MagicMock())
     assert not inst.is_running
@@ -407,6 +405,7 @@ async def test_tun_mode_mocked(monkeypatch):
     await inst.stop()
     assert not inst.is_running
     assert inst.tun_name is None
+
 
 @pytest.fixture()
 def patched_local_redirector(monkeypatch):

--- a/test/mitmproxy/proxy/test_mode_specs.py
+++ b/test/mitmproxy/proxy/test_mode_specs.py
@@ -71,7 +71,7 @@ def test_parse_specific_modes():
     assert ProxyMode.parse("wireguard:foo.conf").data == "foo.conf"
     assert ProxyMode.parse("wireguard@51821").listen_port() == 51821
     assert ProxyMode.parse("tun")
-    assert ProxyMode.parse("tun:mitmproxy")
+    assert ProxyMode.parse("tun:utun42")
 
     assert ProxyMode.parse("local")
 

--- a/test/mitmproxy/proxy/test_mode_specs.py
+++ b/test/mitmproxy/proxy/test_mode_specs.py
@@ -70,6 +70,8 @@ def test_parse_specific_modes():
     assert ProxyMode.parse("wireguard")
     assert ProxyMode.parse("wireguard:foo.conf").data == "foo.conf"
     assert ProxyMode.parse("wireguard@51821").listen_port() == 51821
+    assert ProxyMode.parse("tun")
+    assert ProxyMode.parse("tun:mitmproxy")
 
     assert ProxyMode.parse("local")
 

--- a/web/gen/state_js.py
+++ b/web/gen/state_js.py
@@ -33,7 +33,7 @@ async def make() -> str:
     si3 = ServerInstance.make("socks5", m.proxyserver)
     si4 = ServerInstance.make("tun", m.proxyserver)
     si4._server = Mock()
-    si4._server.tun_name = "tun0"
+    si4._server.tun_name = lambda: "tun0"
     m.proxyserver.servers._instances.update(
         {
             si1.mode: si1,

--- a/web/gen/state_js.py
+++ b/web/gen/state_js.py
@@ -31,11 +31,15 @@ async def make() -> str:
     si2 = ServerInstance.make("reverse:example.com", m.proxyserver)
     si2.last_exception = RuntimeError("I failed somehow.")
     si3 = ServerInstance.make("socks5", m.proxyserver)
+    si4 = ServerInstance.make("tun", m.proxyserver)
+    si4._server = Mock()
+    si4._server.tun_name = "tun0"
     m.proxyserver.servers._instances.update(
         {
             si1.mode: si1,
             si2.mode: si2,
             si3.mode: si3,
+            si4.mode: si4,
         }
     )
 

--- a/web/src/js/__tests__/ducks/_tbackendstate.ts
+++ b/web/src/js/__tests__/ducks/_tbackendstate.ts
@@ -41,6 +41,15 @@ export function TBackendState(): Required<BackendState> {
                 "last_exception": null,
                 "listen_addrs": [],
                 "type": "socks5"
+            },
+            "tun": {
+                "description": "TUN interface",
+                "full_spec": "tun",
+                "is_running": true,
+                "last_exception": null,
+                "listen_addrs": [],
+                "tun_name": "tun0",
+                "type": "tun"
             }
         },
         "version": "1.2.3"

--- a/web/src/js/ducks/backendState.ts
+++ b/web/src/js/ducks/backendState.ts
@@ -16,6 +16,7 @@ export interface ServerInfo {
     listen_addrs: [string, number][];
     type: string;
     wireguard_conf?: string;
+    tun_name?: string;
 }
 
 export interface BackendState {


### PR DESCRIPTION
#### Description

~Depends on https://github.com/mitmproxy/mitmproxy_rs/pull/187.~

```
mitmdump --mode tun
curl --interface tun0 https://example.com
```

#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
