### PR TITLE
Fix IP blocking and merge additional DoH blocklists

### DIFF
--- a/examples/contrib/block_dns_over_https.py
+++ b/examples/contrib/block_dns_over_https.py
@@ -257,8 +257,8 @@ additional_doh_ips: list[str] = []
 doh_hostnames, doh_ips = default_blocklist["hostnames"], default_blocklist["ips"]
 
 # convert to sets for faster lookups
-doh_hostnames = set(doh_hostnames)
-doh_ips = set(doh_ips)
+doh_hostnames = set(doh_hostnames) | set(additional_doh_names)
+doh_ips = set(doh_ips) | set(additional_doh_ips)
 
 
 def _has_dns_message_content_type(flow):
@@ -335,7 +335,7 @@ def _requested_hostname_is_in_doh_blocklist(flow):
     :return: True if server's hostname is in DoH blocklist, otherwise False
     """
     hostname = flow.request.host
-    ip = flow.server_conn.address
+    ip = flow.server_conn.address[0]
     return hostname in doh_hostnames or hostname in doh_ips or ip in doh_ips
 
 


### PR DESCRIPTION
Fixed broken IP-based DoH blocking by extracting the host string from the server_conn.address tuple, and ensured additional_doh_names and additional_doh_ips are actually merged into the lookup sets at runtime.
