### PR TITLE
Added invisible attribute for FlowColumn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ✨ You do not need to add a pull request reference or author information, this will be done automatically by CI. ✨
 -->
 
+- Add invisible attribute for FlowColumns
+
 ## Unreleased: mitmproxy next
 
 - Add cache-busting for mitmweb's front end code.

--- a/web/src/js/components/FlowTable/FlowColumns.tsx
+++ b/web/src/js/components/FlowTable/FlowColumns.tsx
@@ -25,6 +25,7 @@ interface FlowColumn {
     (props: FlowColumnProps): JSX.Element;
 
     headerName: string; // Shown in the UI
+    invisible?: boolean;
 }
 
 export const tls: FlowColumn = ({ flow }) => {

--- a/web/src/js/components/FlowTable/FlowRow.tsx
+++ b/web/src/js/components/FlowTable/FlowRow.tsx
@@ -43,7 +43,7 @@ export default React.memo(function FlowRow({
 
     const displayColumns = displayColumnNames
         .map((x) => columns[x])
-        .filter((x) => x)
+        .filter((x) => x.invisible == undefined)
         .concat(columns.quickactions);
 
     return (

--- a/web/src/js/components/FlowTable/FlowTableHead.tsx
+++ b/web/src/js/components/FlowTable/FlowTableHead.tsx
@@ -16,7 +16,7 @@ export default React.memo(function FlowTableHead() {
     const sortType = sortDesc ? "sort-desc" : "sort-asc";
     const displayColumns = displayColumnNames
         .map((x) => columns[x])
-        .filter((x) => x)
+        .filter((x) => x.invisible == undefined)
         .concat(columns.quickactions);
 
     return (


### PR DESCRIPTION
#### Description

I have added a new attribute to FlowColumn to be displayed or not based on invisible property in mitmweb ui. This property helps me to show other columns that are sourcing data about flows from custom addons that enrich flow information.

#### Checklist

 - [x] I have added an entry to the CHANGELOG.
