### PR TITLE
Don't `return` in `finally` block (PEP 765)

### DIFF
--- a/mitmproxy/addons/script.py
+++ b/mitmproxy/addons/script.py
@@ -29,7 +29,7 @@ def load_script(path: str) -> types.ModuleType | None:
     sys.modules.pop(fullname, None)
     oldpath = sys.path
     sys.path.insert(0, os.path.dirname(path))
-    m = None
+
     try:
         loader = importlib.machinery.SourceFileLoader(fullname, path)
         spec = importlib.util.spec_from_loader(fullname, loader=loader)
@@ -38,6 +38,7 @@ def load_script(path: str) -> types.ModuleType | None:
         loader.exec_module(m)
         if not getattr(m, "name", None):
             m.name = path  # type: ignore
+        return m
     except ImportError as e:
         if getattr(sys, "frozen", False):
             e.msg += (
@@ -48,11 +49,12 @@ def load_script(path: str) -> types.ModuleType | None:
                 f"(https://docs.mitmproxy.org/stable/overview-installation/#installation-from-the-python-package-index-pypi)."
             )
         script_error_handler(path, e)
+        return None
     except Exception as e:
         script_error_handler(path, e)
+        return None
     finally:
         sys.path[:] = oldpath
-        return m
 
 
 def script_error_handler(path: str, exc: Exception) -> None:


### PR DESCRIPTION
#### Description

Fixes a SyntaxWarning when running in Python 3.14 (I forget exactly what caused it).

#### Checklist

 - [ ] I have updated tests where applicable.
 - [ ] I have added an entry to the CHANGELOG.