### PR TITLE
Fix better error message for wire guard port conflict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * In DNS proxy mode, user-provided addons now trigger before DNS resolution has taken place.
   ([#7685](https://github.com/mitmproxy/mitmproxy/pull/7685), @Florigolo)
 * Improve error message for WireGuard port conflict.
+  ([#7688](https://github.com/mitmproxy/mitmproxy/pull/7688), @turboOrange)
 
 ## 29 April 2025: mitmproxy 12.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 * In DNS proxy mode, user-provided addons now trigger before DNS resolution has taken place.
   ([#7685](https://github.com/mitmproxy/mitmproxy/pull/7685), @Florigolo)
+* Improve error message for WireGuard port conflict.
 
 ## 29 April 2025: mitmproxy 12.0.0
 

--- a/mitmproxy/proxy/mode_servers.py
+++ b/mitmproxy/proxy/mode_servers.py
@@ -22,18 +22,28 @@ import sys
 import textwrap
 import traceback
 import typing
-from abc import ABCMeta, abstractmethod
+from abc import ABCMeta
+from abc import abstractmethod
 from contextlib import contextmanager
 from pathlib import Path
-from typing import TYPE_CHECKING, ClassVar, Generic, TypeVar, cast, get_args
+from typing import cast
+from typing import ClassVar
+from typing import Generic
+from typing import get_args
+from typing import TYPE_CHECKING
+from typing import TypeVar
 
 import mitmproxy_rs
-
-from mitmproxy import ctx, flow, platform
+from mitmproxy import ctx
+from mitmproxy import flow
+from mitmproxy import platform
 from mitmproxy.connection import Address
 from mitmproxy.net import local_ip
 from mitmproxy.net.free_port import get_free_port
-from mitmproxy.proxy import commands, layers, mode_specs, server
+from mitmproxy.proxy import commands
+from mitmproxy.proxy import layers
+from mitmproxy.proxy import mode_specs
+from mitmproxy.proxy import server
 from mitmproxy.proxy.context import Context
 from mitmproxy.proxy.layer import Layer
 from mitmproxy.utils import human

--- a/mitmproxy/proxy/mode_servers.py
+++ b/mitmproxy/proxy/mode_servers.py
@@ -22,28 +22,18 @@ import sys
 import textwrap
 import traceback
 import typing
-from abc import ABCMeta
-from abc import abstractmethod
+from abc import ABCMeta, abstractmethod
 from contextlib import contextmanager
 from pathlib import Path
-from typing import cast
-from typing import ClassVar
-from typing import Generic
-from typing import get_args
-from typing import TYPE_CHECKING
-from typing import TypeVar
+from typing import TYPE_CHECKING, ClassVar, Generic, TypeVar, cast, get_args
 
 import mitmproxy_rs
-from mitmproxy import ctx
-from mitmproxy import flow
-from mitmproxy import platform
+
+from mitmproxy import ctx, flow, platform
 from mitmproxy.connection import Address
 from mitmproxy.net import local_ip
 from mitmproxy.net.free_port import get_free_port
-from mitmproxy.proxy import commands
-from mitmproxy.proxy import layers
-from mitmproxy.proxy import mode_specs
-from mitmproxy.proxy import server
+from mitmproxy.proxy import commands, layers, mode_specs, server
 from mitmproxy.proxy.context import Context
 from mitmproxy.proxy.layer import Layer
 from mitmproxy.utils import human

--- a/mitmproxy/proxy/mode_servers.py
+++ b/mitmproxy/proxy/mode_servers.py
@@ -549,3 +549,4 @@ class TunInstance(ServerInstance[mode_specs.TunMode]):
 # class Http3Instance(AsyncioServerInstance[mode_specs.Http3Mode]):
 #     def make_top_layer(self, context: Context) -> Layer:
 #         return layers.modes.HttpProxy(context)
+#         return layers.modes.HttpProxy(context)

--- a/mitmproxy/proxy/mode_servers.py
+++ b/mitmproxy/proxy/mode_servers.py
@@ -21,6 +21,7 @@ import socket
 import sys
 import textwrap
 import typing
+import traceback
 from abc import ABCMeta
 from abc import abstractmethod
 from contextlib import contextmanager
@@ -381,14 +382,18 @@ class WireGuardServerInstance(AsyncioServerInstance[mode_specs.WireGuardMode]):
     async def start_udp_based_server(
         self, host, port
     ) -> mitmproxy_rs.wireguard.WireGuardServer:
-        return await mitmproxy_rs.wireguard.start_wireguard_server(
-            host,
-            port,
-            self.server_key,
-            [self.pubkey],
-            self.handle_stream,
-            self.handle_stream,
-        )
+        try:
+            return await mitmproxy_rs.wireguard.start_wireguard_server(
+                host,
+                port,
+                self.server_key,
+                [self.pubkey],
+                self.handle_stream,
+                self.handle_stream,
+            )
+        except Exception as e:
+            traceback.print_exc()
+            raise RuntimeError("WireGuard failed to start") from e
 
     def client_conf(self) -> str | None:
         if not self._servers:

--- a/mitmproxy/proxy/mode_servers.py
+++ b/mitmproxy/proxy/mode_servers.py
@@ -20,8 +20,8 @@ import os
 import socket
 import sys
 import textwrap
-import typing
 import traceback
+import typing
 from abc import ABCMeta
 from abc import abstractmethod
 from contextlib import contextmanager

--- a/test/mitmproxy/proxy/test_mode_servers.py
+++ b/test/mitmproxy/proxy/test_mode_servers.py
@@ -191,6 +191,7 @@ async def test_wireguard(tdata, monkeypatch, caplog):
         await inst.stop()
         assert "stopped" in caplog.text
 
+
 async def test_wireguard_port_unavailable(tdata, monkeypatch, caplog):
     caplog.set_level("DEBUG")
     monkeypatch.setattr(ConnectionHandler, "handle_client", _echo_server)
@@ -203,7 +204,7 @@ async def test_wireguard_port_unavailable(tdata, monkeypatch, caplog):
         return pytest.skip("Unsupported architecture for wg-test-client.")
 
     test_conf = tdata.path(f"wg-test-client/test.conf")
-    with patch('mitmproxy_rs.wireguard.start_wireguard_server') as mock_start:
+    with patch("mitmproxy_rs.wireguard.start_wireguard_server") as mock_start:
         mock_start.side_effect = RuntimeError("Forced failure")
 
         inst = WireGuardServerInstance.make(f"wireguard:{test_conf}@0", MagicMock())
@@ -212,6 +213,7 @@ async def test_wireguard_port_unavailable(tdata, monkeypatch, caplog):
             await inst.start()
 
         assert "WireGuard failed to start" in caplog.text
+
 
 @pytest.mark.parametrize("host", ["127.0.0.1", "::1"])
 async def test_wireguard_dual_stack(host, caplog_async):


### PR DESCRIPTION
#### Description

This relates to issue #7650. The current behavior is due to Rust errors not including a traceback by default. When using the PyO3 library, it's expected that exceptions may appear like this. That said, we can still improve the situation by enhancing error handling within the Rust code (mitmproxy_rs) and by adding more context on the Python side when an exception is raised. Below is the crash generated by the current version: `Traceback (most recent call last):
  File "/home/no_more_heroes/projet/mitmproxy/mitmproxy/proxy/mode_servers.py", line 386, in start_udp_based_server
    return await mitmproxy_rs.wireguard.start_wireguard_server(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<6 lines>...
    )
    ^
RuntimeError: Failed to bind UDP socket to 0.0.0.0:51820

Caused by:
    Address already in use (os error 98)
[20:37:25.913] WireGuard failed to start
Error logged during startup, exiting...`



#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
