### PR TITLE
Fix query content view for missing request bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ## Unreleased: mitmproxy next
 
+- Render the Query content view for requests whose body content is still being received.
 - Fix `IndexError` in `is_mostly_bin` when exporting flows to HAR with payloads
   that have a UTF-8 continuation byte at the 100-byte cutoff.
   ([#8196](https://github.com/mitmproxy/mitmproxy/pull/8196), @juliosuas)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ## Unreleased: mitmproxy next
 
 - Render the Query content view for requests whose body content is still being received.
+  ([#8202](https://github.com/mitmproxy/mitmproxy/pull/8202), @emanuele-em)
 - Fix `IndexError` in `is_mostly_bin` when exporting flows to HAR with payloads
   that have a UTF-8 continuation byte at the 100-byte cutoff.
   ([#8196](https://github.com/mitmproxy/mitmproxy/pull/8196), @juliosuas)

--- a/mitmproxy/contentviews/__init__.py
+++ b/mitmproxy/contentviews/__init__.py
@@ -43,6 +43,7 @@ from ._view_zip import zip
 from .base import View
 import mitmproxy_rs.contentviews
 from mitmproxy import flow
+from mitmproxy import http
 from mitmproxy.utils import strutils
 
 logger = logging.getLogger(__name__)
@@ -67,15 +68,30 @@ def prettify_message(
 ) -> ContentviewResult:
     data, enc = get_data(message)
     if data is None:
-        return ContentviewResult(
-            text="Content is missing.",
-            syntax_highlight="error",
-            description="",
-            view_name=None,
-        )
+        if isinstance(message, http.Request):
+            # The query view only depends on request metadata, not body content.
+            metadata = Metadata(flow=flow, http_message=message)
+            view = registry.get_view(b"", metadata, view_name)
+            if view.name == query.name:
+                data = b""
+            else:
+                return ContentviewResult(
+                    text="Content is missing.",
+                    syntax_highlight="error",
+                    description="",
+                    view_name=None,
+                )
+        else:
+            return ContentviewResult(
+                text="Content is missing.",
+                syntax_highlight="error",
+                description="",
+                view_name=None,
+            )
+    else:
+        metadata = make_metadata(message, flow)
 
     # Determine the correct view
-    metadata = make_metadata(message, flow)
     view = registry.get_view(data, metadata, view_name)
 
     # Finally, we can pretty-print!

--- a/mitmproxy/tools/console/flowview.py
+++ b/mitmproxy/tools/console/flowview.py
@@ -307,7 +307,12 @@ class FlowDetails(tabs.Tabs):
         self, viewmode: str, message: http.Message
     ) -> tuple[str, list[urwid.Text]]:
         if message.raw_content is None:
-            return "", [urwid.Text([("error", "[content missing]")])]
+            if isinstance(message, http.Request):
+                query = getattr(message, "query", "")
+                if not query or viewmode.lower() not in ("auto", "default", "query"):
+                    return "", [urwid.Text([("error", "[content missing]")])]
+            else:
+                return "", [urwid.Text([("error", "[content missing]")])]
 
         if message.raw_content == b"":
             if isinstance(message, http.Request):

--- a/test/mitmproxy/contentviews/test___init__.py
+++ b/test/mitmproxy/contentviews/test___init__.py
@@ -57,6 +57,18 @@ class TestPrettifyMessage:
             assert result.syntax_highlight == "error"
             assert result.view_name is None
 
+    def test_missing_content_query_view(self):
+        with taddons.context():
+            f = tflow.tflow()
+            f.request.path = "/?a=b&c=d"
+            f.request.content = None
+
+            result = prettify_message(f.request, f, "query")
+
+            assert result.text == "a: b\nc: d\n"
+            assert result.syntax_highlight == "yaml"
+            assert result.view_name == "Query"
+
     def test_hex_stream(self):
         with taddons.context():
             f = tflow.tflow()

--- a/test/mitmproxy/tools/console/test_flowview.py
+++ b/test/mitmproxy/tools/console/test_flowview.py
@@ -55,6 +55,28 @@ async def test_content_missing_returns_error(console):
     assert "[content missing]" == first_text
 
 
+async def test_missing_content_query_view(console):
+    f = tflow.tflow(
+        req=http.Request.make("GET", "http://example.com/?a=b&c=d", b"initial"),
+    )
+    f.request.raw_content = None
+
+    await console.load_flow(f)
+
+    fd = FlowDetails(console)
+
+    title, txt_objs = fd.content_view("query", f.request)
+    assert title == "Query "
+
+    text = txt_objs[0].get_text()[0]
+    assert "a: b" in text
+    assert "c: d" in text
+
+    title, txt_objs = fd.content_view("raw", f.request)
+    assert title == ""
+    assert txt_objs[0].get_text()[0] == "[content missing]"
+
+
 async def test_empty_content_request_and_response(console):
     fd = FlowDetails(console)
 

--- a/test/mitmproxy/tools/web/test_app.py
+++ b/test/mitmproxy/tools/web/test_app.py
@@ -363,6 +363,19 @@ class TestApp(tornado.testing.AsyncHTTPTestCase):
         }
         assert self.fetch("/flows/42/messages/content/raw").code == 400
 
+    def test_flow_contentview_missing_content_query(self):
+        f = self.view.get_by_id("42")
+        assert f
+        f.request.path = "/?a=b&c=d"
+        f.request.raw_content = None
+
+        assert get_json(self.fetch("/flows/42/request/content/query")) == {
+            "description": "",
+            "syntax_highlight": "yaml",
+            "text": "a: b\nc: d\n",
+            "view_name": "Query",
+        }
+
     def test_flow_contentview_websocket(self):
         assert get_json(self.fetch("/flows/43/messages/content/raw?lines=2")) == [
             {


### PR DESCRIPTION
#### Description

Fixes #7941.

This allows the Query content view to render request query parameters even while the request body is still missing or being received. Previously, missing request content short-circuited content view rendering before the Query view had a chance to render data that is already available from the request URL.

I am not super happy with having such a specific hard-coded exception for the Query view, but I do not have a better idea here.

The change covers both mitmproxy console and mitmweb, and keeps other explicit body views such as Raw showing `[content missing]` when body content is unavailable.

#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
