### PR TITLE
Content view for socket.io over websocket transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 - Enhance homebrew installation command for Brewfile users.
   ([#7566](https://github.com/mitmproxy/mitmproxy/pull/7566), @AntoineJT)
+- Create content view for Socket.IO over WebSocket transport
 
 ## 17 February 2025: mitmproxy 11.1.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Enhance homebrew installation command for Brewfile users.
   ([#7566](https://github.com/mitmproxy/mitmproxy/pull/7566), @AntoineJT)
 - Create content view for Socket.IO over WebSocket transport
+  ([#7570](https://github.com/mitmproxy/mitmproxy/pull/7570), @DenizenB)
 
 ## 17 February 2025: mitmproxy 11.1.3
 

--- a/mitmproxy/contentviews/__init__.py
+++ b/mitmproxy/contentviews/__init__.py
@@ -33,6 +33,7 @@ from . import multipart
 from . import protobuf
 from . import query
 from . import raw
+from . import socketio
 from . import urlencoded
 from . import wbxml
 from . import xml_html
@@ -249,6 +250,7 @@ add(grpc.ViewGrpcProtobuf())
 add(mqtt.ViewMQTT())
 add(http3.ViewHttp3())
 add(dns.ViewDns())
+add(socketio.ViewSocketIO())
 
 __all__ = [
     "View",

--- a/mitmproxy/contentviews/socketio.py
+++ b/mitmproxy/contentviews/socketio.py
@@ -3,6 +3,7 @@ from typing import Tuple
 
 from mitmproxy.contentviews import base
 from mitmproxy.flow import Flow
+from mitmproxy.http import HTTPFlow
 
 
 class PacketType(Enum):
@@ -50,16 +51,16 @@ class SocketIO(PacketType):
 
 def parse_packet(data) -> Tuple[PacketType, bytes | str]:
     # throws IndexError/ValueError if invalid packet
-    packet_type = EngineIO(data[0])
+    engineio_type = EngineIO(data[0])
     data = data[1:]
 
-    if packet_type is not EngineIO.MESSAGE:
-        return packet_type, data
+    if engineio_type is not EngineIO.MESSAGE:
+        return engineio_type, data
 
-    packet_type = SocketIO(data[0])
+    socketio_type = SocketIO(data[0])
     data = data[1:]
 
-    return packet_type, data
+    return socketio_type, data
 
 
 def format_packet(packet_type: PacketType, data):
@@ -92,7 +93,7 @@ class ViewSocketIO(base.View):
     ) -> float:
         if (
             data
-            and flow is not None
+            and isinstance(flow, HTTPFlow)
             and flow.websocket is not None
             and "/socket.io/?" in flow.request.path
         ):

--- a/mitmproxy/contentviews/socketio.py
+++ b/mitmproxy/contentviews/socketio.py
@@ -1,5 +1,4 @@
 from enum import Enum
-from typing import Iterable
 
 from mitmproxy.contentviews import base
 from mitmproxy.flow import Flow
@@ -10,6 +9,7 @@ class PacketType(Enum):
 
     def __str__(self):
         return f"{type(self).__name__}.{self.name}"
+
 
 class EngineIO(PacketType):
     # https://github.com/socketio/engine.io-protocol?tab=readme-ov-file#protocol
@@ -28,6 +28,7 @@ class EngineIO(PacketType):
             self.PONG,
         )
 
+
 class SocketIO(PacketType):
     # https://github.com/socketio/socket.io-protocol?tab=readme-ov-file#exchange-protocol
     CONNECT = ord("0")
@@ -40,18 +41,22 @@ class SocketIO(PacketType):
 
     @property
     def visible(self):
-        return self not in (
-            self.ACK,
-            self.BINARY_ACK
-        )
+        return self not in (self.ACK, self.BINARY_ACK)
+
 
 BLANK = "Socket.IO", iter([])
 
+
 def format_text(packet_type: PacketType, data):
-    return "Socket.IO", iter([[
-        ("content_none", f"{packet_type} "),
-        ("text", data),
-    ]])
+    return "Socket.IO", iter(
+        [
+            [
+                ("content_none", f"{packet_type} "),
+                ("text", data),
+            ]
+        ]
+    )
+
 
 class ViewSocketIO(base.View):
     name = "Socket.IO"

--- a/mitmproxy/contentviews/socketio.py
+++ b/mitmproxy/contentviews/socketio.py
@@ -91,10 +91,10 @@ class ViewSocketIO(base.View):
         self, data: bytes, *, flow: Flow | None = None, **metadata
     ) -> float:
         if (
-                data
-                and flow is not None
-                and flow.websocket is not None
-                and "/socket.io/?" in flow.request.path
+            data
+            and flow is not None
+            and flow.websocket is not None
+            and "/socket.io/?" in flow.request.path
         ):
             return 1
         return 0

--- a/mitmproxy/contentviews/socketio.py
+++ b/mitmproxy/contentviews/socketio.py
@@ -1,0 +1,86 @@
+from enum import Enum
+from typing import Iterable
+
+from mitmproxy.contentviews import base
+from mitmproxy.flow import Flow
+
+
+class PacketType(Enum):
+    visible: bool
+
+    def __str__(self):
+        return f"{type(self).__name__}.{self.name}"
+
+class EngineIO(PacketType):
+    # https://github.com/socketio/engine.io-protocol?tab=readme-ov-file#protocol
+    OPEN = ord("0")
+    CLOSE = ord("1")
+    PING = ord("2")
+    PONG = ord("3")
+    MESSAGE = ord("4")
+    UPGRADE = ord("5")
+    NOOP = ord("6")
+
+    @property
+    def visible(self):
+        return self not in (
+            self.PING,
+            self.PONG,
+        )
+
+class SocketIO(PacketType):
+    # https://github.com/socketio/socket.io-protocol?tab=readme-ov-file#exchange-protocol
+    CONNECT = ord("0")
+    DISCONNECT = ord("1")
+    EVENT = ord("2")
+    ACK = ord("3")
+    CONNECT_ERROR = ord("4")
+    BINARY_EVENT = ord("5")
+    BINARY_ACK = ord("6")
+
+    @property
+    def visible(self):
+        return self not in (
+            self.ACK,
+            self.BINARY_ACK
+        )
+
+BLANK = "Socket.IO", iter([])
+
+def format_text(packet_type: PacketType, data):
+    return "Socket.IO", iter([[
+        ("content_none", f"{packet_type} "),
+        ("text", data),
+    ]])
+
+class ViewSocketIO(base.View):
+    name = "Socket.IO"
+
+    def __call__(self, data, **metadata):
+        try:
+            packet_type = EngineIO(data[0])
+            data = data[1:]
+        except (IndexError, ValueError):
+            return None
+
+        if not packet_type.visible:
+            return BLANK
+
+        if packet_type != EngineIO.MESSAGE:
+            return format_text(packet_type, data)
+
+        try:
+            packet_type = SocketIO(data[0])
+            data = data[1:]
+        except (IndexError, ValueError):
+            return None
+
+        if not packet_type.visible:
+            return BLANK
+
+        return format_text(packet_type, data)
+
+    def render_priority(
+        self, data: bytes, *, flow: Flow | None = None, **metadata
+    ) -> float:
+        return 0

--- a/mitmproxy/tools/console/flowview.py
+++ b/mitmproxy/tools/console/flowview.py
@@ -217,10 +217,6 @@ class FlowDetails(tabs.Tabs):
 
         viewmode = self.master.commands.call("console.flowview.mode")
 
-        if viewmode == "auto" and "/socket.io/?" in flow.request.path:
-            self.master.commands.call("console.flowview.mode.set", "socket.io")
-            viewmode = self.master.commands.call("console.flowview.mode")
-
         widget_lines = []
         for m in flow.websocket.messages:
             _, lines, _ = contentviews.get_message_content_view(viewmode, m, flow)

--- a/mitmproxy/tools/console/flowview.py
+++ b/mitmproxy/tools/console/flowview.py
@@ -217,6 +217,10 @@ class FlowDetails(tabs.Tabs):
 
         viewmode = self.master.commands.call("console.flowview.mode")
 
+        if viewmode == "auto" and "/socket.io/?" in flow.request.path:
+            self.master.commands.call("console.flowview.mode.set", "socket.io")
+            viewmode = self.master.commands.call("console.flowview.mode")
+
         widget_lines = []
         for m in flow.websocket.messages:
             _, lines, _ = contentviews.get_message_content_view(viewmode, m, flow)

--- a/test/mitmproxy/contentviews/test_socketio.py
+++ b/test/mitmproxy/contentviews/test_socketio.py
@@ -1,0 +1,61 @@
+from hypothesis import given
+from hypothesis.strategies import binary
+
+from . import full_eval
+from mitmproxy.contentviews.socketio import (
+    EngineIO,
+    PacketType,
+    SocketIO,
+    ViewSocketIO,
+    format_packet,
+    parse_packet,
+)
+from mitmproxy.test import tflow
+
+
+def test_parse_packet():
+    assert parse_packet(b"0payload") == (EngineIO.OPEN, b"payload")
+    assert parse_packet(b"40") == (SocketIO.CONNECT, b"")
+    assert parse_packet(b"40payload") == (SocketIO.CONNECT, b"payload")
+
+
+def test_format_packet():
+    assert list(format_packet(SocketIO.EVENT, b"data")[1]) == [
+        [
+            ("content_none", "SocketIO.EVENT "),
+            ("text", b"data"),
+        ],
+    ]
+    assert not list(format_packet(EngineIO.PING, b"")[1])
+    assert not list(format_packet(SocketIO.ACK, b"")[1])
+
+
+def test_view():
+    v = full_eval(ViewSocketIO())
+    assert not v(b"HTTP/1.1")
+    assert not v(b"GET")
+    assert v(b"0")
+    assert v(b"6")
+    assert v(b"40")
+    assert not v(b"4")
+    assert v(b"42")
+    assert v(b"42eventdata")
+
+
+@given(binary())
+def test_view_doesnt_crash(data):
+    v = full_eval(ViewSocketIO())
+    v(data)
+
+
+def test_render_priority():
+    v = ViewSocketIO()
+    assert not v.render_priority(b"")
+
+    flow = tflow.twebsocketflow()
+    assert not v.render_priority(b"", flow=flow)
+    assert not v.render_priority(b"message", flow=flow)
+
+    flow.request.path = b"/asdf/socket.io/?..."
+    assert v.render_priority(b"message", flow=flow)
+    assert not v.render_priority(b"", flow=flow)

--- a/test/mitmproxy/contentviews/test_socketio.py
+++ b/test/mitmproxy/contentviews/test_socketio.py
@@ -2,14 +2,11 @@ from hypothesis import given
 from hypothesis.strategies import binary
 
 from . import full_eval
-from mitmproxy.contentviews.socketio import (
-    EngineIO,
-    PacketType,
-    SocketIO,
-    ViewSocketIO,
-    format_packet,
-    parse_packet,
-)
+from mitmproxy.contentviews.socketio import EngineIO
+from mitmproxy.contentviews.socketio import format_packet
+from mitmproxy.contentviews.socketio import parse_packet
+from mitmproxy.contentviews.socketio import SocketIO
+from mitmproxy.contentviews.socketio import ViewSocketIO
 from mitmproxy.test import tflow
 
 


### PR DESCRIPTION
#### Description

This PR implements a socket.io content view and auto-selects it in the "WebSocket Messages" tab if the view mode is set to "Auto" and the request path contains `/socket.io/?`.

This content view hides engine.io ping/pong packets as well as socket.io acknowledgements, so that it's easier to analyze the messages being exchanged. It also prefixes the data with the name of the engine.io/socket.io packet type in a muted color.

#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.