### PR TITLE
Run pyupgrade and improve f-strings

### DIFF
--- a/mitmproxy/addons/core.py
+++ b/mitmproxy/addons/core.py
@@ -158,7 +158,7 @@ class Core:
                         req.url = val
                     except ValueError as e:
                         raise exceptions.CommandError(
-                            f"URL {repr(val)} is invalid: {e}"
+                            f"URL {val!r} is invalid: {e}"
                         ) from e
                 else:
                     self.rupdate = False

--- a/mitmproxy/addons/onboardingapp/__init__.py
+++ b/mitmproxy/addons/onboardingapp/__init__.py
@@ -46,7 +46,7 @@ def magisk():
 
     return cert, {
         "Content-Type": "application/zip",
-        "Content-Disposition": f"attachment; filename={filename}",
+        "Content-Disposition": f"attachment; {filename=!s}",
     }
 
 
@@ -59,5 +59,5 @@ def read_cert(ext, content_type):
 
     return cert, {
         "Content-Type": content_type,
-        "Content-Disposition": f"attachment; filename={filename}",
+        "Content-Disposition": f"attachment; {filename=!s}",
     }

--- a/mitmproxy/certs.py
+++ b/mitmproxy/certs.py
@@ -122,18 +122,18 @@ class Cert(serializable.Serializable):
             return self._cert.not_valid_before_utc  # type: ignore
         except AttributeError:  # pragma: no cover
             # cryptography < 42.0
-            return self._cert.not_valid_before.replace(tzinfo=datetime.timezone.utc)
+            return self._cert.not_valid_before.replace(tzinfo=datetime.UTC)
 
     @property
     def notafter(self) -> datetime.datetime:
         try:
             return self._cert.not_valid_after_utc  # type: ignore
         except AttributeError:  # pragma: no cover
-            return self._cert.not_valid_after.replace(tzinfo=datetime.timezone.utc)
+            return self._cert.not_valid_after.replace(tzinfo=datetime.UTC)
 
     def has_expired(self) -> bool:
         if sys.version_info < (3, 11):  # pragma: no cover
-            return datetime.datetime.now(datetime.timezone.utc) > self.notafter
+            return datetime.datetime.now(datetime.UTC) > self.notafter
         return datetime.datetime.now(datetime.UTC) > self.notafter
 
     @property

--- a/mitmproxy/command.py
+++ b/mitmproxy/command.py
@@ -118,8 +118,8 @@ class Command:
         try:
             bound_arguments = self.signature.bind(*args)
         except TypeError:
-            expected = f"Expected: {str(self.signature.parameters)}"
-            received = f"Received: {str(args)}"
+            expected = f"Expected: {self.signature.parameters}"
+            received = f"Received: {args}"
             raise exceptions.CommandError(
                 f"Command argument mismatch: \n    {expected}\n    {received}"
             )

--- a/mitmproxy/dns.py
+++ b/mitmproxy/dns.py
@@ -421,7 +421,7 @@ class DNSMessage(serializable.SerializableDataclass):
                 offset += Question.HEADER.size
                 msg.questions.append(Question(name=name, type=type, class_=class_))
             except struct.error as e:
-                raise struct.error(f"question #{i}: {str(e)}")
+                raise struct.error(f"question #{i}: {e}")
 
         def unpack_rrs(
             section: list[ResourceRecord], section_name: str, count: int
@@ -449,7 +449,7 @@ class DNSMessage(serializable.SerializableDataclass):
                     section.append(ResourceRecord(name, type, class_, ttl, data))
                     offset += len_data
                 except struct.error as e:
-                    raise struct.error(f"{section_name} #{i}: {str(e)}")
+                    raise struct.error(f"{section_name} #{i}: {e}")
 
         unpack_rrs(msg.answers, "answer", len_answers)
         unpack_rrs(msg.authorities, "authority", len_authorities)

--- a/mitmproxy/dns.py
+++ b/mitmproxy/dns.py
@@ -585,4 +585,4 @@ class DNSFlow(flow.Flow):
         super().set_state(state)
 
     def __repr__(self) -> str:
-        return f"<DNSFlow\r\n  request={repr(self.request)}\r\n  response={repr(self.response)}\r\n>"
+        return f"<DNSFlow\r\n  request={self.request!r}\r\n  response={self.response!r}\r\n>"

--- a/mitmproxy/http.py
+++ b/mitmproxy/http.py
@@ -989,7 +989,7 @@ class Request(Message):
             """
             boundary = "-" * 20 + binascii.hexlify(os.urandom(16)).decode()
             self.headers["content-type"] = ct = (
-                f"multipart/form-data; boundary={boundary}"
+                f"multipart/form-data; {boundary=!s}"
             )
         self.content = multipart.encode_multipart(ct, value)
 

--- a/mitmproxy/http.py
+++ b/mitmproxy/http.py
@@ -988,9 +988,7 @@ class Request(Message):
             on generating the boundary.
             """
             boundary = "-" * 20 + binascii.hexlify(os.urandom(16)).decode()
-            self.headers["content-type"] = ct = (
-                f"multipart/form-data; {boundary=!s}"
-            )
+            self.headers["content-type"] = ct = f"multipart/form-data; {boundary=!s}"
         self.content = multipart.encode_multipart(ct, value)
 
     @property

--- a/mitmproxy/http.py
+++ b/mitmproxy/http.py
@@ -491,7 +491,7 @@ class Message(serializable.Serializable):
         self.headers["content-encoding"] = encoding
         self.content = self.raw_content
         if "content-encoding" not in self.headers:
-            raise ValueError(f"Invalid content encoding {repr(encoding)}")
+            raise ValueError(f"Invalid content encoding {encoding!r}")
 
     def json(self, **kwargs: Any) -> Any:
         """

--- a/mitmproxy/proxy/commands.py
+++ b/mitmproxy/proxy/commands.py
@@ -41,7 +41,7 @@ class Command:
     def __repr__(self):
         x = self.__dict__.copy()
         x.pop("blocking", None)
-        return f"{type(self).__name__}({repr(x)})"
+        return f"{type(self).__name__}({x!r})"
 
 
 class RequestWakeup(Command):

--- a/mitmproxy/proxy/events.py
+++ b/mitmproxy/proxy/events.py
@@ -23,7 +23,7 @@ class Event:
     """
 
     def __repr__(self):
-        return f"{type(self).__name__}({repr(self.__dict__)})"
+        return f"{type(self).__name__}({self.__dict__!r})"
 
 
 class Start(Event):
@@ -97,7 +97,7 @@ class CommandCompleted(Event):
         command_reply_subclasses[command_cls] = cls  # type: ignore
 
     def __repr__(self):
-        return f"Reply({repr(self.command)}, {repr(self.reply)})"
+        return f"Reply({self.command!r}, {self.reply!r})"
 
 
 command_reply_subclasses: dict[commands.Command, type[CommandCompleted]] = {}

--- a/mitmproxy/proxy/layer.py
+++ b/mitmproxy/proxy/layer.py
@@ -263,7 +263,7 @@ class NextLayer(Layer):
         self._handle: Callable[[mevents.Event], CommandGenerator[None]] | None = None
 
     def __repr__(self):
-        return f"NextLayer:{repr(self.layer)}"
+        return f"NextLayer:{self.layer!r}"
 
     def handle_event(self, event: mevents.Event):
         if self._handle is not None:

--- a/mitmproxy/proxy/layers/quic/_stream_layers.py
+++ b/mitmproxy/proxy/layers/quic/_stream_layers.py
@@ -276,7 +276,7 @@ class QuicLayer(tunnel.TunnelLayer):
                 if self.debug:
                     reason = event.reason_phrase or error_code_to_str(event.error_code)
                     yield commands.Log(
-                        f"{self.debug}[quic] close_notify {self.conn} (reason={reason})",
+                        f"{self.debug}[quic] close_notify {self.conn} ({reason=!s})",
                         DEBUG,
                     )
                 # We don't rely on `ConnectionTerminated` to dispatch `QuicConnectionClosed`, because

--- a/mitmproxy/proxy/layers/quic/_stream_layers.py
+++ b/mitmproxy/proxy/layers/quic/_stream_layers.py
@@ -486,7 +486,7 @@ class ClientQuicLayer(QuicLayer):
             )
         except ValueError as e:
             msgs = b"\n".join(self.handshake_datagram_buf)
-            dbg = f"Cannot parse ClientHello: {str(e)} ({msgs.hex()})"
+            dbg = f"Cannot parse ClientHello: {e} ({msgs.hex()})"
             self.handshake_datagram_buf.clear()
             return False, dbg
 

--- a/mitmproxy/tools/console/eventlog.py
+++ b/mitmproxy/tools/console/eventlog.py
@@ -48,7 +48,7 @@ class EventLog(urwid.ListBox, layoutwidget.LayoutWidget):
             entry.level
         ):
             return
-        txt = f"{entry.level}: {str(entry.msg)}"
+        txt = f"{entry.level}: {entry.msg}"
         if entry.level in ("error", "warn", "alert"):
             e = urwid.Text((entry.level, txt))
         else:

--- a/mitmproxy/tools/console/flowview.py
+++ b/mitmproxy/tools/console/flowview.py
@@ -436,7 +436,7 @@ class FlowDetails(tabs.Tabs):
 
             def rr_text(rr: dns.ResourceRecord):
                 return urwid.Text(
-                    f"  {rr.name} {dns.types.to_str(rr.type)} {dns.classes.to_str(rr.class_)} {rr.ttl} {str(rr)}"
+                    f"  {rr.name} {dns.types.to_str(rr.type)} {dns.classes.to_str(rr.class_)} {rr.ttl} {rr}"
                 )
 
             txt = []

--- a/mitmproxy/tools/console/master.py
+++ b/mitmproxy/tools/console/master.py
@@ -89,7 +89,7 @@ class ConsoleMaster(master.Master):
             signals.status_message.send(
                 message=(
                     entry.level,
-                    f"{entry.level.title()}: {str(entry.msg).lstrip()}",
+                    f"{entry.level.title()}: {entry.msg.lstrip()}",
                 ),
                 expire=5,
             )

--- a/mitmproxy/tools/web/app.py
+++ b/mitmproxy/tools/web/app.py
@@ -671,7 +671,7 @@ class FlowContent(RequestHandler):
             filename = self.flow.request.path.split("?")[0].split("/")[-1]
 
         filename = re.sub(r'[^-\w" .()]', "", filename)
-        cd = f"attachment; filename={filename}"
+        cd = f"attachment; {filename=!s}"
         self.set_header("Content-Disposition", cd)
         self.set_header("Content-Type", "application/text")
         self.set_header("X-Content-Type-Options", "nosniff")

--- a/mitmproxy/tools/web/app.py
+++ b/mitmproxy/tools/web/app.py
@@ -304,7 +304,7 @@ class RequestHandler(AuthRequestHandler):
         try:
             return json.loads(self.request.body.decode())
         except Exception as e:
-            raise APIError(400, f"Malformed JSON: {str(e)}")
+            raise APIError(400, f"Malformed JSON: {e}")
 
     @property
     def filecontents(self):

--- a/mitmproxy/utils/human.py
+++ b/mitmproxy/utils/human.py
@@ -90,10 +90,10 @@ def format_address(address: tuple | None) -> str:
         if host.is_unspecified:
             return f"*:{address[1]}"
         if isinstance(host, ipaddress.IPv4Address):
-            return f"{str(host)}:{address[1]}"
+            return f"{host}:{address[1]}"
         # If IPv6 is mapped to IPv4
         elif host.ipv4_mapped:
-            return f"{str(host.ipv4_mapped)}:{address[1]}"
-        return f"[{str(host)}]:{address[1]}"
+            return f"{host.ipv4_mapped}:{address[1]}"
+        return f"[{host}]:{address[1]}"
     except ValueError:
         return f"{address[0]}:{address[1]}"

--- a/release/release.py
+++ b/release/release.py
@@ -203,7 +203,7 @@ if __name__ == "__main__":
         )
         print(f"Last update: {docker_last_updated.isoformat(timespec='minutes')}")
         assert docker_last_updated > datetime.datetime.now(
-            datetime.timezone.utc
+            datetime.UTC
         ) - datetime.timedelta(hours=2)
 
     print("")

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -4,7 +4,6 @@ import asyncio
 import os
 import platform
 import socket
-import sys
 
 import pytest
 
@@ -35,8 +34,7 @@ skip_no_ipv6 = pytest.mark.skipif(no_ipv6, reason="Host has no IPv6 support")
 class EagerTaskCreationEventLoopPolicy(asyncio.DefaultEventLoopPolicy):
     def new_event_loop(self):
         loop = super().new_event_loop()
-        if sys.version_info >= (3, 12):
-            loop.set_task_factory(asyncio.eager_task_factory)
+        loop.set_task_factory(asyncio.eager_task_factory)
         return loop
 
 

--- a/test/mitmproxy/net/http/test_multipart.py
+++ b/test/mitmproxy/net/http/test_multipart.py
@@ -14,18 +14,14 @@ def test_decode():
         "value2\n"
         "--{0}--".format(boundary).encode()
     )
-    form = multipart.decode_multipart(
-        f"multipart/form-data; {boundary=!s}", content
-    )
+    form = multipart.decode_multipart(f"multipart/form-data; {boundary=!s}", content)
 
     assert len(form) == 2
     assert form[0] == (b"field1", b"value1")
     assert form[1] == (b"field2", b"value2")
 
     boundary = "boundary茅莽"
-    result = multipart.decode_multipart(
-        f"multipart/form-data; {boundary=!s}", content
-    )
+    result = multipart.decode_multipart(f"multipart/form-data; {boundary=!s}", content)
     assert result == []
 
     assert multipart.decode_multipart("", content) == []

--- a/test/mitmproxy/net/http/test_multipart.py
+++ b/test/mitmproxy/net/http/test_multipart.py
@@ -15,7 +15,7 @@ def test_decode():
         "--{0}--".format(boundary).encode()
     )
     form = multipart.decode_multipart(
-        f"multipart/form-data; boundary={boundary}", content
+        f"multipart/form-data; {boundary=!s}", content
     )
 
     assert len(form) == 2
@@ -24,7 +24,7 @@ def test_decode():
 
     boundary = "boundary茅莽"
     result = multipart.decode_multipart(
-        f"multipart/form-data; boundary={boundary}", content
+        f"multipart/form-data; {boundary=!s}", content
     )
     assert result == []
 

--- a/test/mitmproxy/proxy/tutils.py
+++ b/test/mitmproxy/proxy/tutils.py
@@ -398,7 +398,7 @@ class _Placeholder(Generic[T]):
         return f"Placeholder:{self._obj!r}"
 
     def __str__(self):
-        return f"Placeholder:{str(self._obj)}"
+        return f"Placeholder:{self._obj}"
 
 
 # noinspection PyPep8Naming

--- a/test/mitmproxy/proxy/tutils.py
+++ b/test/mitmproxy/proxy/tutils.py
@@ -395,7 +395,7 @@ class _Placeholder(Generic[T]):
         return self._obj
 
     def __repr__(self):
-        return f"Placeholder:{repr(self._obj)}"
+        return f"Placeholder:{self._obj!r}"
 
     def __str__(self):
         return f"Placeholder:{str(self._obj)}"

--- a/test/mitmproxy/tools/console/test_commander.py
+++ b/test/mitmproxy/tools/console/test_commander.py
@@ -13,7 +13,7 @@ def commander_tctx(tmpdir):
     confdir = dir_name
 
     opts = options.Options()
-    opts.set(*[f"confdir={confdir}"])
+    opts.set(*[f"{confdir=!s}"])
     commander_tctx = taddons.context(options=opts)
     ch = command_history.CommandHistory()
     commander_tctx.master.addons.add(ch)


### PR DESCRIPTION
#### Description

- Run pyupgrade for Python 3.12+
- Use `!r` flag instead of `repr()` in f-strings
- Remove redundant `str()` in f-strings
- Use self-documenting f-strings

#### Checklist

 - [ ] I have updated tests where applicable.
 - [ ] I have added an entry to the CHANGELOG.
