### PR TITLE
fix: guard against missing loop attribute in ConsoleMaster.done()

### DIFF
--- a/mitmproxy/tools/console/master.py
+++ b/mitmproxy/tools/console/master.py
@@ -59,6 +59,7 @@ class ConsoleMaster(master.Master):
         )
 
         self.window: window.Window | None = None
+        self.loop: urwid.MainLoop | None = None
 
     def __setattr__(self, name, value):
         super().__setattr__(name, value)
@@ -247,7 +248,8 @@ class ConsoleMaster(master.Master):
         await super().running()
 
     async def done(self):
-        self.loop.stop()
+        if self.loop:
+            self.loop.stop()
         await super().done()
 
     def overlay(self, widget, **kwargs):


### PR DESCRIPTION
## Summary
- Initialize `self.loop = None` in `ConsoleMaster.__init__()` to prevent `AttributeError` when `done()` is called before `running()` completes
- Guard `self.loop.stop()` with a None check in `done()`

## Problem
When the console is started without a TTY (or `running()` fails for any reason before creating the urwid MainLoop), `self.loop` is never assigned. The subsequent call to `done()` then raises:
```
AttributeError: 'ConsoleMaster' object has no attribute 'loop'
```

## Fix
Initialize `self.loop = None` in the constructor and add a guard before calling `.stop()` in `done()`.

Fixes #8162

🤖 Generated with [Claude Code](https://claude.com/claude-code)