### PR TITLE
Issue7476

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
   ([#7734](https://github.com/mitmproxy/mitmproxy/pull/7734), @lups2000)
 - Add syntax highlighting for CSS and JavaScript contentviews.
   ([#7749](https://github.com/mitmproxy/mitmproxy/pull/7749), @mhils)
+- Fix TLS to send close_notify alerts and avoid unexpected EOF errors with strict clients like OpenSSL s_client.
 
 ## 25 May 2025: mitmproxy 12.1.1
 


### PR DESCRIPTION
#### Description

Fix(tls): Send TLS close_notify .

Mitmproxy's TLS layer previously did not send a `close_notify` alert
when closing TLS connections,
which led to "unexpected EOF while reading" errors in strict clients such as `openssl s_client` .

This commit fixes the issue by explicitly sending a `close_notify`record.
This ensures that TLS sessions are terminated cleanly.

Fixes: #7476

#### Checklist

 - [ ] I have updated tests where applicable.
 - [ x ] I have added an entry to the CHANGELOG.
