### PR TITLE
Added cusorline-style highlight for the selected flow and made it con…

### DIFF
--- a/mitmproxy/tools/console/consoleaddons.py
+++ b/mitmproxy/tools/console/consoleaddons.py
@@ -112,6 +112,12 @@ class ConsoleAddon:
             choices=sorted(console_flowlist_layout),
         )
         loader.add_option(
+            "console_cursorline",
+            bool,
+            True,
+            "Highlight the background of the currently selected flow in the list.",
+        )
+        loader.add_option(
             "console_strip_trailing_newlines",
             bool,
             False,

--- a/mitmproxy/tools/console/flowlist.py
+++ b/mitmproxy/tools/console/flowlist.py
@@ -21,12 +21,17 @@ class FlowItem(urwid.WidgetWrap):
         else:
             render_mode = common.RenderMode.TABLE
 
-        return common.format_flow(
+        row_widget = common.format_flow(
             self.flow,
             render_mode=render_mode,
             focused=self.flow is self.master.view.focus.flow,
             hostheader=self.master.options.showhost,
         )
+
+        # Apply a cursorline-like background highlight to the focused row if enabled.
+        if getattr(self.master.options, "console_cursorline", False):
+            return urwid.AttrMap(row_widget, None, "cursorline")
+        return row_widget
 
     def selectable(self):
         return True

--- a/mitmproxy/tools/console/palettes.py
+++ b/mitmproxy/tools/console/palettes.py
@@ -70,6 +70,8 @@ class Palette:
         "intercept",
         "replay",
         "mark",
+        # Cursorline background for focused rows
+        "cursorline",
         # Contentview Syntax Highlighting
         "name",
         "string",
@@ -210,6 +212,7 @@ class LowDark(Palette):
         intercept=("brown", "default"),
         replay=("light green", "default"),
         mark=("light red", "default"),
+        cursorline=("default", "dark blue"),
         # Contentview Syntax Highlighting
         name=("dark green", "default"),
         string=("dark blue", "default"),
@@ -309,6 +312,7 @@ class LowLight(Palette):
         intercept=("brown", "default"),
         replay=("dark green", "default"),
         mark=("dark red", "default"),
+        cursorline=("default", "light gray"),
         # Contentview Syntax Highlighting
         name=("dark green", "default"),
         string=("dark blue", "default"),
@@ -432,6 +436,7 @@ class SolarizedLight(LowLight):
             "default",
         ),
         mark=(sol_base01, "default"),
+        cursorline=(sol_base00, sol_base2),
         # Contentview Syntax Highlighting
         name=(sol_green, "default"),
         string=(sol_cyan, "default"),
@@ -512,6 +517,7 @@ class SolarizedDark(LowDark):
             "default",
         ),
         mark=(sol_base01, "default"),
+        cursorline=(sol_base0, sol_base02),
         # Contentview Syntax Highlighting
         name=(sol_green, "default"),
         string=(sol_cyan, "default"),


### PR DESCRIPTION
### Summary

- Adds a cursorline-style background highlight for the selected flow in the TUI flow list.
- New option: `console_cursorline` (default: true) to toggle the highlight.
- New palette entry: `cursorline` with sensible colors across all palettes.
- Improves scanability of the focused row across right-side columns (content type, size, etc.).

Usage:
- Toggle: `--set console_cursorline=true|false`
- Customize color by adjusting the `cursorline` style in the active palette.