### PR TITLE
fix missing content-length header in curl export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ## Unreleased: mitmproxy next
 
+- fix: missing content-length header in curl export
 - fix: update log message with correct header name
   ([#7802](https://github.com/mitmproxy/mitmproxy/pull/7802), @kristof-mattei)
 - Update deprecated `windows-2019` runner to `windows-2025`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ## Unreleased: mitmproxy next
 
 - fix: missing content-length header in curl export
+  ([#7810](https://github.com/mitmproxy/mitmproxy/pull/7810), @mheguy)
 - fix: update log message with correct header name
   ([#7802](https://github.com/mitmproxy/mitmproxy/pull/7802), @kristof-mattei)
 - Update deprecated `windows-2019` runner to `windows-2025`.

--- a/test/mitmproxy/addons/test_export.py
+++ b/test/mitmproxy/addons/test_export.py
@@ -88,7 +88,9 @@ class TestExportCurlCommand:
         result = "curl -X POST http://address:22/path -d nobinarysupport"
         assert export_curl(post_request) == result
 
-    def test_post_with_no_content_has_explicit_content_length_header(self, export_curl, post_request):
+    def test_post_with_no_content_has_explicit_content_length_header(
+        self, export_curl, post_request
+    ):
         post_request.request.content = None
         result = "curl -H 'content-length: 0' -X POST http://address:22/path"
         assert export_curl(post_request) == result

--- a/test/mitmproxy/addons/test_export.py
+++ b/test/mitmproxy/addons/test_export.py
@@ -88,6 +88,16 @@ class TestExportCurlCommand:
         result = "curl -X POST http://address:22/path -d nobinarysupport"
         assert export_curl(post_request) == result
 
+    def test_non_zero_length_post_has_content_length_header_removed(self, export_curl, post_request):
+        post_request.request.content = b"content"
+        result = "curl -X POST http://address:22/path -d content"
+        assert export_curl(post_request) == result
+
+    def test_zero_length_post_has_content_length_header_intact(self, export_curl, post_request):
+        post_request.request.content = b""
+        result = "curl -H 'content-length: 0' -X POST http://address:22/path"
+        assert export_curl(post_request) == result
+
     def test_fails_with_binary_data(self, export_curl, post_request):
         # shlex.quote doesn't support a bytes object
         # see https://github.com/python/cpython/pull/10871

--- a/test/mitmproxy/addons/test_export.py
+++ b/test/mitmproxy/addons/test_export.py
@@ -88,17 +88,8 @@ class TestExportCurlCommand:
         result = "curl -X POST http://address:22/path -d nobinarysupport"
         assert export_curl(post_request) == result
 
-    def test_non_zero_length_post_has_content_length_header_removed(
-        self, export_curl, post_request
-    ):
-        post_request.request.content = b"content"
-        result = "curl -X POST http://address:22/path -d content"
-        assert export_curl(post_request) == result
-
-    def test_zero_length_post_has_content_length_header_intact(
-        self, export_curl, post_request
-    ):
-        post_request.request.content = b""
+    def test_post_with_no_content_has_explicit_content_length_header(self, export_curl, post_request):
+        post_request.request.content = None
         result = "curl -H 'content-length: 0' -X POST http://address:22/path"
         assert export_curl(post_request) == result
 

--- a/test/mitmproxy/addons/test_export.py
+++ b/test/mitmproxy/addons/test_export.py
@@ -88,12 +88,16 @@ class TestExportCurlCommand:
         result = "curl -X POST http://address:22/path -d nobinarysupport"
         assert export_curl(post_request) == result
 
-    def test_non_zero_length_post_has_content_length_header_removed(self, export_curl, post_request):
+    def test_non_zero_length_post_has_content_length_header_removed(
+        self, export_curl, post_request
+    ):
         post_request.request.content = b"content"
         result = "curl -X POST http://address:22/path -d content"
         assert export_curl(post_request) == result
 
-    def test_zero_length_post_has_content_length_header_intact(self, export_curl, post_request):
+    def test_zero_length_post_has_content_length_header_intact(
+        self, export_curl, post_request
+    ):
         post_request.request.content = b""
         result = "curl -H 'content-length: 0' -X POST http://address:22/path"
         assert export_curl(post_request) == result


### PR DESCRIPTION
#### Description

closes #7664

curl does not generate a content-length header when not given content. This can cause issues with some servers as they require a content-length header for certain http verbs (ex. POST). The changes in this PR adds some logic to add a 0-length content-length when needed.

I changed the signature of `pop_headers` to reflect that it changes the state of the received object in-place.

#### Checklist

 - [X] I have updated tests where applicable.
 - [X] I have added an entry to the CHANGELOG.
