### PR TITLE
Fix raw response export incorrectly zeroing non-zero `Content-Length` header for HEAD requests.

### DIFF
--- a/mitmproxy/addons/export.py
+++ b/mitmproxy/addons/export.py
@@ -39,7 +39,8 @@ def cleanup_response(f: flow.Flow) -> http.Response:
         raise exceptions.CommandError("Can't export flow with no response.")
     assert isinstance(f, http.HTTPFlow)
     response = f.response.copy()  # type: ignore
-    response.decode(strict=False)
+    if response.content:
+        response.decode(strict=False)
     return response
 
 

--- a/test/mitmproxy/addons/test_export.py
+++ b/test/mitmproxy/addons/test_export.py
@@ -274,6 +274,13 @@ class TestRawResponse:
         with pytest.raises(exceptions.CommandError):
             export.raw_response(udp_flow)
 
+    def test_head_non_zero_content_length(self):
+        request = tflow.tflow(
+            req=tutils.treq(method=b"HEAD"),
+            resp=tutils.tresp(headers=((b"content-length", b"7"),), content=b""),
+        )
+        assert b"content-length: 7" in export.raw_response(request)
+
 
 def qr(f):
     with open(f, "rb") as fp:


### PR DESCRIPTION
#### Description

Fixes #7695.

#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
