### PR TITLE
Docs: Change 'uvx' to 'uv tool install' for Installation from PyPI

### DIFF
--- a/docs/src/content/overview/installation.md
+++ b/docs/src/content/overview/installation.md
@@ -59,16 +59,16 @@ on GitHub.
 If your mitmproxy addons require the installation of additional Python packages,
 you can install mitmproxy from [PyPI](https://pypi.org/project/mitmproxy/).
 
-While there are plenty of options around[^1], we recommend the installation using uvx:
+While there are plenty of options around[^1], we recommend the installation using uv:
 
 [^1]: If you are familiar with the Python ecosystem, you may know that there are a million ways to install Python
     packages. Most of them (pip, virtualenv, pipenv, etc.) should just work, but we don't have the capacity to
     provide support for it.
 
 1. Install [uv](https://docs.astral.sh/uv/).
-2. `uvx mitmproxy` (or `uvx --from mitmproxy mitmweb`)
+2. `uv tool install mitmproxy`.
 
-To install additional Python packages, run `uvx --with <your-package-name> mitmproxy`.
+To install additional Python packages, run `uv tool install --with <your-package-name> mitmproxy`.
 
 ### Docker Images
 


### PR DESCRIPTION
#### Description
Changed references to 'uvx' to 'uv tool install'.

'uvx' is an alias for 'uv tool run' that installs packages in a temporary virtual environment that is deleted when the uv cache is cleaned. The correct installation command should be 'uv tool install' which installs the virtual environment in the uv tools directory and makes the executable available on the PATH. See: https://docs.astral.sh/uv/concepts/tools/

#### Checklist

 - [x] I have updated tests where applicable.
 - [ ] I have added an entry to the CHANGELOG.
