### PR TITLE
infer_content_encoding: Fallback to UTF-8 for more content types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 ## Unreleased: mitmproxy next
 
+- infer_content_encoding: Fallback to UTF-8 for more content types
+  ([#7961](https://github.com/mitmproxy/mitmproxy/pull/7961), @xu-cheng)
 - Remove `bless` from hex editors to avoid issues with macOS
   ([#7937](https://github.com/mitmproxy/mitmproxy/pull/7937), @caiquejjx)
 - Improves `is_mostly_bin` check to support chinese characters

--- a/test/mitmproxy/data/har_files/firefox.json
+++ b/test/mitmproxy/data/har_files/firefox.json
@@ -1024,11 +1024,11 @@
                 ],
                 [
                     "content-length",
-                    "10452"
+                    "10453"
                 ]
             ],
-            "contentLength": 10452,
-            "contentHash": "ebe20255d8922ecbc1a159357d0cb0eb1ef05b8cc5a9d59f2a9f7e6fb585d7d3",
+            "contentLength": 10453,
+            "contentHash": "8a7739925f4c03586479852df840b7061948832a7fda30c8c812d2ea4dd4c4f2",
             "timestamp_start": 1680134339.498,
             "timestamp_end": 1680134339.498
         }

--- a/test/mitmproxy/data/har_files/safari.json
+++ b/test/mitmproxy/data/har_files/safari.json
@@ -1045,11 +1045,11 @@
                 ],
                 [
                     "content-length",
-                    "10452"
+                    "10453"
                 ]
             ],
-            "contentLength": 10452,
-            "contentHash": "ebe20255d8922ecbc1a159357d0cb0eb1ef05b8cc5a9d59f2a9f7e6fb585d7d3",
+            "contentLength": 10453,
+            "contentHash": "8a7739925f4c03586479852df840b7061948832a7fda30c8c812d2ea4dd4c4f2",
             "timestamp_start": 1680135212.559,
             "timestamp_end": 1680135212.5590725
         }

--- a/test/mitmproxy/net/http/test_headers.py
+++ b/test/mitmproxy/net/http/test_headers.py
@@ -60,12 +60,22 @@ def test_assemble_content_type():
             b'content="text/html;charset=gb2312">\xe6\x98\x8e\xe4\xbc\xaf',
             "gb18030",
         ),
+        (
+            "text/html",
+            b"<html></html>",
+            "utf8",
+        ),
         # xml declaration encoding
         (
             "application/xml",
             b'<?xml version="1.0" encoding="gb2312"?>'
             b"<root>\xe6\x98\x8e\xe4\xbc\xaf</root>",
             "gb18030",
+        ),
+        (
+            "application/xml",
+            b'<?xml version="1.0"?>',
+            "utf8",
         ),
         # css charset
         (
@@ -83,6 +93,10 @@ def test_assemble_content_type():
             b"h1 {}",
             "utf8",
         ),
+        # js
+        ("application/javascript", b"", "utf8"),
+        ("application/ecmascript", b"", "utf8"),
+        ("text/javascript", b"", "utf8"),
     ],
 )
 def test_infer_content_encoding(content_type, content, expected):


### PR DESCRIPTION
#### Description

For html, css, js, and xml content types, the official specs tell us to use UTF-8 as fallback when charset are not specified.

Relevant sections of the specs are included in the comments for the corresponding branches.

This commit also uncovered incorrect decoding in the following har tests:

test/mitmproxy/data/har_files/firefox.json
test/mitmproxy/data/har_files/safari.json

```diff
- * Licensed MIT © Zeno Rocha
+ * Licensed MIT  Zeno Rocha
```

Noted that the UTF-8 char `©` was missing due to the incorrect encoding.

#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
