### PR TITLE
feat: add setup_terminal addon for automatic shell environment configuration

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,9 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(uv run python:*)"
+    ],
+    "deny": [],
+    "ask": []
+  }
+}

--- a/docs/src/content/howto/automatic-shell-setup.md
+++ b/docs/src/content/howto/automatic-shell-setup.md
@@ -1,0 +1,124 @@
+---
+title: "Automatic shell environment setup"
+weight: 2
+aliases:
+  - /howto-automatic-shell-setup/
+---
+
+# Automatic Shell Environment Setup
+
+Instead of manually configuring proxy settings in your shell, mitmproxy provides automatic setup endpoints that generate shell configuration scripts for different shells. These scripts configure environment variables for the proxy, certificates, and other tools.
+
+## Quick Start
+
+Replace `127.0.0.1:8080` with your actual mitmproxy address and port.
+
+### Bash/Zsh/Ksh
+```bash
+eval "$(curl -sS http://127.0.0.1:8080/setup.sh)"
+```
+
+### Fish
+```bash
+source (curl -sS http://127.0.0.1:8080/setup.fish | psub)
+```
+
+### PowerShell
+```powershell
+. (curl -Uri http://127.0.0.1:8080/setup.ps1).Content
+```
+
+## Available Endpoints
+
+The setup endpoints are available on any proxy address/port where mitmproxy is listening:
+
+| Endpoint | Format | Shell | Description |
+|----------|--------|-------|-------------|
+| `/setup` | JSON | - | Returns proxy configuration and certificate paths as JSON |
+| `/setup.sh` | Bash | bash/sh | Shell script with environment variables and winpty aliases |
+| `/setup.fish` | Fish | fish | Fish shell script with environment variables and aliases |
+| `/setup.ps1` | PowerShell | pwsh | PowerShell script with `Stop-Intercepting` function |
+
+## What Gets Configured
+
+These setup scripts automatically export environment variables for:
+
+### Proxy Configuration
+- Standard: `HTTP_PROXY`, `HTTPS_PROXY`, `http_proxy`, `https_proxy`
+- WebSocket: `WS_PROXY`, `WSS_PROXY`
+- Tool-specific: `npm_config_proxy`, `GLOBAL_AGENT_HTTP_PROXY`, `CGI_HTTP_PROXY`
+
+### Certificate Trust
+Paths are set for multiple tools to trust the mitmproxy CA certificate:
+- `SSL_CERT_FILE`, `REQUESTS_CA_BUNDLE`, `CURL_CA_BUNDLE`
+- `NODE_EXTRA_CA_CERTS`, `DENO_CERT`
+- `GIT_SSL_CAINFO`, `CARGO_HTTP_CAINFO`, `AWS_CA_BUNDLE`, `PERL_LWP_SSL_CA_FILE`
+
+### Status Indicator
+- `MITMPROXY_ACTIVE=true` indicates that mitmproxy interception is active
+
+## Stopping Interception
+
+### Bash/Fish
+Close your shell or manually unset the environment variables:
+```bash
+unset HTTP_PROXY HTTPS_PROXY http_proxy https_proxy WS_PROXY WSS_PROXY \
+      npm_config_proxy GLOBAL_AGENT_HTTP_PROXY CGI_HTTP_PROXY \
+      SSL_CERT_FILE REQUESTS_CA_BUNDLE CURL_CA_BUNDLE NODE_EXTRA_CA_CERTS \
+      DENO_CERT GIT_SSL_CAINFO CARGO_HTTP_CAINFO AWS_CA_BUNDLE \
+      PERL_LWP_SSL_CA_FILE MITMPROXY_ACTIVE
+```
+
+### PowerShell
+Use the `Stop-Intercepting` function:
+```powershell
+Stop-Intercepting
+```
+
+## Programmatic Access
+
+If you need to retrieve the configuration programmatically (e.g., in a script or application):
+
+```bash
+curl -sS http://127.0.0.1:8080/setup | jq
+```
+
+This returns a JSON object with:
+```json
+{
+  "proxy_url": "127.0.0.1:8080",
+  "proxy_host": "127.0.0.1",
+  "proxy_port": 8080,
+  "certificates": {
+    "pem": "~/.mitmproxy/mitmproxy-ca-cert.pem",
+    "p12": "~/.mitmproxy/mitmproxy-ca-cert.p12",
+    "cer": "~/.mitmproxy/mitmproxy-ca-cert.cer"
+  },
+  "setup_scripts": {
+    "sh": "http://127.0.0.1:8080/setup.sh",
+    "bash": "http://127.0.0.1:8080/setup.sh",
+    "zsh": "http://127.0.0.1:8080/setup.sh",
+    "ksh": "http://127.0.0.1:8080/setup.sh",
+    "fish": "http://127.0.0.1:8080/setup.fish",
+    "powershell": "http://127.0.0.1:8080/setup.ps1",
+    "pwsh": "http://127.0.0.1:8080/setup.ps1"
+  }
+}
+```
+
+## Configuration Requirements
+
+For automatic setup to work:
+
+1. **mitmproxy must be running** - Start mitmproxy with `mitmproxy`, `mitmweb`, or `mitmdump`
+2. **Access the proxy directly** - Request the setup endpoints from the proxy's IP/port (e.g., `http://127.0.0.1:8080/setup.sh`)
+
+For example, if mitmproxy is running on `127.0.0.1:8080`:
+```bash
+eval "$(curl -sS http://127.0.0.1:8080/setup.sh)"
+```
+
+Or if your mitmproxy instance is on a remote machine:
+```bash
+eval "$(curl -sS http://remote-proxy:8080/setup.sh)"
+```

--- a/mitmproxy/addons/__init__.py
+++ b/mitmproxy/addons/__init__.py
@@ -23,6 +23,7 @@ from mitmproxy.addons import save
 from mitmproxy.addons import savehar
 from mitmproxy.addons import script
 from mitmproxy.addons import serverplayback
+from mitmproxy.addons import setup_terminal
 from mitmproxy.addons import stickyauth
 from mitmproxy.addons import stickycookie
 from mitmproxy.addons import strip_dns_https_records
@@ -47,6 +48,7 @@ def default_addons():
         disable_h2c.DisableH2C(),
         export.Export(),
         onboarding.Onboarding(),
+        setup_terminal.SetupTerminal(),
         proxyauth.ProxyAuth(),
         proxyserver.Proxyserver(),
         script.ScriptLoader(),

--- a/mitmproxy/addons/setup_terminal/__init__.py
+++ b/mitmproxy/addons/setup_terminal/__init__.py
@@ -1,0 +1,135 @@
+import os
+
+from flask import Flask
+from flask import jsonify
+from flask import render_template
+from flask import Response
+
+from mitmproxy import ctx
+from mitmproxy import http
+from mitmproxy.addons import asgiapp
+
+app = Flask(__name__)
+
+
+def get_setup_vars():
+    """Get proxy and certificate variables for setup scripts."""
+    proxy_host = app.config.get("PROXY_HOST", "127.0.0.1")
+    proxy_port = app.config.get("PROXY_PORT", 8080)
+    confdir = app.config.get("CONFDIR")
+
+    confdir = os.path.expanduser(confdir)
+    proxy_url = f"http://{proxy_host}:{proxy_port}"
+    cert_path = f"{confdir}/mitmproxy-ca-cert.pem"
+
+    return {
+        "proxy_url": proxy_url,
+        "cert_path": cert_path,
+    }
+
+
+@app.route("/setup")
+def setup():
+    """Return proxy configuration as JSON."""
+    proxy_host = app.config.get("PROXY_HOST", "127.0.0.1")
+    proxy_port = app.config.get("PROXY_PORT", 8080)
+    confdir = app.config.get("CONFDIR")
+
+    base_url = f"http://{proxy_host}:{proxy_port}"
+    return jsonify({
+        "proxy_url": f"{proxy_host}:{proxy_port}",
+        "proxy_host": proxy_host,
+        "proxy_port": proxy_port,
+        "certificates": {
+            "pem": f"{confdir}/mitmproxy-ca-cert.pem",
+            "p12": f"{confdir}/mitmproxy-ca-cert.p12",
+            "cer": f"{confdir}/mitmproxy-ca-cert.cer",
+        },
+        "setup_scripts": {
+            "sh": f"{base_url}/setup.sh",
+            "bash": f"{base_url}/setup.sh",
+            "zsh": f"{base_url}/setup.sh",
+            "ksh": f"{base_url}/setup.sh",
+            "fish": f"{base_url}/setup.fish",
+            "powershell": f"{base_url}/setup.ps1",
+            "pwsh": f"{base_url}/setup.ps1",
+        },
+    })
+
+
+@app.route("/setup.sh")
+def setup_sh():
+    """Return bash script with environment variables."""
+    return Response(
+        render_template("setup.sh", **get_setup_vars()),
+        mimetype="text/x-shellscript",
+    )
+
+
+@app.route("/setup.fish")
+def fish_setup():
+    """Return fish shell script with environment variables."""
+    return Response(
+        render_template("setup.fish", **get_setup_vars()),
+        mimetype="application/x-fish",
+    )
+
+
+@app.route("/setup.ps1")
+def ps_setup():
+    """Return PowerShell script with environment variables."""
+    return Response(
+        render_template("setup.ps1", **get_setup_vars()),
+        mimetype="text/plain",
+    )
+
+
+class SetupTerminal(asgiapp.WSGIApp):
+    """
+    An addon that hosts terminal setup endpoints within mitmproxy at mitm.it.
+
+    Provides automatic shell environment configuration scripts for bash, fish, and PowerShell.
+    """
+
+    name = "setup_terminal"
+
+    def __init__(self):
+        super().__init__(app, None, None)
+
+    def should_serve(self, flow: http.HTTPFlow) -> bool:
+        """Serve setup endpoints on any host."""
+        setup_paths = {"/setup", "/setup.sh", "/setup.fish", "/setup.ps1"}
+        return (
+            flow.request.path in setup_paths
+            and flow.live
+        )
+
+    def load(self, loader):
+        loader.add_option(
+            "setup_terminal",
+            bool,
+            True,
+            "Toggle the mitmproxy terminal setup app."
+        )
+
+    def configure(self, updated):
+        # Extract and store proxy server info
+        proxyserver = ctx.master.addons.get("proxyserver")
+        if proxyserver and proxyserver.servers:
+            first_server = next(iter(proxyserver.servers))
+            if first_server.listen_addrs:
+                host, port = first_server.listen_addrs[0][:2]
+                app.config["PROXY_HOST"] = host if host else "127.0.0.1"
+                app.config["PROXY_PORT"] = port
+            else:
+                app.config["PROXY_HOST"] = ctx.options.listen_host or "127.0.0.1"
+                app.config["PROXY_PORT"] = ctx.options.listen_port or 8080
+        else:
+            app.config["PROXY_HOST"] = ctx.options.listen_host or "127.0.0.1"
+            app.config["PROXY_PORT"] = ctx.options.listen_port or 8080
+
+        app.config["CONFDIR"] = ctx.options.confdir
+
+    async def request(self, f):
+        if ctx.options.setup_terminal:
+            await super().request(f)

--- a/mitmproxy/addons/setup_terminal/__init__.py
+++ b/mitmproxy/addons/setup_terminal/__init__.py
@@ -16,7 +16,7 @@ def get_setup_vars():
     """Get proxy and certificate variables for setup scripts."""
     proxy_host = app.config.get("PROXY_HOST", "127.0.0.1")
     proxy_port = app.config.get("PROXY_PORT", 8080)
-    confdir = app.config.get("CONFDIR")
+    confdir = app.config.get("CONFDIR", "~/.mitmproxy")
 
     confdir = os.path.expanduser(confdir)
     proxy_url = f"http://{proxy_host}:{proxy_port}"
@@ -96,7 +96,7 @@ class SetupTerminal(asgiapp.WSGIApp):
     name = "setup_terminal"
 
     def __init__(self):
-        super().__init__(app, None, None)
+        super().__init__(app, "", None)
 
     def should_serve(self, flow: http.HTTPFlow) -> bool:
         """Serve setup endpoints on any host."""

--- a/mitmproxy/addons/setup_terminal/__init__.py
+++ b/mitmproxy/addons/setup_terminal/__init__.py
@@ -36,25 +36,27 @@ def setup():
     confdir = app.config.get("CONFDIR")
 
     base_url = f"http://{proxy_host}:{proxy_port}"
-    return jsonify({
-        "proxy_url": f"{proxy_host}:{proxy_port}",
-        "proxy_host": proxy_host,
-        "proxy_port": proxy_port,
-        "certificates": {
-            "pem": f"{confdir}/mitmproxy-ca-cert.pem",
-            "p12": f"{confdir}/mitmproxy-ca-cert.p12",
-            "cer": f"{confdir}/mitmproxy-ca-cert.cer",
-        },
-        "setup_scripts": {
-            "sh": f"{base_url}/setup.sh",
-            "bash": f"{base_url}/setup.sh",
-            "zsh": f"{base_url}/setup.sh",
-            "ksh": f"{base_url}/setup.sh",
-            "fish": f"{base_url}/setup.fish",
-            "powershell": f"{base_url}/setup.ps1",
-            "pwsh": f"{base_url}/setup.ps1",
-        },
-    })
+    return jsonify(
+        {
+            "proxy_url": f"{proxy_host}:{proxy_port}",
+            "proxy_host": proxy_host,
+            "proxy_port": proxy_port,
+            "certificates": {
+                "pem": f"{confdir}/mitmproxy-ca-cert.pem",
+                "p12": f"{confdir}/mitmproxy-ca-cert.p12",
+                "cer": f"{confdir}/mitmproxy-ca-cert.cer",
+            },
+            "setup_scripts": {
+                "sh": f"{base_url}/setup.sh",
+                "bash": f"{base_url}/setup.sh",
+                "zsh": f"{base_url}/setup.sh",
+                "ksh": f"{base_url}/setup.sh",
+                "fish": f"{base_url}/setup.fish",
+                "powershell": f"{base_url}/setup.ps1",
+                "pwsh": f"{base_url}/setup.ps1",
+            },
+        }
+    )
 
 
 @app.route("/setup.sh")
@@ -99,17 +101,11 @@ class SetupTerminal(asgiapp.WSGIApp):
     def should_serve(self, flow: http.HTTPFlow) -> bool:
         """Serve setup endpoints on any host."""
         setup_paths = {"/setup", "/setup.sh", "/setup.fish", "/setup.ps1"}
-        return (
-            flow.request.path in setup_paths
-            and flow.live
-        )
+        return flow.request.path in setup_paths and flow.live
 
     def load(self, loader):
         loader.add_option(
-            "setup_terminal",
-            bool,
-            True,
-            "Toggle the mitmproxy terminal setup app."
+            "setup_terminal", bool, True, "Toggle the mitmproxy terminal setup app."
         )
 
     def configure(self, updated):

--- a/mitmproxy/addons/setup_terminal/templates/setup.fish
+++ b/mitmproxy/addons/setup_terminal/templates/setup.fish
@@ -1,0 +1,27 @@
+set -gx HTTP_PROXY "{{ proxy_url }}"
+set -gx HTTPS_PROXY "{{ proxy_url }}"
+set -gx http_proxy "{{ proxy_url }}"
+set -gx https_proxy "{{ proxy_url }}"
+set -gx WS_PROXY "{{ proxy_url }}"
+set -gx WSS_PROXY "{{ proxy_url }}"
+set -gx GLOBAL_AGENT_HTTP_PROXY "{{ proxy_url }}"
+set -gx CGI_HTTP_PROXY "{{ proxy_url }}"
+set -gx npm_config_proxy "{{ proxy_url }}"
+set -gx npm_config_https_proxy "{{ proxy_url }}"
+set -gx npm_config_scripts_prepend_node_path "false"
+set -gx SSL_CERT_FILE "{{ cert_path }}"
+set -gx NODE_EXTRA_CA_CERTS "{{ cert_path }}"
+set -gx DENO_CERT "{{ cert_path }}"
+set -gx PERL_LWP_SSL_CA_FILE "{{ cert_path }}"
+set -gx GIT_SSL_CAINFO "{{ cert_path }}"
+set -gx CARGO_HTTP_CAINFO "{{ cert_path }}"
+set -gx CURL_CA_BUNDLE "{{ cert_path }}"
+set -gx AWS_CA_BUNDLE "{{ cert_path }}"
+set -gx MITMPROXY_ACTIVE "true"
+
+if command -v winpty >/dev/null 2>&1
+    alias php=php
+    alias node=node
+end
+
+echo 'mitmproxy interception enabled'

--- a/mitmproxy/addons/setup_terminal/templates/setup.ps1
+++ b/mitmproxy/addons/setup_terminal/templates/setup.ps1
@@ -1,0 +1,41 @@
+$MITMPROXY_envVars = Get-ChildItem Env:
+
+$Env:HTTP_PROXY = "{{ proxy_url }}"
+$Env:HTTPS_PROXY = "{{ proxy_url }}"
+$Env:http_proxy = "{{ proxy_url }}"
+$Env:https_proxy = "{{ proxy_url }}"
+$Env:WS_PROXY = "{{ proxy_url }}"
+$Env:WSS_PROXY = "{{ proxy_url }}"
+$Env:GLOBAL_AGENT_HTTP_PROXY = "{{ proxy_url }}"
+$Env:CGI_HTTP_PROXY = "{{ proxy_url }}"
+$Env:npm_config_proxy = "{{ proxy_url }}"
+$Env:npm_config_https_proxy = "{{ proxy_url }}"
+$Env:npm_config_scripts_prepend_node_path = "false"
+$Env:SSL_CERT_FILE = "{{ cert_path }}"
+$Env:NODE_EXTRA_CA_CERTS = "{{ cert_path }}"
+$Env:DENO_CERT = "{{ cert_path }}"
+$Env:PERL_LWP_SSL_CA_FILE = "{{ cert_path }}"
+$Env:GIT_SSL_CAINFO = "{{ cert_path }}"
+$Env:CARGO_HTTP_CAINFO = "{{ cert_path }}"
+$Env:CURL_CA_BUNDLE = "{{ cert_path }}"
+$Env:AWS_CA_BUNDLE = "{{ cert_path }}"
+$Env:MITMPROXY_ACTIVE = "true"
+
+function Stop-Intercepting {
+    $currentEnvVars = Get-ChildItem Env:
+    foreach ($envVar in $currentEnvVars) {
+        [System.Environment]::SetEnvironmentVariable($envVar.Name, $null)
+    }
+    foreach ($var in $MITMPROXY_envVars) {
+        [System.Environment]::SetEnvironmentVariable($var.Name, $var.Value)
+    }
+    $PSDefaultParameterValues.Remove("invoke-webrequest:proxy")
+    $PSDefaultParameterValues.Remove("invoke-webrequest:SkipCertificateCheck")
+    Write-Host 'mitmproxy interception disabled'
+}
+
+$PSDefaultParameterValues["invoke-webrequest:proxy"] = $Env:HTTP_PROXY
+$PSDefaultParameterValues["invoke-webrequest:SkipCertificateCheck"] = $True
+
+Write-Host "mitmproxy interception enabled`nTo stop intercepting type " -NoNewline
+Write-Host "Stop-Intercepting" -ForegroundColor Red

--- a/mitmproxy/addons/setup_terminal/templates/setup.sh
+++ b/mitmproxy/addons/setup_terminal/templates/setup.sh
@@ -1,0 +1,27 @@
+export HTTP_PROXY="{{ proxy_url }}"
+export HTTPS_PROXY="{{ proxy_url }}"
+export http_proxy="{{ proxy_url }}"
+export https_proxy="{{ proxy_url }}"
+export WS_PROXY="{{ proxy_url }}"
+export WSS_PROXY="{{ proxy_url }}"
+export GLOBAL_AGENT_HTTP_PROXY="{{ proxy_url }}"
+export CGI_HTTP_PROXY="{{ proxy_url }}"
+export npm_config_proxy="{{ proxy_url }}"
+export npm_config_https_proxy="{{ proxy_url }}"
+export npm_config_scripts_prepend_node_path="false"
+export SSL_CERT_FILE="{{ cert_path }}"
+export NODE_EXTRA_CA_CERTS="{{ cert_path }}"
+export DENO_CERT="{{ cert_path }}"
+export PERL_LWP_SSL_CA_FILE="{{ cert_path }}"
+export GIT_SSL_CAINFO="{{ cert_path }}"
+export CARGO_HTTP_CAINFO="{{ cert_path }}"
+export CURL_CA_BUNDLE="{{ cert_path }}"
+export AWS_CA_BUNDLE="{{ cert_path }}"
+export MITMPROXY_ACTIVE="true"
+
+if command -v winpty >/dev/null 2>&1; then
+    alias php=php
+    alias node=node
+fi
+
+echo 'mitmproxy interception enabled'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,6 +157,7 @@ exclude = [
   "mitmproxy/addons/__init__.py",
   "mitmproxy/addons/onboarding.py",
   "mitmproxy/addons/onboardingapp/__init__.py",
+  "mitmproxy/addons/setup_terminal/__init__.py",
   "mitmproxy/contentviews/__init__.py",
   "mitmproxy/contentviews/base.py",
   "mitmproxy/contentviews/grpc.py",

--- a/test/mitmproxy/addons/test_setup_terminal.py
+++ b/test/mitmproxy/addons/test_setup_terminal.py
@@ -132,7 +132,9 @@ class TestSetupTerminal:
 
         addon = setup_terminal.SetupTerminal()
         with taddons.context(addon) as tctx:
-            tctx.configure(addon, confdir=tdata.path("mitmproxy/data/confdir"), setup_terminal=True)
+            tctx.configure(
+                addon, confdir=tdata.path("mitmproxy/data/confdir"), setup_terminal=True
+            )
             f = tflow.tflow()
             f.request.path = "/setup"
             # Just verify it doesn't raise an error
@@ -144,7 +146,11 @@ class TestSetupTerminal:
 
         addon = setup_terminal.SetupTerminal()
         with taddons.context(addon) as tctx:
-            tctx.configure(addon, confdir=tdata.path("mitmproxy/data/confdir"), setup_terminal=False)
+            tctx.configure(
+                addon,
+                confdir=tdata.path("mitmproxy/data/confdir"),
+                setup_terminal=False,
+            )
             f = tflow.tflow()
             f.request.path = "/setup"
             # Should not call super().request() when disabled
@@ -163,7 +169,7 @@ class TestSetupTerminal:
             mock_server.listen_addrs = [("127.0.0.1", 9999)]
             mock_proxyserver.servers = [mock_server]
 
-            with patch.object(tctx.master.addons, 'get', return_value=mock_proxyserver):
+            with patch.object(tctx.master.addons, "get", return_value=mock_proxyserver):
                 tctx.configure(addon, confdir=tdata.path("mitmproxy/data/confdir"))
 
                 # Verify proxy config was set from proxyserver
@@ -183,7 +189,7 @@ class TestSetupTerminal:
             mock_server.listen_addrs = []
             mock_proxyserver.servers = [mock_server]
 
-            with patch.object(tctx.master.addons, 'get', return_value=mock_proxyserver):
+            with patch.object(tctx.master.addons, "get", return_value=mock_proxyserver):
                 tctx.configure(addon, confdir=tdata.path("mitmproxy/data/confdir"))
 
                 # Should fall back to options

--- a/test/mitmproxy/addons/test_setup_terminal.py
+++ b/test/mitmproxy/addons/test_setup_terminal.py
@@ -109,3 +109,19 @@ class TestSetupTerminal:
             tctx.configure(addon, confdir=tdata.path("mitmproxy/data/confdir"))
             # Verify Flask app config was updated
             assert setup_terminal.app.config.get("CONFDIR") is not None
+
+    def test_should_serve(self):
+        """Test should_serve method correctly identifies setup paths."""
+        addon = setup_terminal.SetupTerminal()
+        from mitmproxy.test import tflow
+
+        # Test setup paths are served
+        for path in ["/setup", "/setup.sh", "/setup.fish", "/setup.ps1"]:
+            f = tflow.tflow()
+            f.request.path = path
+            assert addon.should_serve(f)
+
+        # Test other paths are not served
+        f = tflow.tflow()
+        f.request.path = "/other"
+        assert not addon.should_serve(f)

--- a/test/mitmproxy/addons/test_setup_terminal.py
+++ b/test/mitmproxy/addons/test_setup_terminal.py
@@ -1,0 +1,111 @@
+import json
+
+import pytest
+
+from mitmproxy.addons import setup_terminal
+from mitmproxy.test import taddons
+
+
+@pytest.fixture
+def client():
+    with setup_terminal.app.test_client() as client:
+        yield client
+
+
+class TestSetupTerminal:
+    def test_setup_json(self, client, tdata):
+        """Test /setup endpoint returns valid JSON with proxy config."""
+        addon = setup_terminal.SetupTerminal()
+        with taddons.context(addon) as tctx:
+            tctx.configure(addon, confdir=tdata.path("mitmproxy/data/confdir"))
+            resp = client.get("/setup")
+            assert resp.status_code == 200
+            assert "application/json" in resp.content_type
+
+            data = json.loads(resp.data)
+            assert "proxy_url" in data
+            assert "proxy_host" in data
+            assert "proxy_port" in data
+            assert "certificates" in data
+            assert "setup_scripts" in data
+
+            # Check proxy format
+            assert ":" in data["proxy_url"]
+            assert data["proxy_port"] == 8080
+
+            # Check certificate paths
+            assert data["certificates"]["pem"].endswith(".pem")
+            assert data["certificates"]["p12"].endswith(".p12")
+            assert data["certificates"]["cer"].endswith(".cer")
+
+            # Check setup scripts with shell aliases
+            assert data["setup_scripts"]["sh"] == data["setup_scripts"]["bash"]
+            assert data["setup_scripts"]["bash"] == data["setup_scripts"]["zsh"]
+            assert data["setup_scripts"]["zsh"] == data["setup_scripts"]["ksh"]
+            assert data["setup_scripts"]["fish"].endswith("/setup.fish")
+            assert data["setup_scripts"]["powershell"] == data["setup_scripts"]["pwsh"]
+            assert data["setup_scripts"]["powershell"].endswith("/setup.ps1")
+
+    def test_setup_sh_endpoint(self, client, tdata):
+        """Test /setup.sh endpoint returns bash script."""
+        addon = setup_terminal.SetupTerminal()
+        with taddons.context(addon) as tctx:
+            tctx.configure(addon, confdir=tdata.path("mitmproxy/data/confdir"))
+            resp = client.get("/setup.sh")
+            assert resp.status_code == 200
+            assert "text/x-shellscript" in resp.content_type
+            assert b"export HTTP_PROXY=" in resp.data
+            assert b"export HTTPS_PROXY=" in resp.data
+            assert b"export MITMPROXY_ACTIVE=" in resp.data
+
+    def test_setup_fish_endpoint(self, client, tdata):
+        """Test /setup.fish endpoint returns fish script."""
+        addon = setup_terminal.SetupTerminal()
+        with taddons.context(addon) as tctx:
+            tctx.configure(addon, confdir=tdata.path("mitmproxy/data/confdir"))
+            resp = client.get("/setup.fish")
+            assert resp.status_code == 200
+            assert resp.content_type == "application/x-fish"
+            assert b"set -gx HTTP_PROXY" in resp.data
+            assert b"set -gx HTTPS_PROXY" in resp.data
+            assert b"set -gx MITMPROXY_ACTIVE" in resp.data
+
+    def test_setup_ps1_endpoint(self, client, tdata):
+        """Test /setup.ps1 endpoint returns PowerShell script."""
+        addon = setup_terminal.SetupTerminal()
+        with taddons.context(addon) as tctx:
+            tctx.configure(addon, confdir=tdata.path("mitmproxy/data/confdir"))
+            resp = client.get("/setup.ps1")
+            assert resp.status_code == 200
+            assert "text/plain" in resp.content_type
+            assert b"$Env:HTTP_PROXY" in resp.data
+            assert b"$Env:HTTPS_PROXY" in resp.data
+            assert b"Stop-Intercepting" in resp.data
+
+    def test_setup_vars_interpolation(self, client, tdata):
+        """Test that setup variables are correctly interpolated."""
+        addon = setup_terminal.SetupTerminal()
+        with taddons.context(addon) as tctx:
+            tctx.configure(addon, confdir=tdata.path("mitmproxy/data/confdir"))
+            resp = client.get("/setup.sh")
+            content = resp.data.decode()
+
+            # Check that proxy variables are interpolated (not template strings)
+            assert "{{ proxy_url }}" not in content
+            assert "{{ cert_path }}" not in content
+            # Should contain actual values
+            assert "http://" in content
+            assert ".pem" in content
+
+    def test_addon_initialization(self, tdata):
+        """Test addon initializes correctly."""
+        addon = setup_terminal.SetupTerminal()
+        assert addon.name == "setup_terminal"
+
+    def test_addon_configure(self, tdata):
+        """Test addon configure method sets Flask config."""
+        addon = setup_terminal.SetupTerminal()
+        with taddons.context(addon) as tctx:
+            tctx.configure(addon, confdir=tdata.path("mitmproxy/data/confdir"))
+            # Verify Flask app config was updated
+            assert setup_terminal.app.config.get("CONFDIR") is not None

--- a/web/src/js/ducks/_options_gen.ts
+++ b/web/src/js/ducks/_options_gen.ts
@@ -68,6 +68,7 @@ export interface OptionsState {
     server_replay_refresh: boolean;
     server_replay_reuse: boolean;
     server_replay_use_headers: string[];
+    setup_terminal: boolean;
     show_ignored_hosts: boolean;
     showhost: boolean;
     ssl_insecure: boolean;
@@ -175,6 +176,7 @@ export const defaultState: OptionsState = {
     server_replay_refresh: true,
     server_replay_reuse: false,
     server_replay_use_headers: [],
+    setup_terminal: true,
     show_ignored_hosts: false,
     showhost: false,
     ssl_insecure: false,


### PR DESCRIPTION
#### Description

Implements terminal setup endpoints for automatic shell environment configuration, similar to HTTP Toolkit. Users can now easily configure their proxy settings by running a single command.

I personally prefer mitmproxy over http toolkit, but to be honest what I missed the most was the auto setup script. I'm used to call my local proxy setup script like this `source ./setup-term-proxy 8000` which does basically what is in this PR.

#### What's New

- **New addon**: `setup_terminal` that provides setup endpoints on any proxy address/port
- **4 endpoints**:
  - `/setup` - Returns JSON with proxy configuration and certificate paths
  - `/setup.sh` - Bash script with environment variables (works with sh, bash, zsh, ksh)
  - `/setup.fish` - Fish shell script
  - `/setup.ps1` - PowerShell script with `Stop-Intercepting` function

#### Usage

```bash
# Bash/Zsh/Ksh
eval "$(curl -sS http://127.0.0.1:8080/setup.sh)"

# Fish
source (curl -sS http://127.0.0.1:8080/setup.fish | psub)

# PowerShell
. (curl -Uri http://127.0.0.1:8080/setup.ps1).Content
```
**What Gets Configured**

- Proxy variables: HTTP_PROXY, HTTPS_PROXY, WS_PROXY, WSS_PROXY, npm_config_proxy, etc.
- Certificate paths: SSL_CERT_FILE, NODE_EXTRA_CA_CERTS, GIT_SSL_CAINFO, CARGO_HTTP_CAINFO, etc.
- Shell aliases: winpty compatibility on Windows (just like http toolkit)

**Documentation**

Added docs/src/content/howto/automatic-shell-setup.md with:
- Quick start for each shell
- Available endpoints documentation
- Environment variables reference
- Programmatic access examples

#### Checklist

- [x] I have updated tests where applicable.
- [x] I have added an entry to the CHANGELOG.
