### PR TITLE
Fix Hugo deprecation error

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -232,8 +232,8 @@ jobs:
         with:
           python-version-file: .github/python-version.txt
       - run: |
-          wget -q https://github.com/gohugoio/hugo/releases/download/v0.92.1/hugo_extended_0.92.1_Linux-64bit.deb
-          echo "a9440adfd3ecce40089def287dee4e42ffae252ba08c77d1ac575b880a079ce6 hugo_extended_0.92.1_Linux-64bit.deb" | sha256sum -c
+          wget -q https://github.com/gohugoio/hugo/releases/download/v0.139.3/hugo_extended_0.139.3_linux-amd64.deb
+          echo "3e58800d1fee57269208d07d104ae1a6ab886615344099f2dca0c6ad5279bc11 hugo_extended_0.139.3_linux-amd64.deb" | sha256sum -c
           sudo dpkg -i hugo*.deb
       - run: pip install -e .[dev]
       - run: ./docs/build.py

--- a/docs/src/layouts/shortcodes/asciicast.html
+++ b/docs/src/layouts/shortcodes/asciicast.html
@@ -3,7 +3,7 @@
     <asciinema-player id="asciinema-player" src="/recordings/{{ $file }}.cast" font-size="13px" poster="npt:{{ .Get "poster" }}" preload></asciinema-player>
     {{- if .Get "instructions" -}}
         {{- $instructions_file := print "static/recordings/" $file "_instructions.json" -}}
-        {{ $data := getJSON $instructions_file }}
+        {{ $data := resources.Get $instructions_file | transform.Unmarshal }}
         <article class="panel">
             <p class="panel-heading">
                 Video Content


### PR DESCRIPTION
I encountered this problem because the version of Hugo installed with Homebrew is much newer than the one in CI. I fixed the error and updated Hugo in CI so the build keeps working.

#### Checklist

 - [x] I have updated tests where applicable.
 - [ ] I have added an entry to the CHANGELOG.
	- Does a documentation build fix like this require a CHANGELOG entry?