### PR TITLE
Invert check for unsupported platforms in local mode (mitmweb)

### DIFF
--- a/web/src/js/components/Modes.tsx
+++ b/web/src/js/components/Modes.tsx
@@ -21,7 +21,8 @@ export default function Modes() {
                 <h3>Recommended</h3>
                 <div className="modes-container">
                     <Regular />
-                    {!platform.startsWith("linux") ? (
+                    {platform.startsWith("win32") ||
+                    platform.startsWith("darwin") ? (
                         <Local />
                     ) : (
                         <MissingMode


### PR DESCRIPTION
#### Description

This should fix #7347.
I'm considering whether to include other platforms (e.g., cygwin, msys, etc.): https://stackoverflow.com/questions/446209/possible-values-from-sys-platform. 

#### Checklist

 - [x] I have updated tests where applicable.
 - [ ] I have added an entry to the CHANGELOG.
