### PR TITLE
fix(flow): kill() wakes wait_for_resume so proxy teardown closes the client connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Fix killing an intercepted flow leaving the client connection open. `Flow.kill()`
   now wakes any pending `wait_for_resume()` awaiter so the proxy can run its
   post-hook teardown and close the connection.
+  ([#8199](https://github.com/mitmproxy/mitmproxy/pull/8199), @georgeglarson)
 
 ## 12 April 2026: mitmproxy 12.2.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 - Fix `IndexError` in `is_mostly_bin` when exporting flows to HAR with payloads
   that have a UTF-8 continuation byte at the 100-byte cutoff.
   ([#8196](https://github.com/mitmproxy/mitmproxy/pull/8196), @juliosuas)
+- Fix killing an intercepted flow leaving the client connection open. `Flow.kill()`
+  now wakes any pending `wait_for_resume()` awaiter so the proxy can run its
+  post-hook teardown and close the connection.
 
 ## 12 April 2026: mitmproxy 12.2.2
 

--- a/mitmproxy/flow.py
+++ b/mitmproxy/flow.py
@@ -240,6 +240,8 @@ class Flow(serializable.Serializable):
         self.error = Error(Error.KILLED_MESSAGE)
         self.intercepted = False
         self.live = False
+        if self._resume_event is not None:
+            self._resume_event.set()
 
     def intercept(self):
         """

--- a/test/mitmproxy/test_http.py
+++ b/test/mitmproxy/test_http.py
@@ -785,6 +785,23 @@ class TestHTTPFlow:
         f2.resume()
         assert f.intercepted is f2.intercepted is False
 
+    async def test_kill_unblocks_wait_for_resume(self):
+        # Regression test for https://github.com/mitmproxy/mitmproxy/issues/8045:
+        # Killing an intercepted flow that is currently being awaited via
+        # wait_for_resume() must wake the awaiter so the proxy can run its
+        # post-hook teardown (which closes the client connection).
+        f = tflow()
+        f.intercept()
+        resume_task = asyncio.ensure_future(f.wait_for_resume())
+        # Yield once so the task reaches the internal `await self._resume_event.wait()`.
+        await asyncio.sleep(0)
+        assert not resume_task.done()
+        f.kill()
+        await asyncio.wait_for(resume_task, 0.2)
+        assert f.error.msg == flow.Error.KILLED_MESSAGE
+        assert not f.intercepted
+        assert not f.live
+
     def test_timestamp_start(self):
         f = tflow()
         assert f.timestamp_start == f.request.timestamp_start


### PR DESCRIPTION
## Description

Closes #8045.

### Problem

When the user hits `X` on an intercepted flow in the TUI (or otherwise calls `Flow.kill()` while a hook is awaiting `wait_for_resume()`), the kill marks state correctly (`error = KILLED_MESSAGE`, `intercepted = False`, `live = False`) but never sets `_resume_event`. The pending `await self._resume_event.wait()` in `Flow.wait_for_resume()` blocks forever.

Because `mode_servers.handle_hook` awaits `data.wait_for_resume()` after running addon handlers, the hook task never returns, `HookCompleted` never fires, and the HTTP layer's existing `check_killed` (which would emit `ResponseProtocolError(... KILL)` and close the client connection) never runs. Externally: `curl --proxy ...` hangs until Ctrl-C even though mitmproxy says "Connection killed."

### Fix

`Flow.kill()` now sets `_resume_event` if it exists. This wakes any pending `wait_for_resume()` awaiter, allowing the post-hook teardown path to run its existing kill-handling logic.

### Test

Added `test_kill_unblocks_wait_for_resume` in `test/mitmproxy/test_http.py`: starts a `wait_for_resume()` task on an intercepted flow, lets it reach the internal `await`, kills the flow, and verifies the task completes within 200ms with the expected post-kill state.

### Scope

This addresses the specific case @Prinzhorn described in #8045 as *"exactly the use case that should work."* The broader architectural concern called out in the `Flow.kill()` TODO comment — killing flows in transit (#4711) — is a separate problem that this PR does not attempt; a follow-up implementing the \`KillInjected\` event per that TODO should be following later.