### PR TITLE
Add --quiet flag to suppress all output except errors

### DIFF
--- a/mitmproxy/addons/dumper.py
+++ b/mitmproxy/addons/dumper.py
@@ -278,6 +278,9 @@ class Dumper:
         self.outfp.flush()
 
     def match(self, f):
+        # If quiet mode is enabled, only allow errors through
+        if ctx.options.quiet:
+            return f.error is not None
         if ctx.options.flow_detail == 0:
             return False
         if not self.filter:

--- a/mitmproxy/options.py
+++ b/mitmproxy/options.py
@@ -245,5 +245,11 @@ class Options(optmanager.OptManager):
             Timeout in seconds for inactive TCP connections. Connections will be closed after this period of inactivity.
             """,
         )
+        self.add_option(
+            "quiet",
+            bool,
+            False,
+            "Suppress all output except errors.",
+        )
 
         self.update(**kwargs)

--- a/test/mitmproxy/addons/test_dumper.py
+++ b/test/mitmproxy/addons/test_dumper.py
@@ -341,3 +341,24 @@ def test_styling():
 def test_has_styles_for_tags():
     missing = set(mitmproxy_rs.syntax_highlight.tags()) - set(CONTENTVIEW_STYLES)
     assert not missing, f"Missing styles for tags: {missing}"
+
+
+def test_quiet_flag():
+    sio = io.StringIO()
+    d = dumper.Dumper(sio)
+    with taddons.context(d) as ctx:
+        # With quiet enabled, normal flows should not be displayed
+        ctx.configure(d, quiet=True, flow_detail=4)
+        d.response(tflow.tflow(resp=True))
+        assert not sio.getvalue()
+        sio.truncate(0)
+
+        # With quiet enabled, errors should still be displayed
+        d.error(tflow.tflow(err=True))
+        assert sio.getvalue()
+        sio.truncate(0)
+
+        # Without quiet, flows display normally
+        ctx.configure(d, quiet=False, flow_detail=4)
+        d.response(tflow.tflow(resp=True))
+        assert sio.getvalue()

--- a/web/src/js/ducks/_options_gen.ts
+++ b/web/src/js/ducks/_options_gen.ts
@@ -48,6 +48,7 @@ export interface OptionsState {
     protobuf_definitions: string | undefined;
     proxy_debug: boolean;
     proxyauth: string | undefined;
+    quiet: boolean;
     rawtcp: boolean;
     readfile_filter: string | undefined;
     request_client_cert: boolean;
@@ -155,6 +156,7 @@ export const defaultState: OptionsState = {
     protobuf_definitions: undefined,
     proxy_debug: false,
     proxyauth: undefined,
+    quiet: false,
     rawtcp: true,
     readfile_filter: undefined,
     request_client_cert: false,


### PR DESCRIPTION
## Summary
Adds a `--quiet` CLI flag to mitmdump that suppresses all flow output except for flows with errors.

## Changes
- Added `quiet` option (bool, default False) in `mitmproxy/options.py`
- Modified `Dumper.match()` in `mitmproxy/addons/dumper.py` to only display flows that have errors when quiet mode is active

## Use Case
When running mitmdump in scripts/CI pipelines, you often want completely clean output — no flow details, no connection logs — but you still need to see errors. Currently you have to set `--flow-detail 0` which still shows some output. The `--quiet` flag gives you truly silent operation with error-only visibility.

## Testing
```bash
mitmdump --quiet  # No output except errors
mitmdump --quiet --flow-detail 3  # Quiet takes precedence
```

This is a TaskBounty submission for the mitmproxy feature improvement bounty.