### PR TITLE
Web: Setting custom name when saving flows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
   ([#7734](https://github.com/mitmproxy/mitmproxy/pull/7734), @lups2000)
 - Add syntax highlighting for CSS and JavaScript contentviews.
   ([#7749](https://github.com/mitmproxy/mitmproxy/pull/7749), @mhils)
+- Setting custom name when saving flows in mitmweb.
+  ([#7756](https://github.com/mitmproxy/mitmproxy/pull/7756), @lups2000)
 
 ## 25 May 2025: mitmproxy 12.1.1
 

--- a/mitmproxy/tools/web/app.py
+++ b/mitmproxy/tools/web/app.py
@@ -497,7 +497,8 @@ class Flows(RequestHandler):
 
 class DumpFlows(RequestHandler):
     def get(self) -> None:
-        self.set_header("Content-Disposition", "attachment; filename=flows")
+        filename = self.get_argument("filename", "flows")
+        self.set_header("Content-Disposition", f"attachment; filename={filename}")
         self.set_header("Content-Type", "application/octet-stream")
 
         match: Callable[[mitmproxy.flow.Flow], bool]

--- a/web/src/js/__tests__/components/Header/FileMenuSpec.tsx
+++ b/web/src/js/__tests__/components/Header/FileMenuSpec.tsx
@@ -1,18 +1,121 @@
-import * as React from "react";
+import React from "react";
 import FileMenu from "../../../components/Header/FileMenu";
 import { Provider } from "react-redux";
 import { TStore } from "../../ducks/tutils";
-import { render } from "../../test-utils";
+import { act, fireEvent, render, screen } from "../../test-utils";
+import * as flowsActions from "../../../ducks/flows";
+import { fetchApi } from "../../../utils";
+
+jest.mock("../../../utils");
 
 describe("FileMenu Component", () => {
-    const store = TStore();
-    const { asFragment } = render(
-        <Provider store={store}>
-            <FileMenu />
-        </Provider>,
-    );
+    let store;
+
+    beforeEach(() => {
+        store = TStore();
+        jest.resetAllMocks();
+    });
 
     it("should render correctly", () => {
+        const { asFragment } = render(
+            <Provider store={store}>
+                <FileMenu />
+            </Provider>,
+        );
         expect(asFragment()).toMatchSnapshot();
+    });
+
+    describe("File menu interactions", () => {
+        let confirmMock;
+
+        beforeEach(() => {
+            confirmMock = jest.spyOn(window, "confirm").mockReturnValue(true);
+        });
+
+        afterEach(() => {
+            confirmMock.mockRestore();
+        });
+
+        it("should clear all the flows", async () => {
+            render(
+                <Provider store={store}>
+                    <FileMenu />
+                </Provider>,
+            );
+
+            await act(() => fireEvent.click(screen.getByText("File")));
+
+            // Click Clear All and assert side effects
+            fireEvent.click(screen.getByText("Clear All"));
+            expect(confirmMock).toHaveBeenCalled();
+            await store.dispatch(flowsActions.clear());
+            expect(fetchApi).toHaveBeenCalledWith("/clear", { method: "POST" });
+        });
+
+        it("it should trigger file upload correctly", async () => {
+            render(
+                <Provider store={store}>
+                    <FileMenu />
+                </Provider>,
+            );
+
+            await act(() => fireEvent.click(screen.getByText("File")));
+
+            // Click Open... and dispatch upload
+            fireEvent.click(screen.getByText("Open..."));
+            const fileInput = document.querySelector('input[type="file"]');
+            expect(fileInput).toBeTruthy();
+
+            const dummyFile = new File(["dummy content"], "dummy.txt", {
+                type: "text/plain",
+            });
+
+            // Simulate selecting a file
+            await act(() =>
+                fireEvent.change(fileInput as Element, {
+                    target: { files: [dummyFile] },
+                }),
+            );
+
+            expect(fetchApi).toHaveBeenCalledWith(
+                "/flows/dump",
+                expect.objectContaining({
+                    method: "POST",
+                    body: expect.any(FormData),
+                }),
+            );
+        });
+
+        it("should display save filename prompt and trigger anchor click to save file", async () => {
+            const promptMock = jest
+                .spyOn(window, "prompt")
+                .mockReturnValue("myfile");
+            const clickMock = jest.fn();
+            const originalCreateElement = document.createElement.bind(document);
+
+            jest.spyOn(document, "createElement").mockImplementation(
+                (tagName) => {
+                    const element = originalCreateElement(tagName);
+                    if (tagName === "a") {
+                        element.click = clickMock;
+                    }
+                    return element;
+                },
+            );
+
+            render(
+                <Provider store={store}>
+                    <FileMenu />
+                </Provider>,
+            );
+
+            await act(() => fireEvent.click(screen.getByText("File")));
+            fireEvent.click(screen.getByText("Save"));
+
+            expect(promptMock).toHaveBeenCalledWith("Enter filename", "flows");
+            expect(clickMock).toHaveBeenCalled();
+
+            promptMock.mockRestore();
+        });
     });
 });

--- a/web/src/js/components/Header/FileMenu.tsx
+++ b/web/src/js/components/Header/FileMenu.tsx
@@ -11,6 +11,26 @@ export default React.memo(function FileMenu() {
     const filter = useAppSelector(
         (state) => state.ui.filter[FilterName.Search],
     );
+
+    const handleSave = () => {
+        const defaultName = "flows";
+        const name = prompt("Enter filename", defaultName);
+        if (!name) return;
+
+        const params = new URLSearchParams();
+        if (filter && filter.trim() !== "") {
+            params.set("filter", filter);
+        }
+        params.set("filename", name);
+
+        const a = document.createElement("a");
+        a.href = `/flows/dump?${params.toString()}`;
+        a.download = name;
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+    };
+
     return (
         <Dropdown
             className="pull-left special"
@@ -31,13 +51,11 @@ export default React.memo(function FileMenu() {
                     }}
                 />
             </li>
-            <MenuItem onClick={() => location.replace("/flows/dump")}>
+            <MenuItem onClick={handleSave}>
                 <i className="fa fa-fw fa-floppy-o" />
                 &nbsp;Save
             </MenuItem>
-            <MenuItem
-                onClick={() => location.replace("/flows/dump?filter=" + filter)}
-            >
+            <MenuItem onClick={handleSave}>
                 <i className="fa fa-fw fa-floppy-o" />
                 &nbsp;Save filtered
             </MenuItem>


### PR DESCRIPTION
#### Description

In this PR, I’m adding support for setting a custom file name when saving flows.
DEMO:

https://github.com/user-attachments/assets/0e37a912-2e73-47e4-9d1c-5f52d0680933


#### Checklist

 - [ ] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
