### PR TITLE
fix type annotations to be compatible with future h2 release

### DIFF
--- a/mitmproxy/proxy/layers/http/_http2.py
+++ b/mitmproxy/proxy/layers/http/_http2.py
@@ -4,7 +4,7 @@ from collections.abc import Sequence
 from enum import Enum
 from logging import DEBUG
 from logging import ERROR
-from typing import ClassVar
+from typing import ClassVar, Any
 
 import h2.config
 import h2.connection
@@ -61,7 +61,7 @@ CATCH_HYPER_H2_ERRORS = (ValueError, IndexError)
 
 class Http2Connection(HttpConnection):
     h2_conf: ClassVar[h2.config.H2Configuration]
-    h2_conf_defaults = dict(
+    h2_conf_defaults: dict[str, Any] = dict(
         header_encoding=False,
         validate_outbound_headers=False,
         # validate_inbound_headers is controlled by the validate_inbound_headers option.
@@ -229,9 +229,10 @@ class Http2Connection(HttpConnection):
                     err_str = h2.errors.ErrorCodes(event.error_code).name
                 except ValueError:
                     err_str = str(event.error_code)
-                err_code = {
-                    h2.errors.ErrorCodes.CANCEL: status_codes.CLIENT_CLOSED_REQUEST,
-                }.get(event.error_code, self.ReceiveProtocolError.code)
+                if event.error_code == h2.errors.ErrorCodes.CANCEL:
+                    err_code = status_codes.CLIENT_CLOSED_REQUEST
+                else:
+                    err_code = self.ReceiveProtocolError.code
                 yield ReceiveHttp(
                     self.ReceiveProtocolError(
                         event.stream_id,
@@ -308,14 +309,14 @@ def normalize_h1_headers(
 ) -> list[tuple[bytes, bytes]]:
     # HTTP/1 servers commonly send capitalized headers (Content-Length vs content-length),
     # which isn't valid HTTP/2. As such we normalize.
-    headers = h2.utilities.normalize_outbound_headers(
-        headers,
-        h2.utilities.HeaderValidationFlags(is_client, False, not is_client, False),
-    )
-    # make sure that this is not just an iterator but an iterable,
+    # Make sure that this is not just an iterator but an iterable,
     # otherwise hyper-h2 will silently drop headers.
-    headers = list(headers)
-    return headers
+    return list(
+        h2.utilities.normalize_outbound_headers(
+            headers,
+            h2.utilities.HeaderValidationFlags(is_client, False, not is_client, False),
+        )
+    )
 
 
 def normalize_h2_headers(headers: list[tuple[bytes, bytes]]) -> CommandGenerator[None]:

--- a/mitmproxy/proxy/layers/http/_http2.py
+++ b/mitmproxy/proxy/layers/http/_http2.py
@@ -4,7 +4,8 @@ from collections.abc import Sequence
 from enum import Enum
 from logging import DEBUG
 from logging import ERROR
-from typing import ClassVar, Any
+from typing import Any
+from typing import ClassVar
 
 import h2.config
 import h2.connection


### PR DESCRIPTION
#### Description

This PR prepares mitmproxy to pass with mypy on the next h2 release.

refs https://github.com/python-hyper/h2/pull/1296

#### Checklist

 - [x] I have updated tests where applicable.
