### PR TITLE
Fix issue 8188: index out of range when saving .har file

### DIFF
--- a/mitmproxy/utils/strutils.py
+++ b/mitmproxy/utils/strutils.py
@@ -136,7 +136,7 @@ def is_mostly_bin(s: bytes) -> bool:
             if cut >= len(s):
                 s = s[:cut]
                 break
-            
+
             is_continuation_byte = (s[cut] >> 6) == 0b10
             if not is_continuation_byte:
                 # A new character starts here, so we cut off just before that.

--- a/mitmproxy/utils/strutils.py
+++ b/mitmproxy/utils/strutils.py
@@ -133,6 +133,10 @@ def is_mostly_bin(s: bytes) -> bool:
     # chop a multibyte code point in half.
     if len(s) > 100:
         for cut in range(100, 104):
+            if cut >= len(s):
+                s = s[:cut]
+                break
+            
             is_continuation_byte = (s[cut] >> 6) == 0b10
             if not is_continuation_byte:
                 # A new character starts here, so we cut off just before that.

--- a/test/mitmproxy/utils/test_strutils.py
+++ b/test/mitmproxy/utils/test_strutils.py
@@ -94,6 +94,10 @@ def test_is_mostly_bin():
     assert not strutils.is_mostly_bin(b"aaaaa" + 50 * "𐍅".encode())
     # only utf8 continuation chars
     assert strutils.is_mostly_bin(150 * b"\x80")
+    # test 101-103 byte boundary
+    assert not strutils.is_mostly_bin(b"a" * 99 + "𐍅".encode())
+    assert not strutils.is_mostly_bin(b"a" * 100 + "é".encode())
+    assert not strutils.is_mostly_bin(b"a" * 100 + "ñ".encode())
 
 
 def test_is_xml():


### PR DESCRIPTION
#### Description

Proposal for fix regarding an issue I've encountered https://github.com/mitmproxy/mitmproxy/issues/8188

After examining the source it seems that it's just an unchecked direct access to an array of bytes. We assure we're>= 100 bytes, but the lines after attempt to access bytes up to index 104.

#### Checklist

 - [x] I have updated tests where applicable.
 - [ ] I have added an entry to the CHANGELOG.
