### PR TITLE
Fix reading har with empty response content

### DIFF
--- a/mitmproxy/io/har.py
+++ b/mitmproxy/io/har.py
@@ -37,6 +37,7 @@ def fix_headers(
 
     return http.Headers(flow_headers)
 
+
 def fix_content_encoding(content_encoding: str | None) -> str:
     """
     Converts invalid content-encoding values to "indentity" while leaving valid values unchanged.

--- a/test/mitmproxy/data/har_files/invalid_content_encoding.har
+++ b/test/mitmproxy/data/har_files/invalid_content_encoding.har
@@ -1,0 +1,208 @@
+{
+  "log": {
+    "version": "1.2",
+    "creator": {
+      "name": "mitmproxy",
+      "version": "11.0.2",
+      "comment": ""
+    },
+    "pages": [],
+    "entries": [
+      {
+        "startedDateTime": "2024-08-09T17:14:01.050195+00:00",
+        "time": 214.67280387878418,
+        "request": {
+          "method": "POST",
+          "url": "https://fmfmobile.icloud.com/fmipservice/friends/%25@/00008101-001C59490C80801E/first/initClient",
+          "httpVersion": "HTTP/1.1",
+          "cookies": [],
+          "headers": [
+            {
+              "name": "Host",
+              "value": "fmfmobile.icloud.com"
+            },
+            {
+              "name": "X-Apple-Realm-Support",
+              "value": "1.0"
+            },
+            {
+              "name": "X-Apple-I-MD-RINFO",
+              "value": "67437824"
+            },
+            {
+              "name": "Accept",
+              "value": "application/json"
+            },
+            {
+              "name": "User-Agent",
+              "value": "FindMyWidgetIntentsPeople/1 CFNetwork/1498.700.2 Darwin/23.6.0"
+            },
+            {
+              "name": "Connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            },
+            {
+              "name": "X-MME-CLIENT-INFO",
+              "value": "<iPad13,19> <iPhone OS;17.6.1;21G93> <com.apple.AuthKit/1 (com.apple.findmy.FindMyWidgetIntentsPeople/1)>"
+            },
+            {
+              "name": "Accept-Encoding",
+              "value": "gzip, deflate, br"
+            },
+            {
+              "name": "Accept-Language",
+              "value": "en-US,en;q=0.9"
+            },
+            {
+              "name": "X-Apple-I-MD-M",
+              "value": "p+EmzLiqLRHSh8Dqw+iBwGktE2W6nBY7gz4UqhLVechI0NKb6kIxlSnKSQIyeaK5GPDwIJQ4NN1IeUqS"
+            },
+            {
+              "name": "Content-Length",
+              "value": "494"
+            },
+            {
+              "name": "X-Apple-Find-API-Ver",
+              "value": "2.0"
+            },
+            {
+              "name": "X-Apple-I-Client-Time",
+              "value": "2024-08-09T17:14:00Z"
+            },
+            {
+              "name": "X-Apple-I-MD",
+              "value": "AAAABQAAABBTN/9Qbjqxr488VFKIu48yAAAAAw=="
+            },
+            {
+              "name": "X-Apple-AuthScheme",
+              "value": "Forever"
+            },
+            {
+              "name": "X-FMF-Model-Version",
+              "value": "1"
+            },
+            {
+              "name": "X-Apple-I-TimeZone",
+              "value": "EDT"
+            },
+            {
+              "name": "X-Apple-I-Locale",
+              "value": "en_US"
+            }
+          ],
+          "queryString": [],
+          "headersSize": 948,
+          "bodySize": 494,
+          "postData": {
+            "mimeType": "application/json",
+            "text": "{\"clientContext\":{\"appVersion\":\"7.0\",\"productType\":\"iPad13,19\",\"liveSessionStatistics\":{},\"legacyFallbackData\":{},\"deviceSKU\":\"LL\",\"regionCode\":\"US\",\"limitedPrecision\":false,\"tabs\":{\"currentTab\":[],\"timeSpent\":[],\"lastVisitedTime\":[]},\"countryCode\":\"US\",\"deviceClass\":\"iPad\",\"appPushModeAllowed\":true,\"pushMode\":true,\"deviceUDID\":\"00008101-001C59490C80801E\",\"osVersion\":\"17.6.1\",\"osBuild\":\"21G93\",\"currentTime\":744916440838.90503,\"userInactivityTimeInMS\":0},\"serverContext\":{},\"dataContext\":{}}",
+            "params": []
+          }
+        },
+        "response": {
+          "status": 401,
+          "statusText": "Unauthorized",
+          "httpVersion": "HTTP/1.1",
+          "cookies": [
+            {
+              "name": "xr_3n2093n1a",
+              "value": "57c8oBNPtexnilacE+aGE8hv94Araside5IAwbQqY617VhF29qn2BJEWJH0=",
+              "path": "/",
+              "domain": "",
+              "httpOnly": true,
+              "secure": true
+            }
+          ],
+          "headers": [
+            {
+              "name": "Server",
+              "value": "AppleHttpServer/b866cf47a603"
+            },
+            {
+              "name": "Date",
+              "value": "Fri, 09 Aug 2024 17:14:01 GMT"
+            },
+            {
+              "name": "Content-Length",
+              "value": "0"
+            },
+            {
+              "name": "Connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "Set-Cookie",
+              "value": "xr_3n2093n1a=57c8oBNPtexnilacE+aGE8hv94Araside5IAwbQqY617VhF29qn2BJEWJH0=; Path=/; Secure; HttpOnly"
+            },
+            {
+              "name": "X-Responding-Instance",
+              "value": "fmipservice:3:prod-p34-fmipservice--remaining-6f5c7dd784-vf9j8:80:2409B2390:aac3c2df0e31"
+            },
+            {
+              "name": "content-encoding",
+              "value": "UTF-8"
+            },
+            {
+              "name": "X-Robots-Tag",
+              "value": "noindex, noarchive, nosnippet, nofollow"
+            },
+            {
+              "name": "X-Responding-Server",
+              "value": "prod-p34-fmipservice--remaining-6f5c7dd784-vf9j8_99"
+            },
+            {
+              "name": "X-Responding-Partition",
+              "value": "p34"
+            },
+            {
+              "name": "Strict-Transport-Security",
+              "value": "max-age=31536000; includeSubDomains;"
+            },
+            {
+              "name": "x-apple-user-partition",
+              "value": "34"
+            },
+            {
+              "name": "via",
+              "value": "xrail:mr42p00ic-qujn08142102.me.com:8301:24R333:grp21,631194250daa17e24277dea86cf30319:a57fb501bf4a51059fac6c5879bf060c:usqas5"
+            },
+            {
+              "name": "X-Apple-Request-UUID",
+              "value": "041b4ac3-bd5b-4934-a25e-4b2205339d36"
+            },
+            {
+              "name": "access-control-expose-headers",
+              "value": "X-Apple-Request-UUID,Via"
+            },
+            {
+              "name": "X-Apple-Edge-Response-Time",
+              "value": "54"
+            }
+          ],
+          "content": {
+            "size": 0,
+            "compression": 0,
+            "mimeType": "",
+            "text": ""
+          },
+          "redirectURL": "",
+          "headersSize": 1037,
+          "bodySize": 0
+        },
+        "cache": {},
+        "timings": {
+          "connect": 55.06396293640137,
+          "ssl": 80.66129684448242,
+          "send": 1.1196136474609375,
+          "receive": 0.9088516235351562,
+          "wait": 76.9190788269043
+        },
+        "serverIPAddress": "17.248.228.71"
+      }
+    ]
+  }
+}

--- a/test/mitmproxy/data/har_files/invalid_content_encoding.json
+++ b/test/mitmproxy/data/har_files/invalid_content_encoding.json
@@ -1,0 +1,217 @@
+[
+  {
+    "id": "hardcoded_for_test",
+    "intercepted": false,
+    "is_replay": null,
+    "type": "http",
+    "modified": false,
+    "marked": "",
+    "comment": "",
+    "timestamp_created": 0,
+    "client_conn": {
+      "id": "hardcoded_for_test",
+      "peername": [
+        "127.0.0.1",
+        0
+      ],
+      "sockname": [
+        "127.0.0.1",
+        0
+      ],
+      "tls_established": false,
+      "cert": null,
+      "sni": null,
+      "cipher": null,
+      "alpn": null,
+      "tls_version": null,
+      "timestamp_start": 1723223641.050195,
+      "timestamp_tls_setup": null,
+      "timestamp_end": 1723223641.2648678
+    },
+    "server_conn": {
+      "id": "hardcoded_for_test",
+      "peername": null,
+      "sockname": null,
+      "address": [
+        "17.248.228.71",
+        443
+      ],
+      "tls_established": false,
+      "cert": null,
+      "sni": null,
+      "cipher": null,
+      "alpn": null,
+      "tls_version": null,
+      "timestamp_start": null,
+      "timestamp_tcp_setup": null,
+      "timestamp_tls_setup": null,
+      "timestamp_end": null
+    },
+    "request": {
+      "method": "POST",
+      "scheme": "https",
+      "host": "fmfmobile.icloud.com",
+      "port": 443,
+      "path": "/fmipservice/friends/%25@/00008101-001C59490C80801E/first/initClient",
+      "http_version": "HTTP/1.1",
+      "headers": [
+        [
+          "Host",
+          "fmfmobile.icloud.com"
+        ],
+        [
+          "X-Apple-Realm-Support",
+          "1.0"
+        ],
+        [
+          "X-Apple-I-MD-RINFO",
+          "67437824"
+        ],
+        [
+          "Accept",
+          "application/json"
+        ],
+        [
+          "User-Agent",
+          "FindMyWidgetIntentsPeople/1 CFNetwork/1498.700.2 Darwin/23.6.0"
+        ],
+        [
+          "Connection",
+          "keep-alive"
+        ],
+        [
+          "Content-Type",
+          "application/json"
+        ],
+        [
+          "X-MME-CLIENT-INFO",
+          "<iPad13,19> <iPhone OS;17.6.1;21G93> <com.apple.AuthKit/1 (com.apple.findmy.FindMyWidgetIntentsPeople/1)>"
+        ],
+        [
+          "Accept-Encoding",
+          "gzip, deflate, br"
+        ],
+        [
+          "Accept-Language",
+          "en-US,en;q=0.9"
+        ],
+        [
+          "X-Apple-I-MD-M",
+          "p+EmzLiqLRHSh8Dqw+iBwGktE2W6nBY7gz4UqhLVechI0NKb6kIxlSnKSQIyeaK5GPDwIJQ4NN1IeUqS"
+        ],
+        [
+          "Content-Length",
+          "494"
+        ],
+        [
+          "X-Apple-Find-API-Ver",
+          "2.0"
+        ],
+        [
+          "X-Apple-I-Client-Time",
+          "2024-08-09T17:14:00Z"
+        ],
+        [
+          "X-Apple-I-MD",
+          "AAAABQAAABBTN/9Qbjqxr488VFKIu48yAAAAAw=="
+        ],
+        [
+          "X-Apple-AuthScheme",
+          "Forever"
+        ],
+        [
+          "X-FMF-Model-Version",
+          "1"
+        ],
+        [
+          "X-Apple-I-TimeZone",
+          "EDT"
+        ],
+        [
+          "X-Apple-I-Locale",
+          "en_US"
+        ]
+      ],
+      "contentLength": 494,
+      "contentHash": "34a6c8b4769e82919756a44bf85e2719f61e7e696f0c3ad4a0b5da190b4c34e2",
+      "timestamp_start": 1723223641.050195,
+      "timestamp_end": 1723223641.2648678,
+      "pretty_host": "fmfmobile.icloud.com"
+    },
+    "response": {
+      "http_version": "HTTP/1.1",
+      "status_code": 401,
+      "reason": "Unauthorized",
+      "headers": [
+        [
+          "Server",
+          "AppleHttpServer/b866cf47a603"
+        ],
+        [
+          "Date",
+          "Fri, 09 Aug 2024 17:14:01 GMT"
+        ],
+        [
+          "Content-Length",
+          "0"
+        ],
+        [
+          "Connection",
+          "keep-alive"
+        ],
+        [
+          "Set-Cookie",
+          "xr_3n2093n1a=57c8oBNPtexnilacE+aGE8hv94Araside5IAwbQqY617VhF29qn2BJEWJH0=; Path=/; Secure; HttpOnly"
+        ],
+        [
+          "X-Responding-Instance",
+          "fmipservice:3:prod-p34-fmipservice--remaining-6f5c7dd784-vf9j8:80:2409B2390:aac3c2df0e31"
+        ],
+        [
+          "content-encoding",
+          "UTF-8"
+        ],
+        [
+          "X-Robots-Tag",
+          "noindex, noarchive, nosnippet, nofollow"
+        ],
+        [
+          "X-Responding-Server",
+          "prod-p34-fmipservice--remaining-6f5c7dd784-vf9j8_99"
+        ],
+        [
+          "X-Responding-Partition",
+          "p34"
+        ],
+        [
+          "Strict-Transport-Security",
+          "max-age=31536000; includeSubDomains;"
+        ],
+        [
+          "x-apple-user-partition",
+          "34"
+        ],
+        [
+          "via",
+          "xrail:mr42p00ic-qujn08142102.me.com:8301:24R333:grp21,631194250daa17e24277dea86cf30319:a57fb501bf4a51059fac6c5879bf060c:usqas5"
+        ],
+        [
+          "X-Apple-Request-UUID",
+          "041b4ac3-bd5b-4934-a25e-4b2205339d36"
+        ],
+        [
+          "access-control-expose-headers",
+          "X-Apple-Request-UUID,Via"
+        ],
+        [
+          "X-Apple-Edge-Response-Time",
+          "54"
+        ]
+      ],
+      "contentLength": 0,
+      "contentHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "timestamp_start": 1723223641.050195,
+      "timestamp_end": 1723223641.2648678
+    }
+  }
+]


### PR DESCRIPTION
#### Description

I exported a mitmproxy flow file to a har file but discovered that mitmproxy couldn't read the resulting har. The problem appears to be a response with an empty content. The empty byte string gets passed to http.encoding.encode but it can't encode it, resulting in an unhandled exception.

I added a har test file that reproduces the problem and a simple fix.

#### Checklist

 - [x] I have updated tests where applicable.
 - [ ] I have added an entry to the CHANGELOG.
