### PR TITLE
Do not capitalize method value. It causes confusion when editing requ…

### DIFF
--- a/mitmproxy/http.py
+++ b/mitmproxy/http.py
@@ -659,7 +659,7 @@ class Request(Message):
         """
         HTTP request method, e.g. "GET".
         """
-        return self.data.method.decode("utf-8", "surrogateescape").upper()
+        return self.data.method.decode("utf-8", "surrogateescape")
 
     @method.setter
     def method(self, val: str | bytes) -> None:


### PR DESCRIPTION
#### Description

Do not capitalize HTTP methods after editing.
It causes confusion and it's not reflecting the true state of the request being sent.

#### Checklist

 - [ ] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
