### PR TITLE
keepserving: do not exit before client has disconnected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 - Enhance homebrew installation command for Brewfile users.
   ([#7566](https://github.com/mitmproxy/mitmproxy/pull/7566), @AntoineJT)
+- Fix a bug where mitmdump would exit prematurely in server replay mode.
 
 ## 17 February 2025: mitmproxy 11.1.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Enhance homebrew installation command for Brewfile users.
   ([#7566](https://github.com/mitmproxy/mitmproxy/pull/7566), @AntoineJT)
 - Fix a bug where mitmdump would exit prematurely in server replay mode.
+  ([#7571](https://github.com/mitmproxy/mitmproxy/pull/7571), @mhils)
 
 ## 17 February 2025: mitmproxy 11.1.3
 

--- a/mitmproxy/addons/keepserving.py
+++ b/mitmproxy/addons/keepserving.py
@@ -20,10 +20,14 @@ class KeepServing:
         )
 
     def keepgoing(self) -> bool:
+        # Checking for proxyserver.active_connections is important for server replay,
+        # the addon may report that replay is finished but not the entire response has been sent yet.
+        # (https://github.com/mitmproxy/mitmproxy/issues/7569)
         checks = [
             "readfile.reading",
             "replay.client.count",
             "replay.server.count",
+            "proxyserver.active_connections",
         ]
         return any([ctx.master.commands.call(c) for c in checks])
 

--- a/mitmproxy/addons/proxyserver.py
+++ b/mitmproxy/addons/proxyserver.py
@@ -129,6 +129,10 @@ class Proxyserver(ServerManager):
     def __repr__(self):
         return f"Proxyserver({len(self.connections)} active conns)"
 
+    @command.command("proxyserver.active_connections")
+    def active_connections(self) -> int:
+        return len(self.connections)
+
     @contextmanager
     def register_connection(
         self, connection_id: tuple | str, handler: ProxyConnectionHandler

--- a/test/mitmproxy/addons/test_keepserving.py
+++ b/test/mitmproxy/addons/test_keepserving.py
@@ -26,6 +26,9 @@ class Dummy:
     def sreplay(self) -> int:
         return 1 if self.val else 0
 
+    @command.command("proxyserver.active_connections")
+    def active_connections(self) -> int:
+        return 1 if self.val else 0
 
 class TKS(keepserving.KeepServing):
     _is_shutdown = False

--- a/test/mitmproxy/addons/test_keepserving.py
+++ b/test/mitmproxy/addons/test_keepserving.py
@@ -30,6 +30,7 @@ class Dummy:
     def active_connections(self) -> int:
         return 1 if self.val else 0
 
+
 class TKS(keepserving.KeepServing):
     _is_shutdown = False
 

--- a/test/mitmproxy/addons/test_proxyserver.py
+++ b/test/mitmproxy/addons/test_proxyserver.py
@@ -87,6 +87,7 @@ async def test_start_stop(caplog_async):
                 == b"HTTP/1.1 204 No Content\r\n\r\n"
             )
             assert repr(ps) == "Proxyserver(1 active conns)"
+            assert ps.active_connections() == 1
 
             await (
                 ps.setup_servers()


### PR DESCRIPTION
#### Description

This fixes https://github.com/mitmproxy/mitmproxy/issues/7569

#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
