### PR TITLE
docs: Enhance homebrew installation command for Brewfile users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ## Unreleased: mitmproxy next
 
+- Enhance homebrew installation command for Brewfile users.
 
 ## 17 February 2025: mitmproxy 11.1.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ## Unreleased: mitmproxy next
 
 - Enhance homebrew installation command for Brewfile users.
+  ([#7566](https://github.com/mitmproxy/mitmproxy/pull/7566), @AntoineJT)
 
 ## 17 February 2025: mitmproxy 11.1.3
 

--- a/docs/src/content/overview-installation.md
+++ b/docs/src/content/overview-installation.md
@@ -16,7 +16,7 @@ The recommended way to install mitmproxy on macOS is to use
 [Homebrew](https://brew.sh/):
 
 ```bash
-brew install mitmproxy
+brew install --cask mitmproxy
 ```
 
 Alternatively, you can download standalone binaries on [mitmproxy.org](https://mitmproxy.org/).


### PR DESCRIPTION
#### Description

##### Motivation

As a Brewfile user, the current installation command in the documentation does not tell me that mitmproxy is a Cask, which is a bit of an inconvenience due to how Brewfile works.

Adding a formulae in a Brewfile is done by adding the line `brew "<formulae>"` while adding a cask in a Brewfile is done by adding the line `cask "<cask>"`

Contrarily to the behavior of the brew install command, adding a formulae line in the Brewfile will not check for a Cask if the formulae does not exist: it will just fail.

##### Impact

The brew install command currently works by first checking if a "mitmproxy" formulae exists in the homebrew repository, then after finding out there is none, it checks for a "mitmproxy" cask in the homebrew repository.

Adding the explicit `--cask` argument allows to skip the unnecessary formulae existence check, while being more convenient for Brewfile users.

##### TL;DR

Adding the explicit `--cask` argument is useful to Brewfile users in such that they directly know that mitmproxy is a Cask, while not impacting users copy-pasting the command directly in their terminal (while also avoiding an unwanted check for a corresponding formulae before the cask installation).

#### Checklist

 - [x] I have updated tests where applicable. (unapplicable)
 - [x] I have added an entry to the CHANGELOG.
