### PR TITLE
Console: Show query parameters for empty-body requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 ## Unreleased: mitmproxy next
 
+- Show query parameters for empty-body requests in the mitmproxy console.
+  ([#7923](https://github.com/mitmproxy/mitmproxy/pull/7918), @lups2000)
 
 ## 15 October 2025: mitmproxy 12.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 ## Unreleased: mitmproxy next
 
 - Show query parameters for empty-body requests in the mitmproxy console.
-  ([#7923](https://github.com/mitmproxy/mitmproxy/pull/7918), @lups2000)
+  ([#7923](https://github.com/mitmproxy/mitmproxy/pull/7923), @lups2000)
 
 ## 15 October 2025: mitmproxy 12.2.0
 

--- a/mitmproxy/tools/console/flowview.py
+++ b/mitmproxy/tools/console/flowview.py
@@ -316,9 +316,8 @@ class FlowDetails(tabs.Tabs):
 
         if message.raw_content == b"":
             if isinstance(message, http.Request):
-                path = getattr(message, "path", "") or ""
-                parsed = urlparse(path)
-                if not parsed.query:
+                query = getattr(message, "query", "") or ""
+                if not query:
                     # No body and no query params
                     return "", [urwid.Text("No request content")]
                 # else: there are query params -> fall through to render them

--- a/mitmproxy/tools/console/flowview.py
+++ b/mitmproxy/tools/console/flowview.py
@@ -1,6 +1,5 @@
 import sys
 from functools import lru_cache
-from urllib.parse import urlparse
 
 import urwid
 

--- a/mitmproxy/tools/console/flowview.py
+++ b/mitmproxy/tools/console/flowview.py
@@ -311,7 +311,6 @@ class FlowDetails(tabs.Tabs):
     def content_view(
         self, viewmode: str, message: http.Message
     ) -> tuple[str, list[urwid.Text]]:
-
         if message.raw_content is None:
             return "", [urwid.Text([("error", "[content missing]")])]
 
@@ -329,7 +328,7 @@ class FlowDetails(tabs.Tabs):
         full = self.master.commands.execute(
             "view.settings.getval @focus fullcontents false"
         )
-        
+
         if full == "true":
             limit = sys.maxsize
         else:
@@ -344,9 +343,7 @@ class FlowDetails(tabs.Tabs):
         )
         # we need to pass the message off-band because it's not hashable
         self._get_content_view_message = message
-        return self._get_content_view(
-            viewmode, limit, flow_modify_cache_invalidation
-        )
+        return self._get_content_view(viewmode, limit, flow_modify_cache_invalidation)
 
     @lru_cache(maxsize=200)
     def _get_content_view(

--- a/mitmproxy/tools/console/flowview.py
+++ b/mitmproxy/tools/console/flowview.py
@@ -315,7 +315,7 @@ class FlowDetails(tabs.Tabs):
 
         if message.raw_content == b"":
             if isinstance(message, http.Request):
-                query = getattr(message, "query", "") or ""
+                query = getattr(message, "query", "")
                 if not query:
                     # No body and no query params
                     return "", [urwid.Text("No request content")]

--- a/test/mitmproxy/tools/console/test_flowview.py
+++ b/test/mitmproxy/tools/console/test_flowview.py
@@ -1,5 +1,6 @@
 from mitmproxy import http
 from mitmproxy.test import tflow
+from mitmproxy.tools.console.flowview import FlowDetails
 
 
 async def test_flowview(console):
@@ -31,3 +32,47 @@ async def test_edit(console, monkeypatch, caplog):
     console.type(':console.edit.focus "request-body (MsgPack)"<enter><enter>')
     assert "hello: false" in console.screen_contents()
     assert f.request.content == MSGPACK_WITH_FALSE
+
+async def test_content_missing_returns_error(console):
+    # message.raw_content is None -> expect "[content missing]" error text
+    f_missing = tflow.tflow(
+        req=http.Request.make("GET", "http://example.com", b"initial"),
+    )
+    f_missing.request.raw_content = None
+
+    await console.load_flow(f_missing)
+
+    fd = FlowDetails(console)
+
+    title, txt_objs = fd.content_view("default", f_missing.request)
+    assert title == ""
+
+    first_text = txt_objs[0].get_text()[0]
+    assert "[content missing]" in first_text
+
+
+async def test_empty_content_request_and_response(console):
+    fd = FlowDetails(console)
+
+    # 1) Request with empty body and no query -> "No request content"
+    f_req_empty = tflow.tflow(
+        req=http.Request.make("GET", "http://example.com", b""),
+    )
+    f_req_empty.request.raw_content = b""
+    await console.load_flow(f_req_empty)
+    title_req, txt_objs_req = fd.content_view("default", f_req_empty.request)
+    assert title_req == ""
+    req_text = txt_objs_req[0].get_text()[0]
+    assert "No request content" in req_text
+
+    # 2) Response with empty body -> "No content"
+    f_resp_empty = tflow.tflow(
+        req=http.Request.make("GET", "http://example.com", b""),
+        resp=http.Response.make(200, b"", {})
+    )
+    f_resp_empty.response.raw_content = b""
+    await console.load_flow(f_resp_empty)
+    title_resp, txt_objs_resp = fd.content_view("default", f_resp_empty.response)
+    assert title_resp == ""
+    resp_text = txt_objs_resp[0].get_text()[0]
+    assert "No content" in resp_text

--- a/test/mitmproxy/tools/console/test_flowview.py
+++ b/test/mitmproxy/tools/console/test_flowview.py
@@ -1,6 +1,7 @@
 import sys
 
 import urwid
+
 from mitmproxy import http
 from mitmproxy.test import tflow
 from mitmproxy.tools.console.flowview import FlowDetails
@@ -80,6 +81,7 @@ async def test_empty_content_request_and_response(console):
     assert title_resp == ""
     resp_text = txt_objs_resp[0].get_text()[0]
     assert "No content" in resp_text
+
 
 async def test_content_view_fullcontents_true_uses_unlimited_limit(console):
     f = tflow.tflow(req=http.Request.make("POST", "http://example.com", b"non-empty"))

--- a/test/mitmproxy/tools/console/test_flowview.py
+++ b/test/mitmproxy/tools/console/test_flowview.py
@@ -87,7 +87,7 @@ async def test_content_view_fullcontents_true_uses_unlimited_limit(console):
     await console.load_flow(f)
 
     fd = FlowDetails(console)
-    
+
     console.commands.execute("view.settings.setval @focus fullcontents true")
     fd._get_content_view = mock.MagicMock()
     fd.content_view("default", f.request)

--- a/test/mitmproxy/tools/console/test_flowview.py
+++ b/test/mitmproxy/tools/console/test_flowview.py
@@ -33,6 +33,7 @@ async def test_edit(console, monkeypatch, caplog):
     assert "hello: false" in console.screen_contents()
     assert f.request.content == MSGPACK_WITH_FALSE
 
+
 async def test_content_missing_returns_error(console):
     # message.raw_content is None -> expect "[content missing]" error text
     f_missing = tflow.tflow(
@@ -68,7 +69,7 @@ async def test_empty_content_request_and_response(console):
     # 2) Response with empty body -> "No content"
     f_resp_empty = tflow.tflow(
         req=http.Request.make("GET", "http://example.com", b""),
-        resp=http.Response.make(200, b"", {})
+        resp=http.Response.make(200, b"", {}),
     )
     f_resp_empty.response.raw_content = b""
     await console.load_flow(f_resp_empty)


### PR DESCRIPTION
#### Description

This PR fixes: #7914
We now explicitly check for query parameters and display them even when the request body is empty.

#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
