### PR TITLE
Do not escape non-ascii characters in the JSON contentview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ## Unreleased: mitmproxy next
 
+- Do not escape non-ascii characters in the JSON contentview.
 - Fix crash in mitmweb when no explicit Server-Connection is logged.
   ([#7734](https://github.com/mitmproxy/mitmproxy/pull/7734), @lups2000)
 

--- a/mitmproxy/contentviews/_view_json.py
+++ b/mitmproxy/contentviews/_view_json.py
@@ -9,7 +9,7 @@ class JSONContentview(Contentview):
 
     def prettify(self, data: bytes, metadata: Metadata) -> str:
         data = json.loads(data)
-        return json.dumps(data, indent=4)
+        return json.dumps(data, indent=4, ensure_ascii=False)
 
     def render_priority(self, data: bytes, metadata: Metadata) -> float:
         if not data:

--- a/test/mitmproxy/contentviews/test__view_json.py
+++ b/test/mitmproxy/contentviews/test__view_json.py
@@ -17,6 +17,11 @@ def test_view_json():
     assert json_view.syntax_highlight == "yaml"
 
 
+def test_view_json_nonascii():
+    """https://github.com/mitmproxy/mitmproxy/issues/7739"""
+    assert json_view.prettify('{"a": "日本語"}'.encode(), Metadata()) == '{\n    "a": "日本語"\n}'
+
+
 def test_render_priority():
     assert json_view.render_priority(b"data", Metadata(content_type="application/json"))
     assert json_view.render_priority(


### PR DESCRIPTION
#### Description

This fixes #7739.

#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
