### PR TITLE
Unescape escaped characters in curl and httpie args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
   ([#7514](https://github.com/mitmproxy/mitmproxy/pull/7514), @sujaldev)
 - Fix a bug where mitmproxy would get stuck in secure web proxy mode when using `ignore_hosts` or `allow_hosts`.
   ([#7519](https://github.com/mitmproxy/mitmproxy/pull/7519), @mhils)
+- Fix a bug where exporting a curl or httpie command with escaped characters would lead to different data being sent.
 
 ## 12 January 2025: mitmproxy 11.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Fix a bug where mitmproxy would get stuck in secure web proxy mode when using `ignore_hosts` or `allow_hosts`.
   ([#7519](https://github.com/mitmproxy/mitmproxy/pull/7519), @mhils)
 - Fix a bug where exporting a curl or httpie command with escaped characters would lead to different data being sent.
+  ([#7520](https://github.com/mitmproxy/mitmproxy/pull/7520), @proteusvacuum)
 
 ## 12 January 2025: mitmproxy 11.1.0
 

--- a/mitmproxy/addons/export.py
+++ b/mitmproxy/addons/export.py
@@ -53,7 +53,13 @@ def request_content_for_console(request: http.Request) -> str:
         # see https://github.com/python/cpython/pull/10871
         raise exceptions.CommandError("Request content must be valid unicode")
     escape_control_chars = {chr(i): f"\\x{i:02x}" for i in range(32)}
-    return "".join(escape_control_chars.get(x, x) for x in text)
+    escaped_text = "".join(escape_control_chars.get(x, x) for x in text)
+    if any(char in escape_control_chars for char in text):
+        # Escaped chars need to be unescaped by the shell to be properly inperpreted by curl and httpie
+        return f'"$(printf {shlex.quote(escaped_text)})"'
+
+    return shlex.quote(escaped_text)
+
 
 
 def curl_command(f: flow.Flow) -> str:
@@ -83,9 +89,10 @@ def curl_command(f: flow.Flow) -> str:
 
     args.append(request.pretty_url)
 
+    command = " ".join(shlex.quote(arg) for arg in args)
     if request.content:
-        args += ["-d", request_content_for_console(request)]
-    return " ".join(shlex.quote(arg) for arg in args)
+        command += f' -d {request_content_for_console(request)}'
+    return command
 
 
 def httpie_command(f: flow.Flow) -> str:
@@ -102,7 +109,7 @@ def httpie_command(f: flow.Flow) -> str:
         args.append(f"{k}: {v}")
     cmd = " ".join(shlex.quote(arg) for arg in args)
     if request.content:
-        cmd += " <<< " + shlex.quote(request_content_for_console(request))
+        cmd += " <<< " + request_content_for_console(request)
     return cmd
 
 

--- a/mitmproxy/addons/export.py
+++ b/mitmproxy/addons/export.py
@@ -61,7 +61,6 @@ def request_content_for_console(request: http.Request) -> str:
     return shlex.quote(escaped_text)
 
 
-
 def curl_command(f: flow.Flow) -> str:
     request = cleanup_request(f)
     request = pop_headers(request)
@@ -91,7 +90,7 @@ def curl_command(f: flow.Flow) -> str:
 
     command = " ".join(shlex.quote(arg) for arg in args)
     if request.content:
-        command += f' -d {request_content_for_console(request)}'
+        command += f" -d {request_content_for_console(request)}"
     return command
 
 

--- a/test/mitmproxy/addons/test_export.py
+++ b/test/mitmproxy/addons/test_export.py
@@ -112,7 +112,7 @@ class TestExportCurlCommand:
 
     def test_expand_escaped(self, export_curl, post_request):
         post_request.request.content = b"foo\nbar"
-        result = 'curl -X POST http://address:22/path -d "$(printf \'foo\\x0abar\')"'
+        result = "curl -X POST http://address:22/path -d \"$(printf 'foo\\x0abar')\""
         assert export_curl(post_request) == result
 
     def test_no_expand_when_no_escaped(self, export_curl, post_request):

--- a/test/mitmproxy/addons/test_export.py
+++ b/test/mitmproxy/addons/test_export.py
@@ -110,6 +110,16 @@ class TestExportCurlCommand:
         assert shlex.split(command)[-2] == "-d"
         assert shlex.split(command)[-1] == "'&#"
 
+    def test_expand_escaped(self, export_curl, post_request):
+        post_request.request.content = b"foo\nbar"
+        result = 'curl -X POST http://address:22/path -d "$(printf \'foo\\x0abar\')"'
+        assert export_curl(post_request) == result
+
+    def test_no_expand_when_no_escaped(self, export_curl, post_request):
+        post_request.request.content = b"foobar"
+        result = "curl -X POST http://address:22/path -d foobar"
+        assert export_curl(post_request) == result
+
     def test_strip_unnecessary(self, export_curl, get_request):
         get_request.request.headers.clear()
         get_request.request.headers["host"] = "address"


### PR DESCRIPTION
#### Description

This fixes a bug where exporting a curl or httpie command with escaped characters would lead to different data being sent. 

Fixes https://github.com/mitmproxy/mitmproxy/issues/7517

#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
