### PR TITLE
chore: update deprecated windows-2019 github runner image

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,7 +70,7 @@ jobs:
             platform: macos-arm64
           - image: macos-13
             platform: macos-x86_64
-          - image: windows-2019
+          - image: windows-2025
             platform: windows
           - image: ubuntu-latest
             platform: linux-x86_64

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ## Unreleased: mitmproxy next
 
+- Update deprecated `windows-2019` runner to `windows-2025`.
 - Do not escape non-ascii characters in the JSON contentview.
   ([#7740](https://github.com/mitmproxy/mitmproxy/pull/7740), @mhils)
 - Fix crash in mitmweb when no explicit Server-Connection is logged.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ## Unreleased: mitmproxy next
 
 - Update deprecated `windows-2019` runner to `windows-2025`.
+  ([#7801](https://github.com/mitmproxy/mitmproxy/pull/7801), @chedieck)
 - Do not escape non-ascii characters in the JSON contentview.
   ([#7740](https://github.com/mitmproxy/mitmproxy/pull/7740), @mhils)
 - Fix crash in mitmweb when no explicit Server-Connection is logged.


### PR DESCRIPTION
#### Description

<!-- describe your changes here -->
**Update GitHub Actions runner to `windows-2025`**

Some tests have been failing due to the deprecated `windows-2019` runner.

This updates it to `windows-2025`, as suggested in [actions/runner-images#12045](https://github.com/actions/runner-images/issues/12045).



 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
