### PR TITLE
Remove dependency on protobuf library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
   ([#7286](https://github.com/mitmproxy/mitmproxy/pull/7286), @lukant)
 - Fix a crash when handling corrupted compressed body in savehar addon and its tests.
   ([#7320](https://github.com/mitmproxy/mitmproxy/pull/7320), @8192bytes)
+- Remove dependency on `protobuf` library as it was no longer being used.
 
 ## 02 October 2024: mitmproxy 11.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Fix a crash when handling corrupted compressed body in savehar addon and its tests.
   ([#7320](https://github.com/mitmproxy/mitmproxy/pull/7320), @8192bytes)
 - Remove dependency on `protobuf` library as it was no longer being used.
+  ([#7327](https://github.com/mitmproxy/mitmproxy/pull/7327), @matthew16550)
 
 ## 02 October 2024: mitmproxy 11.0.0
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,6 @@ dependencies = [
     "mitmproxy_rs>=0.10.7,<0.11",  # relaxed upper bound here: we control this
     "msgpack>=1.0.0,<=1.1.0",
     "passlib>=1.6.5,<=1.7.4",
-    "protobuf>=5.27.2,<=5.28.3",
     "pydivert>=2.0.3,<=2.1.0; sys_platform == 'win32'",
     "pyOpenSSL>=22.1,<=24.2.1",
     "pyparsing>=2.4.2,<=3.2.0",


### PR DESCRIPTION
#### Description

Hello, this is my first contribution to mitmproxy.

The `protobuf` dependency seems unused now, I think the need went away in #4349.

All the tests pass on my Mac without protobuf and hopefully CI will find if there is a need I overlooked.

If the dependency can be removed it will simplify my attempt at updating MacPorts which currently installs v7.0.4.

Also it would help some older issues - #5160, #6881

#### Checklist

 - [n/a] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
