### PR TITLE
Add `store_streamed_bodies` ad relevant options for programmatic use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@
 
 - Add a new feature to store streamed bodies for requests and responses.
   ([#7637](https://github.com/mitmproxy/mitmproxy/pull/7637), @mkiami)
+- Add store_streamed_bodies ad relevant options for programmatic use, this is an enhancement for [#7637](https://github.com/mitmproxy/mitmproxy/pull/7637)
+  ([#7665](https://github.com/mitmproxy/mitmproxy/pull/7665), @nth347)
 - Add support for TLS 1.3 Post Handshake Authentication.
   ([#7576](https://github.com/mitmproxy/mitmproxy/pull/7576), @mhils, @cataggar)
 - Add search functionality to the documentation.

--- a/mitmproxy/options.py
+++ b/mitmproxy/options.py
@@ -37,6 +37,33 @@ class Options(optmanager.OptManager):
 
         # Proxy options
         self.add_option(
+            "store_streamed_bodies",
+            bool,
+            False,
+            "Store HTTP request and response bodies when streamed (see `stream_large_bodies`). "
+            "This increases memory consumption, but makes it possible to inspect streamed bodies.",
+        )
+        self.add_option(
+            "stream_large_bodies",
+            Optional[str],
+            None,
+            """
+            Stream data to the client if request or response body exceeds the given
+            threshold. If streamed, the body will not be stored in any way,
+            and such responses cannot be modified. Understands k/m/g
+            suffixes, i.e. 3m for 3 megabytes. To store streamed bodies, see `store_streamed_bodies`.
+            """,
+        )
+        self.add_option(
+            "body_size_limit",
+            Optional[str],
+            None,
+            """
+            Byte size limit of HTTP request and response bodies. Understands
+            k/m/g suffixes, i.e. 3m for 3 megabytes.
+            """,
+        )
+        self.add_option(
             "add_upstream_certs_to_client_chain",
             bool,
             False,


### PR DESCRIPTION
…mit` options for programmatic use

#### Description

Added the following options: `store_streamed_bodies`, `stream_large_bodies`, and `body_size_limit` for programmatic use.

This is an enhancement for https://github.com/mitmproxy/mitmproxy/pull/7637

#### Checklist

 - [ ] I have updated tests where applicable.
 - [ x] I have added an entry to the CHANGELOG.
 - [x ] I have tested the options, they worked as expected.
