### PR TITLE
Fix use of `asyncio.create_task`

### DIFF
--- a/mitmproxy/addons/clientplayback.py
+++ b/mitmproxy/addons/clientplayback.py
@@ -147,18 +147,20 @@ class ClientPlayback:
     inflight: http.HTTPFlow | None
     queue: asyncio.Queue
     options: Options
+    replay_tasks: set[asyncio.Task]
 
     def __init__(self):
         self.queue = asyncio.Queue()
         self.inflight = None
         self.task = None
+        self.replay_tasks = set()
 
     def running(self):
         self.options = ctx.options
         self.playback_task = asyncio_utils.create_task(
             self.playback(),
             name="client playback",
-            keep_ref=False,  # we keep a reference here.
+            keep_ref=False,
         )
 
     async def done(self):
@@ -176,11 +178,14 @@ class ClientPlayback:
                 assert self.inflight
                 h = ReplayHandler(self.inflight, self.options)
                 if ctx.options.client_replay_concurrency == -1:
-                    asyncio_utils.create_task(
+                    t = asyncio_utils.create_task(
                         h.replay(),
                         name="client playback awaiting response",
-                        keep_ref=True,
+                        keep_ref=False,
                     )
+                    # keep a reference so this is not garbage collected
+                    self.replay_tasks.add(t)
+                    t.add_done_callback(self.replay_tasks.remove)
                 else:
                     await h.replay()
             except Exception:

--- a/mitmproxy/addons/keepserving.py
+++ b/mitmproxy/addons/keepserving.py
@@ -7,8 +7,6 @@ from mitmproxy.utils import asyncio_utils
 
 
 class KeepServing:
-    _watch_task: asyncio.Task | None = None
-
     def load(self, loader):
         loader.add_option(
             "keepserving",
@@ -45,6 +43,8 @@ class KeepServing:
             ctx.options.rfile,
         ]
         if any(opts) and not ctx.options.keepserving:
-            self._watch_task = asyncio_utils.create_task(
-                self.watch(), name="keepserving"
+            asyncio_utils.create_task(
+                self.watch(),
+                name="keepserving",
+                keep_ref=True,
             )

--- a/mitmproxy/addons/readfile.py
+++ b/mitmproxy/addons/readfile.py
@@ -10,6 +10,7 @@ from mitmproxy import ctx
 from mitmproxy import exceptions
 from mitmproxy import flowfilter
 from mitmproxy import io
+from mitmproxy.utils import asyncio_utils
 
 logger = logging.getLogger(__name__)
 
@@ -74,7 +75,11 @@ class ReadFile:
 
     def running(self):
         if ctx.options.rfile:
-            self._read_task = asyncio.create_task(self.doread(ctx.options.rfile))
+            self._read_task = asyncio_utils.create_task(
+                self.doread(ctx.options.rfile),
+                name="readfile",
+                keep_ref=False,
+            )
 
     @command.command("readfile.reading")
     def reading(self) -> bool:

--- a/mitmproxy/addons/script.py
+++ b/mitmproxy/addons/script.py
@@ -92,6 +92,7 @@ class Script:
             self.reloadtask = asyncio_utils.create_task(
                 self.watcher(),
                 name=f"script watcher for {path}",
+                keep_ref=False,
             )
         else:
             self.loadscript()

--- a/mitmproxy/master.py
+++ b/mitmproxy/master.py
@@ -65,8 +65,12 @@ class Master:
                 # This may block for some proxy modes, so we also monitor should_exit.
                 await asyncio.wait(
                     [
-                        asyncio.create_task(ps.setup_servers()),
-                        asyncio.create_task(self.should_exit.wait()),
+                        asyncio_utils.create_task(
+                            ps.setup_servers(), name="setup_servers", keep_ref=False
+                        ),
+                        asyncio_utils.create_task(
+                            self.should_exit.wait(), name="should_exit", keep_ref=False
+                        ),
                     ],
                     return_when=asyncio.FIRST_COMPLETED,
                 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -251,8 +251,15 @@ ignore_errors = true
 extend-exclude = ["mitmproxy/contrib/"]
 
 [tool.ruff.lint]
-select = ["E", "F", "I"]
+select = ["E", "F", "I", "TID251"]
 ignore = ["F541", "E501"]
+
+[tool.ruff.lint.per-file-ignores]
+"examples/**" = ["TID251"]
+"test/**" = ["TID251"]
+
+[tool.ruff.lint.flake8-tidy-imports.banned-api]
+"asyncio.create_task".msg = "Use mitmproxy.utils.asyncio_utils.create_task instead to avoid GC footgun."
 
 
 [tool.ruff.lint.isort]

--- a/release/selftest.py
+++ b/release/selftest.py
@@ -11,6 +11,7 @@ import sys
 from pathlib import Path
 
 from mitmproxy import ctx
+from mitmproxy.utils import asyncio_utils
 
 
 def load(_):
@@ -23,8 +24,11 @@ def load(_):
 
 
 def running():
-    # attach is somewhere so that it's not collected.
-    ctx.task = asyncio.create_task(make_request())  # type: ignore
+    asyncio_utils.create_task(
+        make_request(),
+        name="selftest",
+        keep_ref=True,
+    )
 
 
 async def make_request():

--- a/test/mitmproxy/utils/test_asyncio_utils.py
+++ b/test/mitmproxy/utils/test_asyncio_utils.py
@@ -16,7 +16,7 @@ async def ttask():
 async def test_simple(monkeypatch):
     monkeypatch.setenv("PYTEST_CURRENT_TEST", "test_foo")
     task = asyncio_utils.create_task(
-        ttask(), name="ttask", keep_ref=False, client=("127.0.0.1", 42313)
+        ttask(), name="ttask", keep_ref=True, client=("127.0.0.1", 42313)
     )
     assert (
         asyncio_utils.task_repr(task)

--- a/test/mitmproxy/utils/test_asyncio_utils.py
+++ b/test/mitmproxy/utils/test_asyncio_utils.py
@@ -8,17 +8,19 @@ from mitmproxy.utils import asyncio_utils
 
 
 async def ttask():
+    await asyncio.sleep(0)
     asyncio_utils.set_current_task_debug_info(name="newname")
     await asyncio.sleep(999)
 
 
 async def test_simple(monkeypatch):
     monkeypatch.setenv("PYTEST_CURRENT_TEST", "test_foo")
-    task = asyncio_utils.create_task(ttask(), name="ttask", client=("127.0.0.1", 42313))
+    task = asyncio_utils.create_task(ttask(), name="ttask", keep_ref=False, client=("127.0.0.1", 42313))
     assert (
         asyncio_utils.task_repr(task)
         == "127.0.0.1:42313: ttask [created in test_foo] (age: 0s)"
     )
+    await asyncio.sleep(0)
     await asyncio.sleep(0)
     assert "newname" in asyncio_utils.task_repr(task)
     delattr(task, "created")

--- a/test/mitmproxy/utils/test_asyncio_utils.py
+++ b/test/mitmproxy/utils/test_asyncio_utils.py
@@ -15,7 +15,9 @@ async def ttask():
 
 async def test_simple(monkeypatch):
     monkeypatch.setenv("PYTEST_CURRENT_TEST", "test_foo")
-    task = asyncio_utils.create_task(ttask(), name="ttask", keep_ref=False, client=("127.0.0.1", 42313))
+    task = asyncio_utils.create_task(
+        ttask(), name="ttask", keep_ref=False, client=("127.0.0.1", 42313)
+    )
     assert (
         asyncio_utils.task_repr(task)
         == "127.0.0.1:42313: ttask [created in test_foo] (age: 0s)"


### PR DESCRIPTION

#### Description

The stdlib API has a massive footgun where tasks are garbage-collected mid execution, so we enforce our own wrapper.

#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
