### PR TITLE
Refine handling of invalid request transfer-encodings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,8 @@
   ([#7355](https://github.com/mitmproxy/mitmproxy/pull/7355), @nneonneo)
 - Fix a bug where the mitmproxy UI would crash on negative durations.
   ([#7358](https://github.com/mitmproxy/mitmproxy/pull/7358), @mhils)
-- Allow HTTP transfer encodings with read-until-EOF semantics in requests if `validate_inbound_headers` is disabled.
-  ([#7361](https://github.com/mitmproxy/mitmproxy/pull/7361), @mhils)
+- Allow technically invalid HTTP transfer encodings in requests if `validate_inbound_headers` is disabled.
+  ([#7361](https://github.com/mitmproxy/mitmproxy/pull/7361), [#7373](https://github.com/mitmproxy/mitmproxy/pull/7373), @mhils)
 - Fix a bug in windows management in mitmproxy TUI whereby the help window does not appear if "?" is pressed within the overlay
   ([#6500](https://github.com/mitmproxy/mitmproxy/pull/6500), @emanuele-em)
 

--- a/mitmproxy/net/http/http1/read.py
+++ b/mitmproxy/net/http/http1/read.py
@@ -119,7 +119,9 @@ def expected_http_body_size(
                 if te == "identity" or "content-length" in headers:
                     pass  # Content-Length or 0
                 else:
-                    return -1  # compress/deflate/gzip with no content-length -> read until eof
+                    return (
+                        -1
+                    )  # compress/deflate/gzip with no content-length -> read until eof
             case other:  # pragma: no cover
                 typing.assert_never(other)
 

--- a/test/mitmproxy/net/http/http1/test_read.py
+++ b/test/mitmproxy/net/http/http1/test_read.py
@@ -130,27 +130,23 @@ def test_expected_http_body_size():
     # requests with non-chunked transfer encoding.
     # technically invalid, but we want to maximize compatibility if validate_inbound_headers is false.
     assert (
-            expected_http_body_size(
-                treq(headers=Headers(transfer_encoding="identity", content_length="42")),
-                None
-            )
-            == 42
+        expected_http_body_size(
+            treq(headers=Headers(transfer_encoding="identity", content_length="42")),
+            None,
+        )
+        == 42
     )
     # Example of a misbehaving client:
     # https://github.com/tensorflow/tensorflow/blob/fd9471e7d48e8e86684c847c0e1897c76e737805/third_party/xla/xla/tsl/platform/cloud/curl_http_request.cc
     assert (
-            expected_http_body_size(
-                treq(headers=Headers(transfer_encoding="identity")),
-                None
-            )
-            == 0
+        expected_http_body_size(
+            treq(headers=Headers(transfer_encoding="identity")), None
+        )
+        == 0
     )
     assert (
-            expected_http_body_size(
-                treq(headers=Headers(transfer_encoding="gzip")),
-                None
-            )
-            == -1
+        expected_http_body_size(treq(headers=Headers(transfer_encoding="gzip")), None)
+        == -1
     )
 
     # explicit length

--- a/test/mitmproxy/net/http/http1/test_read.py
+++ b/test/mitmproxy/net/http/http1/test_read.py
@@ -127,6 +127,31 @@ def test_expected_http_body_size():
         )
         == -1
     )
+    # requests with non-chunked transfer encoding.
+    # technically invalid, but we want to maximize compatibility if validate_inbound_headers is false.
+    assert (
+            expected_http_body_size(
+                treq(headers=Headers(transfer_encoding="identity", content_length="42")),
+                None
+            )
+            == 42
+    )
+    # Example of a misbehaving client:
+    # https://github.com/tensorflow/tensorflow/blob/fd9471e7d48e8e86684c847c0e1897c76e737805/third_party/xla/xla/tsl/platform/cloud/curl_http_request.cc
+    assert (
+            expected_http_body_size(
+                treq(headers=Headers(transfer_encoding="identity")),
+                None
+            )
+            == 0
+    )
+    assert (
+            expected_http_body_size(
+                treq(headers=Headers(transfer_encoding="gzip")),
+                None
+            )
+            == -1
+    )
 
     # explicit length
     assert expected_http_body_size(treq(headers=Headers(content_length="42"))) == 42


### PR DESCRIPTION
#### Description

For requests with `transfer-encoding: identity`, we want to respect content-length headers or otherwise not expect a body.

#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
