### PR TITLE
fix: Remove filter expression lowercasing in block_list addon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
   ([#7386](https://github.com/mitmproxy/mitmproxy/pull/7386), @mhils)
 - Clicking the URL in mitmweb now places the cursor at the current position instead of selecting the entire URL.
   ([#7385](https://github.com/mitmproxy/mitmproxy/pull/7385), @lups2000)
+- Remove filter expression lowercasing in block_list addon
+  ([#7456](https://github.com/mitmproxy/mitmproxy/pull/7456), @jwadolowski)
 
 ## 05 December 2024: mitmproxy 11.0.2
 

--- a/mitmproxy/addons/blocklist.py
+++ b/mitmproxy/addons/blocklist.py
@@ -24,7 +24,7 @@ def parse_spec(option: str) -> BlockSpec:
     """
     sep, rem = option[0], option[1:]
 
-    parts = rem.lower().split(sep, 2)
+    parts = rem.split(sep, 2)
     if len(parts) != 2:
         raise ValueError("Invalid number of parameters (2 are expected)")
     flow_patt, status = parts

--- a/test/mitmproxy/addons/test_blocklist.py
+++ b/test/mitmproxy/addons/test_blocklist.py
@@ -47,7 +47,7 @@ class TestBlockList:
             else:
                 assert not f.response
 
-    def test_upppercased_header_values(self):
+    def test_uppercase_header_values(self):
         bl = blocklist.BlockList()
         with taddons.context(bl) as tctx:
             tctx.configure(bl, block_list=["|~hq Cookie:\\sfoo=BAR|403"])
@@ -58,7 +58,8 @@ class TestBlockList:
             assert f.response.status_code == 403
             assert f.metadata["blocklisted"]
 
-    def test_mixedcased_header_names(self):
+    def test_mixedcase_header_names(self):
+        # this test is meant to document existing behavior, not advocate for it.
         bl = blocklist.BlockList()
         with taddons.context(bl) as tctx:
             tctx.configure(bl, block_list=["|~hq User-Agent:\\scurl|401"])

--- a/test/mitmproxy/addons/test_blocklist.py
+++ b/test/mitmproxy/addons/test_blocklist.py
@@ -29,6 +29,9 @@ class TestBlockList:
             (":~u test:404", b"https://example.org/images/TEST.jpg", 404),
             ("/!jpg/418", b"https://example.org/images/test.jpg", None),
             ("/!png/418", b"https://example.org/images/test.jpg", 418),
+            ("|~u /DATA|500", b"https://example.org/DATA", 500),
+            ("|~u /ASSETS|501", b"https://example.org/assets", 501),
+            ("|~u /ping|201", b"https://example.org/PING", 201),
         ],
     )
     def test_block(self, filter, request_url, status_code):

--- a/test/mitmproxy/addons/test_blocklist.py
+++ b/test/mitmproxy/addons/test_blocklist.py
@@ -58,7 +58,7 @@ class TestBlockList:
             assert f.response.status_code == 403
             assert f.metadata["blocklisted"]
 
-    def test_mixedcased_headers(self):
+    def test_mixedcased_header_names(self):
         bl = blocklist.BlockList()
         with taddons.context(bl) as tctx:
             tctx.configure(bl, block_list=["|~hq User-Agent:\\scurl|401"])

--- a/test/mitmproxy/addons/test_blocklist.py
+++ b/test/mitmproxy/addons/test_blocklist.py
@@ -47,6 +47,27 @@ class TestBlockList:
             else:
                 assert not f.response
 
+    def test_upppercased_header_values(self):
+        bl = blocklist.BlockList()
+        with taddons.context(bl) as tctx:
+            tctx.configure(bl, block_list=["|~hq Cookie:\\sfoo=BAR|403"])
+            f = tflow.tflow()
+            f.request.url = "https://example.org/robots.txt"
+            f.request.headers["Cookie"] = "foo=BAR; key1=value1"
+            bl.request(f)
+            assert f.response.status_code == 403
+            assert f.metadata["blocklisted"]
+
+    def test_mixedcased_headers(self):
+        bl = blocklist.BlockList()
+        with taddons.context(bl) as tctx:
+            tctx.configure(bl, block_list=["|~hq User-Agent:\\scurl|401"])
+            f = tflow.tflow()
+            f.request.url = "https://example.org/products/123"
+            f.request.headers["user-agent"] = "curl/8.11.1"
+            bl.request(f)
+            assert not f.response
+
     def test_special_kill_status_closes_connection(self):
         bl = blocklist.BlockList()
         with taddons.context(bl) as tctx:


### PR DESCRIPTION
#### Description

`block_list`'s filter expression must not be lowercased and interpreted as-is. Fixes #7450

#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
