### PR TITLE
Remove hard coded default window size for HTTP/2 connections.

### DIFF
--- a/mitmproxy/proxy/layers/http/_http_h2.py
+++ b/mitmproxy/proxy/layers/http/_http_h2.py
@@ -61,7 +61,7 @@ class BufferedH2Connection(h2.connection.H2Connection):
         super().initiate_connection()
         # We increase the flow-control window for new streams with a setting,
         # but we need to increase the overall connection flow-control window as well.
-        self.increment_flow_control_window(2**31 - 1 - 65535)  # maximum - default
+        self.increment_flow_control_window(2**31 - 1 - self.inbound_flow_control_window)  # maximum - default
 
     def send_data(
         self,

--- a/mitmproxy/proxy/layers/http/_http_h2.py
+++ b/mitmproxy/proxy/layers/http/_http_h2.py
@@ -61,7 +61,9 @@ class BufferedH2Connection(h2.connection.H2Connection):
         super().initiate_connection()
         # We increase the flow-control window for new streams with a setting,
         # but we need to increase the overall connection flow-control window as well.
-        self.increment_flow_control_window(2**31 - 1 - self.inbound_flow_control_window)  # maximum - default
+        self.increment_flow_control_window(
+            2**31 - 1 - self.inbound_flow_control_window
+        )  # maximum - default
 
     def send_data(
         self,


### PR DESCRIPTION
#### Description

Use `H2Connection.inbound_flow_control_window` instead of hard coding the default value while incrementing the connection flow control window.

#### Checklist

 - [x] I have updated tests where applicable.
 - [ ] I have added an entry to the CHANGELOG.
