### PR TITLE
mitmweb: Add local timezone display option for timing info (fixes #7773)

### DIFF
--- a/web/src/js/__tests__/ducks/tutils.ts
+++ b/web/src/js/__tests__/ducks/tutils.ts
@@ -220,26 +220,29 @@ export function TStore(
     });
 }
 // Add this to your test utility file
-export function createUIState(overrides: Partial<RootState['ui']> = {}): RootState['ui'] {
-  return {
-    flow: {
-      // ... existing flow state
-    },
-    modal: {
-      activeModal: undefined,
-    },
-    optionsEditor: {
-      // ... existing optionsEditor state
-    },
-    tabs: {
-      // ... existing tabs state
-    },
-    filter: {
-      // ... existing filter state
-    },
-    preferences: {  // Add this new section
-      timezoneDisplay: 'utc'
-    },
-    ...overrides
-  };
+export function createUIState(
+    overrides: Partial<RootState["ui"]> = {},
+): RootState["ui"] {
+    return {
+        flow: {
+            // ... existing flow state
+        },
+        modal: {
+            activeModal: undefined,
+        },
+        optionsEditor: {
+            // ... existing optionsEditor state
+        },
+        tabs: {
+            // ... existing tabs state
+        },
+        filter: {
+            // ... existing filter state
+        },
+        preferences: {
+            // Add this new section
+            timezoneDisplay: "utc",
+        },
+        ...overrides,
+    };
 }

--- a/web/src/js/__tests__/ducks/tutils.ts
+++ b/web/src/js/__tests__/ducks/tutils.ts
@@ -219,3 +219,27 @@ export function TStore(
         middleware: (getDefaultMiddleware) => getDefaultMiddleware(middlewares),
     });
 }
+// Add this to your test utility file
+export function createUIState(overrides: Partial<RootState['ui']> = {}): RootState['ui'] {
+  return {
+    flow: {
+      // ... existing flow state
+    },
+    modal: {
+      activeModal: undefined,
+    },
+    optionsEditor: {
+      // ... existing optionsEditor state
+    },
+    tabs: {
+      // ... existing tabs state
+    },
+    filter: {
+      // ... existing filter state
+    },
+    preferences: {  // Add this new section
+      timezoneDisplay: 'utc'
+    },
+    ...overrides
+  };
+}

--- a/web/src/js/components/FlowView/Timing.tsx
+++ b/web/src/js/components/FlowView/Timing.tsx
@@ -1,7 +1,7 @@
 import { Flow } from "../../flow";
 import * as React from "react";
 import { formatTimeDelta, formatTimeStamp } from "../../utils";
-import { useAppSelector } from '../../../ducks/hooks'; // Correct import path
+import { useAppSelector } from "../../../ducks/hooks"; // Correct import path
 
 export type TimeStampProps = {
     t: number;
@@ -9,21 +9,24 @@ export type TimeStampProps = {
     title: string;
 };
 
-export function TimeStamp({ t, deltaTo, title, timezone }: 
-    TimeStampProps & { timezone: 'utc' | 'local' }) 
-{
+export function TimeStamp({
+    t,
+    deltaTo,
+    title,
+    timezone,
+}: TimeStampProps & { timezone: "utc" | "local" }) {
     if (!t) return null;
-    
+
     return (
         <tr>
             <td>{title}:</td>
             <td>
                 {formatTimeStamp(t, { timezone })}
-                {deltaTo && 
+                {deltaTo && (
                     <span className="text-muted">
                         ({formatTimeDelta(1000 * (t - deltaTo))})
                     </span>
-                }
+                )}
             </td>
         </tr>
     );
@@ -31,38 +34,77 @@ export function TimeStamp({ t, deltaTo, title, timezone }:
 
 export default function Timing({ flow }: { flow: Flow }) {
     // Determine reference timestamp
-    const ref = flow.type === "http" 
-        ? flow.request.timestamp_start 
-        : flow.client_conn.timestamp_start;
+    const ref =
+        flow.type === "http"
+            ? flow.request.timestamp_start
+            : flow.client_conn.timestamp_start;
 
     // Build timestamps array
     const timestamps: (Partial<TimeStampProps> & { t?: number })[] = [
-        { title: "Server conn. initiated", t: flow.server_conn?.timestamp_start, deltaTo: ref },
-        { title: "Server conn. TCP handshake", t: flow.server_conn?.timestamp_tcp_setup, deltaTo: ref },
-        { title: "Server conn. TLS handshake", t: flow.server_conn?.timestamp_tls_setup, deltaTo: ref },
-        { title: "Server conn. closed", t: flow.server_conn?.timestamp_end, deltaTo: ref },
-        { 
-            title: "Client conn. established", 
-            t: flow.client_conn.timestamp_start, 
-            deltaTo: flow.type === "http" ? ref : undefined 
+        {
+            title: "Server conn. initiated",
+            t: flow.server_conn?.timestamp_start,
+            deltaTo: ref,
         },
-        { title: "Client conn. TLS handshake", t: flow.client_conn.timestamp_tls_setup, deltaTo: ref },
-        { title: "Client conn. closed", t: flow.client_conn.timestamp_end, deltaTo: ref },
+        {
+            title: "Server conn. TCP handshake",
+            t: flow.server_conn?.timestamp_tcp_setup,
+            deltaTo: ref,
+        },
+        {
+            title: "Server conn. TLS handshake",
+            t: flow.server_conn?.timestamp_tls_setup,
+            deltaTo: ref,
+        },
+        {
+            title: "Server conn. closed",
+            t: flow.server_conn?.timestamp_end,
+            deltaTo: ref,
+        },
+        {
+            title: "Client conn. established",
+            t: flow.client_conn.timestamp_start,
+            deltaTo: flow.type === "http" ? ref : undefined,
+        },
+        {
+            title: "Client conn. TLS handshake",
+            t: flow.client_conn.timestamp_tls_setup,
+            deltaTo: ref,
+        },
+        {
+            title: "Client conn. closed",
+            t: flow.client_conn.timestamp_end,
+            deltaTo: ref,
+        },
     ];
 
     // Add HTTP-specific timestamps
     if (flow.type === "http") {
         timestamps.push(
             { title: "First request byte", t: flow.request.timestamp_start },
-            { title: "Request complete", t: flow.request.timestamp_end, deltaTo: ref },
-            { title: "First response byte", t: flow.response?.timestamp_start, deltaTo: ref },
-            { title: "Response complete", t: flow.response?.timestamp_end, deltaTo: ref }
+            {
+                title: "Request complete",
+                t: flow.request.timestamp_end,
+                deltaTo: ref,
+            },
+            {
+                title: "First response byte",
+                t: flow.response?.timestamp_start,
+                deltaTo: ref,
+            },
+            {
+                title: "Response complete",
+                t: flow.response?.timestamp_end,
+                deltaTo: ref,
+            },
         );
     }
 
     // Get timezone setting from Redux - CORRECT PATH
-    const timezoneDisplay = useAppSelector(state => state.ui.preferences.timezoneDisplay);
-    
+    const timezoneDisplay = useAppSelector(
+        (state) => state.ui.preferences.timezoneDisplay,
+    );
+
     // Filter and sort valid timestamps
     const validTimestamps = timestamps
         .filter((v): v is TimeStampProps => !!v.t)

--- a/web/src/js/components/FlowView/Timing.tsx
+++ b/web/src/js/components/FlowView/Timing.tsx
@@ -1,6 +1,7 @@
 import { Flow } from "../../flow";
 import * as React from "react";
 import { formatTimeDelta, formatTimeStamp } from "../../utils";
+import { useAppSelector } from '../../../ducks/hooks'; // Correct import path
 
 export type TimeStampProps = {
     t: number;
@@ -8,114 +9,83 @@ export type TimeStampProps = {
     title: string;
 };
 
-export function TimeStamp({ t, deltaTo, title }: TimeStampProps) {
-    return t ? (
+export function TimeStamp({ t, deltaTo, title, timezone }: 
+    TimeStampProps & { timezone: 'utc' | 'local' }) 
+{
+    if (!t) return null;
+    
+    return (
         <tr>
             <td>{title}:</td>
             <td>
-                {formatTimeStamp(t)}
-                {deltaTo && (
+                {formatTimeStamp(t, { timezone })}
+                {deltaTo && 
                     <span className="text-muted">
                         ({formatTimeDelta(1000 * (t - deltaTo))})
                     </span>
-                )}
+                }
             </td>
         </tr>
-    ) : (
-        <tr />
     );
 }
 
 export default function Timing({ flow }: { flow: Flow }) {
-    let ref: number;
-    if (flow.type === "http") {
-        ref = flow.request.timestamp_start;
-    } else {
-        ref = flow.client_conn.timestamp_start;
-    }
+    // Determine reference timestamp
+    const ref = flow.type === "http" 
+        ? flow.request.timestamp_start 
+        : flow.client_conn.timestamp_start;
 
-    const timestamps: Partial<TimeStampProps>[] = [
-        {
-            title: "Server conn. initiated",
-            t: flow.server_conn?.timestamp_start,
-            deltaTo: ref,
+    // Build timestamps array
+    const timestamps: (Partial<TimeStampProps> & { t?: number })[] = [
+        { title: "Server conn. initiated", t: flow.server_conn?.timestamp_start, deltaTo: ref },
+        { title: "Server conn. TCP handshake", t: flow.server_conn?.timestamp_tcp_setup, deltaTo: ref },
+        { title: "Server conn. TLS handshake", t: flow.server_conn?.timestamp_tls_setup, deltaTo: ref },
+        { title: "Server conn. closed", t: flow.server_conn?.timestamp_end, deltaTo: ref },
+        { 
+            title: "Client conn. established", 
+            t: flow.client_conn.timestamp_start, 
+            deltaTo: flow.type === "http" ? ref : undefined 
         },
-        {
-            title: "Server conn. TCP handshake",
-            t: flow.server_conn?.timestamp_tcp_setup,
-            deltaTo: ref,
-        },
-        {
-            title: "Server conn. TLS handshake",
-            t: flow.server_conn?.timestamp_tls_setup,
-            deltaTo: ref,
-        },
-        {
-            title: "Server conn. closed",
-            t: flow.server_conn?.timestamp_end,
-            deltaTo: ref,
-        },
-        {
-            title: "Client conn. established",
-            t: flow.client_conn.timestamp_start,
-            deltaTo: flow.type === "http" ? ref : undefined,
-        },
-        {
-            title: "Client conn. TLS handshake",
-            t: flow.client_conn.timestamp_tls_setup,
-            deltaTo: ref,
-        },
-        {
-            title: "Client conn. closed",
-            t: flow.client_conn.timestamp_end,
-            deltaTo: ref,
-        },
+        { title: "Client conn. TLS handshake", t: flow.client_conn.timestamp_tls_setup, deltaTo: ref },
+        { title: "Client conn. closed", t: flow.client_conn.timestamp_end, deltaTo: ref },
     ];
+
+    // Add HTTP-specific timestamps
     if (flow.type === "http") {
         timestamps.push(
-            ...[
-                {
-                    title: "First request byte",
-                    t: flow.request.timestamp_start,
-                },
-                {
-                    title: "Request complete",
-                    t: flow.request.timestamp_end,
-                    deltaTo: ref,
-                },
-                {
-                    title: "First response byte",
-                    t: flow.response?.timestamp_start,
-                    deltaTo: ref,
-                },
-                {
-                    title: "Response complete",
-                    t: flow.response?.timestamp_end,
-                    deltaTo: ref,
-                },
-            ],
+            { title: "First request byte", t: flow.request.timestamp_start },
+            { title: "Request complete", t: flow.request.timestamp_end, deltaTo: ref },
+            { title: "First response byte", t: flow.response?.timestamp_start, deltaTo: ref },
+            { title: "Response complete", t: flow.response?.timestamp_end, deltaTo: ref }
         );
     }
+
+    // Get timezone setting from Redux - CORRECT PATH
+    const timezoneDisplay = useAppSelector(state => state.ui.preferences.timezoneDisplay);
+    
+    // Filter and sort valid timestamps
+    const validTimestamps = timestamps
+        .filter((v): v is TimeStampProps => !!v.t)
+        .sort((a, b) => a.t - b.t);
 
     return (
         <section className="timing">
             <h4>Timing</h4>
             <table className="timing-table">
                 <tbody>
-                    {timestamps
-                        .filter((v): v is TimeStampProps => !!v.t)
-                        .sort((a, b) => a.t - b.t)
-                        .map(({ title, t, deltaTo }) => (
-                            <TimeStamp
-                                key={title}
-                                title={title}
-                                t={t}
-                                deltaTo={deltaTo}
-                            />
-                        ))}
+                    {validTimestamps.map(({ title, t, deltaTo }) => (
+                        <TimeStamp
+                            key={title}
+                            title={title}
+                            t={t}
+                            deltaTo={deltaTo}
+                            timezone={timezoneDisplay}
+                        />
+                    ))}
                 </tbody>
             </table>
         </section>
     );
 }
+
 Timing.displayName = "Timing";

--- a/web/src/js/components/Modal/OptionModal.tsx
+++ b/web/src/js/components/Modal/OptionModal.tsx
@@ -6,6 +6,8 @@ import { Option } from "../../ducks/options";
 import { compact, isEmpty } from "lodash";
 import { RootState, useAppDispatch, useAppSelector } from "../../ducks";
 import OptionInput from "./OptionInput";
+import { setTimezoneDisplay } from "../../ducks/ui"; // Added this import
+import { selectTimezoneDisplay } from "../../ducks/ui"; // Added this import
 
 function OptionHelp({ name }: { name: Option }) {
     const help = useAppSelector((state) => state.options_meta[name]?.help);
@@ -58,6 +60,14 @@ export default function OptionModal() {
         (state) => Object.keys(state.options_meta),
         shallowEqual,
     ).sort() as Option[];
+    // Get current timezone setting
+    const timezoneDisplay = useAppSelector(selectTimezoneDisplay);
+    
+    // Handle timezone change
+    const handleTimezoneChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+        const value = e.target.value as 'utc' | 'local';
+        dispatch(setTimezoneDisplay(value));
+    };
 
     return (
         <div>
@@ -76,6 +86,28 @@ export default function OptionModal() {
             </div>
 
             <div className="modal-body">
+            {/* Add frontend preferences section */}
+                <div className="form-group">
+                    <div className="col-xs-6">
+                        <label>Timestamp Display</label>
+                        <div className="help-block small">
+                            Choose between UTC or local time for timestamps
+                        </div>
+                    </div>
+                    <div className="col-xs-6">
+                        <select
+                            value={timezoneDisplay}
+                            onChange={handleTimezoneChange}
+                            className="form-control"
+                        >
+                            <option value="utc">UTC</option>
+                            <option value="local">Local Timezone</option>
+                        </select>
+                    </div>
+                </div>
+                
+                <hr style={{ margin: "15px 0" }} />
+                
                 <div className="form-horizontal">
                     {options.map((name) => (
                         <div key={name} className="form-group">

--- a/web/src/js/components/Modal/OptionModal.tsx
+++ b/web/src/js/components/Modal/OptionModal.tsx
@@ -62,10 +62,10 @@ export default function OptionModal() {
     ).sort() as Option[];
     // Get current timezone setting
     const timezoneDisplay = useAppSelector(selectTimezoneDisplay);
-    
+
     // Handle timezone change
     const handleTimezoneChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-        const value = e.target.value as 'utc' | 'local';
+        const value = e.target.value as "utc" | "local";
         dispatch(setTimezoneDisplay(value));
     };
 
@@ -86,7 +86,7 @@ export default function OptionModal() {
             </div>
 
             <div className="modal-body">
-            {/* Add frontend preferences section */}
+                {/* Add frontend preferences section */}
                 <div className="form-group">
                     <div className="col-xs-6">
                         <label>Timestamp Display</label>
@@ -105,9 +105,9 @@ export default function OptionModal() {
                         </select>
                     </div>
                 </div>
-                
+
                 <hr style={{ margin: "15px 0" }} />
-                
+
                 <div className="form-horizontal">
                     {options.map((name) => (
                         <div key={name} className="form-group">

--- a/web/src/js/ducks/ui/index.ts
+++ b/web/src/js/ducks/ui/index.ts
@@ -5,11 +5,30 @@ import optionsEditor from "./optionsEditor";
 import tabs from "./tabs";
 import filter from "./filter";
 
-// TODO: Just move ducks/ui/* into ducks/?
+const initialPreferencesState = {
+    timezoneDisplay: 'utc' as 'utc' | 'local'
+};
+
+function preferences(state = initialPreferencesState, action: any) {
+    switch (action.type) {
+        case 'SET_TIMEZONE_DISPLAY':
+            return { ...state, timezoneDisplay: action.value };
+        default:
+            return state;
+    }
+}
+
+export function setTimezoneDisplay(value: 'utc' | 'local') {
+    return { type: 'SET_TIMEZONE_DISPLAY', value };
+}
+
+export const selectTimezoneDisplay = (state: any) => state.ui.preferences.timezoneDisplay;
+
 export default combineReducers({
     flow,
     modal,
     optionsEditor,
     tabs,
     filter,
+    preferences
 });

--- a/web/src/js/ducks/ui/index.ts
+++ b/web/src/js/ducks/ui/index.ts
@@ -6,23 +6,24 @@ import tabs from "./tabs";
 import filter from "./filter";
 
 const initialPreferencesState = {
-    timezoneDisplay: 'utc' as 'utc' | 'local'
+    timezoneDisplay: "utc" as "utc" | "local",
 };
 
 function preferences(state = initialPreferencesState, action: any) {
     switch (action.type) {
-        case 'SET_TIMEZONE_DISPLAY':
+        case "SET_TIMEZONE_DISPLAY":
             return { ...state, timezoneDisplay: action.value };
         default:
             return state;
     }
 }
 
-export function setTimezoneDisplay(value: 'utc' | 'local') {
-    return { type: 'SET_TIMEZONE_DISPLAY', value };
+export function setTimezoneDisplay(value: "utc" | "local") {
+    return { type: "SET_TIMEZONE_DISPLAY", value };
 }
 
-export const selectTimezoneDisplay = (state: any) => state.ui.preferences.timezoneDisplay;
+export const selectTimezoneDisplay = (state: any) =>
+    state.ui.preferences.timezoneDisplay;
 
 export default combineReducers({
     flow,
@@ -30,5 +31,5 @@ export default combineReducers({
     optionsEditor,
     tabs,
     filter,
-    preferences
+    preferences,
 });

--- a/web/src/js/utils.ts
+++ b/web/src/js/utils.ts
@@ -33,12 +33,32 @@ export const formatTimeDelta = function (milliseconds) {
 
 export const formatTimeStamp = function (
     seconds: number,
-    { milliseconds = true } = {},
+    { milliseconds = true, timezone = 'utc' }: { milliseconds?: boolean; timezone?: 'utc' | 'local' } = {},
 ) {
-    const utc = new Date(seconds * 1000);
-    let ts = utc.toISOString().replace("T", " ").replace("Z", "");
-    if (!milliseconds) ts = ts.slice(0, -4);
-    return ts;
+    const date = new Date(seconds * 1000);
+    
+    if (timezone === 'local') {
+        // Format as local time with milliseconds 
+        const pad = (n: number) => n.toString().padStart(2, '0');
+        return [
+            date.getFullYear(),
+            '-',
+            pad(date.getMonth() + 1),
+            '-',
+            pad(date.getDate()),
+            ' ',
+            pad(date.getHours()),
+            ':',
+            pad(date.getMinutes()),
+            ':',
+            pad(date.getSeconds()),
+            milliseconds ? `.${date.getMilliseconds().toString().padStart(3, '0')}` : ''
+        ].join('');
+    } else {    
+        let ts = date.toISOString().replace("T", " ").replace("Z", "");
+        if (!milliseconds) ts = ts.slice(0, -4);
+        return ts;
+    }
 };
 
 export function formatAddress(address: [string, number]): string {
@@ -49,6 +69,7 @@ export function formatAddress(address: [string, number]): string {
     }
 }
 
+// ... rest of the file unchanged ...
 // At some places, we need to sort strings alphabetically descending,
 // but we can only provide a key function.
 // This beauty "reverses" a JS string.

--- a/web/src/js/utils.ts
+++ b/web/src/js/utils.ts
@@ -33,28 +33,33 @@ export const formatTimeDelta = function (milliseconds) {
 
 export const formatTimeStamp = function (
     seconds: number,
-    { milliseconds = true, timezone = 'utc' }: { milliseconds?: boolean; timezone?: 'utc' | 'local' } = {},
+    {
+        milliseconds = true,
+        timezone = "utc",
+    }: { milliseconds?: boolean; timezone?: "utc" | "local" } = {},
 ) {
     const date = new Date(seconds * 1000);
-    
-    if (timezone === 'local') {
-        // Format as local time with milliseconds 
-        const pad = (n: number) => n.toString().padStart(2, '0');
+
+    if (timezone === "local") {
+        // Format as local time with milliseconds
+        const pad = (n: number) => n.toString().padStart(2, "0");
         return [
             date.getFullYear(),
-            '-',
+            "-",
             pad(date.getMonth() + 1),
-            '-',
+            "-",
             pad(date.getDate()),
-            ' ',
+            " ",
             pad(date.getHours()),
-            ':',
+            ":",
             pad(date.getMinutes()),
-            ':',
+            ":",
             pad(date.getSeconds()),
-            milliseconds ? `.${date.getMilliseconds().toString().padStart(3, '0')}` : ''
-        ].join('');
-    } else {    
+            milliseconds
+                ? `.${date.getMilliseconds().toString().padStart(3, "0")}`
+                : "",
+        ].join("");
+    } else {
         let ts = date.toISOString().replace("T", " ").replace("Z", "");
         if (!milliseconds) ts = ts.slice(0, -4);
         return ts;


### PR DESCRIPTION
mitmweb: Add local timezone display option for timing info (fixes #7773)

## Description
Adds an option to display timestamps in the Timing tab using the local timezone instead of UTC. Users can toggle between UTC and local time via the Options modal.

## Changes
- Added preferences reducer to UI state with timezone setting
- Modified `formatTimeStamp` utility to support UTC/local conversion
- Updated Timing component to respect timezone preference
- Added UI control in OptionModal for timezone selection

## Testing
- Verified UTC and local time display in Timing component
- Tested with various flow types (HTTP, TCP, UDP)
- Confirmed setting persistence across modal open/close
- Checked formatting consistency across different timezones

Closes #7773.