### PR TITLE
docs: add local capture mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ## Unreleased: mitmproxy next
 
+- Add documentation for local capture mode.
 
 ## 06 February 2025: mitmproxy 11.1.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ## Unreleased: mitmproxy next
 
 - Add documentation for local capture mode.
+  ([#7540](https://github.com/mitmproxy/mitmproxy/pull/7540), @mhils)
 
 ## 06 February 2025: mitmproxy 11.1.2
 


### PR DESCRIPTION
#### Description

This PR adds documentation for local capture mode to https://docs.mitmproxy.org/stable/concepts-modes/.

#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
