### PR TITLE
Require Python 3.12+

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,10 +51,6 @@ jobs:
             py: "3.13"
           - os: ubuntu-latest
             py: "3.12"
-          - os: ubuntu-latest
-            py: "3.11"
-          - os: ubuntu-latest
-            py: "3.10"
     runs-on: ${{ matrix.os }}
     steps:
       - run: printenv

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@
 ## Unreleased: mitmproxy next
 
 - **Local Capture Mode** is now available on Linux as well.
+  ([#7440](https://github.com/mitmproxy/mitmproxy/pull/7440), @mhils)
 - mitmproxy now requires Python 3.10 or above.
+  ([#7440](https://github.com/mitmproxy/mitmproxy/pull/7440), @mhils)
 - Add cache-busting for mitmweb's front end code.
   ([#7386](https://github.com/mitmproxy/mitmproxy/pull/7386), @mhils)
 - Clicking the URL in mitmweb now places the cursor at the current position instead of selecting the entire URL.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 ## Unreleased: mitmproxy next
 
+- **Local Capture Mode** is now available on Linux as well.
+- mitmproxy now requires Python 3.10 or above.
 - Add cache-busting for mitmweb's front end code.
   ([#7386](https://github.com/mitmproxy/mitmproxy/pull/7386), @mhils)
 - Clicking the URL in mitmweb now places the cursor at the current position instead of selecting the entire URL.

--- a/docs/src/content/overview-installation.md
+++ b/docs/src/content/overview-installation.md
@@ -66,7 +66,7 @@ While there are plenty of options around[^1], we recommend the installation usin
     packages. Most of them (pip, virtualenv, pipenv, etc.) should just work, but we don't have the capacity to
     provide support for it.
 
-1. Install a recent version of Python (we require at least 3.10).
+1. Install a recent version of Python (we require at least 3.12).
 2. Install [pipx](https://pipxproject.github.io/pipx/).
 3. `pipx install mitmproxy`
 

--- a/examples/addons/websocket-inject-message.py
+++ b/examples/addons/websocket-inject-message.py
@@ -34,7 +34,6 @@ async def inject_async(flow: http.HTTPFlow):
         msg = msg[1:] + msg[:1]
 
 
-# Python 3.11: replace with TaskGroup
 tasks = set()
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "mitmproxy"
 description = "An interactive, SSL/TLS-capable intercepting proxy for HTTP/1, HTTP/2, and WebSockets."
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.12"
 license = {file="LICENSE"}
 authors = [{name = "Aldo Cortesi", email = "aldo@corte.si"}]
 maintainers = [{name = "Maximilian Hils", email = "mitmproxy@maximilianhils.com"}]
@@ -16,8 +16,6 @@ classifiers = [
     "Operating System :: POSIX",
     "Operating System :: Microsoft :: Windows",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: Implementation :: CPython",
@@ -43,7 +41,7 @@ dependencies = [
     "hyperframe>=6.0,<=6.0.1",
     "kaitaistruct>=0.10,<=0.10",
     "ldap3>=2.8,<=2.9.1",
-    "mitmproxy_rs>=0.11.1,<0.12",  # relaxed upper bound here: we control this
+    "mitmproxy_rs>=0.11.2,<0.12",  # relaxed upper bound here: we control this
     "msgpack>=1.0.0,<=1.1.0",
     "passlib>=1.6.5,<=1.7.4",
     "pydivert>=2.0.3,<=2.1.0; sys_platform == 'win32'",
@@ -53,7 +51,6 @@ dependencies = [
     "ruamel.yaml>=0.16,<=0.18.7",
     "sortedcontainers>=2.3,<=2.4.0",
     "tornado>=6.4.1,<=6.4.2",
-    "typing-extensions>=4.3,<=4.11.0; python_version<'3.11'",
     "urwid>=2.6.14,<=2.6.16",
     "wsproto>=1.0,<=1.2.0",
     "publicsuffix2>=2.20190812,<=2.20191221",
@@ -143,8 +140,6 @@ filterwarnings = [
     "ignore:datetime.datetime.utcnow:DeprecationWarning:aioquic.*:",
     "error::RuntimeWarning",
     "error::pytest.PytestUnraisableExceptionWarning",
-    # The following warning should only appear on Python 3.11 and below where eager_task_factory is not present
-    "default:coroutine 'ConnectionHandler.hook_task' was never awaited:RuntimeWarning",
 ]
 
 [tool.pytest.individual_coverage]

--- a/test/individual_coverage.py
+++ b/test/individual_coverage.py
@@ -6,9 +6,8 @@ import os
 import re
 import subprocess
 import sys
-from pathlib import Path
-
 import tomllib
+from pathlib import Path
 
 root = Path(__file__).parent.parent.absolute()
 


### PR DESCRIPTION
#### Description

All recommended installation methods (https://docs.mitmproxy.org/stable/overview-installation/) ship with Python 3.13 already, we shouldn't drag us down with supporting ancient configurations.

#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
