### PR TITLE
Do not send empty HTTP/2 data frames without EoS bit unless the client sent some

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ## Unreleased: mitmproxy next
 
+- Fix a bug where mitmproxy would incorrectly send empty HTTP/2 data frames.
 - Enhance homebrew installation command for Brewfile users.
   ([#7566](https://github.com/mitmproxy/mitmproxy/pull/7566), @AntoineJT)
 - Fix a bug where mitmdump would exit prematurely in server replay mode.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 ## Unreleased: mitmproxy next
 
 - Fix a bug where mitmproxy would incorrectly send empty HTTP/2 data frames.
-  ([#7574](https://github.com/mitmproxy/mitmproxy/pull/7574), @mhils)
+  ([#7574](https://github.com/mitmproxy/mitmproxy/pull/7574), @mhils, @Dieken)
 - Enhance homebrew installation command for Brewfile users.
   ([#7566](https://github.com/mitmproxy/mitmproxy/pull/7566), @AntoineJT)
 - Fix a bug where mitmdump would exit prematurely in server replay mode.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ## Unreleased: mitmproxy next
 
 - Fix a bug where mitmproxy would incorrectly send empty HTTP/2 data frames.
+  ([#7574](https://github.com/mitmproxy/mitmproxy/pull/7574), @mhils)
 - Enhance homebrew installation command for Brewfile users.
   ([#7566](https://github.com/mitmproxy/mitmproxy/pull/7566), @AntoineJT)
 - Fix a bug where mitmdump would exit prematurely in server replay mode.

--- a/mitmproxy/proxy/layers/http/_http2.py
+++ b/mitmproxy/proxy/layers/http/_http2.py
@@ -204,10 +204,7 @@ class Http2Connection(HttpConnection):
         if isinstance(event, h2.events.DataReceived):
             state = self.streams.get(event.stream_id, None)
             if state is StreamState.HEADERS_RECEIVED:
-                is_empty_eos_data_frame = (
-                    event.stream_ended and
-                    not event.data
-                )
+                is_empty_eos_data_frame = event.stream_ended and not event.data
                 if not is_empty_eos_data_frame:
                     yield ReceiveHttp(self.ReceiveData(event.stream_id, event.data))
             elif state is StreamState.EXPECTING_HEADERS:

--- a/mitmproxy/proxy/layers/http/_http2.py
+++ b/mitmproxy/proxy/layers/http/_http2.py
@@ -204,7 +204,12 @@ class Http2Connection(HttpConnection):
         if isinstance(event, h2.events.DataReceived):
             state = self.streams.get(event.stream_id, None)
             if state is StreamState.HEADERS_RECEIVED:
-                yield ReceiveHttp(self.ReceiveData(event.stream_id, event.data))
+                is_empty_eos_data_frame = (
+                    event.stream_ended and
+                    not event.data
+                )
+                if not is_empty_eos_data_frame:
+                    yield ReceiveHttp(self.ReceiveData(event.stream_id, event.data))
             elif state is StreamState.EXPECTING_HEADERS:
                 yield from self.protocol_error(
                     f"Received HTTP/2 data frame, expected headers."

--- a/test/mitmproxy/proxy/layers/http/test_http2.py
+++ b/test/mitmproxy/proxy/layers/http/test_http2.py
@@ -86,9 +86,9 @@ def start_h2_client(tctx: Context, keepalive: int = 0) -> tuple[Playbook, FrameF
 
 
 def make_h2(open_connection: OpenConnection) -> None:
-    assert isinstance(
-        open_connection, OpenConnection
-    ), f"Expected OpenConnection event, not {open_connection}"
+    assert isinstance(open_connection, OpenConnection), (
+        f"Expected OpenConnection event, not {open_connection}"
+    )
     open_connection.connection.alpn = b"h2"
 
 
@@ -1316,18 +1316,26 @@ def test_no_empty_data_frame(tctx):
 
     assert (
         playbook
-        >> DataReceived(tctx.client, cff.build_data_frame(b"", flags=["END_STREAM"]).serialize())
+        >> DataReceived(
+            tctx.client, cff.build_data_frame(b"", flags=["END_STREAM"]).serialize()
+        )
         << http.HttpRequestHook(flow)
         >> reply()
         << SendData(server, cff.build_data_frame(b"", flags=["END_STREAM"]).serialize())
-
-        >> DataReceived(server, cff.build_headers_frame(example_response_headers).serialize())
+        >> DataReceived(
+            server, cff.build_headers_frame(example_response_headers).serialize()
+        )
         << http.HttpResponseHeadersHook(flow)
         >> reply(side_effect=enable_streaming)
-        << SendData(tctx.client, cff.build_headers_frame(example_response_headers).serialize())
-
-        >> DataReceived(server, cff.build_data_frame(b"", flags=["END_STREAM"]).serialize())
+        << SendData(
+            tctx.client, cff.build_headers_frame(example_response_headers).serialize()
+        )
+        >> DataReceived(
+            server, cff.build_data_frame(b"", flags=["END_STREAM"]).serialize()
+        )
         << http.HttpResponseHook(flow)
         >> reply()
-        << SendData(tctx.client,  cff.build_data_frame(b"", flags=["END_STREAM"]).serialize())
+        << SendData(
+            tctx.client, cff.build_data_frame(b"", flags=["END_STREAM"]).serialize()
+        )
     )


### PR DESCRIPTION
#### Description

Closes #7480

/cc @Dieken

#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
