### PR TITLE
Add Docker Compose section to Dockerhub README

### DIFF
--- a/release/docker/DockerHub-README.md
+++ b/release/docker/DockerHub-README.md
@@ -52,10 +52,14 @@ For further details, please consult the mitmproxy [documentation](https://docs.m
 
 ## Docker Compose
 
-Many python applications run in Docker experience logging buffering issues. These are avoided when running in regular mode with the -t flag.
-When running in Docker Compose use the environmental variable PYTHONUNBUFFERED=1 to avoid logs being buffered by Python and not passed to Docker.
+Many python applications run in Docker experience logging buffering issues. The buffering behavior is standard for Python when stdout is not connected to a TTY (terminal), which is the case in Docker containers.
 
-Example Docker Compose configuration with web UI:
+When running in Docker Compose there are 2 ways to over come this:
+1. use the environmental variable PYTHONUNBUFFERED=1 to avoid logs being buffered by Python and not passed to Docker.
+2. connect python to the tty
+Depending on your system you might get better looks logs from the second option (colours etc...) 
+
+Example Docker Compose configuration with web UI using PYTHONUNBUFFERED=1:
 
 ```yaml
 services:
@@ -66,6 +70,24 @@ services:
       - PYTHONUNBUFFERED=1
     volumes:
       - ~/.mitmproxy:/home/mitmproxy/.mitmproxy
+    ports:
+      - 8080:8080
+      - 8081:8081
+    restart: unless-stopped
+    command: mitmweb --web-host 0.0.0.0
+```
+
+Example Docker Compose configuration with web UI connecting to the TTY:
+
+```yaml
+services:
+  mitmproxy:
+    image: mitmproxy/mitmproxy:latest
+    container_name: mitmproxy
+    volumes:
+      - ~/.mitmproxy:/home/mitmproxy/.mitmproxy
+    stdin_open: true
+    tty: true
     ports:
       - 8080:8080
       - 8081:8081


### PR DESCRIPTION
Added Docker Compose configuration example to README.
 

#### Description

Added information about the necessity of using environmental variable PYTHONUNBUFFERED=1 when using docker compose to overcome python logging buffering issues.
Included docker compose example.
