### PR TITLE
Option to hide quickhelp UI (#5746)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
   ([#8046](https://github.com/mitmproxy/mitmproxy/pull/8046), @HueCodes)
 - Added support for adding and editing comments on individual flows in the mitmproxy console.
   ([#7944](https://github.com/mitmproxy/mitmproxy/pull/7944), @lups2000)
-- Be able to hide quickhelp UI
+- Allow hiding the Quick Help UI in the mitmproxy console with the 'H' key.
   ([#8095](https://github.com/mitmproxy/mitmproxy/pull/8095), @seroperson)
 
 ## 24 November 2025: mitmproxy 12.2.1

--- a/mitmproxy/tools/console/consoleaddons.py
+++ b/mitmproxy/tools/console/consoleaddons.py
@@ -118,7 +118,7 @@ class ConsoleAddon:
             "Strip trailing newlines from edited request/response bodies.",
         )
         loader.add_option(
-            "console_quickhelp",
+            "console_quickhelp_visible",
             bool,
             True,
             "Show the quick help bar at the bottom of the console.",

--- a/mitmproxy/tools/console/defaultkeys.py
+++ b/mitmproxy/tools/console/defaultkeys.py
@@ -18,7 +18,12 @@ def map(km: Keymap) -> None:
     km.add("Q", "console.exit", ["global"], "Exit immediately")
     km.add("q", "console.view.pop", ["commonkey", "global"], "Exit the current view")
     km.add("esc", "console.view.pop", ["commonkey", "global"], "Exit the current view")
-    km.add("H", "set console_quickhelp toggle", ["global"], "Toggle quick help bar")
+    km.add(
+        "H",
+        "set console_quickhelp_visible toggle",
+        ["global"],
+        "Toggle quick help bar visibility",
+    )
     km.add("-", "console.layout.cycle", ["global"], "Cycle to next layout")
     km.add("ctrl right", "console.panes.next", ["global"], "Focus next layout pane")
     km.add("ctrl left", "console.panes.prev", ["global"], "Focus previous layout pane")

--- a/mitmproxy/tools/console/statusbar.py
+++ b/mitmproxy/tools/console/statusbar.py
@@ -64,7 +64,7 @@ class ActionBar(urwid.WidgetWrap):
         signals.window_refresh.connect(self.sig_update)
         master.view.focus.sig_change.connect(self.sig_update)
         master.view.sig_view_update.connect(self.sig_update)
-        master.options.subscribe(self.sig_options_update, ["console_quickhelp"])
+        master.options.subscribe(self.sig_options_update, ["console_quickhelp_visible"])
 
         self.prompting: Callable[[str], None] | None = None
 
@@ -173,7 +173,7 @@ class ActionBar(urwid.WidgetWrap):
                     return k
 
     def show_quickhelp(self) -> None:
-        if not self.master.options.console_quickhelp:
+        if not self.master.options.console_quickhelp_visible:
             self._w = urwid.Pile([])
             return
         self.ensure_bottom_bar_is_visible()

--- a/test/mitmproxy/tools/console/test_statusbar.py
+++ b/test/mitmproxy/tools/console/test_statusbar.py
@@ -1,4 +1,5 @@
 import pytest
+import urwid
 
 from mitmproxy.tools.console import statusbar
 
@@ -65,12 +66,10 @@ def test_shorten_message_narrow():
 
 async def test_console_quickhelp_option(console, monkeypatch):
     """Test that console_quickhelp option controls the display of quick help bar."""
-    import urwid
-
     monkeypatch.setattr(statusbar.StatusBar, "refresh", lambda x: None)
 
     # quickhelp enabled (default)
-    console.options.console_quickhelp = True
+    console.options.console_quickhelp_visible = True
     bar = statusbar.StatusBar(console)
     assert isinstance(bar.ab._w, urwid.Pile)
     assert len(bar.ab._w.contents) == 2
@@ -78,7 +77,7 @@ async def test_console_quickhelp_option(console, monkeypatch):
     assert isinstance(bar.ab.bottom._w, urwid.Columns)
 
     # quickhelp disabled
-    console.options.console_quickhelp = False
+    console.options.console_quickhelp_visible = False
     bar2 = statusbar.StatusBar(console)
     assert isinstance(bar2.ab._w, urwid.Pile)
     assert len(bar2.ab._w.contents) == 0
@@ -86,14 +85,12 @@ async def test_console_quickhelp_option(console, monkeypatch):
 
 async def test_console_quickhelp_toggle(console, monkeypatch):
     """Test that toggling console_quickhelp option updates the display."""
-    import urwid
-
     monkeypatch.setattr(statusbar.StatusBar, "refresh", lambda x: None)
 
     bar = statusbar.StatusBar(console)
 
     # quickhelp enabled (default)
-    assert console.options.console_quickhelp is True
+    assert console.options.console_quickhelp_visible is True
     bar.ab.show_quickhelp()
     assert isinstance(bar.ab._w, urwid.Pile)
     assert len(bar.ab._w.contents) == 2
@@ -101,13 +98,13 @@ async def test_console_quickhelp_toggle(console, monkeypatch):
     assert isinstance(bar.ab.bottom._w, urwid.Columns)
 
     # quickhelp disabled
-    console.options.console_quickhelp = False
+    console.options.console_quickhelp_visible = False
     bar.ab.show_quickhelp()
     assert isinstance(bar.ab._w, urwid.Pile)
     assert len(bar.ab._w.contents) == 0
 
     # quickhelp toggling
-    console.options.console_quickhelp = True
+    console.options.console_quickhelp_visible = True
     bar.ab.show_quickhelp()
     assert isinstance(bar.ab._w, urwid.Pile)
     assert len(bar.ab._w.contents) == 2
@@ -117,23 +114,21 @@ async def test_console_quickhelp_toggle(console, monkeypatch):
 
 async def test_console_quickhelp_hotkey(console):
     """Test that the 'H' hotkey toggles the console_quickhelp option."""
-    assert console.options.console_quickhelp is True
+    assert console.options.console_quickhelp_visible is True
 
     console.type("H")
-    assert console.options.console_quickhelp is False
+    assert console.options.console_quickhelp_visible is False
 
     console.type("H")
-    assert console.options.console_quickhelp is True
+    assert console.options.console_quickhelp_visible is True
 
 
 async def test_console_quickhelp_prompts_visible_when_disabled(console, monkeypatch):
     """Test that prompts and messages are visible even when quickhelp is disabled."""
-    import urwid
-
     monkeypatch.setattr(statusbar.StatusBar, "refresh", lambda x: None)
 
     # Disable quickhelp
-    console.options.console_quickhelp = False
+    console.options.console_quickhelp_visible = False
     bar = statusbar.StatusBar(console)
 
     # Initially, Pile should be empty (quickhelp disabled)


### PR DESCRIPTION
#### Description

Now you can hide bottom bar using "H" hotkey, option `console_quickhelp`. It will be restored back on prompt or some confirmation dialogs.

#### Checklist

 - [✅] I have updated tests where applicable.
 - [✅] I have added an entry to the CHANGELOG.

Closes #5746