### PR TITLE
Fix console command panel losing focus due to incoming traffic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ## Unreleased: mitmproxy next
 
 - Fix console command panel losing focus due to incoming traffic (e.g. websocket messages).
+  ([#8173](https://github.com/mitmproxy/mitmproxy/pull/8173), @emanuele-em)
 - mitmweb: Reduce FlowTable Redux subscriptions from O(rows) to O(1).
   ([#8104](https://github.com/mitmproxy/mitmproxy/pull/8104), @ariel42)
 - mitmweb: Fix editors not allowing content to be cleared to an empty string

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ## Unreleased: mitmproxy next
 
+- Fix console command panel losing focus due to incoming traffic (e.g. websocket messages).
 - mitmweb: Reduce FlowTable Redux subscriptions from O(rows) to O(1).
   ([#8104](https://github.com/mitmproxy/mitmproxy/pull/8104), @ariel42)
 - mitmweb: Fix editors not allowing content to be cleared to an empty string

--- a/mitmproxy/tools/console/statusbar.py
+++ b/mitmproxy/tools/console/statusbar.py
@@ -77,7 +77,7 @@ class ActionBar(urwid.WidgetWrap):
             self._w = urwid.Pile([self.top, self.bottom])
 
     def sig_update(self, flow=None) -> None:
-        if not self.prompting and flow is None or flow == self.master.view.focus.flow:
+        if not self.prompting and (flow is None or flow == self.master.view.focus.flow):
             self.show_quickhelp()
 
     def sig_options_update(self, options, updated) -> None:


### PR DESCRIPTION
Fix operator precedence bug in ActionBar.sig_update where `not self.prompting and flow is None or flow == ...` was evaluated as `(not self.prompting and flow is None) or (flow == ...)`, causing show_quickhelp() to overwrite the command editor when the focused flow received updates (e.g. websocket messages).

Fixes #8030

#### Description

Fixed  parentheses so `not self.prompting` properly guards the whole condition

#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
