### PR TITLE
Convert `mitmproxy.optmanager` functions into `OptManager` methods

### DIFF
--- a/docs/scripts/options.py
+++ b/docs/scripts/options.py
@@ -2,7 +2,6 @@
 import asyncio
 
 from mitmproxy import options
-from mitmproxy import optmanager
 from mitmproxy.tools import console
 from mitmproxy.tools import dump
 from mitmproxy.tools import web
@@ -20,7 +19,7 @@ async def dump():
     for tool_name, master in masters.items():
         opts = options.Options()
         _ = master(opts)
-        for key, option in optmanager.dump_dicts(opts).items():
+        for key, option in opts.dump_dicts().items():
             if key in unified_options:
                 unified_options[key]["tools"].append(tool_name)
             else:

--- a/mitmproxy/addons/core.py
+++ b/mitmproxy/addons/core.py
@@ -8,7 +8,6 @@ from mitmproxy import ctx
 from mitmproxy import exceptions
 from mitmproxy import flow
 from mitmproxy import hooks
-from mitmproxy import optmanager
 from mitmproxy.log import ALERT
 from mitmproxy.net.http import status_codes
 from mitmproxy.utils import emoji
@@ -251,7 +250,7 @@ class Core:
         Load options from a file.
         """
         try:
-            optmanager.load_paths(ctx.options, path)
+            ctx.options.load_paths(path)
         except (OSError, exceptions.OptionsError) as e:
             raise exceptions.CommandError("Could not load options - %s" % e) from e
 
@@ -261,7 +260,7 @@ class Core:
         Save options to a file.
         """
         try:
-            optmanager.save(ctx.options, path)
+            ctx.options.save(path)
         except OSError as e:
             raise exceptions.CommandError("Could not save options - %s" % e) from e
 

--- a/mitmproxy/optmanager.py
+++ b/mitmproxy/optmanager.py
@@ -477,50 +477,123 @@ class OptManager:
         else:
             raise ValueError("Unsupported option type: %s", o.typespec)
 
+    def dump_defaults(self, out: TextIO):
+        """
+        Dumps an annotated file with all options.
+        """
+        # Sort data
+        s = ruamel.yaml.comments.CommentedMap()
+        for k in sorted(self.keys()):
+            o = self._options[k]
+            s[k] = o.default
+            txt = o.help.strip()
 
-def dump_defaults(opts, out: TextIO):
-    """
-    Dumps an annotated file with all options.
-    """
-    # Sort data
-    s = ruamel.yaml.comments.CommentedMap()
-    for k in sorted(opts.keys()):
-        o = opts._options[k]
-        s[k] = o.default
-        txt = o.help.strip()
+            if o.choices:
+                txt += " Valid values are %s." % ", ".join(repr(c) for c in o.choices)
+            else:
+                t = typecheck.typespec_to_str(o.typespec)
+                txt += " Type %s." % t
 
-        if o.choices:
-            txt += " Valid values are %s." % ", ".join(repr(c) for c in o.choices)
-        else:
+            txt = "\n".join(textwrap.wrap(txt))
+            s.yaml_set_comment_before_after_key(k, before="\n" + txt)
+        return ruamel.yaml.YAML().dump(s, out)
+
+    def dump_dicts(self, keys: Iterable[str] | None = None) -> dict:
+        """
+        Dumps the options into a list of dict object.
+
+        Return: A list like: { "anticache": { type: "bool", default: false, value: true, help: "help text"} }
+        """
+        options_dict = {}
+        if keys is None:
+            keys = self.keys()
+        for k in sorted(keys):
+            o = self._options[k]
             t = typecheck.typespec_to_str(o.typespec)
-            txt += " Type %s." % t
+            option = {
+                "type": t,
+                "default": o.default,
+                "value": o.current(),
+                "help": o.help,
+                "choices": o.choices,
+            }
+            options_dict[k] = option
+        return options_dict
 
-        txt = "\n".join(textwrap.wrap(txt))
-        s.yaml_set_comment_before_after_key(k, before="\n" + txt)
-    return ruamel.yaml.YAML().dump(s, out)
+    def load(self, text: str, cwd: Path | str | None = None) -> None:
+        """
+        Load configuration from text, over-writing options already set in
+        this object. May raise OptionsError if the config file is invalid.
+        """
+        data = parse(text)
 
+        scripts = data.get("scripts")
+        if scripts is not None and cwd is not None:
+            data["scripts"] = [
+                str(relative_path(Path(path), relative_to=Path(cwd)))
+                for path in scripts
+            ]
 
-def dump_dicts(opts, keys: Iterable[str] | None = None) -> dict:
-    """
-    Dumps the options into a list of dict object.
+        self.update_defer(**data)
 
-    Return: A list like: { "anticache": { type: "bool", default: false, value: true, help: "help text"} }
-    """
-    options_dict = {}
-    if keys is None:
-        keys = opts.keys()
-    for k in sorted(keys):
-        o = opts._options[k]
-        t = typecheck.typespec_to_str(o.typespec)
-        option = {
-            "type": t,
-            "default": o.default,
-            "value": o.current(),
-            "help": o.help,
-            "choices": o.choices,
-        }
-        options_dict[k] = option
-    return options_dict
+    def load_paths(self, *paths: Path | str) -> None:
+        """
+        Load paths in order. Each path takes precedence over the previous
+        path. Paths that don't exist are ignored, errors raise an
+        OptionsError.
+        """
+        for p in paths:
+            p = Path(p).expanduser()
+            if p.exists() and p.is_file():
+                with p.open(encoding="utf8") as f:
+                    try:
+                        txt = f.read()
+                    except UnicodeDecodeError as e:
+                        raise exceptions.OptionsError(f"Error reading {p}: {e}")
+                try:
+                    self.load(txt, cwd=p.absolute().parent)
+                except exceptions.OptionsError as e:
+                    raise exceptions.OptionsError(f"Error reading {p}: {e}")
+
+    def serialize(self, file: TextIO, text: str, defaults: bool = False) -> None:
+        """
+        Performs a round-trip serialization. If text is not None, it is
+        treated as a previous serialization that should be modified
+        in-place.
+
+        - If "defaults" is False, only options with non-default values are
+            serialized. Default values in text are preserved.
+        - Unknown options in text are removed.
+        - Raises OptionsError if text is invalid.
+        """
+        data = parse(text)
+        for k in self.keys():
+            if defaults or self.has_changed(k):
+                data[k] = getattr(self, k)
+        for k in list(data.keys()):
+            if k not in self._options:
+                del data[k]
+
+        ruamel.yaml.YAML().dump(data, file)
+
+    def save(self, path: Path | str, defaults: bool = False) -> None:
+        """
+        Save to path. If the destination file exists, modify it in-place.
+
+        Raises OptionsError if the existing data is corrupt.
+        """
+        path = Path(path).expanduser()
+        if path.exists() and path.is_file():
+            with path.open(encoding="utf8") as f:
+                try:
+                    data = f.read()
+                except UnicodeDecodeError as e:
+                    raise exceptions.OptionsError(f"Error trying to modify {path}: {e}")
+        else:
+            data = ""
+
+        with path.open("w", encoding="utf8") as f:
+            self.serialize(f, data, defaults)
 
 
 def parse(text):
@@ -543,86 +616,6 @@ def parse(text):
     elif data is None:
         return {}
     return data
-
-
-def load(opts: OptManager, text: str, cwd: Path | str | None = None) -> None:
-    """
-    Load configuration from text, over-writing options already set in
-    this object. May raise OptionsError if the config file is invalid.
-    """
-    data = parse(text)
-
-    scripts = data.get("scripts")
-    if scripts is not None and cwd is not None:
-        data["scripts"] = [
-            str(relative_path(Path(path), relative_to=Path(cwd))) for path in scripts
-        ]
-
-    opts.update_defer(**data)
-
-
-def load_paths(opts: OptManager, *paths: Path | str) -> None:
-    """
-    Load paths in order. Each path takes precedence over the previous
-    path. Paths that don't exist are ignored, errors raise an
-    OptionsError.
-    """
-    for p in paths:
-        p = Path(p).expanduser()
-        if p.exists() and p.is_file():
-            with p.open(encoding="utf8") as f:
-                try:
-                    txt = f.read()
-                except UnicodeDecodeError as e:
-                    raise exceptions.OptionsError(f"Error reading {p}: {e}")
-            try:
-                load(opts, txt, cwd=p.absolute().parent)
-            except exceptions.OptionsError as e:
-                raise exceptions.OptionsError(f"Error reading {p}: {e}")
-
-
-def serialize(
-    opts: OptManager, file: TextIO, text: str, defaults: bool = False
-) -> None:
-    """
-    Performs a round-trip serialization. If text is not None, it is
-    treated as a previous serialization that should be modified
-    in-place.
-
-    - If "defaults" is False, only options with non-default values are
-        serialized. Default values in text are preserved.
-    - Unknown options in text are removed.
-    - Raises OptionsError if text is invalid.
-    """
-    data = parse(text)
-    for k in opts.keys():
-        if defaults or opts.has_changed(k):
-            data[k] = getattr(opts, k)
-    for k in list(data.keys()):
-        if k not in opts._options:
-            del data[k]
-
-    ruamel.yaml.YAML().dump(data, file)
-
-
-def save(opts: OptManager, path: Path | str, defaults: bool = False) -> None:
-    """
-    Save to path. If the destination file exists, modify it in-place.
-
-    Raises OptionsError if the existing data is corrupt.
-    """
-    path = Path(path).expanduser()
-    if path.exists() and path.is_file():
-        with path.open(encoding="utf8") as f:
-            try:
-                data = f.read()
-            except UnicodeDecodeError as e:
-                raise exceptions.OptionsError(f"Error trying to modify {path}: {e}")
-    else:
-        data = ""
-
-    with path.open("w", encoding="utf8") as f:
-        serialize(opts, f, data, defaults)
 
 
 def relative_path(script_path: Path | str, *, relative_to: Path | str) -> Path:

--- a/mitmproxy/tools/console/options.py
+++ b/mitmproxy/tools/console/options.py
@@ -9,7 +9,6 @@ from typing import Optional
 import urwid
 
 from mitmproxy import exceptions
-from mitmproxy import optmanager
 from mitmproxy.tools.console import layoutwidget
 from mitmproxy.tools.console import overlay
 from mitmproxy.tools.console import signals
@@ -163,7 +162,7 @@ class OptionsList(urwid.ListBox):
 
     def save_config(self, path):
         try:
-            optmanager.save(self.master.options, path)
+            self.master.options.save(path)
         except exceptions.OptionsError as e:
             signals.status_message.send(message=str(e))
 

--- a/mitmproxy/tools/main.py
+++ b/mitmproxy/tools/main.py
@@ -14,7 +14,6 @@ from typing import TypeVar
 from mitmproxy import exceptions
 from mitmproxy import master
 from mitmproxy import options
-from mitmproxy import optmanager
 from mitmproxy.tools import cmdline
 from mitmproxy.utils import arg_check
 from mitmproxy.utils import debug
@@ -83,15 +82,14 @@ def run(
 
         try:
             opts.set(*args.setoptions, defer=True)
-            optmanager.load_paths(
-                opts,
+            opts.load_paths(
                 os.path.join(opts.confdir, "config.yaml"),
                 os.path.join(opts.confdir, "config.yml"),
             )
             process_options(parser, opts, args)
 
             if args.options:
-                optmanager.dump_defaults(opts, sys.stdout)
+                opts.dump_defaults(sys.stdout)
                 sys.exit(0)
             if args.commands:
                 master.commands.dump()

--- a/mitmproxy/tools/web/app.py
+++ b/mitmproxy/tools/web/app.py
@@ -34,7 +34,6 @@ from mitmproxy import flowfilter
 from mitmproxy import http
 from mitmproxy import io
 from mitmproxy import log
-from mitmproxy import optmanager
 from mitmproxy import version
 from mitmproxy.dns import DNSFlow
 from mitmproxy.http import HTTPFlow
@@ -802,7 +801,7 @@ class Events(RequestHandler):
 
 class Options(RequestHandler):
     def get(self):
-        self.write(optmanager.dump_dicts(self.master.options))
+        self.write(self.master.options.dump_dicts())
 
     def put(self):
         update = self.json
@@ -815,7 +814,7 @@ class Options(RequestHandler):
 class SaveOptions(RequestHandler):
     def post(self):
         # try:
-        #     optmanager.save(self.master.options, CONFIG_PATH, True)
+        #     self.master.options.save(CONFIG_PATH, True)
         # except Exception as err:
         #     raise APIError(400, "{}".format(err))
         pass

--- a/mitmproxy/tools/web/master.py
+++ b/mitmproxy/tools/web/master.py
@@ -10,7 +10,6 @@ from mitmproxy import flow
 from mitmproxy import log
 from mitmproxy import master
 from mitmproxy import options
-from mitmproxy import optmanager
 from mitmproxy.addons import errorcheck
 from mitmproxy.addons import eventstore
 from mitmproxy.addons import intercept
@@ -81,7 +80,7 @@ class WebMaster(master.Master):
         )
 
     def _sig_options_update(self, updated: set[str]) -> None:
-        options_dict = optmanager.dump_dicts(self.options, updated)
+        options_dict = self.options.dump_dicts(updated)
         app.ClientConnection.broadcast(
             type="options/update",
             payload=options_dict,

--- a/test/mitmproxy/test_optmanager.py
+++ b/test/mitmproxy/test_optmanager.py
@@ -258,7 +258,7 @@ def test_serialize():
         opts: optmanager.OptManager, text: str, defaults: bool = False
     ) -> str:
         buf = io.StringIO()
-        optmanager.serialize(opts, buf, text, defaults)
+        opts.serialize(buf, text, defaults)
         return buf.getvalue()
 
     o = TD2()
@@ -269,7 +269,7 @@ def test_serialize():
     assert "dfour" not in data
 
     o2 = TD2()
-    optmanager.load(o2, data)
+    o2.load(data)
     assert o2 == o
     assert not o == 42
 
@@ -278,32 +278,32 @@ def test_serialize():
     """
     data = serialize(o, t)
     o2 = TD2()
-    optmanager.load(o2, data)
+    o2.load(data)
     assert o2 == o
 
     t = "invalid: foo\ninvalid"
     with pytest.raises(Exception, match="Config error"):
-        optmanager.load(o2, t)
+        o2.load(t)
 
     t = "invalid"
     with pytest.raises(Exception, match="Config error"):
-        optmanager.load(o2, t)
+        o2.load(t)
 
     t = "# a comment"
-    optmanager.load(o2, t)
-    optmanager.load(o2, "foobar: '123'")
+    o2.load(t)
+    o2.load("foobar: '123'")
     assert o2.deferred == {"foobar": "123"}
 
     t = ""
-    optmanager.load(o2, t)
-    optmanager.load(o2, "foobar: '123'")
+    o2.load(t)
+    o2.load("foobar: '123'")
     assert o2.deferred == {"foobar": "123"}
 
 
 def test_serialize_defaults():
     o = options.Options()
     buf = io.StringIO()
-    optmanager.serialize(o, buf, "", defaults=True)
+    o.serialize(buf, "", defaults=True)
     assert buf.getvalue()
 
 
@@ -311,39 +311,39 @@ def test_saving(tmpdir):
     o = TD2()
     o.three = "set"
     dst = Path(tmpdir.join("conf"))
-    optmanager.save(o, dst, defaults=True)
+    o.save(dst, defaults=True)
 
     o2 = TD2()
-    optmanager.load_paths(o2, dst)
+    o2.load_paths(dst)
     o2.three = "foo"
-    optmanager.save(o2, dst, defaults=True)
+    o2.save(dst, defaults=True)
 
-    optmanager.load_paths(o, dst)
+    o.load_paths(dst)
     assert o.three == "foo"
 
     with open(dst, "a") as f:
         f.write("foobar: '123'")
-    optmanager.load_paths(o, dst)
+    o.load_paths(dst)
     assert o.deferred == {"foobar": "123"}
 
     with open(dst, "a") as f:
         f.write("'''")
     with pytest.raises(exceptions.OptionsError):
-        optmanager.load_paths(o, dst)
+        o.load_paths(dst)
 
     with open(dst, "wb") as f:
         f.write(b"\x01\x02\x03")
     with pytest.raises(exceptions.OptionsError):
-        optmanager.load_paths(o, dst)
+        o.load_paths(dst)
     with pytest.raises(exceptions.OptionsError):
-        optmanager.save(o, dst)
+        o.save(dst)
 
     with open(dst, "wb") as f:
         f.write(b"\xff\xff\xff")
     with pytest.raises(exceptions.OptionsError):
-        optmanager.load_paths(o, dst)
+        o.load_paths(dst)
     with pytest.raises(exceptions.OptionsError):
-        optmanager.save(o, dst)
+        o.save(dst)
 
 
 def test_merge():
@@ -373,14 +373,14 @@ def test_option():
 def test_dump_defaults():
     o = TTypes()
     buf = io.StringIO()
-    optmanager.dump_defaults(o, buf)
+    o.dump_defaults(buf)
     assert buf.getvalue()
 
 
 def test_dump_dicts():
     o = options.Options()
-    assert optmanager.dump_dicts(o)
-    assert optmanager.dump_dicts(o, ["http2", "listen_port"])
+    assert o.dump_dicts()
+    assert o.dump_dicts(["http2", "listen_port"])
 
 
 class TTypes(optmanager.OptManager):
@@ -482,7 +482,7 @@ def test_set():
 def test_load_paths(tdata):
     opts = TS()
     conf_path = tdata.path("mitmproxy/data/test_config.yml")
-    optmanager.load_paths(opts, conf_path)
+    opts.load_paths(conf_path)
     assert opts.scripts == [
         str(Path.home().absolute().joinpath("abc")),
         str(Path(conf_path).parent.joinpath("abc")),


### PR DESCRIPTION
#### Description

Move almost all functions in `mitmproxy.optmanager` into `OptManager` methods. I left `parse` and `relative_path` as-is because they don't operate on an `OptManager` instance.

#### Checklist

 - [x] I have updated tests where applicable.
 - [ ] I have added an entry to the CHANGELOG.

closes https://github.com/mitmproxy/mitmproxy/issues/7753