### PR TITLE
fix: avoid IndexError in is_mostly_bin for short tails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 ## Unreleased: mitmproxy next
 
+- Fix `IndexError` in `is_mostly_bin` when exporting flows to HAR with payloads
+  that have a UTF-8 continuation byte at the 100-byte cutoff.
 
 ## 12 April 2026: mitmproxy 12.2.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 - Fix `IndexError` in `is_mostly_bin` when exporting flows to HAR with payloads
   that have a UTF-8 continuation byte at the 100-byte cutoff.
+  ([#8196](https://github.com/mitmproxy/mitmproxy/pull/8196), @juliosuas)
 
 ## 12 April 2026: mitmproxy 12.2.2
 

--- a/mitmproxy/utils/strutils.py
+++ b/mitmproxy/utils/strutils.py
@@ -132,7 +132,7 @@ def is_mostly_bin(s: bytes) -> bool:
     # Cut off at ~100 chars, but do it smartly so that if the input is UTF-8, we don't
     # chop a multibyte code point in half.
     if len(s) > 100:
-        for cut in range(100, 104):
+        for cut in range(100, min(104, len(s))):
             is_continuation_byte = (s[cut] >> 6) == 0b10
             if not is_continuation_byte:
                 # A new character starts here, so we cut off just before that.

--- a/test/mitmproxy/utils/test_strutils.py
+++ b/test/mitmproxy/utils/test_strutils.py
@@ -94,6 +94,11 @@ def test_is_mostly_bin():
     assert not strutils.is_mostly_bin(b"aaaaa" + 50 * "𐍅".encode())
     # only utf8 continuation chars
     assert strutils.is_mostly_bin(150 * b"\x80")
+    # regression #8188: payloads with len 101-103 and a continuation byte at
+    # the 100-byte cutoff used to raise IndexError because the lookahead loop
+    # ran past the end of the string. Should not raise.
+    for tail in (1, 2, 3):
+        strutils.is_mostly_bin(b"a" * 100 + b"\x80" * tail)
 
 
 def test_is_xml():


### PR DESCRIPTION
fixes #8188.

reproducible with any bytes payload of len 101–103 where index 100 is a UTF-8 continuation byte:

```python
>>> from mitmproxy.utils import strutils
>>> strutils.is_mostly_bin(b'a' * 100 + b'\x80')
Traceback (most recent call last):
  ...
IndexError: index out of range
```

the lookahead loop `range(100, 104)` reads `s[100]` through `s[103]` to find the start of the next UTF-8 char and avoid chopping a multibyte code point in half. when len(s) is between 101 and 103 and the first byte past the 100-byte cutoff is a continuation byte, the loop continues into out-of-range indices.

cap the loop end at `len(s)`. the existing `s[:100]` fallback still covers the case where every byte in the lookahead window is a continuation byte.

added a small regression assertion for the three affected lengths.