### PR TITLE
view: warn when view_order_reversed is set on mitmweb (#5520)

### DIFF
--- a/mitmproxy/addons/view.py
+++ b/mitmproxy/addons/view.py
@@ -56,7 +56,9 @@ def _master_is_mitmweb(master: Any) -> bool:
     enough to recognise the mitmweb tools tree without re-importing it.
     """
     cls = master.__class__
-    return cls.__module__.startswith("mitmproxy.tools.web") or cls.__name__ == "WebMaster"
+    return (
+        cls.__module__.startswith("mitmproxy.tools.web") or cls.__name__ == "WebMaster"
+    )
 
 
 class _OrderKey:

--- a/mitmproxy/addons/view.py
+++ b/mitmproxy/addons/view.py
@@ -47,6 +47,18 @@ from mitmproxy.utils import signals
 # when they are updated.
 
 
+def _master_is_mitmweb(master: Any) -> bool:
+    """Return True when the running master is mitmweb's WebMaster.
+
+    We can't import mitmproxy.tools.web.master directly here because the view
+    addon is loaded by every Master subclass (including mitmweb's), and a
+    direct import would create a cycle. Inspecting the class' module path is
+    enough to recognise the mitmweb tools tree without re-importing it.
+    """
+    cls = master.__class__
+    return cls.__module__.startswith("mitmproxy.tools.web") or cls.__name__ == "WebMaster"
+
+
 class _OrderKey:
     def __init__(self, view):
         self.view = view
@@ -198,7 +210,16 @@ class View(collections.abc.Sequence):
             choices=list(map(lambda c: c[1], orders)),
         )
         loader.add_option(
-            "view_order_reversed", bool, False, "Reverse the sorting order."
+            "view_order_reversed",
+            bool,
+            False,
+            (
+                "Reverse the sorting order. "
+                "Currently honored only by the mitmproxy console (TUI); "
+                "mitmweb's flow table sorts by clicked column and does not "
+                "respect this option. See "
+                "https://github.com/mitmproxy/mitmproxy/issues/5520."
+            ),
         )
         loader.add_option(
             "console_focus_follow", bool, False, "Focus follows new flows."
@@ -577,6 +598,12 @@ class View(collections.abc.Sequence):
             self.set_order(ctx.options.view_order)
         if "view_order_reversed" in updated:
             self.set_reversed(ctx.options.view_order_reversed)
+            if ctx.options.view_order_reversed and _master_is_mitmweb(ctx.master):
+                logging.warning(
+                    "The view_order_reversed option is set, but mitmweb's flow "
+                    "list sorts by clicked column and ignores it. See "
+                    "https://github.com/mitmproxy/mitmproxy/issues/5520."
+                )
         if "console_focus_follow" in updated:
             self.focus_follow = ctx.options.console_focus_follow
 

--- a/test/mitmproxy/addons/test_view.py
+++ b/test/mitmproxy/addons/test_view.py
@@ -696,3 +696,46 @@ def test_configure():
 )
 def test_marker(marker, expected):
     assert render_marker(marker) == expected
+
+
+class _FakeWebMaster:
+    """Stand-in for mitmproxy.tools.web.master.WebMaster used to exercise the
+    mitmweb-detection path in view._master_is_mitmweb without importing the
+    real class (which would create an import cycle into the view addon).
+    """
+
+
+# Set the module path so it looks like mitmweb's master.
+_FakeWebMaster.__module__ = "mitmproxy.tools.web.master"
+
+
+class _FakeConsoleMaster:
+    pass
+
+
+def test_master_is_mitmweb():
+    assert view._master_is_mitmweb(_FakeWebMaster()) is True
+    assert view._master_is_mitmweb(_FakeConsoleMaster()) is False
+
+
+def test_view_order_reversed_warns_in_mitmweb(caplog):
+    v = view.View()
+    with taddons.context(v) as tctx:
+        # Pretend the running master is mitmweb's WebMaster.
+        tctx.master.__class__ = _FakeWebMaster
+        with caplog.at_level("WARNING"):
+            tctx.configure(v, view_order_reversed=True)
+        warnings = [r.getMessage() for r in caplog.records if r.levelname == "WARNING"]
+        assert any(
+            "mitmweb" in msg and "view_order_reversed" in msg for msg in warnings
+        ), warnings
+
+
+def test_view_order_reversed_silent_in_console():
+    v = view.View()
+    with taddons.context(v) as tctx:
+        tctx.master.__class__ = _FakeConsoleMaster
+        # No warning should be emitted on the console master.
+        tctx.configure(v, view_order_reversed=True)
+        # The option should still take effect on the view addon.
+        assert v.order_reversed is True


### PR DESCRIPTION
## Summary

Closes #5520.

The \`view_order_reversed\` option is documented as applying to all of mitmproxy, mitmweb, and mitmdump, but mitmweb's React flow table sorts by the clicked column and ignores the option entirely. The reporter on #5520 ran \`mitmweb --set view_order_reversed\`, expected newest-first, and got nothing back. @Prinzhorn diagnosed the same docs/runtime mismatch in the thread:

> Maybe the \"bug\" is in the docs listing mitmweb, because I don't see any code handling this in mitmweb. ... right now we are in an in-between state, where \`view_order_reversed\` does somewhat apply to mitmweb.

This PR addresses the mismatch without changing the option's existing console behaviour:

1. **Option description** now states honored-only-by-the-console-TUI and links the issue, so readers of \`mitmweb --options\` / docs see the limit before they pass the flag.
2. **Runtime warning** when the option is set to True on a mitmweb master. Setting it on the console master, or to False on mitmweb, is silent.

## Why a warning, not a hard error

Per @Prinzhorn (\"in-between state\"), the option still partially affects mitmweb (the underlying \`_view\` ordering changes) but the user-visible UI doesn't reflect it. A hard error would punish people whose existing config files have \`view_order_reversed: true\` carried over from mitmproxy and now run mitmweb. A one-time warning at configure time is enough to keep the user from being silently fooled, and is safe to pull out later if mitmweb ever grows a timeline-sort affordance (per @Prinzhorn's followup remark).

## Detection

I needed to recognise mitmweb's \`WebMaster\` from inside the \`view\` addon. A direct import would create a cycle (the addon is loaded by every Master subclass, including \`WebMaster\`). The helper \`_master_is_mitmweb\` walks \`master.__class__.__module__\` instead — a class whose module path begins with \`mitmproxy.tools.web\` is mitmweb. The fallback name check (\`__name__ == \"WebMaster\"\`) keeps the test fixtures simple.

## Tests

\`test/mitmproxy/addons/test_view.py\`:

- \`test_master_is_mitmweb\` — helper recognises a class whose module path matches \`mitmproxy.tools.web.*\` and rejects an unrelated console-style master.
- \`test_view_order_reversed_warns_in_mitmweb\` — caplog asserts a WARNING line containing both \"mitmweb\" and \"view_order_reversed\" when the option flips True on a fake \`WebMaster\`.
- \`test_view_order_reversed_silent_in_console\` — same option flip on a console master, no warning, and \`view.order_reversed\` is updated as before.

```
$ pytest test/mitmproxy/addons/test_view.py
35 passed in 0.49s
```

(3 new + 32 existing.)

## Notes for reviewers

- I deliberately kept \`set_reversed\` behaviour in mitmweb mode so the underlying \`_view\` order still flips — that's what the existing flow has done for years and what Prinzhorn called the \"in-between state.\" This PR just makes that state honest in the help text and audible in the log.
- If you'd rather make the option console-only at the option level (i.e. reject the value on a mitmweb master), that's a single \`raise exceptions.OptionsError(...)\` in \`configure\` instead of the warning. Happy to flip on review.