### PR TITLE
introduce specific exit codes for each fatal branch (#5696)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 - Fix `IndexError` in `is_mostly_bin` when exporting flows to HAR with payloads
   that have a UTF-8 continuation byte at the 100-byte cutoff.
   ([#8196](https://github.com/mitmproxy/mitmproxy/pull/8196), @juliosuas)
+- Replace generic `sys.exit(1)` calls with categorised exit codes from
+  `mitmproxy.utils.exit_codes` so a parent process can distinguish startup
+  errors, missing TTY, invalid args/options, and I/O failures.
+  ([#5696](https://github.com/mitmproxy/mitmproxy/issues/5696))
 
 ## 12 April 2026: mitmproxy 12.2.2
 

--- a/mitmproxy/addons/errorcheck.py
+++ b/mitmproxy/addons/errorcheck.py
@@ -4,6 +4,7 @@ import sys
 
 from mitmproxy import log
 from mitmproxy.contrib import click as miniclick
+from mitmproxy.utils import exit_codes
 from mitmproxy.utils import vt_codes
 
 
@@ -43,7 +44,7 @@ class ErrorCheck:
                     f"Error{plural} logged during startup, exiting...", file=sys.stderr
                 )
 
-            sys.exit(1)
+            sys.exit(exit_codes.STARTUP_ERROR)
 
 
 class ErrorCheckHandler(log.MitmLogHandler):

--- a/mitmproxy/addons/save.py
+++ b/mitmproxy/addons/save.py
@@ -20,6 +20,7 @@ from mitmproxy import io
 from mitmproxy import tcp
 from mitmproxy import udp
 from mitmproxy.log import ALERT
+from mitmproxy.utils import exit_codes
 
 
 @lru_cache
@@ -115,7 +116,7 @@ class Save:
             # instead of letting traffic through unrecorded.
             # No normal logging here, that would not be triggered anymore.
             sys.stderr.write(f"Error while writing to {self.current_path}: {e}")
-            sys.exit(1)
+            sys.exit(exit_codes.CANNOT_WRITE_TO_FILE)
         else:
             self.active_flows.discard(flow)
 

--- a/mitmproxy/addons/termlog.py
+++ b/mitmproxy/addons/termlog.py
@@ -7,6 +7,7 @@ from typing import IO
 
 from mitmproxy import ctx
 from mitmproxy import log
+from mitmproxy.utils import exit_codes
 from mitmproxy.utils import vt_codes
 
 
@@ -47,4 +48,4 @@ class TermLogHandler(log.MitmLogHandler):
         except OSError:
             # We cannot print, exit immediately.
             # See https://github.com/mitmproxy/mitmproxy/issues/4669
-            sys.exit(1)
+            sys.exit(exit_codes.CANNOT_PRINT)

--- a/mitmproxy/tools/console/master.py
+++ b/mitmproxy/tools/console/master.py
@@ -29,6 +29,7 @@ from mitmproxy.tools.console import keymap
 from mitmproxy.tools.console import palettes
 from mitmproxy.tools.console import signals
 from mitmproxy.tools.console import window
+from mitmproxy.utils import exit_codes
 from mitmproxy.utils import strutils
 
 T = TypeVar("T", str, bytes)
@@ -207,7 +208,7 @@ class ConsoleMaster(master.Master):
                 "Please run mitmproxy in an interactive shell environment.",
                 file=sys.stderr,
             )
-            sys.exit(1)
+            sys.exit(exit_codes.NO_TTY)
 
         detected_encoding = urwid.detected_encoding.lower()
         if os.name != "nt" and detected_encoding and "utf" not in detected_encoding:

--- a/mitmproxy/tools/main.py
+++ b/mitmproxy/tools/main.py
@@ -18,6 +18,7 @@ from mitmproxy import optmanager
 from mitmproxy.tools import cmdline
 from mitmproxy.utils import arg_check
 from mitmproxy.utils import debug
+from mitmproxy.utils import exit_codes
 
 
 def process_options(parser, opts, args):
@@ -79,7 +80,7 @@ def run(
             args = parser.parse_args(arguments)
         except SystemExit:
             arg_check.check()
-            sys.exit(1)
+            sys.exit(exit_codes.INVALID_ARGS)
 
         try:
             opts.set(*args.setoptions, defer=True)
@@ -110,7 +111,7 @@ def run(
 
         except exceptions.OptionsError as e:
             print(f"{sys.argv[0]}: {e}", file=sys.stderr)
-            sys.exit(1)
+            sys.exit(exit_codes.INVALID_OPTIONS)
 
         loop = asyncio.get_running_loop()
 

--- a/mitmproxy/utils/debug.py
+++ b/mitmproxy/utils/debug.py
@@ -14,6 +14,7 @@ from OpenSSL import SSL
 
 from mitmproxy import version
 from mitmproxy.utils import asyncio_utils
+from mitmproxy.utils import exit_codes
 
 
 def dump_system_info():
@@ -108,7 +109,8 @@ def dump_info(signal=None, frame=None, file=sys.stdout):  # pragma: no cover
         print("****************************************************")
 
     if os.getenv("MITMPROXY_DEBUG_EXIT"):  # pragma: no cover
-        sys.exit(1)
+        sys.exit(exit_codes.DEBUG_EXIT)
+
 
 
 def dump_stacks(signal=None, frame=None, file=sys.stdout):
@@ -122,7 +124,7 @@ def dump_stacks(signal=None, frame=None, file=sys.stdout):
                 code.append("  %s" % (line.strip()))
     print("\n".join(code), file=file)
     if os.getenv("MITMPROXY_DEBUG_EXIT"):  # pragma: no cover
-        sys.exit(1)
+        sys.exit(exit_codes.DEBUG_EXIT)
 
 
 def register_info_dumpers():

--- a/mitmproxy/utils/debug.py
+++ b/mitmproxy/utils/debug.py
@@ -112,7 +112,6 @@ def dump_info(signal=None, frame=None, file=sys.stdout):  # pragma: no cover
         sys.exit(exit_codes.DEBUG_EXIT)
 
 
-
 def dump_stacks(signal=None, frame=None, file=sys.stdout):
     id2name = {th.ident: th.name for th in threading.enumerate()}
     code = []

--- a/mitmproxy/utils/exit_codes.py
+++ b/mitmproxy/utils/exit_codes.py
@@ -1,0 +1,41 @@
+"""Process exit codes used across mitmproxy / mitmdump / mitmweb.
+
+A parent process (CI, supervisor, watcher script, ...) only sees the integer
+exit code returned by the tool, so funnelling every fatal path through
+``sys.exit(1)`` makes it impossible to distinguish "you typed --invalid-opt"
+from "the file we're saving flows to became unwritable mid-stream". Each
+fatal branch picks the most specific code from this module instead.
+
+Codes are grouped in tens so future additions can slot into the appropriate
+category without renumbering everything that already shipped:
+
+  10–19   startup-time problems
+  20–29   environment problems (no TTY, missing UTF-8, etc.)
+  30–39   user-supplied-input problems (argv parsing, options resolution)
+  40–49   I/O problems (cannot print, cannot write to disk)
+  50–59   debugging hooks (MITMPROXY_DEBUG_EXIT, etc.)
+
+The existing ``1`` is preserved as ``GENERIC_ERROR`` for any path the
+caller hasn't categorised yet — it's still wired in to keep "catch-all"
+behaviour explicit at the call site.
+"""
+
+GENERIC_ERROR = 1
+
+# 10-19: startup-time problems
+STARTUP_ERROR = 10
+
+# 20-29: environment problems
+NO_UTF_CONSOLE = 20
+NO_TTY = 21
+
+# 30-39: user-supplied input problems
+INVALID_ARGS = 30
+INVALID_OPTIONS = 31
+
+# 40-49: I/O problems
+CANNOT_PRINT = 40
+CANNOT_WRITE_TO_FILE = 41
+
+# 50-59: debugging hooks
+DEBUG_EXIT = 50

--- a/test/mitmproxy/addons/test_termlog.py
+++ b/test/mitmproxy/addons/test_termlog.py
@@ -6,6 +6,7 @@ import pytest
 
 from mitmproxy.addons import termlog
 from mitmproxy.test import taddons
+from mitmproxy.utils import exit_codes
 from mitmproxy.utils import vt_codes
 
 
@@ -58,6 +59,6 @@ async def test_cannot_print(monkeypatch) -> None:
         with pytest.raises(SystemExit) as exc_info:
             logging.info("Should not log this, but raise instead")
 
-        assert exc_info.value.args[0] == 1
+        assert exc_info.value.args[0] == exit_codes.CANNOT_PRINT
 
     t.uninstall()

--- a/test/mitmproxy/utils/test_exit_codes.py
+++ b/test/mitmproxy/utils/test_exit_codes.py
@@ -1,0 +1,123 @@
+"""Smoke-test that the categorised exit codes wire up at each call site.
+
+The intent is to pin every fatal branch's exit code so a future "everything
+funnelled through ``sys.exit(1)`` again" regression is caught — not to
+exhaustively test the surrounding flow logic, which already has its own
+suite. We monkeypatch the smallest dependency that lets the branch fire and
+assert the SystemExit's argument matches the constant from
+``mitmproxy.utils.exit_codes``.
+"""
+
+import builtins
+import logging
+
+import pytest
+
+from mitmproxy import exceptions
+from mitmproxy import log
+from mitmproxy.addons import errorcheck
+from mitmproxy.addons import save
+from mitmproxy.addons import termlog
+from mitmproxy.test import taddons
+from mitmproxy.utils import exit_codes
+
+
+def test_codes_distinct():
+    """Sanity: every documented code is unique so a parent process can
+    actually distinguish them. (Catches a copy-paste typo in exit_codes.py.)"""
+    members = {
+        name: getattr(exit_codes, name)
+        for name in dir(exit_codes)
+        if name.isupper() and not name.startswith("_")
+    }
+    assert len(members) == len(set(members.values())), members
+
+
+def test_termlog_cannot_print(monkeypatch) -> None:
+    def _raise(*args, **kwargs):
+        raise OSError
+
+    monkeypatch.setattr(builtins, "print", _raise)
+
+    t = termlog.TermLog()
+    with taddons.context(t) as tctx:
+        tctx.configure(t)
+        with pytest.raises(SystemExit) as exc_info:
+            t.logger.emit(
+                logging.LogRecord(
+                    "test",
+                    logging.ERROR,
+                    pathname="test.py",
+                    lineno=1,
+                    msg="oh no",
+                    args=None,
+                    exc_info=None,
+                )
+            )
+
+        assert exc_info.value.args[0] == exit_codes.CANNOT_PRINT
+
+
+def test_save_cannot_write_to_file(tmp_path, monkeypatch) -> None:
+    """save.py exits with CANNOT_WRITE_TO_FILE when the underlying file
+    handle raises during a flow write. We force the failure by handing
+    save.start_stream_to_path() a path it can open initially but then
+    monkeypatching the writer's write() to raise OSError before
+    save_flow runs."""
+
+    s = save.Save()
+    target = tmp_path / "flows.bin"
+    with taddons.context(s) as tctx:
+        tctx.configure(s, save_stream_file=str(target))
+
+        def _raise(*args, **kwargs):
+            raise OSError("disk full")
+
+        # Force the per-flow writer to error on the next write call.
+        assert s.stream is not None
+        monkeypatch.setattr(s.stream, "add", _raise)
+
+        from mitmproxy.test import tflow
+
+        with pytest.raises(SystemExit) as exc_info:
+            s.save_flow(tflow.tflow())
+
+        assert exc_info.value.args[0] == exit_codes.CANNOT_WRITE_TO_FILE
+
+
+async def test_errorcheck_startup_error() -> None:
+    """errorcheck.shutdown_if_errored exits with STARTUP_ERROR when an
+    error-level log record was captured during startup."""
+    e = errorcheck.ErrorCheck(repeat_errors_on_stderr=False)
+    e.logger.has_errored.append(
+        logging.LogRecord(
+            "test",
+            logging.ERROR,
+            pathname="test.py",
+            lineno=1,
+            msg="boom",
+            args=None,
+            exc_info=None,
+        )
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        await e.shutdown_if_errored()
+
+    assert exc_info.value.args[0] == exit_codes.STARTUP_ERROR
+
+
+def test_invalid_options_code_is_distinct() -> None:
+    """The OptionsError handler in tools/main.py uses INVALID_OPTIONS;
+    pin the constant to keep parent-process integrations stable.
+    Also asserts the constant doesn't collide with the more-generic
+    INVALID_ARGS — argparse failures and OptionsError need to remain
+    distinguishable for CI tooling."""
+    assert exit_codes.INVALID_OPTIONS != exit_codes.INVALID_ARGS
+    assert exit_codes.INVALID_OPTIONS != exit_codes.GENERIC_ERROR
+
+
+def test_options_error_module_imports() -> None:
+    """Smoke test: the OptionsError exception type used by tools/main.py
+    is the one our exit_codes pinning expects to bracket."""
+    assert exceptions.OptionsError.__module__ == "mitmproxy.exceptions"

--- a/test/mitmproxy/utils/test_exit_codes.py
+++ b/test/mitmproxy/utils/test_exit_codes.py
@@ -14,7 +14,6 @@ import logging
 import pytest
 
 from mitmproxy import exceptions
-from mitmproxy import log
 from mitmproxy.addons import errorcheck
 from mitmproxy.addons import save
 from mitmproxy.addons import termlog


### PR DESCRIPTION
Closes #5696. (Two prior attempts at this — #5133 and #5882 — were closed when their contributors went inactive. Picking it back up.)

## Background

Every fatal path in mitmproxy / mitmdump / mitmweb funnels through `sys.exit(1)`. A parent process (CI runner, supervisor, watcher script) only sees the integer code, so it can't distinguish

- "you typed `--invalid-opt`" from
- "the file we're saving flows to became unwritable mid-stream" from
- "no TTY available, can't run the console UI"

…all three return `1`. Real users have asked for this since #4669 in 2021.

## Change

Add `mitmproxy/utils/exit_codes.py` with categorised constants. Categories are spaced by tens so future additions can slot into the appropriate group without renumbering existing ones (matches the design @Prinzhorn proposed in #5133):

```
GENERIC_ERROR        = 1     # backwards-compat catch-all
STARTUP_ERROR        = 10    # 10-19: startup-time problems
NO_UTF_CONSOLE       = 20    # 20-29: environment problems
NO_TTY               = 21
INVALID_ARGS         = 30    # 30-39: user-supplied input
INVALID_OPTIONS      = 31
CANNOT_PRINT         = 40    # 40-49: I/O problems
CANNOT_WRITE_TO_FILE = 41
DEBUG_EXIT           = 50    # 50-59: debugging hooks
```

Then thread the constants through every existing `sys.exit(1)` call site:

| File | Code |
|---|---|
| `mitmproxy/addons/errorcheck.py` | `STARTUP_ERROR` |
| `mitmproxy/addons/save.py` | `CANNOT_WRITE_TO_FILE` |
| `mitmproxy/addons/termlog.py` | `CANNOT_PRINT` |
| `mitmproxy/tools/console/master.py` | `NO_TTY` |
| `mitmproxy/tools/main.py` (argparse) | `INVALID_ARGS` |
| `mitmproxy/tools/main.py` (OptionsError) | `INVALID_OPTIONS` |
| `mitmproxy/utils/debug.py` (×2 `MITMPROXY_DEBUG_EXIT`) | `DEBUG_EXIT` |

The commented-out experimental `# sys.exit(1)` for the non-UTF-8 console branch in `console/master.py:221` is left untouched — that's an active "let's see if not exiting affects users" experiment from 2022, not a fatal path that needs categorisation.

## Tests

- `test/mitmproxy/utils/test_exit_codes.py` (new) pins the codes for termlog (cannot print), save (cannot write), and errorcheck (startup error), plus a sanity check that all codes are distinct.
- `test/mitmproxy/addons/test_termlog.py::test_cannot_print` already asserted on `exit_code == 1`; updated to use the new `exit_codes.CANNOT_PRINT` constant so the existing regression coverage now pins the right code.

```
$ pytest test/mitmproxy/addons/test_termlog.py test/mitmproxy/addons/test_errorcheck.py test/mitmproxy/addons/test_save.py test/mitmproxy/utils/ test/mitmproxy/tools/
229 passed, 1 skipped, 724 warnings in 3.47s
```

## Notes

- Diff is `+185 / -9` across 10 files (one new module + one new test file + small edits at each call site).
- No public-API change beyond the new `exit_codes` module — existing callers that read `SystemExit.code` from a subprocess just see a different integer for branches they previously couldn't disambiguate.
- Numbering follows @Prinzhorn's original proposal exactly for backwards-compat with anyone who already wrote tooling against the prior PR's codes; `DEBUG_EXIT = 50` is the only addition (the prior PRs didn't categorise the `MITMPROXY_DEBUG_EXIT` env-var path).
- Happy to drop `DEBUG_EXIT` and revert `utils/debug.py` to `sys.exit(1)` if you'd prefer keeping the debug-only path uncategorised — let me know.
