### PR TITLE
Treat ALPN "grpc-exp" as HTTP/2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Reduce `CERT_EXPIRY` to 199 days.
   ([#8142](https://github.com/mitmproxy/mitmproxy/pull/8142), @opstic)
 - Treat ALPN "grpc-exp" as HTTP/2
+  ([#8150](https://github.com/mitmproxy/mitmproxy/pull/8150), @AlexTech01)
 
 ## 24 November 2025: mitmproxy 12.2.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
   ([#8136](https://github.com/mitmproxy/mitmproxy/pull/8136), @duriantaco)
 - Reduce `CERT_EXPIRY` to 199 days.
   ([#8142](https://github.com/mitmproxy/mitmproxy/pull/8142), @opstic)
+- Treat ALPN "grpc-exp" as HTTP/2
 
 ## 24 November 2025: mitmproxy 12.2.1
 

--- a/mitmproxy/addons/tlsconfig.py
+++ b/mitmproxy/addons/tlsconfig.py
@@ -299,7 +299,8 @@ class TlsConfig:
                     server.alpn_offers = tuple(client.alpn_offers)
                 else:
                     server.alpn_offers = tuple(
-                        x for x in client.alpn_offers if x != b"h2"
+                        x for x in client.alpn_offers
+                        if x not in (b"h2", b"grpc-exp")
                     )
             else:
                 # We either have no client TLS or a client without ALPN.

--- a/mitmproxy/addons/tlsconfig.py
+++ b/mitmproxy/addons/tlsconfig.py
@@ -299,8 +299,7 @@ class TlsConfig:
                     server.alpn_offers = tuple(client.alpn_offers)
                 else:
                     server.alpn_offers = tuple(
-                        x for x in client.alpn_offers
-                        if x not in (b"h2", b"grpc-exp")
+                        x for x in client.alpn_offers if x not in (b"h2", b"grpc-exp")
                     )
             else:
                 # We either have no client TLS or a client without ALPN.

--- a/mitmproxy/proxy/layers/http/__init__.py
+++ b/mitmproxy/proxy/layers/http/__init__.py
@@ -1088,10 +1088,9 @@ class HttpLayer(layer.Layer):
                         return
                     elif connection.connected:
                         # see "tricky multiplexing edge case" in make_http_connection for an explanation
-                        h2_to_h1 = (
-                            is_h2_alpn(self.context.client.alpn)
-                            and not is_h2_alpn(connection.alpn)
-                        )
+                        h2_to_h1 = is_h2_alpn(
+                            self.context.client.alpn
+                        ) and not is_h2_alpn(connection.alpn)
                         if not h2_to_h1:
                             stream = self.command_sources.pop(event)
                             yield from self.event_to_child(

--- a/mitmproxy/proxy/layers/http/__init__.py
+++ b/mitmproxy/proxy/layers/http/__init__.py
@@ -94,6 +94,10 @@ def validate_request(
     return None
 
 
+def is_h2_alpn(alpn: bytes | None) -> bool:
+    return alpn in (b"h2", b"grpc-exp")
+
+
 def is_h3_alpn(alpn: bytes | None) -> bool:
     return alpn == b"h3" or (alpn is not None and alpn.startswith(b"h3-"))
 
@@ -953,7 +957,7 @@ class HttpLayer(layer.Layer):
             http_conn: HttpConnection
             if is_h3_alpn(self.context.client.alpn):
                 http_conn = Http3Server(self.context.fork())
-            elif self.context.client.alpn == b"h2":
+            elif is_h2_alpn(self.context.client.alpn):
                 http_conn = Http2Server(self.context.fork())
             else:
                 http_conn = Http1Server(self.context.fork())
@@ -1003,7 +1007,7 @@ class HttpLayer(layer.Layer):
                     child_layer: HttpConnection
                     if is_h3_alpn(self.context.server.alpn):
                         child_layer = Http3Client(self.context.fork())
-                    elif self.context.server.alpn == b"h2":
+                    elif is_h2_alpn(self.context.server.alpn):
                         child_layer = Http2Client(self.context.fork())
                     else:
                         child_layer = Http1Client(self.context.fork())
@@ -1085,8 +1089,8 @@ class HttpLayer(layer.Layer):
                     elif connection.connected:
                         # see "tricky multiplexing edge case" in make_http_connection for an explanation
                         h2_to_h1 = (
-                            self.context.client.alpn == b"h2"
-                            and connection.alpn != b"h2"
+                            is_h2_alpn(self.context.client.alpn)
+                            and not is_h2_alpn(connection.alpn)
                         )
                         if not h2_to_h1:
                             stream = self.command_sources.pop(event)
@@ -1180,8 +1184,8 @@ class HttpLayer(layer.Layer):
             # same connection. The only workaround left is to open a separate connection for each flow.
             if (
                 not command.err
-                and self.context.client.alpn == b"h2"
-                and command.connection.alpn != b"h2"
+                and is_h2_alpn(self.context.client.alpn)
+                and not is_h2_alpn(command.connection.alpn)
             ):
                 for cmd in waiting[1:]:
                     yield from self.get_connection(cmd, reuse=False)
@@ -1201,7 +1205,7 @@ class HttpClient(layer.Layer):
         if not err:
             if is_h3_alpn(self.context.server.alpn):
                 self.child_layer = Http3Client(self.context)
-            elif self.context.server.alpn == b"h2":
+            elif is_h2_alpn(self.context.server.alpn):
                 self.child_layer = Http2Client(self.context)
             else:
                 self.child_layer = Http1Client(self.context)

--- a/mitmproxy/proxy/layers/tls.py
+++ b/mitmproxy/proxy/layers/tls.py
@@ -160,8 +160,9 @@ def dtls_parse_client_hello(data: bytes) -> ClientHello | None:
 
 HTTP1_ALPNS = (b"http/1.1", b"http/1.0", b"http/0.9")
 HTTP2_ALPN = b"h2"
+HTTP2_GRPC_EXP_ALPN = b"grpc-exp"
 HTTP3_ALPN = b"h3"
-HTTP_ALPNS = (HTTP3_ALPN, HTTP2_ALPN, *HTTP1_ALPNS)
+HTTP_ALPNS = (HTTP3_ALPN, HTTP2_ALPN, HTTP2_GRPC_EXP_ALPN, *HTTP1_ALPNS)
 
 
 # We need these classes as hooks can only have one argument at the moment.

--- a/test/mitmproxy/addons/test_next_layer.py
+++ b/test/mitmproxy/addons/test_next_layer.py
@@ -756,6 +756,15 @@ transparent_proxy_configs = [
     ),
     pytest.param(
         TConf(
+            before=[modes.TransparentProxy, ServerTLSLayer, ClientTLSLayer],
+            after=[modes.TransparentProxy, ServerTLSLayer, ClientTLSLayer, HttpLayer],
+            data_client=b"GO /method-too-short-for-heuristic HTTP/1.1\r\n",
+            alpn=b"grpc-exp",
+        ),
+        id="transparent proxy: grpc-exp via ALPN",
+    ),
+    pytest.param(
+        TConf(
             before=[modes.TransparentProxy],
             after=[modes.TransparentProxy, TCPLayer],
             server_address=("192.0.2.1", 23),

--- a/test/mitmproxy/addons/test_tlsconfig.py
+++ b/test/mitmproxy/addons/test_tlsconfig.py
@@ -55,7 +55,9 @@ def test_alpn_select_callback():
 
     # Test that grpc-exp is recognized as a valid HTTP ALPN
     conn.set_app_data(tlsconfig.AppData(server_alpn=None, http2=True, client_alpn=None))
-    assert tlsconfig.alpn_select_callback(conn, [b"grpc-exp", b"http/1.1"]) == b"grpc-exp"
+    assert (
+        tlsconfig.alpn_select_callback(conn, [b"grpc-exp", b"http/1.1"]) == b"grpc-exp"
+    )
 
     # Test no overlap
     assert (
@@ -465,7 +467,7 @@ class TestTlsConfig:
                 (b"grpc-exp", *proxy_tls.HTTP1_ALPNS),
                 (*proxy_tls.HTTP1_ALPNS,),
             )
-            
+
             assert_alpn(True, [], [])
             assert_alpn(False, [], [])
             ctx.client.timestamp_tls_setup = time.time()

--- a/test/mitmproxy/addons/test_tlsconfig.py
+++ b/test/mitmproxy/addons/test_tlsconfig.py
@@ -53,6 +53,10 @@ def test_alpn_select_callback():
     )
     assert tlsconfig.alpn_select_callback(conn, [b"qux", b"h2", b"http/1.1"]) == b"h2"
 
+    # Test that grpc-exp is recognized as a valid HTTP ALPN
+    conn.set_app_data(tlsconfig.AppData(server_alpn=None, http2=True, client_alpn=None))
+    assert tlsconfig.alpn_select_callback(conn, [b"grpc-exp", b"http/1.1"]) == b"grpc-exp"
+
     # Test no overlap
     assert (
         tlsconfig.alpn_select_callback(conn, [b"qux", b"quux"])
@@ -451,6 +455,17 @@ class TestTlsConfig:
                 (proxy_tls.HTTP2_ALPN, *proxy_tls.HTTP1_ALPNS, b"foo"),
                 (*proxy_tls.HTTP1_ALPNS, b"foo"),
             )
+            assert_alpn(
+                True,
+                (b"grpc-exp", *proxy_tls.HTTP1_ALPNS),
+                (b"grpc-exp", *proxy_tls.HTTP1_ALPNS),
+            )
+            assert_alpn(
+                False,
+                (b"grpc-exp", *proxy_tls.HTTP1_ALPNS),
+                (*proxy_tls.HTTP1_ALPNS,),
+            )
+            
             assert_alpn(True, [], [])
             assert_alpn(False, [], [])
             ctx.client.timestamp_tls_setup = time.time()


### PR DESCRIPTION
#### Description

This PR makes mitmproxy treat ALPN "grpc-exp" as HTTP/2, making it show properly as HTTP/2 in mitmproxy/mitmweb instead of as raw TCP. ALPN "grpc-exp" is used by some gRPC applications/servers instead of ALPN "h2", so this change makes it easier for users to mitm these applications without needing to patch them to use ALPN "h2" instead.

#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
