### PR TITLE
Fix `message_to_json` to always show raw payloads when message content is empty

### DIFF
--- a/mitmproxy/tools/web/app.py
+++ b/mitmproxy/tools/web/app.py
@@ -587,6 +587,26 @@ class FlowContent(RequestHandler):
 
 
 class FlowContentView(RequestHandler):
+    # def message_to_json(
+    #     self,
+    #     viewname: str,
+    #     message: http.Message | TCPMessage | UDPMessage | WebSocketMessage,
+    #     flow: HTTPFlow | TCPFlow | UDPFlow,
+    #     max_lines: int | None = None,
+    # ):
+    #     description, lines, error = contentviews.get_message_content_view(
+    #         viewname, message, flow
+    #     )
+    #     if error:
+    #         logging.error(error)
+    #     if max_lines:
+    #         lines = islice(lines, max_lines)
+
+    #     return dict(
+    #         lines=list(lines),
+    #         description=description,
+    #     )
+
     def message_to_json(
         self,
         viewname: str,
@@ -599,11 +619,23 @@ class FlowContentView(RequestHandler):
         )
         if error:
             logging.error(error)
+
+        # Convert lines to a list so we can reliably check if it's empty
+        lines = list(lines)
+
+        if not lines or all(not part for line in lines for part in line):
+            try:
+                raw_text = message.content.decode("utf-8", errors="replace")
+            except Exception:
+                raw_text = repr(message.content)
+            lines = [[["text", raw_text]]]
+            description = "Raw"
+
         if max_lines:
-            lines = islice(lines, max_lines)
+            lines = list(islice(lines, max_lines))
 
         return dict(
-            lines=list(lines),
+            lines=lines,
             description=description,
         )
 


### PR DESCRIPTION
This commit modifies the `message_to_json` function to ensure that raw message payloads are always shown when the parsed content is empty or consists of only empty parts. Previously, the function would not fallback to showing raw content if the parsed lines were empty, which led to missing data in some cases. 

With this fix, if the `lines` are empty or consist of only empty parts, the raw payload of the message is decoded and included in the output. This change improves the handling of edge cases where the content view parsing fails or doesn't generate any meaningful data, ensuring that the raw message content is always available for inspection.

Changes:
- Added a fallback to display raw payload if `lines` are empty or contain only empty parts.
- The raw message is decoded using UTF-8 and added to the lines if needed, with proper error handling in case of decoding issues.

#### Description

Fix `message_to_json` to always show raw payloads when message content is empty.

This change ensures that if the parsed message content (lines) is empty or consists of empty parts, the raw payload of the message will be shown. Previously, the function failed to display raw content in such cases, which could lead to missing message data. With this fix, raw content is decoded and included when necessary, providing a fallback for edge cases where content parsing fails.

#### Checklist

 - [x] I have updated tests where applicable.
 - [ ] I have added an entry to the CHANGELOG.
