### PR TITLE
Adjust popover anchor positioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@
   ([#7575](https://github.com/mitmproxy/mitmproxy/pull/7575), @mhils)
 - Fix a bug where mitmweb would crash when viewing flows with undefined headers.
   ([#7595](https://github.com/mitmproxy/mitmproxy/pull/7595), @emanuele-em)
+- Adjust popover placement for browsers that support anchor positioning (Chrome, Edge)
+  ([#7642](https://github.com/mitmproxy/mitmproxy/pull/7642), @lups2000)
 
 ## 17 February 2025: mitmproxy 11.1.3
 

--- a/web/src/css/mode.less
+++ b/web/src/css/mode.less
@@ -4,7 +4,7 @@
 @import (reference) "../../node_modules/bootstrap/less/labels.less";
 
 .modes {
-    padding: 1em 2em;
+    padding: 1em 2em 2em 2em;
     overflow-y: auto;
     height: 100%;
     width: 100vw;
@@ -193,10 +193,8 @@
                 > div {
                     margin: 0;
                     position: absolute;
-                    left: 0;
-                    top: calc(anchor(bottom) + 10px);
-                    justify-self: anchor-center;
-                    align-self: auto;
+                    top: 10px;
+                    position-area: bottom;
                 }
             }
 
@@ -281,8 +279,7 @@
             > div {
                 margin: 0;
                 position: absolute;
-                left: calc(anchor(right) + 5px);
-                align-self: anchor-center;
+                position-area: right;
             }
         }
 


### PR DESCRIPTION
#### Description

Fixes: #7627
Currently this change works on supported browsers only: **Chrome** and **Edge**. Ref: https://developer.chrome.com/docs/css-ui/anchor-positioning-api

https://github.com/user-attachments/assets/a83add47-6282-47db-8c08-6717b1ac9b2e


#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
