### PR TITLE
Stop sorting keys in JSON contentview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ## Unreleased: mitmproxy next
 
 - Stop sorting keys in JSON contentview
+  ([#7346](https://github.com/mitmproxy/mitmproxy/pull/7346), @injust)
 
 ## 24 November 2024: mitmproxy 11.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ## Unreleased: mitmproxy next
 
+- Stop sorting keys in JSON contentview
 
 ## 24 November 2024: mitmproxy 11.0.1
 

--- a/mitmproxy/contentviews/json.py
+++ b/mitmproxy/contentviews/json.py
@@ -18,7 +18,7 @@ def parse_json(s: bytes) -> Any:
 
 
 def format_json(data: Any) -> Iterator[base.TViewLine]:
-    encoder = json.JSONEncoder(indent=4, sort_keys=True, ensure_ascii=False)
+    encoder = json.JSONEncoder(indent=4, ensure_ascii=False)
     current_line: base.TViewLine = []
     for chunk in encoder.iterencode(data):
         if "\n" in chunk:


### PR DESCRIPTION
#### Description

This was discussed in https://github.com/mitmproxy/mitmproxy/discussions/5853.

I tested locally and confirmed that the JSON keys are no longer sorted.

#### Checklist

 - [ ] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
