### PR TITLE
Fix #7354 "AttributeError" from tlsconfig.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 - Stop sorting keys in JSON contentview
   ([#7346](https://github.com/mitmproxy/mitmproxy/pull/7346), @injust)
+- Fix a bug where a custom CA would raise an error.
 
 ## 24 November 2024: mitmproxy 11.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Stop sorting keys in JSON contentview
   ([#7346](https://github.com/mitmproxy/mitmproxy/pull/7346), @injust)
 - Fix a bug where a custom CA would raise an error.
+  ([#7355](https://github.com/mitmproxy/mitmproxy/pull/7355), @nneonneo)
 
 ## 24 November 2024: mitmproxy 11.0.1
 

--- a/mitmproxy/certs.py
+++ b/mitmproxy/certs.py
@@ -376,7 +376,12 @@ class CertStore:
         self.default_ca = default_ca
         self.default_chain_file = default_chain_file
         self.default_chain_certs = (
-            [Cert(c) for c in x509.load_pem_x509_certificates(self.default_chain_file.read_bytes())]
+            [
+                Cert(c)
+                for c in x509.load_pem_x509_certificates(
+                    self.default_chain_file.read_bytes()
+                )
+            ]
             if self.default_chain_file
             else [default_ca]
         )

--- a/mitmproxy/certs.py
+++ b/mitmproxy/certs.py
@@ -376,7 +376,7 @@ class CertStore:
         self.default_ca = default_ca
         self.default_chain_file = default_chain_file
         self.default_chain_certs = (
-            x509.load_pem_x509_certificates(self.default_chain_file.read_bytes())
+            [Cert(c) for c in x509.load_pem_x509_certificates(self.default_chain_file.read_bytes())]
             if self.default_chain_file
             else [default_ca]
         )

--- a/mitmproxy/certs.py
+++ b/mitmproxy/certs.py
@@ -362,6 +362,11 @@ class CertStore:
     """
 
     STORE_CAP = 100
+    default_privatekey: rsa.RSAPrivateKey
+    default_ca: Cert
+    default_chain_file: Path | None
+    default_chain_certs: list[Cert]
+    dhparams: DHParams
     certs: dict[TCertId, CertStoreEntry]
     expire_queue: list[CertStoreEntry]
 


### PR DESCRIPTION
CertStore was inserting raw x509.Certificate objects into default_chain_certs instead of Cert objects, which caused an error later in tlsconfig.py when the certs were used.

#### Description

This fixes #7354, and has been tested to work locally.

#### Checklist

 - [ ] I have updated tests where applicable.
 - [ ] I have added an entry to the CHANGELOG.
