### PR TITLE
Web: Show Local timezone in the Timing tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
   ([#7734](https://github.com/mitmproxy/mitmproxy/pull/7734), @lups2000)
 - Add syntax highlighting for CSS and JavaScript contentviews.
   ([#7749](https://github.com/mitmproxy/mitmproxy/pull/7749), @mhils)
+- Display local timezone in the Timing tab of mitmweb.
+  ([#7804](https://github.com/mitmproxy/mitmproxy/pull/7804), @lups2000)
 
 ## 25 May 2025: mitmproxy 12.1.1
 

--- a/web/eslint.config.mjs
+++ b/web/eslint.config.mjs
@@ -38,7 +38,12 @@ export default defineConfig([
         },
     },
     {
-        files: ["jest.config.js", "gulpfile.js", "setup-jest.js"],
+        files: [
+            "jest.config.js",
+            "gulpfile.js",
+            "setup-jest.js",
+            "setup-global-jest.js",
+        ],
         languageOptions: { globals: globals.node },
     },
     {

--- a/web/jest.config.js
+++ b/web/jest.config.js
@@ -25,5 +25,6 @@ module.exports = async () => {
             ],
         },
         setupFilesAfterEnv: ["<rootDir>/setup-jest.js"],
+        globalSetup: "<rootDir>/setup-global-jest.js",
     };
 };

--- a/web/package.json
+++ b/web/package.json
@@ -2,7 +2,7 @@
     "name": "mitmproxy",
     "private": true,
     "scripts": {
-        "test": "eslint . && tsc --noEmit && jest --coverage",
+        "test": "TZ=UTC eslint . && TZ=UTC tsc --noEmit && TZ=UTC jest --coverage",
         "build": "gulp prod",
         "start": "gulp",
         "prettier": "prettier --write .",

--- a/web/package.json
+++ b/web/package.json
@@ -2,7 +2,7 @@
     "name": "mitmproxy",
     "private": true,
     "scripts": {
-        "test": "TZ=UTC eslint . && TZ=UTC tsc --noEmit && TZ=UTC jest --coverage",
+        "test": "eslint . && tsc --noEmit && jest --coverage",
         "build": "gulp prod",
         "start": "gulp",
         "prettier": "prettier --write .",

--- a/web/setup-global-jest.js
+++ b/web/setup-global-jest.js
@@ -1,3 +1,3 @@
 export default function () {
-    process.env.TZ = 'UTC';
-};
+    process.env.TZ = "UTC";
+}

--- a/web/setup-global-jest.js
+++ b/web/setup-global-jest.js
@@ -1,0 +1,3 @@
+export default function () {
+    process.env.TZ = 'UTC';
+};

--- a/web/setup-jest.js
+++ b/web/setup-jest.js
@@ -1,4 +1,3 @@
-process.env.TZ = "UTC";
 const err = console.error;
 console.warn = console.error = function () {
     err.apply(console, arguments);

--- a/web/src/js/__tests__/utilsSpec.tsx
+++ b/web/src/js/__tests__/utilsSpec.tsx
@@ -23,10 +23,10 @@ describe("formatTimeDelta", () => {
 describe("formatTimeStamp", () => {
     it("should return formatted time", () => {
         expect(
-            utils.formatTimeStamp(1483228800, { milliseconds: false }),
+            utils.formatTimeStamp(1483228800, { includeMilliseconds: false }),
         ).toEqual("2017-01-01 00:00:00");
         expect(
-            utils.formatTimeStamp(1483228800, { milliseconds: true }),
+            utils.formatTimeStamp(1483228800, { includeMilliseconds: true }),
         ).toEqual("2017-01-01 00:00:00.000");
     });
 });

--- a/web/src/js/components/FlowView/Connection.tsx
+++ b/web/src/js/components/FlowView/Connection.tsx
@@ -115,7 +115,7 @@ export function CertificateInfo({ flow }: { flow: Flow }): React.ReactElement {
                         <td>Valid from</td>
                         <td>
                             {formatTimeStamp(cert.notbefore, {
-                                milliseconds: false,
+                                includeMilliseconds: false,
                             })}
                         </td>
                     </tr>
@@ -123,7 +123,7 @@ export function CertificateInfo({ flow }: { flow: Flow }): React.ReactElement {
                         <td>Valid to</td>
                         <td>
                             {formatTimeStamp(cert.notafter, {
-                                milliseconds: false,
+                                includeMilliseconds: false,
                             })}
                         </td>
                     </tr>

--- a/web/src/js/utils.ts
+++ b/web/src/js/utils.ts
@@ -35,9 +35,19 @@ export const formatTimeStamp = function (
     seconds: number,
     { milliseconds = true } = {},
 ) {
-    const utc = new Date(seconds * 1000);
-    let ts = utc.toISOString().replace("T", " ").replace("Z", "");
-    if (!milliseconds) ts = ts.slice(0, -4);
+    const local = new Date(seconds * 1000);
+
+    const year = local.getFullYear();
+    const month = String(local.getMonth() + 1).padStart(2, "0");
+    const day = String(local.getDate()).padStart(2, "0");
+    const hours = String(local.getHours()).padStart(2, "0");
+    const minutes = String(local.getMinutes()).padStart(2, "0");
+    const secondsPart = String(local.getSeconds()).padStart(2, "0");
+    const millisPart = String(local.getMilliseconds()).padStart(3, "0");
+
+    let ts = `${year}-${month}-${day} ${hours}:${minutes}:${secondsPart}`;
+    if (milliseconds) ts += `.${millisPart}`;
+
     return ts;
 };
 

--- a/web/src/js/utils.ts
+++ b/web/src/js/utils.ts
@@ -33,22 +33,22 @@ export const formatTimeDelta = function (milliseconds) {
 
 export const formatTimeStamp = function (
     seconds: number,
-    { milliseconds = true } = {},
+    { includeMilliseconds = true } = {},
 ) {
-    const local = new Date(seconds * 1000);
+    const date = new Date(seconds * 1000);
 
-    const year = local.getFullYear();
-    const month = String(local.getMonth() + 1).padStart(2, "0");
-    const day = String(local.getDate()).padStart(2, "0");
-    const hours = String(local.getHours()).padStart(2, "0");
-    const minutes = String(local.getMinutes()).padStart(2, "0");
-    const secondsPart = String(local.getSeconds()).padStart(2, "0");
-    const millisPart = String(local.getMilliseconds()).padStart(3, "0");
+    const yearStr = String(date.getFullYear());
+    const monthStr = String(date.getMonth() + 1).padStart(2, "0");
+    const dayStr = String(date.getDate()).padStart(2, "0");
+    const hourStr = String(date.getHours()).padStart(2, "0");
+    const minuteStr = String(date.getMinutes()).padStart(2, "0");
+    const secondStr = String(date.getSeconds()).padStart(2, "0");
+    const millisecondStr = String(date.getMilliseconds()).padStart(3, "0");
 
-    let ts = `${year}-${month}-${day} ${hours}:${minutes}:${secondsPart}`;
-    if (milliseconds) ts += `.${millisPart}`;
+    let timestamp = `${yearStr}-${monthStr}-${dayStr} ${hourStr}:${minuteStr}:${secondStr}`;
+    if (includeMilliseconds) timestamp += `.${millisecondStr}`;
 
-    return ts;
+    return timestamp;
 };
 
 export function formatAddress(address: [string, number]): string {


### PR DESCRIPTION
#### Description

Fixes: #7773. 
One note: I had to explicitly add `TZ=UTC` in the **test script** because keeping it in `setup-jest.js` didn’t work for some reason.

<img width="526" height="243" alt="Screenshot 2025-07-14 at 20 52 19" src="https://github.com/user-attachments/assets/0d721111-fa34-4d9f-b665-0fe8f8c7b144" />


#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
