### PR TITLE
Add a Clear Screen button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@
   ([#8046](https://github.com/mitmproxy/mitmproxy/pull/8046), @HueCodes)
 - Added support for adding and editing comments on individual flows in the mitmproxy console.
   ([#7944](https://github.com/mitmproxy/mitmproxy/pull/7944), @lups2000)
+- Add a Clear Screen button to mitmweb for easier access.
+  ([#8121](https://github.com/mitmproxy/mitmproxy/pull/8121), @iBug)
 
 ## 24 November 2025: mitmproxy 12.2.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@
   ([#7944](https://github.com/mitmproxy/mitmproxy/pull/7944), @lups2000)
 - Allow hiding the Quick Help UI in the mitmproxy console with the 'H' key.
   ([#8095](https://github.com/mitmproxy/mitmproxy/pull/8095), @seroperson)
-- Add a Clear Screen button to mitmweb for easier access.
+- Add an additional “Clear All Flows” button in mitmweb for easier access.
   ([#8121](https://github.com/mitmproxy/mitmproxy/pull/8121), @iBug)
 
 ## 24 November 2025: mitmproxy 12.2.1

--- a/web/src/js/__tests__/components/Header/MainMenuSpec.tsx
+++ b/web/src/js/__tests__/components/Header/MainMenuSpec.tsx
@@ -1,8 +1,25 @@
 import * as React from "react";
-import FlowListMenu from "../../../components/Header/FlowListMenu";
-import { render } from "../../test-utils";
+import FlowListMenu, {
+    ClearAll,
+} from "../../../components/Header/FlowListMenu";
+import { fireEvent, render, screen } from "../../test-utils";
+import { enableFetchMocks } from "jest-fetch-mock";
+
+enableFetchMocks();
 
 test("MainMenu", () => {
     const { asFragment } = render(<FlowListMenu />);
     expect(asFragment()).toMatchSnapshot();
+});
+
+test("ClearAll dispatches clear action", async () => {
+    fetchMock.mockOnce("", { status: 200 });
+
+    render(<ClearAll />);
+    fireEvent.click(screen.getByText("Clear All"));
+
+    expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringContaining("/clear"),
+        expect.objectContaining({ method: "POST" }),
+    );
 });

--- a/web/src/js/__tests__/components/Header/__snapshots__/MainMenuSpec.tsx.snap
+++ b/web/src/js/__tests__/components/Header/__snapshots__/MainMenuSpec.tsx.snap
@@ -92,7 +92,7 @@ exports[`MainMenu 1`] = `
           title="clear the front-end flow cache"
         >
           <i
-            class="fa iconfont icon-edit-clear-svgrepo-com text-danger"
+            class="fa fa-trash text-danger"
           />
            Clear All
         </button>

--- a/web/src/js/__tests__/components/Header/__snapshots__/MainMenuSpec.tsx.snap
+++ b/web/src/js/__tests__/components/Header/__snapshots__/MainMenuSpec.tsx.snap
@@ -94,7 +94,7 @@ exports[`MainMenu 1`] = `
           <i
             class="fa iconfont icon-edit-clear-svgrepo-com text-danger"
           />
-           Clear Screen
+           Clear All
         </button>
       </div>
       <div

--- a/web/src/js/__tests__/components/Header/__snapshots__/MainMenuSpec.tsx.snap
+++ b/web/src/js/__tests__/components/Header/__snapshots__/MainMenuSpec.tsx.snap
@@ -87,6 +87,15 @@ exports[`MainMenu 1`] = `
           />
            Resume All
         </button>
+        <button
+          class="btn-sm btn btn-default"
+          title="clear the front-end flow cache"
+        >
+          <i
+            class="fa iconfont icon-edit-clear-svgrepo-com text-danger"
+          />
+           Clear Screen
+        </button>
       </div>
       <div
         class="menu-legend"

--- a/web/src/js/components/Header/FlowListMenu.tsx
+++ b/web/src/js/components/Header/FlowListMenu.tsx
@@ -23,6 +23,7 @@ export default function FlowListMenu() {
                 <div className="menu-content">
                     <InterceptInput />
                     <ResumeAll />
+                    <ClearScreen />
                 </div>
                 <div className="menu-legend">Intercept</div>
             </div>
@@ -72,6 +73,16 @@ function HighlightInput() {
             onChange={(expr) => dispatch(setHighlight(expr))}
         />
     );
+}
+
+export function ClearScreen() {
+    const dispatch = useAppDispatch();
+    return (
+        <Button className="btn-sm" title="clear the front-end flow cache"
+                icon="iconfont icon-edit-clear-svgrepo-com text-danger" onClick={() => dispatch(flowsActions.clear())}>
+            Clear Screen
+        </Button>
+    )
 }
 
 export function ResumeAll() {

--- a/web/src/js/components/Header/FlowListMenu.tsx
+++ b/web/src/js/components/Header/FlowListMenu.tsx
@@ -23,7 +23,7 @@ export default function FlowListMenu() {
                 <div className="menu-content">
                     <InterceptInput />
                     <ResumeAll />
-                    <ClearScreen />
+                    <ClearAll />
                 </div>
                 <div className="menu-legend">Intercept</div>
             </div>
@@ -75,7 +75,7 @@ function HighlightInput() {
     );
 }
 
-export function ClearScreen() {
+export function ClearAll() {
     const dispatch = useAppDispatch();
     return (
         <Button
@@ -84,7 +84,7 @@ export function ClearScreen() {
             icon="iconfont icon-edit-clear-svgrepo-com text-danger"
             onClick={() => dispatch(flowsActions.clear())}
         >
-            Clear Screen
+            Clear All
         </Button>
     );
 }

--- a/web/src/js/components/Header/FlowListMenu.tsx
+++ b/web/src/js/components/Header/FlowListMenu.tsx
@@ -78,11 +78,15 @@ function HighlightInput() {
 export function ClearScreen() {
     const dispatch = useAppDispatch();
     return (
-        <Button className="btn-sm" title="clear the front-end flow cache"
-                icon="iconfont icon-edit-clear-svgrepo-com text-danger" onClick={() => dispatch(flowsActions.clear())}>
+        <Button
+            className="btn-sm"
+            title="clear the front-end flow cache"
+            icon="iconfont icon-edit-clear-svgrepo-com text-danger"
+            onClick={() => dispatch(flowsActions.clear())}
+        >
             Clear Screen
         </Button>
-    )
+    );
 }
 
 export function ResumeAll() {

--- a/web/src/js/components/Header/FlowListMenu.tsx
+++ b/web/src/js/components/Header/FlowListMenu.tsx
@@ -81,7 +81,7 @@ export function ClearAll() {
         <Button
             className="btn-sm"
             title="clear the front-end flow cache"
-            icon="iconfont icon-edit-clear-svgrepo-com text-danger"
+            icon="fa-trash text-danger"
             onClick={() => dispatch(flowsActions.clear())}
         >
             Clear All


### PR DESCRIPTION
#### Description

Add a "Clear Screen" button for easier access so users unbeknownst to the `z` keyboard shortcut can have an intuitive access to the functionality.

Preview:

<img width="516" height="216" alt="image" src="https://github.com/user-attachments/assets/4ed67f63-b19a-4693-8774-e39720f71eea" />


#### Checklist

 - [ ] I have updated tests where applicable.
 - [ ] I have added an entry to the CHANGELOG.
