### PR TITLE
Bump h11 dependency version for critical security fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
     "certifi>=2019.9.11",  # no upper bound here to get latest CA bundle
     "cryptography>=42.0,<44.1",  # relaxed upper bound here to get security fixes
     "flask>=3.0,<=3.1.0",
-    "h11>=0.11,<=0.14.0",
+    "h11>=0.16.0,<1",  # relaxed upper bound here to get security fixes
     "h2>=4.1,<=4.1.0",
     "hyperframe>=6.0,<=6.1.0",
     "kaitaistruct>=0.10,<=0.10",


### PR DESCRIPTION
A critical CVE affecting h11 < 0.16.0 has been published: [CVE-2025-43859](https://github.com/advisories/GHSA-vqfr-h8mv-ghfj)
