### PR TITLE
Use sys.executable instead of python3 in docs build script

### DIFF
--- a/docs/build.py
+++ b/docs/build.py
@@ -2,12 +2,13 @@
 import shutil
 import subprocess
 from pathlib import Path
+import sys
 
 here = Path(__file__).parent
 
 for script in sorted((here / "scripts").glob("*.py")):
     print(f"Generating output for {script.name}...")
-    out = subprocess.check_output(["python3", script.absolute()], cwd=here, text=True)
+    out = subprocess.check_output([sys.executable, script.absolute()], cwd=here, text=True)
     if out:
         (here / "src" / "generated" / f"{script.stem}.html").write_text(
             out, encoding="utf8"

--- a/docs/build.py
+++ b/docs/build.py
@@ -1,14 +1,16 @@
 #!/usr/bin/env python3
 import shutil
 import subprocess
-from pathlib import Path
 import sys
+from pathlib import Path
 
 here = Path(__file__).parent
 
 for script in sorted((here / "scripts").glob("*.py")):
     print(f"Generating output for {script.name}...")
-    out = subprocess.check_output([sys.executable, script.absolute()], cwd=here, text=True)
+    out = subprocess.check_output(
+        [sys.executable, script.absolute()], cwd=here, text=True
+    )
     if out:
         (here / "src" / "generated" / f"{script.stem}.html").write_text(
             out, encoding="utf8"


### PR DESCRIPTION
Problem:
The docs build script uses `python3` in subprocess calls, which can fail in environments where:
- `python3` is not available
- pyenv is installed but not configured
- the active virtual environment differs from `python3`

This leads to errors like:
"ModuleNotFoundError: No module named 'mitmproxy'"

Solution:
Replace `python3` with `sys.executable` to ensure the currently active Python interpreter is used.

Tested by running:
`python docs/build.py`