### PR TITLE
Improve WireGuard port conflict error message

### DIFF
--- a/mitmproxy/proxy/mode_servers.py
+++ b/mitmproxy/proxy/mode_servers.py
@@ -372,7 +372,21 @@ class WireGuardServerInstance(AsyncioServerInstance[mode_specs.WireGuardMode]):
         self.pubkey = mitmproxy_rs.wireguard.pubkey(self.client_key)
         _ = mitmproxy_rs.wireguard.pubkey(self.server_key)
 
-        await super()._start()
+        try:
+            await super()._start()
+        except Exception as e:
+            # The Rust WireGuard layer raises a generic exception (not OSError)
+            # for port conflicts. Provide a user-friendly message with a fix hint.
+            err_str = str(e)
+            if "Address already in use" in err_str or "EADDRINUSE" in err_str:
+                port = self.mode.listen_port(ctx.options.listen_port)
+                host = self.mode.custom_listen_host or "*"
+                msg = (
+                    f"WireGuard server failed to listen on {host}:{port} with {e}\n"
+                    f"Try specifying a different port by using `--mode {self.mode.full_spec}@{port + 2}`."
+                )
+                raise OSError(errno.EADDRINUSE, msg) from e
+            raise
 
         conf = self.client_conf()
         assert conf


### PR DESCRIPTION
## Summary

Fixes #7650 — WireGuard mode shows a cryptic error message when the port is already in use.

## Problem

When running two WireGuard mode instances, the second one fails with:
```
Address already in use (os error 48)
Error logged during startup, exiting...
```

The Rust WireGuard layer raises a generic exception (not a Python `OSError`), so the existing user-friendly error handling in `AsyncioServerInstance._start()` doesn't catch it.

## Fix

Wrap `super()._start()` in `WireGuardServerInstance._start()` with a try/except that catches "Address already in use" errors from the Rust layer and re-raises with a clear message and port suggestion, consistent with how TCP port conflicts are already handled.

## After

```
WireGuard server failed to listen on *:51820 with Address already in use (os error 48)
Try specifying a different port by using `--mode wireguard@51822`.
```

## Changes

- `mitmproxy/proxy/mode_servers.py`: Catch WireGuard port conflict exceptions and provide actionable error message