### PR TITLE
load pending scripts before dumping options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 ## Unreleased: mitmproxy next
 
+- Fix addon options not being included in `--options` output.
+  ([#4423](https://github.com/mitmproxy/mitmproxy/issues/4423))
 - mitmweb: Reduce FlowTable Redux subscriptions from O(rows) to O(1).
   ([#8104](https://github.com/mitmproxy/mitmproxy/pull/8104), @ariel42)
 - mitmweb: Fix editors not allowing content to be cleared to an empty string

--- a/mitmproxy/tools/main.py
+++ b/mitmproxy/tools/main.py
@@ -91,6 +91,10 @@ def run(
             process_options(parser, opts, args)
 
             if args.options:
+                if sl := master.addons.get("scriptloader"):
+                    for s in sl.addons:
+                        if s.ns is None:
+                            s.loadscript()
                 optmanager.dump_defaults(opts, sys.stdout)
                 sys.exit(0)
             if args.commands:

--- a/mitmproxy/tools/main.py
+++ b/mitmproxy/tools/main.py
@@ -91,6 +91,7 @@ def run(
             process_options(parser, opts, args)
 
             if args.options:
+                # Load custom addons so that their options are registered
                 if sl := master.addons.get("scriptloader"):
                     for s in sl.addons:
                         if s.ns is None:

--- a/test/mitmproxy/data/addonscripts/custom_option.py
+++ b/test/mitmproxy/data/addonscripts/custom_option.py
@@ -1,0 +1,14 @@
+from typing import Optional
+
+
+class CustomOptionAddon:
+    def load(self, loader):
+        loader.add_option(
+            name="custom_addon_option",
+            typespec=Optional[int],
+            default=None,
+            help="A custom option registered by an addon.",
+        )
+
+
+addons = [CustomOptionAddon()]

--- a/test/mitmproxy/tools/test_main.py
+++ b/test/mitmproxy/tools/test_main.py
@@ -1,3 +1,5 @@
+import pytest
+
 from mitmproxy.tools import main
 
 shutdown_script = "mitmproxy/data/addonscripts/shutdown.py"
@@ -28,3 +30,26 @@ def test_mitmdump(tdata):
             "0",
         ]
     )
+
+
+def test_options_includes_addon_options(tdata, capsys):
+    """--options should include options registered by addon scripts."""
+    with pytest.raises(SystemExit):
+        main.mitmdump(
+            [
+                "-s",
+                tdata.path("mitmproxy/data/addonscripts/custom_option.py"),
+                "--options",
+            ]
+        )
+    output = capsys.readouterr().out
+    assert "custom_addon_option" in output
+
+
+def test_options_without_scripts(capsys):
+    """--options without any scripts should still work and list built-in options."""
+    with pytest.raises(SystemExit):
+        main.mitmdump(["--options"])
+    output = capsys.readouterr().out
+    assert "listen_port" in output
+    assert "custom_addon_option" not in output


### PR DESCRIPTION
#### Description

Fix `--options` not including addon-registered options

Addon scripts register their options in Script.loadscript(), which is deferred by Script.watcher(). When --options is passed, we now load pending scripts before dumping options

Closes #4423

#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
