### PR TITLE
added clearer error hint for wireguard port conflicts

### DIFF
--- a/mitmproxy/proxy/mode_servers.py
+++ b/mitmproxy/proxy/mode_servers.py
@@ -263,7 +263,10 @@ class AsyncioServerInstance(ServerInstance[M], metaclass=ABCMeta):
                     self.mode.custom_listen_host is None
                 )  # since [@ [listen_addr:]listen_port]
                 message += f"\nTry specifying a different port by using `--mode {self.mode.full_spec}@{port + 2}`."
+                                if isinstance(self.mode, mode_specs.WireGuardMode):
+                                                        message += "\nIf you already have WireGuard running, stop it first or use a different port."
             raise OSError(e.errno, message, e.filename) from e
+            
 
     async def _stop(self) -> None:
         assert self._servers


### PR DESCRIPTION
hey! i noticed in issue #7650 that the error message for WireGuard port conflicts wasn't super clear - it just said to try a different port but didn't mention that you might already have WireGuard running which is a common cause.

so i added a quick check that when we detect a port conflict AND we're in WireGuard mode, we now tell users "If you already have WireGuard running, stop it first or use a different port."

should help folks troubleshoot faster instead of scratching their heads about why the port's already taken.

let me know if you want me to change anything!