### PR TITLE
Fix type for `Master.opts` to accept `None`

### DIFF
--- a/mitmproxy/master.py
+++ b/mitmproxy/master.py
@@ -26,7 +26,7 @@ class Master:
 
     def __init__(
         self,
-        opts: options.Options,
+        opts: options.Options | None,
         event_loop: asyncio.AbstractEventLoop | None = None,
         with_termlog: bool = False,
     ):


### PR DESCRIPTION
#### Description

I think the type hint for `Master.opts` is missing a `| None`. There's logic to handle a falsey value, and that's how this test instantiates `Master`:

https://github.com/mitmproxy/mitmproxy/blob/b5ac8e62ea633a7a7211d735fabe6008fb64ece0/test/mitmproxy/test_master.py#L15

#### Checklist

 - [ ] I have updated tests where applicable.
 - [ ] I have added an entry to the CHANGELOG.
