### PR TITLE
Exposing 'localModeUnavailable' to the frontend

### DIFF
--- a/mitmproxy/tools/web/app.py
+++ b/mitmproxy/tools/web/app.py
@@ -655,6 +655,7 @@ class State(RequestHandler):
                 s.mode.full_spec: s.to_json() for s in master.proxyserver.servers
             },
             "platform": sys.platform,
+            "localModeUnavailable": mitmproxy_rs.local.LocalRedirector.unavailable_reason()
         }
 
     def get(self):

--- a/mitmproxy/tools/web/app.py
+++ b/mitmproxy/tools/web/app.py
@@ -655,7 +655,7 @@ class State(RequestHandler):
                 s.mode.full_spec: s.to_json() for s in master.proxyserver.servers
             },
             "platform": sys.platform,
-            "localModeUnavailable": mitmproxy_rs.local.LocalRedirector.unavailable_reason()
+            "localModeUnavailable": mitmproxy_rs.local.LocalRedirector.unavailable_reason(),
         }
 
     def get(self):

--- a/web/gen/state_js.py
+++ b/web/gen/state_js.py
@@ -50,6 +50,7 @@ async def make() -> str:
     data["contentViews"] = ["Auto", "Raw"]
     data["version"] = "1.2.3"
     data["platform"] = "darwin"
+    data["localModeUnavailable"] = None
 
     # language=TypeScript
     content = (

--- a/web/src/js/__tests__/ducks/_tbackendstate.ts
+++ b/web/src/js/__tests__/ducks/_tbackendstate.ts
@@ -7,6 +7,7 @@ export function TBackendState(): Required<BackendState> {
             "Auto",
             "Raw"
         ],
+        "localModeUnavailable": null,
         "platform": "darwin",
         "servers": {
             "regular": {

--- a/web/src/js/components/Modes.tsx
+++ b/web/src/js/components/Modes.tsx
@@ -30,7 +30,10 @@ export default function Modes() {
                     ) : (
                         <MissingMode
                             title="Local Redirect Mode"
-                            description={localModeUnavailable ?? "This mode is only supported on Windows and MacOS."}
+                            description={
+                                localModeUnavailable ??
+                                "This mode is only supported on Windows and MacOS."
+                            }
                         />
                     )}
                     <Wireguard />

--- a/web/src/js/components/Modes.tsx
+++ b/web/src/js/components/Modes.tsx
@@ -24,17 +24,13 @@ export default function Modes() {
                 <h3>Recommended</h3>
                 <div className="modes-container">
                     <Regular />
-                    {platform.startsWith("win32") ||
-                    platform.startsWith("darwin") ? (
-                        <Local />
-                    ) : (
+                    {localModeUnavailable !== null ? (
                         <MissingMode
                             title="Local Redirect Mode"
-                            description={
-                                localModeUnavailable ??
-                                "This mode is only supported on Windows and MacOS."
-                            }
+                            description={localModeUnavailable}
                         />
+                    ) : (
+                        <Local />
                     )}
                     <Wireguard />
                     <Reverse />

--- a/web/src/js/components/Modes.tsx
+++ b/web/src/js/components/Modes.tsx
@@ -30,7 +30,7 @@ export default function Modes() {
                     ) : (
                         <MissingMode
                             title="Local Redirect Mode"
-                            description={localModeUnavailable ?? ""}
+                            description={localModeUnavailable ?? "This mode is only supported on Windows and MacOS."}
                         />
                     )}
                     <Wireguard />

--- a/web/src/js/components/Modes.tsx
+++ b/web/src/js/components/Modes.tsx
@@ -11,7 +11,10 @@ import Dns from "./Modes/Dns";
 import MissingMode from "./Modes/MissingMode";
 
 export default function Modes() {
-    const platform = useAppSelector((state) => state.backendState.platform);
+    const { platform, localModeUnavailable } = useAppSelector(
+        (state) => state.backendState,
+    );
+
     return (
         <div className="modes">
             <h2>Intercept Traffic</h2>
@@ -27,7 +30,7 @@ export default function Modes() {
                     ) : (
                         <MissingMode
                             title="Local Redirect Mode"
-                            description="This mode is only supported on Windows and MacOS."
+                            description={localModeUnavailable ?? ""}
                         />
                     )}
                     <Wireguard />

--- a/web/src/js/ducks/backendState.ts
+++ b/web/src/js/ducks/backendState.ts
@@ -25,6 +25,7 @@ export interface BackendState {
     contentViews: string[];
     servers: { [key: string]: ServerInfo };
     platform: string;
+    localModeUnavailable: string | null
 }
 
 export const defaultState: BackendState = {
@@ -33,6 +34,7 @@ export const defaultState: BackendState = {
     contentViews: [],
     servers: {},
     platform: "",
+    localModeUnavailable: null
 };
 
 export function mockUpdate(newState: Partial<BackendState>) {

--- a/web/src/js/ducks/backendState.ts
+++ b/web/src/js/ducks/backendState.ts
@@ -25,7 +25,7 @@ export interface BackendState {
     contentViews: string[];
     servers: { [key: string]: ServerInfo };
     platform: string;
-    localModeUnavailable: string | null
+    localModeUnavailable: string | null;
 }
 
 export const defaultState: BackendState = {
@@ -34,7 +34,7 @@ export const defaultState: BackendState = {
     contentViews: [],
     servers: {},
     platform: "",
-    localModeUnavailable: null
+    localModeUnavailable: null,
 };
 
 export function mockUpdate(newState: Partial<BackendState>) {


### PR DESCRIPTION
#### Description

In this PR, I'm exposing `localModeUnavailable` to the frontend. This allows us to display a string explaining why local mode is unavailable on unsupported platforms.

#### Checklist

 - [ ] I have updated tests where applicable.
 - [ ] I have added an entry to the CHANGELOG.
