### PR TITLE
Fix bug when sending a message while CONNECTING

### DIFF
--- a/web/src/js/backends/websocket.tsx
+++ b/web/src/js/backends/websocket.tsx
@@ -31,7 +31,7 @@ export default class WebsocketBackend {
     constructor(store) {
         this.activeFetches = {};
         this.store = store;
-        this.messagesQueue = []
+        this.messagesQueue = [];
         this.connect();
     }
 
@@ -117,7 +117,7 @@ export default class WebsocketBackend {
         const message = JSON.stringify({ resource, ...data });
         if (this.socket) {
             if (this.socket.readyState === WebSocket.CONNECTING) {
-                this.messagesQueue.push(message)
+                this.messagesQueue.push(message);
             } else if (this.socket.readyState === WebSocket.OPEN) {
                 this.socket.send(message);
             } else {

--- a/web/src/js/backends/websocket.tsx
+++ b/web/src/js/backends/websocket.tsx
@@ -26,10 +26,12 @@ export default class WebsocketBackend {
     };
     store: Store<RootState>;
     socket: WebSocket;
+    messagesQueue: string[]; // Queue for messages while connecting.
 
     constructor(store) {
         this.activeFetches = {};
         this.store = store;
+        this.messagesQueue = []
         this.connect();
     }
 
@@ -48,6 +50,9 @@ export default class WebsocketBackend {
     }
 
     onOpen() {
+        this.messagesQueue.forEach((message) => this.socket.send(message)); // Flush the message queue.
+        this.messagesQueue = [];
+
         this.fetchData("state");
         this.fetchData("flows");
         this.fetchData("events");
@@ -110,21 +115,18 @@ export default class WebsocketBackend {
 
     private sendMessage(resource: string, data: any) {
         const message = JSON.stringify({ resource, ...data });
-        if (
-            // During the CONNECTING state, the message may not be delivered immediately,
-            // but it will be queued by the WebSocket implementation and sent as soon as
-            // the connection is fully established.
-            this.socket &&
-            (this.socket.readyState === WebSocket.CONNECTING ||
-                this.socket.readyState === WebSocket.OPEN)
-        ) {
-            this.socket.send(message);
-        } else {
-            console.error(
-                "WebSocket is not open. Cannot send message:",
-                resource,
-                data,
-            );
+        if (this.socket) {
+            if (this.socket.readyState === WebSocket.CONNECTING) {
+                this.messagesQueue.push(message)
+            } else if (this.socket.readyState === WebSocket.OPEN) {
+                this.socket.send(message);
+            } else {
+                console.error(
+                    "WebSocket is not open. Cannot send message:",
+                    resource,
+                    data,
+                );
+            }
         }
     }
 


### PR DESCRIPTION
#### Description

While implementing the server-side logic to handle the reception of the `updateFilter` message, I quickly realised I was wrong. Unfortunately, during the CONNECTING state, we need to queue messages manually to ensure they're properly sent once the connection is established.
In this PR, I've also added some more tests for the WebSocket component 🙂

#### Checklist

 - [x] I have updated tests where applicable.
 - [ ] I have added an entry to the CHANGELOG.
