### PR TITLE
Force confdir to /home/mitmproxy/.mitmproxy when volume is root-owned

### DIFF
--- a/release/docker/docker-entrypoint.sh
+++ b/release/docker/docker-entrypoint.sh
@@ -20,7 +20,8 @@ usermod -o \
 
 if [[ "$1" = "mitmdump" || "$1" = "mitmproxy" || "$1" = "mitmweb" ]]; then
   # Drop privileges if we are starting one of the mitmproxy tools.
-  exec gosu mitmproxy "$@"
+  # Set HOME to /home/mitmproxy for config dir fix (mitmproxy/mitmproxy#7597)
+  exec env HOME=/home/mitmproxy gosu mitmproxy "$@"
 else
   exec "$@"
 fi


### PR DESCRIPTION
Ensure mitmproxy uses /home/mitmproxy/.mitmproxy as the config directory even if the mapped volume is owned by host root, preventing fallback to /root/.mitmproxy and CA file regeneration on redeploy. Add `HOME` env confdir in entrypoint to enforce this behavior.

Fixes mitmproxy/mitmproxy#7597

#### Description

<!-- describe your changes here -->

#### Checklist

 - [ ] I have updated tests where applicable.
 - [ ] I have added an entry to the CHANGELOG.
