### PR TITLE
docs(fix): fix broken upstream certificate sniffing link in how-mitmp…

### DIFF
--- a/docs/src/content/concepts/how-mitmproxy-works.md
+++ b/docs/src/content/concepts/how-mitmproxy-works.md
@@ -97,7 +97,7 @@ information to initiate the pipe, even though it doesn't reveal the
 remote hostname.
 
 Mitmproxy has a cunning mechanism that smooths this over - [upstream certificate
-sniffing]({{< relref "/overview/features#upstream-certificates" >}}). As soon as
+sniffing]({{< relref "/concepts/certificates/#upstream-certificate-sniffing" >}}). As soon as
 we see the CONNECT request, we pause the client part of the conversation, and
 initiate a simultaneous connection to the server. We complete the TLS handshake
 with the server, and inspect the certificates it used. Now, we use the Common


### PR DESCRIPTION
#### Description

fix #7669 

Updated broken link in [docs/src/content/concepts/how-mitmproxy-works.md](https://github.com/mitmproxy/mitmproxy/blob/b089c5fb83a43af2cb290d501013e23367102d6f/docs/src/content/concepts/how-mitmproxy-works.md?plain=1#L99-L100) from `overview/features` to `concepts/certificates` to point to the correct resource.

#### Checklist

 - [ ] I have updated tests where applicable.
 - [ ] I have added an entry to the CHANGELOG.
