### PR TITLE
Fix websocket view jumps to top bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 - Enhance homebrew installation command for Brewfile users.
   ([#7566](https://github.com/mitmproxy/mitmproxy/pull/7566), @AntoineJT)
+- Fix a bug where WebSocket Messages view jumps to top when a message is received
 
 ## 17 February 2025: mitmproxy 11.1.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Enhance homebrew installation command for Brewfile users.
   ([#7566](https://github.com/mitmproxy/mitmproxy/pull/7566), @AntoineJT)
 - Fix a bug where WebSocket Messages view jumps to top when a message is received
+  ([#7572](https://github.com/mitmproxy/mitmproxy/pull/7572), @DenizenB)
 
 ## 17 February 2025: mitmproxy 11.1.3
 

--- a/mitmproxy/test/tflow.py
+++ b/mitmproxy/test/tflow.py
@@ -289,6 +289,7 @@ def tflows() -> list[flow.Flow]:
         tflow(resp=True),
         tflow(err=True),
         tflow(ws=True),
+        tflow(ws=True), # second run should recycle the previous "Websocket Messages" tab
         ttcpflow(),
         ttcpflow(err=True),
         tudpflow(),

--- a/mitmproxy/test/tflow.py
+++ b/mitmproxy/test/tflow.py
@@ -289,9 +289,6 @@ def tflows() -> list[flow.Flow]:
         tflow(resp=True),
         tflow(err=True),
         tflow(ws=True),
-        tflow(
-            ws=True
-        ),  # second run should recycle the previous "Websocket Messages" tab
         ttcpflow(),
         ttcpflow(err=True),
         tudpflow(),

--- a/mitmproxy/test/tflow.py
+++ b/mitmproxy/test/tflow.py
@@ -289,7 +289,9 @@ def tflows() -> list[flow.Flow]:
         tflow(resp=True),
         tflow(err=True),
         tflow(ws=True),
-        tflow(ws=True), # second run should recycle the previous "Websocket Messages" tab
+        tflow(
+            ws=True
+        ),  # second run should recycle the previous "Websocket Messages" tab
         ttcpflow(),
         ttcpflow(err=True),
         tudpflow(),

--- a/mitmproxy/tools/console/flowview.py
+++ b/mitmproxy/tools/console/flowview.py
@@ -51,6 +51,7 @@ class FlowDetails(tabs.Tabs):
         super().__init__([])
         self.show()
         self.last_displayed_body = None
+        self.last_displayed_websocket_messages = None
         contentviews.on_add.connect(self.contentview_changed)
         contentviews.on_remove.connect(self.contentview_changed)
 
@@ -256,7 +257,14 @@ class FlowDetails(tabs.Tabs):
             0, self._contentview_status_bar(viewmode.capitalize(), viewmode)
         )
 
-        return searchable.Searchable(widget_lines)
+        if (last_view := self.last_displayed_websocket_messages) is not None:
+            last_view.walker[:] = widget_lines
+            view = last_view
+        else:
+            view = searchable.Searchable(widget_lines)
+            self.last_displayed_websocket_messages = view
+
+        return view
 
     def view_message_stream(self) -> urwid.Widget:
         flow = self.flow


### PR DESCRIPTION
#### Description

Fixes #4491

This PR recycles the view created by `view_websocket_messages` and updates its contents in-place, so that you retain your previous scroll position

#### Checklist

 - [ ] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.