### PR TITLE
fix: display failed CONNECT requests in mitmdump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 ## Unreleased: mitmproxy next
 
+- mitmdump: Fix failed CONNECT requests not being displayed.
+  ([#7083](https://github.com/mitmproxy/mitmproxy/issues/7083))
 - mitmweb: Reduce FlowTable Redux subscriptions from O(rows) to O(1).
   ([#8104](https://github.com/mitmproxy/mitmproxy/pull/8104), @ariel42)
 - mitmweb: Fix editors not allowing content to be cleared to an empty string

--- a/mitmproxy/addons/dumper.py
+++ b/mitmproxy/addons/dumper.py
@@ -294,6 +294,10 @@ class Dumper:
         if self.match(f):
             self.echo_flow(f)
 
+    def http_connect_error(self, f):
+        if self.match(f):
+            self.echo_flow(f)
+
     def websocket_message(self, f: http.HTTPFlow):
         assert f.websocket is not None  # satisfy type checker
         if self.match(f):

--- a/test/mitmproxy/addons/test_dumper.py
+++ b/test/mitmproxy/addons/test_dumper.py
@@ -281,6 +281,22 @@ def test_websocket():
         assert "(reason: I swear I had a reason)" in sio.getvalue()
 
 
+def test_http_connect_error():
+    sio = io.StringIO()
+    d = dumper.Dumper(sio)
+    with taddons.context(d) as ctx:
+        ctx.configure(d, flow_detail=1)
+        f = tflow.tflow(resp=tutils.tresp(status_code=502, reason=b"Bad Gateway"))
+        d.http_connect_error(f)
+        assert sio.getvalue()
+        assert "502" in sio.getvalue()
+        sio.truncate(0)
+
+        ctx.configure(d, flow_detail=0)
+        d.http_connect_error(f)
+        assert not sio.getvalue()
+
+
 def test_http2():
     sio = io.StringIO()
     d = dumper.Dumper(sio)


### PR DESCRIPTION
#### Description

Handle HttpConnectErrorHook in the dumper addon so that failed CONNECT requests (e.g. DNS resolution errors) are logged to the terminal.

Closes #7083 

<img width="493" height="44" alt="image" src="https://github.com/user-attachments/assets/260ad8e0-2d74-471b-9690-41987f781e7a" />


#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
