### PR TITLE
fix: show helpful hint on WireGuard port conflicts

### DIFF
--- a/mitmproxy/proxy/mode_servers.py
+++ b/mitmproxy/proxy/mode_servers.py
@@ -256,14 +256,24 @@ class AsyncioServerInstance(ServerInstance[M], metaclass=ABCMeta):
         assert port is not None
         try:
             self._servers = await self.listen(host, port)
-        except OSError as e:
-            message = f"{self.mode.description} failed to listen on {host or '*'}:{port} with {e}"
-            if e.errno == errno.EADDRINUSE and self.mode.custom_listen_port is None:
+        except Exception as e:
+            # `mitmproxy_rs` exceptions don't always inherit from OSError.
+            # In particular, port conflicts may bubble up as a generic exception
+            # with the familiar "Address already in use" message.
+            if isinstance(e, OSError):
+                err: OSError = e
+            elif "Address already in use" in str(e):
+                err = OSError(errno.EADDRINUSE, str(e))
+            else:
+                raise
+
+            message = f"{self.mode.description} failed to listen on {host or '*'}:{port} with {err}"
+            if err.errno == errno.EADDRINUSE and self.mode.custom_listen_port is None:
                 assert (
                     self.mode.custom_listen_host is None
                 )  # since [@ [listen_addr:]listen_port]
                 message += f"\nTry specifying a different port by using `--mode {self.mode.full_spec}@{port + 2}`."
-            raise OSError(e.errno, message, e.filename) from e
+            raise OSError(err.errno, message, err.filename) from e
 
     async def _stop(self) -> None:
         assert self._servers

--- a/test/mitmproxy/proxy/test_mode_servers.py
+++ b/test/mitmproxy/proxy/test_mode_servers.py
@@ -291,6 +291,31 @@ async def test_wireguard_invalid_conf(tmp_path):
         assert "Invalid configuration file" in repr(inst.last_exception)
 
 
+async def test_wireguard_start_port_in_use_has_hint(monkeypatch, tmp_path):
+    """Regression test for https://github.com/mitmproxy/mitmproxy/issues/7650.
+
+    `mitmproxy_rs` may raise a generic exception for EADDRINUSE instead of OSError.
+    We still want a helpful error message with a port-change hint.
+    """
+
+    async def _boom(*args, **kwargs):
+        raise RuntimeError("Address already in use (os error 48)")
+
+    with taddons.context(Proxyserver()) as tctx:
+        tctx.options.confdir = str(tmp_path)
+        inst = WireGuardServerInstance.make("wireguard@51821", MagicMock())
+        monkeypatch.setattr(mitmproxy_rs.wireguard, "start_wireguard_server", _boom)
+
+        with pytest.raises(
+            OSError,
+            match=r"WireGuard server failed to listen on .*:51821.*Address already in use",
+        ) as excinfo:
+            await inst.start()
+
+        # Should include a concrete suggestion for how to pick a different port.
+        assert "Try specifying a different port" in str(excinfo.value)
+
+
 async def test_tcp_start_error():
     manager = MagicMock()
 


### PR DESCRIPTION
Closes #7650

### Problem
WireGuard mode can fail to start with an "address already in use" error, but the message lacks the usual hint suggesting to pick a different port.

### Solution
Extend the listener startup error handling so that WireGuard port-conflict exceptions (including non-OSError exceptions from the Rust backend) get wrapped into an OSError with the same helpful hint text used in other modes.

### Testing
Added a regression test for the WireGuard port-conflict case.