### PR TITLE
Fix auth cookie always using the default `web_port` option.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 ## Unreleased: mitmproxy next
 
+- Fix mitmweb auth cookie always using the default `web_port` option.
+  ([#7827](https://github.com/mitmproxy/mitmproxy/pull/7827), @sujaldev)
 - fix: missing content-length header in curl export
   ([#7810](https://github.com/mitmproxy/mitmproxy/pull/7810), @mheguy)
 - fix: update log message with correct header name

--- a/mitmproxy/tools/web/app.py
+++ b/mitmproxy/tools/web/app.py
@@ -912,6 +912,7 @@ class Application(tornado.web.Application):
         self, master: mitmproxy.tools.web.master.WebMaster, debug: bool
     ) -> None:
         self.master = master
+        self.master.options.changed.connect(self.update_web_port)
         auth_addon: WebAuth = master.addons.get("webauth")
         super().__init__(
             handlers=handlers,  # type: ignore  # https://github.com/tornadoweb/tornado/pull/3455
@@ -926,3 +927,9 @@ class Application(tornado.web.Application):
             is_valid_password=auth_addon.is_valid_password,
             auth_cookie_name=f"mitmproxy-auth-{master.options.web_port}",
         )
+
+    def update_web_port(self, updated: set[str]):
+        if "web_port" in updated:
+            self.settings["auth_cookie_name"] = (
+                f"mitmproxy-auth-{self.master.options.web_port}"
+            )

--- a/mitmproxy/tools/web/webaddons.py
+++ b/mitmproxy/tools/web/webaddons.py
@@ -65,6 +65,10 @@ class WebAuth:
         # noinspection HttpUrlsUsage
         return f"http://{ctx.options.web_host}:{ctx.options.web_port}/{auth}"
 
+    @staticmethod
+    def auth_cookie_name() -> str:
+        return f"mitmproxy-auth-{ctx.options.web_port}"
+
     def is_valid_password(self, password: str) -> bool:
         if self._password.startswith("$"):
             try:

--- a/test/mitmproxy/tools/web/test_app.py
+++ b/test/mitmproxy/tools/web/test_app.py
@@ -615,3 +615,15 @@ class TestApp(tornado.testing.AsyncHTTPTestCase):
             assert e.code == 403
         else:
             assert False
+
+    def test_auth_cookie_port_suffix_modification(self):
+        opts = self.master.options
+
+        old_port = opts.web_port
+        new_port = 8082
+        opts.web_port = new_port
+
+        try:
+            assert self._app.settings["auth_cookie_name"].endswith(str(new_port))
+        finally:
+            opts.web_port = old_port

--- a/test/mitmproxy/tools/web/test_app.py
+++ b/test/mitmproxy/tools/web/test_app.py
@@ -83,10 +83,10 @@ class TestApp(tornado.testing.AsyncHTTPTestCase):
     def auth_cookie(self) -> str:
         auth_cookie = create_signed_value(
             secret=self._app.settings["cookie_secret"],
-            name=self._app.settings["auth_cookie_name"],
+            name=self._app.settings["auth_cookie_name"](),
             value=app.AuthRequestHandler.AUTH_COOKIE_VALUE,
         ).decode()
-        return f"{self._app.settings['auth_cookie_name']}={auth_cookie}"
+        return f"{self._app.settings['auth_cookie_name']()}={auth_cookie}"
 
     def fetch(self, *args, **kwargs) -> httpclient.HTTPResponse:
         kwargs.setdefault("headers", {}).setdefault("Cookie", self.auth_cookie)
@@ -624,6 +624,6 @@ class TestApp(tornado.testing.AsyncHTTPTestCase):
         opts.web_port = new_port
 
         try:
-            assert self._app.settings["auth_cookie_name"].endswith(str(new_port))
+            assert self._app.settings["auth_cookie_name"]().endswith(str(new_port))
         finally:
             opts.web_port = old_port


### PR DESCRIPTION
#### Description

Fixes #7826.

#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
