### PR TITLE
Web: simplify connection state reducer

### DIFF
--- a/web/src/js/__tests__/backends/websocketSpec.tsx
+++ b/web/src/js/__tests__/backends/websocketSpec.tsx
@@ -96,20 +96,18 @@ describe("websocket backend", () => {
             subscribe: () => {},
         });
 
-        backend.onOpen();
+        await backend.onOpen();
 
-        await waitFor(() =>
-            expect(actions).toEqual([
-                connectionActions.startFetching(),
-                // @ts-expect-error mocked
-                STATE_RECEIVE({}),
-                FLOWS_RECEIVE([]),
-                EVENTS_RECEIVE([]),
-                // @ts-expect-error mocked
-                OPTIONS_RECEIVE({}),
-                connectionActions.connectionEstablished(),
-            ]),
-        );
+        expect(actions).toEqual([
+            connectionActions.startFetching(),
+            // @ts-expect-error mocked
+            STATE_RECEIVE({}),
+            FLOWS_RECEIVE([]),
+            EVENTS_RECEIVE([]),
+            // @ts-expect-error mocked
+            OPTIONS_RECEIVE({}),
+            connectionActions.finishFetching(),
+        ]);
 
         actions.length = 0;
         backend.onMessage({
@@ -132,7 +130,6 @@ describe("websocket backend", () => {
         await waitFor(() =>
             expect(actions).toEqual([
                 EVENTS_RECEIVE([]),
-                connectionActions.connectionEstablished(),
             ]),
         );
         actions.length = 0;

--- a/web/src/js/__tests__/backends/websocketSpec.tsx
+++ b/web/src/js/__tests__/backends/websocketSpec.tsx
@@ -127,11 +127,7 @@ describe("websocket backend", () => {
         backend.onMessage({
             type: "events/reset",
         });
-        await waitFor(() =>
-            expect(actions).toEqual([
-                EVENTS_RECEIVE([]),
-            ]),
-        );
+        await waitFor(() => expect(actions).toEqual([EVENTS_RECEIVE([])]));
         actions.length = 0;
         expect(fetchMock.mock.calls).toHaveLength(5);
 

--- a/web/src/js/__tests__/components/Header/ConnectionIndicatorSpec.tsx
+++ b/web/src/js/__tests__/components/Header/ConnectionIndicatorSpec.tsx
@@ -2,20 +2,18 @@ import * as React from "react";
 import ConnectionIndicator from "../../../components/Header/ConnectionIndicator";
 import * as connectionActions from "../../../ducks/connection";
 import { act, render } from "../../test-utils";
+import {TStore} from "../../ducks/tutils";
 
 test("ConnectionIndicator", async () => {
-    const { asFragment, store } = render(<ConnectionIndicator />);
+    const { asFragment, store } = render(<ConnectionIndicator />, {store: TStore(null)});
     expect(asFragment()).toMatchSnapshot();
 
     act(() => store.dispatch(connectionActions.startFetching()));
     expect(asFragment()).toMatchSnapshot();
 
-    act(() => store.dispatch(connectionActions.connectionEstablished()));
+    act(() => store.dispatch(connectionActions.finishFetching()));
     expect(asFragment()).toMatchSnapshot();
 
     act(() => store.dispatch(connectionActions.connectionError("wat")));
-    expect(asFragment()).toMatchSnapshot();
-
-    act(() => store.dispatch(connectionActions.setOffline()));
     expect(asFragment()).toMatchSnapshot();
 });

--- a/web/src/js/__tests__/components/Header/ConnectionIndicatorSpec.tsx
+++ b/web/src/js/__tests__/components/Header/ConnectionIndicatorSpec.tsx
@@ -2,10 +2,12 @@ import * as React from "react";
 import ConnectionIndicator from "../../../components/Header/ConnectionIndicator";
 import * as connectionActions from "../../../ducks/connection";
 import { act, render } from "../../test-utils";
-import {TStore} from "../../ducks/tutils";
+import { TStore } from "../../ducks/tutils";
 
 test("ConnectionIndicator", async () => {
-    const { asFragment, store } = render(<ConnectionIndicator />, {store: TStore(null)});
+    const { asFragment, store } = render(<ConnectionIndicator />, {
+        store: TStore(null),
+    });
     expect(asFragment()).toMatchSnapshot();
 
     act(() => store.dispatch(connectionActions.startFetching()));

--- a/web/src/js/__tests__/components/Header/__snapshots__/ConnectionIndicatorSpec.tsx.snap
+++ b/web/src/js/__tests__/components/Header/__snapshots__/ConnectionIndicatorSpec.tsx.snap
@@ -3,9 +3,9 @@
 exports[`ConnectionIndicator 1`] = `
 <DocumentFragment>
   <span
-    class="connection-indicator established"
+    class="connection-indicator init"
   >
-    connected
+    connecting…
   </span>
 </DocumentFragment>
 `;
@@ -37,16 +37,6 @@ exports[`ConnectionIndicator 4`] = `
     title="wat"
   >
     connection lost
-  </span>
-</DocumentFragment>
-`;
-
-exports[`ConnectionIndicator 5`] = `
-<DocumentFragment>
-  <span
-    class="connection-indicator offline"
-  >
-    offline
   </span>
 </DocumentFragment>
 `;

--- a/web/src/js/__tests__/ducks/connectionSpec.tsx
+++ b/web/src/js/__tests__/ducks/connectionSpec.tsx
@@ -21,12 +21,27 @@ describe("connection reducer", () => {
     it("should handle connection established", () => {
         expect(
             reduceConnection(
-                undefined,
-                ConnectionActions.connectionEstablished(),
+                {
+                    state: ConnectionState.FETCHING,
+                    message: undefined,
+                },
+                ConnectionActions.finishFetching(),
             ),
         ).toEqual({
             state: ConnectionState.ESTABLISHED,
             message: undefined,
+        });
+        expect(
+            reduceConnection(
+                {
+                    state: ConnectionState.ERROR,
+                    message: "we already failed",
+                },
+                ConnectionActions.finishFetching(),
+            ),
+        ).toEqual({
+            state: ConnectionState.ERROR,
+            message: "we already failed",
         });
     });
 
@@ -39,15 +54,6 @@ describe("connection reducer", () => {
         ).toEqual({
             state: ConnectionState.ERROR,
             message: "no internet",
-        });
-    });
-
-    it("should handle offline mode", () => {
-        expect(
-            reduceConnection(undefined, ConnectionActions.setOffline()),
-        ).toEqual({
-            state: ConnectionState.OFFLINE,
-            message: undefined,
         });
     });
 });

--- a/web/src/js/components/Header/ConnectionIndicator.tsx
+++ b/web/src/js/components/Header/ConnectionIndicator.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { ConnectionState } from "../../ducks/connection";
 import { useAppSelector } from "../../ducks";
+import { assertNever } from "../../utils";
 
 export default React.memo(
     function ConnectionIndicator(): React.ReactElement<any> {
@@ -35,12 +36,9 @@ export default React.memo(
                         connection lost
                     </span>
                 );
-            case ConnectionState.OFFLINE:
-                return (
-                    <span className="connection-indicator offline">
-                        offline
-                    </span>
-                );
+            /* istanbul ignore next @preserve */
+            default:
+                assertNever(connState);
         }
     },
 );

--- a/web/src/js/ducks/connection.ts
+++ b/web/src/js/ducks/connection.ts
@@ -5,7 +5,6 @@ export enum ConnectionState {
     FETCHING = "CONNECTION_FETCHING", // WebSocket is established, but still fetching resources.
     ESTABLISHED = "CONNECTION_ESTABLISHED",
     ERROR = "CONNECTION_ERROR",
-    OFFLINE = "CONNECTION_OFFLINE", // indicates that there is no live (websocket) backend.
 }
 
 interface ConnState {
@@ -23,28 +22,22 @@ const connectionSlice = createSlice({
     initialState: defaultState,
     reducers: {
         startFetching: (state) => {
-            state.state = ConnectionState.FETCHING;
-            state.message = undefined;
+            if (state.state === ConnectionState.INIT) {
+                state.state = ConnectionState.FETCHING;
+            }
         },
-        connectionEstablished: (state) => {
-            state.state = ConnectionState.ESTABLISHED;
-            state.message = undefined;
+        finishFetching: (state) => {
+            if (state.state === ConnectionState.FETCHING) {
+                state.state = ConnectionState.ESTABLISHED;
+            }
         },
         connectionError: (state, action) => {
             state.state = ConnectionState.ERROR;
             state.message = action.payload;
         },
-        setOffline: (state) => {
-            state.state = ConnectionState.OFFLINE;
-            state.message = undefined;
-        },
     },
 });
 
-export const {
-    startFetching,
-    connectionEstablished,
-    connectionError,
-    setOffline,
-} = connectionSlice.actions;
+export const { startFetching, finishFetching, connectionError } =
+    connectionSlice.actions;
 export default connectionSlice.reducer;


### PR DESCRIPTION
#### Description

The `connectionEstablished` (now `finishFetching`) should only trigger during startup. This PR fixes that, simplifies the code a bit, and removes the unused offline state.

#### Checklist

 - [x] I have updated tests where applicable.
 