### PR TITLE
fix: force http/1.1 ALPN on secure web proxy outer TLS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 
 ## Unreleased: mitmproxy next
 
+- Fix secure web proxy negotiating `h2` ALPN with the client, which broke
+  HTTP/1.1 CONNECT for clients that offer `h2,http/1.1` on the outer TLS
+  (e.g. Node.js's default).
 - Fix `IndexError` in `is_mostly_bin` when exporting flows to HAR with payloads
   that have a UTF-8 continuation byte at the 100-byte cutoff.
   ([#8196](https://github.com/mitmproxy/mitmproxy/pull/8196), @juliosuas)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Fix secure web proxy negotiating `h2` ALPN with the client, which broke
   HTTP/1.1 CONNECT for clients that offer `h2,http/1.1` on the outer TLS
   (e.g. Node.js's default).
+  ([#8204](https://github.com/mitmproxy/mitmproxy/pull/8204), @emanuele-em)
 - Fix `IndexError` in `is_mostly_bin` when exporting flows to HAR with payloads
   that have a UTF-8 continuation byte at the 100-byte cutoff.
   ([#8196](https://github.com/mitmproxy/mitmproxy/pull/8196), @juliosuas)

--- a/mitmproxy/addons/tlsconfig.py
+++ b/mitmproxy/addons/tlsconfig.py
@@ -254,8 +254,15 @@ class TlsConfig:
         # Force HTTP/1 for secure web proxies, we currently don't support CONNECT over HTTP/2.
         # There is a proof-of-concept branch at https://github.com/mhils/mitmproxy/tree/http2-proxy,
         # but the complexity outweighs the benefits for now.
-        if len(tls_start.context.layers) == 2 and isinstance(
-            tls_start.context.layers[0], modes.HttpProxy
+        # `server.address is None` distinguishes the outer listener TLS from a CONNECT-tunneled
+        # inner TLS, which has server.address set to the CONNECT target.
+        if (
+            tls_start.context.layers
+            and isinstance(
+                tls_start.context.layers[0],
+                (modes.HttpProxy, modes.HttpUpstreamProxy),
+            )
+            and tls_start.context.server.address is None
         ):
             client_alpn: bytes | None = b"http/1.1"
         else:

--- a/test/mitmproxy/addons/test_tlsconfig.py
+++ b/test/mitmproxy/addons/test_tlsconfig.py
@@ -15,6 +15,7 @@ from mitmproxy import tls
 from mitmproxy.addons import tlsconfig
 from mitmproxy.net import tls as net_tls
 from mitmproxy.proxy import context
+from mitmproxy.proxy.layers import http as proxy_http
 from mitmproxy.proxy.layers import modes
 from mitmproxy.proxy.layers import quic
 from mitmproxy.proxy.layers import tls as proxy_tls
@@ -460,7 +461,8 @@ class TestTlsConfig:
 
     def test_no_h2_proxy(self, tdata):
         """Do not negotiate h2 on the client<->proxy connection in secure web proxy mode,
-        https://github.com/mitmproxy/mitmproxy/issues/4689"""
+        https://github.com/mitmproxy/mitmproxy/issues/4689,
+        https://github.com/mitmproxy/mitmproxy/issues/8192"""
 
         ta = tlsconfig.TlsConfig()
         with taddons.context(ta) as tctx:
@@ -472,11 +474,36 @@ class TestTlsConfig:
             )
 
             ctx = _ctx(tctx.options)
-            # mock up something that looks like a secure web proxy.
-            ctx.layers = [modes.HttpProxy(ctx), 123]
+            ctx.layers = [
+                modes.HttpProxy(ctx),
+                proxy_tls.ClientTLSLayer(ctx),
+                proxy_http.HttpLayer(ctx, proxy_http.HTTPMode.regular),
+            ]
             tls_start = tls.TlsData(ctx.client, context=ctx)
             ta.tls_start_client(tls_start)
             assert tls_start.ssl_conn.get_app_data()["client_alpn"] == b"http/1.1"
+
+            ctx = _ctx(tctx.options)
+            ctx.layers = [
+                modes.HttpUpstreamProxy(ctx),
+                proxy_tls.ClientTLSLayer(ctx),
+                proxy_http.HttpLayer(ctx, proxy_http.HTTPMode.upstream),
+            ]
+            tls_start = tls.TlsData(ctx.client, context=ctx)
+            ta.tls_start_client(tls_start)
+            assert tls_start.ssl_conn.get_app_data()["client_alpn"] == b"http/1.1"
+
+            # CONNECT-tunneled inner TLS: server.address is set, so h2 must be allowed.
+            ctx = _ctx(tctx.options)
+            ctx.server.address = ("example.com", 443)
+            ctx.layers = [
+                modes.HttpProxy(ctx),
+                proxy_http.HttpLayer(ctx, proxy_http.HTTPMode.regular),
+            ]
+            ctx.client.alpn = b"h2"
+            tls_start = tls.TlsData(ctx.client, context=ctx)
+            ta.tls_start_client(tls_start)
+            assert tls_start.ssl_conn.get_app_data()["client_alpn"] == b"h2"
 
     @pytest.mark.parametrize(
         "client_certs",


### PR DESCRIPTION
#### Description

Replaced the stale layer-count guard with a `server.address is None` check             `HttpUpstreamProxy`                    
                                                                                                      
Closes #8192

#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
