### PR TITLE
Fix/concurrent mitmweb instances overwrite each others mitmproxy auth cookie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
 - In DNS proxy mode, user-provided addons now trigger before DNS resolution has taken place.
   ([#7685](https://github.com/mitmproxy/mitmproxy/pull/7685), @Florigolo)
 
+* fix concurrent mitmweb instances overwrite each other's mitmproxy-auth cookie
+
 ## 29 April 2025: mitmproxy 12.0.0
 
 ### New Contentview System ([#7623](https://github.com/mitmproxy/mitmproxy/pull/7623), @mhils)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 - Fix raw response export incorrectly zeroing non-zero `Content-Length` header for HEAD requests.
   ([#7701](https://github.com/mitmproxy/mitmproxy/pull/7701), @sujaldev)
+- Fix concurrent mitmweb instances overwrite each other's auth cookie.
+  ([#7690](https://github.com/mitmproxy/mitmproxy/pull/7690), @turboOrange)
 
 ## 06 May 2025: mitmproxy 12.0.1
 
@@ -18,9 +20,6 @@
   ([#7681](https://github.com/mitmproxy/mitmproxy/pull/7681), @gschaer)
 - In DNS proxy mode, user-provided addons now trigger before DNS resolution has taken place.
   ([#7685](https://github.com/mitmproxy/mitmproxy/pull/7685), @Florigolo)
-
-* fix concurrent mitmweb instances overwrite each other's mitmproxy-auth cookie
-  ([#7690](https://github.com/mitmproxy/mitmproxy/pull/7690), @turboOrange)
 
 ## 29 April 2025: mitmproxy 12.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
   ([#7685](https://github.com/mitmproxy/mitmproxy/pull/7685), @Florigolo)
 
 * fix concurrent mitmweb instances overwrite each other's mitmproxy-auth cookie
+  ([#7690](https://github.com/mitmproxy/mitmproxy/pull/7690), @turboOrange)
 
 ## 29 April 2025: mitmproxy 12.0.0
 

--- a/mitmproxy/tools/web/app.py
+++ b/mitmproxy/tools/web/app.py
@@ -224,8 +224,8 @@ class AuthRequestHandler(tornado.web.RequestHandler):
                 setattr(cls, method, AuthRequestHandler._require_auth(fn))
 
     def get_auth_cookie_name(self):
-        host = self.request.host
-        port = host.split(":")[-1]
+        _, port = tornado.httputil.split_host_and_port(self.request.host)
+        port = port if port is not None else 80
         return f"mitmproxy-auth-{port}"
 
     def auth_fail(self, invalid_password: bool) -> None:

--- a/mitmproxy/tools/web/app.py
+++ b/mitmproxy/tools/web/app.py
@@ -223,9 +223,9 @@ class AuthRequestHandler(tornado.web.RequestHandler):
             if fn is not tornado.web.RequestHandler._unimplemented_method:
                 setattr(cls, method, AuthRequestHandler._require_auth(fn))
 
-    def get_auth_cookie_name(self):
-        _, port = tornado.httputil.split_host_and_port(self.request.host)
-        return f"mitmproxy-auth-{port or 80}"
+    @staticmethod
+    def auth_cookie_name(port: int)-> str:
+        return f"mitmproxy-auth-{port}"
 
     def auth_fail(self, invalid_password: bool) -> None:
         """
@@ -256,7 +256,7 @@ class AuthRequestHandler(tornado.web.RequestHandler):
                     self.auth_fail(bool(password))
                     return None
                 self.set_signed_cookie(
-                    self.get_auth_cookie_name(),
+                    AuthRequestHandler.auth_cookie_name(self.master.options.web_port),
                     self.AUTH_COOKIE_VALUE,
                     expires_days=400,
                     httponly=True,
@@ -267,10 +267,8 @@ class AuthRequestHandler(tornado.web.RequestHandler):
         return wrapper
 
     def get_current_user(self) -> bool:
-        return (
-            self.get_signed_cookie(self.get_auth_cookie_name(), min_version=2)
-            == self.AUTH_COOKIE_VALUE
-        )
+        cookie_name = AuthRequestHandler.auth_cookie_name(self.application.master.options.web_port)
+        return (self.get_signed_cookie(cookie_name, min_version=2) == self.AUTH_COOKIE_VALUE)
 
 
 class RequestHandler(AuthRequestHandler):

--- a/mitmproxy/tools/web/app.py
+++ b/mitmproxy/tools/web/app.py
@@ -224,7 +224,7 @@ class AuthRequestHandler(tornado.web.RequestHandler):
                 setattr(cls, method, AuthRequestHandler._require_auth(fn))
 
     @staticmethod
-    def auth_cookie_name(port: int)-> str:
+    def auth_cookie_name(port: int) -> str:
         return f"mitmproxy-auth-{port}"
 
     def auth_fail(self, invalid_password: bool) -> None:
@@ -267,8 +267,12 @@ class AuthRequestHandler(tornado.web.RequestHandler):
         return wrapper
 
     def get_current_user(self) -> bool:
-        cookie_name = AuthRequestHandler.auth_cookie_name(self.application.master.options.web_port)
-        return (self.get_signed_cookie(cookie_name, min_version=2) == self.AUTH_COOKIE_VALUE)
+        cookie_name = AuthRequestHandler.auth_cookie_name(
+            self.application.master.options.web_port
+        )
+        return (
+            self.get_signed_cookie(cookie_name, min_version=2) == self.AUTH_COOKIE_VALUE
+        )
 
 
 class RequestHandler(AuthRequestHandler):

--- a/mitmproxy/tools/web/app.py
+++ b/mitmproxy/tools/web/app.py
@@ -264,7 +264,8 @@ class AuthRequestHandler(tornado.web.RequestHandler):
 
     def get_current_user(self) -> bool:
         return (
-            self.get_signed_cookie(self.settings["auth_cookie_name"], min_version=2) == self.AUTH_COOKIE_VALUE
+            self.get_signed_cookie(self.settings["auth_cookie_name"], min_version=2)
+            == self.AUTH_COOKIE_VALUE
         )
 
 

--- a/mitmproxy/tools/web/app.py
+++ b/mitmproxy/tools/web/app.py
@@ -225,8 +225,7 @@ class AuthRequestHandler(tornado.web.RequestHandler):
 
     def get_auth_cookie_name(self):
         _, port = tornado.httputil.split_host_and_port(self.request.host)
-        port = port if port is not None else 80
-        return f"mitmproxy-auth-{port}"
+        return f"mitmproxy-auth-{port or 80}"
 
     def auth_fail(self, invalid_password: bool) -> None:
         """

--- a/mitmproxy/tools/web/app.py
+++ b/mitmproxy/tools/web/app.py
@@ -213,6 +213,9 @@ class APIError(tornado.web.HTTPError):
 
 
 class AuthRequestHandler(tornado.web.RequestHandler):
+    # mypy: override to access .master
+    application: Application
+
     AUTH_COOKIE_VALUE = b"y"
 
     def __init_subclass__(cls, **kwargs):
@@ -256,7 +259,7 @@ class AuthRequestHandler(tornado.web.RequestHandler):
                     self.auth_fail(bool(password))
                     return None
                 self.set_signed_cookie(
-                    AuthRequestHandler.auth_cookie_name(self.master.options.web_port),
+                    AuthRequestHandler.auth_cookie_name(self.application.master.options.web_port),
                     self.AUTH_COOKIE_VALUE,
                     expires_days=400,
                     httponly=True,

--- a/mitmproxy/tools/web/app.py
+++ b/mitmproxy/tools/web/app.py
@@ -259,7 +259,9 @@ class AuthRequestHandler(tornado.web.RequestHandler):
                     self.auth_fail(bool(password))
                     return None
                 self.set_signed_cookie(
-                    AuthRequestHandler.auth_cookie_name(self.application.master.options.web_port),
+                    AuthRequestHandler.auth_cookie_name(
+                        self.application.master.options.web_port
+                    ),
                     self.AUTH_COOKIE_VALUE,
                     expires_days=400,
                     httponly=True,

--- a/test/mitmproxy/tools/web/test_app.py
+++ b/test/mitmproxy/tools/web/test_app.py
@@ -81,12 +81,16 @@ class TestApp(tornado.testing.AsyncHTTPTestCase):
 
     @property
     def auth_cookie(self) -> str:
+        port = self.get_http_port()
+        cookie_name = f"mitmproxy-auth-{port}"
+        cookie_value = b"y"
+
         auth_cookie = create_signed_value(
             secret=self._app.settings["cookie_secret"],
-            name=app.AuthRequestHandler.AUTH_COOKIE_NAME,
-            value=app.AuthRequestHandler.AUTH_COOKIE_VALUE,
+            name=cookie_name,
+            value=cookie_value,
         ).decode()
-        return f"{app.AuthRequestHandler.AUTH_COOKIE_NAME}={auth_cookie}"
+        return f"{cookie_name}={auth_cookie}"
 
     def fetch(self, *args, **kwargs) -> httpclient.HTTPResponse:
         kwargs.setdefault("headers", {}).setdefault("Cookie", self.auth_cookie)

--- a/test/mitmproxy/tools/web/test_app.py
+++ b/test/mitmproxy/tools/web/test_app.py
@@ -86,7 +86,7 @@ class TestApp(tornado.testing.AsyncHTTPTestCase):
             name=self._app.settings["auth_cookie_name"],
             value=app.AuthRequestHandler.AUTH_COOKIE_VALUE,
         ).decode()
-        return f"{self._app.settings["auth_cookie_name"]}={auth_cookie}"
+        return f"{self._app.settings['auth_cookie_name']}={auth_cookie}"
 
     def fetch(self, *args, **kwargs) -> httpclient.HTTPResponse:
         kwargs.setdefault("headers", {}).setdefault("Cookie", self.auth_cookie)

--- a/test/mitmproxy/tools/web/test_app.py
+++ b/test/mitmproxy/tools/web/test_app.py
@@ -81,7 +81,7 @@ class TestApp(tornado.testing.AsyncHTTPTestCase):
 
     @property
     def auth_cookie(self) -> str:
-        cookie_name = f"mitmproxy-auth-{self.get_http_port()}"
+        cookie_name = f"mitmproxy-auth-{self.master.options.web_port}"
         cookie_value = b"y"
 
         auth_cookie = create_signed_value(

--- a/test/mitmproxy/tools/web/test_app.py
+++ b/test/mitmproxy/tools/web/test_app.py
@@ -81,8 +81,7 @@ class TestApp(tornado.testing.AsyncHTTPTestCase):
 
     @property
     def auth_cookie(self) -> str:
-        port = self.get_http_port()
-        cookie_name = f"mitmproxy-auth-{port}"
+        cookie_name = f"mitmproxy-auth-{self.get_http_port()}"
         cookie_value = b"y"
 
         auth_cookie = create_signed_value(

--- a/test/mitmproxy/tools/web/test_app.py
+++ b/test/mitmproxy/tools/web/test_app.py
@@ -81,15 +81,12 @@ class TestApp(tornado.testing.AsyncHTTPTestCase):
 
     @property
     def auth_cookie(self) -> str:
-        cookie_name = f"mitmproxy-auth-{self.master.options.web_port}"
-        cookie_value = b"y"
-
         auth_cookie = create_signed_value(
             secret=self._app.settings["cookie_secret"],
-            name=cookie_name,
-            value=cookie_value,
+            name=self._app.settings["auth_cookie_name"],
+            value=app.AuthRequestHandler.AUTH_COOKIE_VALUE,
         ).decode()
-        return f"{cookie_name}={auth_cookie}"
+        return f"{self._app.settings["auth_cookie_name"]}={auth_cookie}"
 
     def fetch(self, *args, **kwargs) -> httpclient.HTTPResponse:
         kwargs.setdefault("headers", {}).setdefault("Cookie", self.auth_cookie)


### PR DESCRIPTION
#### Description

This is a fix for #7651.
The issue was that when two instances were running from the same domain or IP address, they shared cookies because cookies are tied to the domain, not the port. This made it difficult to run multiple instances on the same machine.

The solution proposed in this pull request is to include the port number in the cookie name. This ensures that even if cookies are technically shared at the domain level, they remain distinct and do not conflict.

#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
