### PR TITLE
accept leading zeros in Content-Length behind validate_inbound_headers=false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ## Unreleased: mitmproxy next
 
+- Accept leading zeros in Content-Length headers when `validate_inbound_headers` is disabled.
 - mitmweb: Reduce FlowTable Redux subscriptions from O(rows) to O(1).
   ([#8104](https://github.com/mitmproxy/mitmproxy/pull/8104), @ariel42)
 - mitmweb: Fix editors not allowing content to be cleared to an empty string

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ## Unreleased: mitmproxy next
 
 - Accept leading zeros in Content-Length headers when `validate_inbound_headers` is disabled.
+  ([#8177](https://github.com/mitmproxy/mitmproxy/pull/8177), @emanuele-em)
 - mitmweb: Reduce FlowTable Redux subscriptions from O(rows) to O(1).
   ([#8104](https://github.com/mitmproxy/mitmproxy/pull/8104), @ariel42)
 - mitmweb: Fix editors not allowing content to be cleared to an empty string

--- a/mitmproxy/net/http/http1/read.py
+++ b/mitmproxy/net/http/http1/read.py
@@ -45,7 +45,9 @@ def connection_close(http_version, headers):
 
 
 def expected_http_body_size(
-    request: Request, response: Response | None = None
+    request: Request,
+    response: Response | None = None,
+    validate_inbound_headers: bool = True,
 ) -> int | None:
     """
     Returns:
@@ -145,7 +147,7 @@ def expected_http_body_size(
     #        received, the recipient MUST consider the message to be
     #        incomplete and close the connection.
     if cl := headers.get("content-length"):
-        return validate.parse_content_length(cl)
+        return validate.parse_content_length(cl, validate_inbound_headers)
     #    6.  If this is a request message and none of the above are true, then
     #        the message body length is zero (no message body is present).
     if not response:

--- a/mitmproxy/net/http/validate.py
+++ b/mitmproxy/net/http/validate.py
@@ -14,6 +14,8 @@ _valid_header_name = re.compile(rb"^[!#$%&'*+\-.^_`|~0-9a-zA-Z]+$")
 
 _valid_content_length = re.compile(rb"^(?:0|[1-9][0-9]*)$")
 _valid_content_length_str = re.compile(r"^(?:0|[1-9][0-9]*)$")
+_valid_content_length_lax = re.compile(rb"^[0-9]+$")
+_valid_content_length_lax_str = re.compile(r"^[0-9]+$")
 
 # https://datatracker.ietf.org/doc/html/rfc9112#section-6.1:
 # > A sender MUST NOT apply the chunked transfer coding more than once to a message body (i.e., chunking an already
@@ -36,12 +38,23 @@ TransferEncoding = typing.Literal[
 _HTTP_1_1_TRANSFER_ENCODINGS = frozenset(typing.get_args(TransferEncoding))
 
 
-def parse_content_length(value: str | bytes) -> int:
-    """Parse a content-length header value, or raise a ValueError if it is invalid."""
+def parse_content_length(
+    value: str | bytes, validate_inbound_headers: bool = True
+) -> int:
+    """Parse a content-length header value, or raise a ValueError if it is invalid.
+
+    When validate_inbound_headers is False, leading zeros are accepted (e.g. "0012" -> 12).
+    """
     if isinstance(value, str):
-        valid = bool(_valid_content_length_str.match(value))
+        if validate_inbound_headers:
+            valid = bool(_valid_content_length_str.match(value))
+        else:
+            valid = bool(_valid_content_length_lax_str.match(value))
     else:
-        valid = bool(_valid_content_length.match(value))
+        if validate_inbound_headers:
+            valid = bool(_valid_content_length.match(value))
+        else:
+            valid = bool(_valid_content_length_lax.match(value))
     if not valid:
         raise ValueError(f"invalid content-length header: {value!r}")
     return int(value)

--- a/mitmproxy/proxy/layers/http/__init__.py
+++ b/mitmproxy/proxy/layers/http/__init__.py
@@ -590,7 +590,9 @@ class HttpStream(layer.Layer):
             # the 'early' case: we have not started consuming the body
             try:
                 expected_size = expected_http_body_size(
-                    self.flow.request, self.flow.response if response else None
+                    self.flow.request,
+                    self.flow.response if response else None,
+                    self.context.options.validate_inbound_headers,
                 )
             except ValueError:  # pragma: no cover
                 # we just don't stream/kill malformed content-length headers.

--- a/mitmproxy/proxy/layers/http/_http1.py
+++ b/mitmproxy/proxy/layers/http/_http1.py
@@ -396,11 +396,14 @@ class Http1Client(Http1Connection):
             assert self.request
             if "chunked" in self.request.headers.get("transfer-encoding", "").lower():
                 yield commands.SendData(self.conn, b"0\r\n\r\n")
-            elif http1.expected_http_body_size(
-                self.request,
-                self.response,
-                self.context.options.validate_inbound_headers,
-            ) == -1:
+            elif (
+                http1.expected_http_body_size(
+                    self.request,
+                    self.response,
+                    self.context.options.validate_inbound_headers,
+                )
+                == -1
+            ):
                 yield commands.CloseTcpConnection(self.conn, half_close=True)
             yield from self.mark_done(request=True)
         else:

--- a/mitmproxy/proxy/layers/http/_http1.py
+++ b/mitmproxy/proxy/layers/http/_http1.py
@@ -183,7 +183,12 @@ class Http1Connection(HttpConnection, metaclass=abc.ABCMeta):
                 return
             try:
                 read_until_eof_semantics = (
-                    http1.expected_http_body_size(self.request, self.response) == -1
+                    http1.expected_http_body_size(
+                        self.request,
+                        self.response,
+                        self.context.options.validate_inbound_headers,
+                    )
+                    == -1
                 )
             except ValueError:
                 # this may raise only now (and not earlier) because an addon set invalid headers,
@@ -288,7 +293,10 @@ class Http1Server(Http1Connection):
                     self.request = http1.read_request_head(
                         [bytes(x) for x in request_head]
                     )
-                    expected_body_size = http1.expected_http_body_size(self.request)
+                    expected_body_size = http1.expected_http_body_size(
+                        self.request,
+                        validate_inbound_headers=self.context.options.validate_inbound_headers,
+                    )
                 except ValueError as e:
                     yield commands.SendData(self.conn, make_error_response(400, str(e)))
                     yield commands.CloseConnection(self.conn)
@@ -388,7 +396,11 @@ class Http1Client(Http1Connection):
             assert self.request
             if "chunked" in self.request.headers.get("transfer-encoding", "").lower():
                 yield commands.SendData(self.conn, b"0\r\n\r\n")
-            elif http1.expected_http_body_size(self.request, self.response) == -1:
+            elif http1.expected_http_body_size(
+                self.request,
+                self.response,
+                self.context.options.validate_inbound_headers,
+            ) == -1:
                 yield commands.CloseTcpConnection(self.conn, half_close=True)
             yield from self.mark_done(request=True)
         else:
@@ -412,7 +424,9 @@ class Http1Client(Http1Connection):
                         [bytes(x) for x in response_head]
                     )
                     expected_size = http1.expected_http_body_size(
-                        self.request, self.response
+                        self.request,
+                        self.response,
+                        self.context.options.validate_inbound_headers,
                     )
                 except ValueError as e:
                     yield commands.CloseConnection(self.conn)

--- a/test/mitmproxy/net/http/http1/test_read.py
+++ b/test/mitmproxy/net/http/http1/test_read.py
@@ -151,6 +151,17 @@ def test_expected_http_body_size():
 
     # explicit length
     assert expected_http_body_size(treq(headers=Headers(content_length="42"))) == 42
+    # leading zeros are accepted when validate_inbound_headers is false
+    assert (
+        expected_http_body_size(
+            treq(headers=Headers(content_length="0012")),
+            validate_inbound_headers=False,
+        )
+        == 12
+    )
+    # leading zeros are rejected when validate_inbound_headers is true (default)
+    with pytest.raises(ValueError):
+        expected_http_body_size(treq(headers=Headers(content_length="0012")))
     # invalid lengths
     with pytest.raises(ValueError):
         expected_http_body_size(treq(headers=Headers(content_length=b"foo")))

--- a/test/mitmproxy/net/http/test_validate.py
+++ b/test/mitmproxy/net/http/test_validate.py
@@ -25,6 +25,24 @@ def test_parse_content_length_invalid(cl):
         parse_content_length(cl.encode())
 
 
+def test_parse_content_length_lax():
+    assert parse_content_length("0", validate_inbound_headers=False) == 0
+    assert parse_content_length("00", validate_inbound_headers=False) == 0
+    assert parse_content_length("1", validate_inbound_headers=False) == 1
+    assert parse_content_length("01", validate_inbound_headers=False) == 1
+    assert parse_content_length("0100", validate_inbound_headers=False) == 100
+    assert parse_content_length(b"0012", validate_inbound_headers=False) == 12
+    assert parse_content_length(b"42", validate_inbound_headers=False) == 42
+
+
+@pytest.mark.parametrize("cl", ["NaN", "", " ", "-1", "+1", "0x42", "foo", "1, 1"])
+def test_parse_content_length_lax_invalid(cl):
+    with pytest.raises(ValueError, match="invalid content-length"):
+        parse_content_length(cl, validate_inbound_headers=False)
+    with pytest.raises(ValueError, match="invalid content-length"):
+        parse_content_length(cl.encode(), validate_inbound_headers=False)
+
+
 def test_parse_transfer_encoding_ok():
     assert parse_transfer_encoding(b"chunked") == "chunked"
     assert parse_transfer_encoding("chunked") == "chunked"


### PR DESCRIPTION
#### Description

- Accept leading zeros in `Content-Length` headers (e.g. `0012`) when `validate_inbound_headers` is disabled
- Thread `validate_inbound_headers` through `parse_content_length()` and `expected_http_body_size()`
- Strict validation (default) is unchanged — leading zeros are still rejected to prevent "request smuggling" (closes #7786)

#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
