### PR TITLE
Switch dependabot from pip to uv

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
       "github actions":
         patterns:
           - "*"
-  - package-ecosystem: pip
+  - package-ecosystem: uv
     directory: "/"
     schedule:
       interval: "monthly"


### PR DESCRIPTION
uv has its own package ecosystem.

After merging this, you can manually trigger dependabot to run by going to the insights tab -> dependency graph -> dependabot (note: this tab is not accessible to the public) -> "Recent update jobs" next to pyproject.toml -> then click on "check for update".
This is also where you can find the logs of dependabot runs and it's where you will be best able to troubleshoot.

Feel free to follow up (with logs) in #7859 if things don't work.