### PR TITLE
mitmweb: show intercept filter tag at the bottom for default options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 ## Unreleased: mitmproxy next
 
+* mitmweb: show intercept filter tag at the bottom for default options
+  ([#8026](https://github.com/mitmproxy/mitmproxy/pull/8026), @xBZZZZ)
 
 ## 24 November 2025: mitmproxy 12.2.1
 

--- a/web/src/js/__tests__/components/Header/FilterInputSpec.tsx
+++ b/web/src/js/__tests__/components/Header/FilterInputSpec.tsx
@@ -137,6 +137,7 @@ describe("FilterInput Component", () => {
         act(() => filterInput.selectFilter("bar"));
         expect(filterInput.state.value).toEqual("bar");
         expect(input.focus).toBeCalled();
+        expect(filterInput.props.onChange).toBeCalledWith("bar");
     });
 
     it("should handle select", () => {

--- a/web/src/js/components/Header/FilterInput.tsx
+++ b/web/src/js/components/Header/FilterInput.tsx
@@ -111,9 +111,14 @@ export default class FilterInput extends Component<
         e.stopPropagation();
     }
 
-    selectFilter(cmd: string) {
-        this.setState({ value: cmd });
+    selectFilter(value: string) {
+        this.setState({ value });
         this.inputRef.current?.focus();
+
+        // Only propagate valid filters upwards.
+        if (this.isValid(value)) {
+            this.props.onChange(value);
+        }
     }
 
     blur() {


### PR DESCRIPTION
#### Description

<table>
	<tr>
		<td align="left" valign="top"></td>
		<th align="left" valign="top">before</th>
		<th align="left" valign="top">after</th>
	</tr>
	<tr>
		<th align="left" valign="top">1.</th>
		<td align="left" valign="top"><img width="640" height="480" src="https://github.com/user-attachments/assets/d2b1d4cd-c848-440e-b5bb-86288bec5061"></td>
		<td align="left" valign="top"><img width="640" height="480" src="https://github.com/user-attachments/assets/d2b1d4cd-c848-440e-b5bb-86288bec5061"></td>
	</tr>
	<tr>
		<th align="left" valign="top">2.</th>
		<td align="left" valign="top"><img width="640" height="480" src="https://github.com/user-attachments/assets/f7b24ff0-55f0-4f29-9e93-582a4b959457"></td>
		<td align="left" valign="top"><img width="640" height="480" src="https://github.com/user-attachments/assets/2dc37d18-c5e0-4752-8a27-4d302494a1f5"></td>
	</tr>
</table>

#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
