### PR TITLE
Fix mitmweb crash when searching/highlighting by ~h/~hq/~hs 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@
   ([#7637](https://github.com/mitmproxy/mitmproxy/pull/7637), @mkiami)
 - Adjust popover placement for browsers that support anchor positioning (Chrome, Edge)
   ([#7642](https://github.com/mitmproxy/mitmproxy/pull/7642), @lups2000)
+- Fix mitmweb crash when searching or highlighting using ~h, ~hq, or ~hs.
+  ([#7652](https://github.com/mitmproxy/mitmproxy/pull/7652), @lups2000)
 
 ## 17 February 2025: mitmproxy 11.1.3
 

--- a/web/src/js/flow/utils.ts
+++ b/web/src/js/flow/utils.ts
@@ -47,6 +47,7 @@ export class MessageUtils {
 
     static match_header(message, regex) {
         const headers = message.headers;
+        if (!headers) return false;
         let i = headers.length;
         while (i--) {
             if (regex.test(headers[i].join(" "))) {


### PR DESCRIPTION
#### Description

Fixes: #7649 

By the way, this temporarily solves the problem, but in the new version (#7617), we won't need it anymore since we're changing the logic for the filters 😄

#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
