### PR TITLE
fix: update log message with correct header name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ## Unreleased: mitmproxy next
 
 - fix: update log message with correct header name
+  ([#7802](https://github.com/mitmproxy/mitmproxy/pull/7802), @kristof-mattei)
 - Update deprecated `windows-2019` runner to `windows-2025`.
   ([#7801](https://github.com/mitmproxy/mitmproxy/pull/7801), @chedieck)
 - Do not escape non-ascii characters in the JSON contentview.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ## Unreleased: mitmproxy next
 
+- fix: update log message with correct header name
 - Update deprecated `windows-2019` runner to `windows-2025`.
   ([#7801](https://github.com/mitmproxy/mitmproxy/pull/7801), @chedieck)
 - Do not escape non-ascii characters in the JSON contentview.

--- a/mitmproxy/tools/web/webaddons.py
+++ b/mitmproxy/tools/web/webaddons.py
@@ -37,7 +37,7 @@ class WebAuth:
             "everything else is considered a plaintext password. "
             "If no password is provided, a random token is generated on startup."
             "For automated calls, you can pass the password as token query parameter"
-            "or as `Authentication: Bearer ...` header.",
+            "or as `Authorization: Bearer ...` header.",
         )
 
     def configure(self, updated) -> None:


### PR DESCRIPTION

#### Description

https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Authorization

There is no `Authentication` header

No test to update.

#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
