### PR TITLE
Add Charles Proxy JSON Session export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Add a `save.charles` command and a "Export as Charles JSON Session..." entry
   in the mitmweb File menu to export the current session to the Charles Proxy
   JSON Session (`.chlsj`) format.
+  ([#8220](https://github.com/mitmproxy/mitmproxy/pull/8220), @mackode)
 - Fix `IndexError` in `is_mostly_bin` when exporting flows to HAR with payloads
   that have a UTF-8 continuation byte at the 100-byte cutoff.
   ([#8196](https://github.com/mitmproxy/mitmproxy/pull/8196), @juliosuas)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 
 ## Unreleased: mitmproxy next
 
+- Add a `save.charles` command and a "Export as Charles JSON Session..." entry
+  in the mitmweb File menu to export the current session to the Charles Proxy
+  JSON Session (`.chlsj`) format.
 - Fix `IndexError` in `is_mostly_bin` when exporting flows to HAR with payloads
   that have a UTF-8 continuation byte at the 100-byte cutoff.
   ([#8196](https://github.com/mitmproxy/mitmproxy/pull/8196), @juliosuas)

--- a/mitmproxy/addons/__init__.py
+++ b/mitmproxy/addons/__init__.py
@@ -20,6 +20,7 @@ from mitmproxy.addons import onboarding
 from mitmproxy.addons import proxyauth
 from mitmproxy.addons import proxyserver
 from mitmproxy.addons import save
+from mitmproxy.addons import savecharles
 from mitmproxy.addons import savehar
 from mitmproxy.addons import script
 from mitmproxy.addons import serverplayback
@@ -60,6 +61,7 @@ def default_addons():
         stickyauth.StickyAuth(),
         stickycookie.StickyCookie(),
         save.Save(),
+        savecharles.SaveCharles(),
         savehar.SaveHar(),
         tlsconfig.TlsConfig(),
         upstream_auth.UpstreamAuth(),

--- a/mitmproxy/addons/savecharles.py
+++ b/mitmproxy/addons/savecharles.py
@@ -1,0 +1,270 @@
+"""Write flow objects to a Charles Proxy JSON Session (.chlsj) file."""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+from collections.abc import Sequence
+from datetime import datetime
+from datetime import timezone
+from typing import Any
+
+from mitmproxy import command
+from mitmproxy import flow
+from mitmproxy import http
+from mitmproxy import types
+from mitmproxy.log import ALERT
+from mitmproxy.utils import human
+from mitmproxy.utils import strutils
+
+logger = logging.getLogger(__name__)
+
+
+def _isofmt(ts: float | None) -> str | None:
+    if ts is None:
+        return None
+    return datetime.fromtimestamp(ts, timezone.utc).isoformat()
+
+
+def _ms(delta: float | None) -> int:
+    if delta is None or delta < 0:
+        return 0
+    return int(round(delta * 1000))
+
+
+def _split_content_type(value: str) -> tuple[str | None, str | None]:
+    if not value:
+        return None, None
+    parts = [p.strip() for p in value.split(";")]
+    mime = parts[0] or None
+    charset: str | None = None
+    for part in parts[1:]:
+        if part.lower().startswith("charset="):
+            charset = part.split("=", 1)[1].strip().strip('"') or None
+    return mime, charset
+
+
+def _body(message: http.Message | None) -> dict[str, Any]:
+    if message is None or not message.raw_content:
+        return {}
+    raw = message.raw_content
+    text = message.get_text(strict=False)
+    if text is None or strutils.is_mostly_bin(raw):
+        return {
+            "encoded": base64.b64encode(raw).decode(),
+            "charSet": "",
+        }
+    return {"text": text}
+
+
+def _http_version_string(http_version: str) -> str:
+    if not http_version:
+        return "HTTP/1.1"
+    if http_version.upper().startswith("HTTP/"):
+        return http_version
+    return f"HTTP/{http_version}"
+
+
+def _headers_list(message: http.Message) -> list[dict[str, str]]:
+    return [{"name": k, "value": v} for k, v in message.headers.items(multi=True)]
+
+
+class SaveCharles:
+    @command.command("save.charles")
+    def export_charles(
+        self, flows: Sequence[flow.Flow], path: types.Path
+    ) -> None:
+        """Export flows to a Charles Proxy JSON Session (.chlsj) file."""
+        data = json.dumps(self.make_charles(flows), indent=4).encode()
+        with open(path, "wb") as f:
+            f.write(data)
+        logging.log(
+            ALERT,
+            f"Charles JSON session saved ({human.pretty_size(len(data))} bytes).",
+        )
+
+    def make_charles(self, flows: Sequence[flow.Flow]) -> list[dict[str, Any]]:
+        entries: list[dict[str, Any]] = []
+        skipped = 0
+        for f in flows:
+            if isinstance(f, http.HTTPFlow):
+                entries.append(self.flow_entry(f))
+            else:
+                skipped += 1
+        if skipped:
+            logger.info(f"Skipped {skipped} flows that weren't HTTP flows.")
+        return entries
+
+    def flow_entry(self, f: http.HTTPFlow) -> dict[str, Any]:
+        req = f.request
+        resp = f.response
+
+        if f.error:
+            status = "Failed"
+        elif resp:
+            status = "Complete"
+        else:
+            status = "Active"
+
+        # Path/query split
+        if "?" in req.path:
+            path, _, query = req.path.partition("?")
+        else:
+            path, query = req.path, ""
+
+        # Times
+        times: dict[str, str | None] = {
+            "start": _isofmt(req.timestamp_start),
+        }
+        if req.timestamp_end is not None:
+            times["request"] = _isofmt(req.timestamp_end)
+        if resp is not None:
+            times["response"] = _isofmt(resp.timestamp_start)
+        if resp is not None and resp.timestamp_end is not None:
+            times["end"] = _isofmt(resp.timestamp_end)
+        elif req.timestamp_end is not None:
+            times["end"] = _isofmt(req.timestamp_end)
+        else:
+            times["end"] = times["start"]
+
+        # Timing (in ms)
+        sc = f.server_conn
+        if sc and sc.timestamp_start and sc.timestamp_tcp_setup:
+            connect_ms = _ms(sc.timestamp_tcp_setup - sc.timestamp_start)
+        else:
+            connect_ms = 0
+        if sc and sc.timestamp_tcp_setup and sc.timestamp_tls_setup:
+            ssl_ms = _ms(sc.timestamp_tls_setup - sc.timestamp_tcp_setup)
+        else:
+            ssl_ms = 0
+        if req.timestamp_end is not None:
+            request_ms = _ms(req.timestamp_end - req.timestamp_start)
+        else:
+            request_ms = 0
+        if resp is not None and resp.timestamp_end is not None:
+            response_ms = _ms(resp.timestamp_end - resp.timestamp_start)
+        else:
+            response_ms = 0
+        if resp is not None and req.timestamp_end is not None:
+            latency_ms = _ms(resp.timestamp_start - req.timestamp_end)
+        else:
+            latency_ms = 0
+        end_ts = (
+            (resp.timestamp_end if resp and resp.timestamp_end is not None else None)
+            or (resp.timestamp_start if resp else None)
+            or req.timestamp_end
+            or req.timestamp_start
+        )
+        duration_ms = _ms(end_ts - req.timestamp_start) if end_ts else 0
+
+        timing = {
+            "dnsNs": 0,
+            "connectMs": connect_ms,
+            "sslMs": ssl_ms,
+            "requestMs": request_ms,
+            "responseMs": response_ms,
+            "latencyMs": latency_ms,
+            "durationMs": duration_ms,
+            "totalMs": duration_ms,
+        }
+
+        # Connection addresses
+        remote_address = ""
+        if sc and sc.peername:
+            remote_address = str(sc.peername[0])
+        client_address = ""
+        client_port = 0
+        if f.client_conn and f.client_conn.peername:
+            client_address = str(f.client_conn.peername[0])
+            client_port = int(f.client_conn.peername[1])
+
+        # Request side
+        req_mime, req_charset = _split_content_type(
+            req.headers.get("Content-Type", "")
+        )
+        req_encoding = req.headers.get("Content-Encoding") or None
+        request_obj: dict[str, Any] = {
+            "sizes": {
+                "headers": len(str(req.headers)),
+                "body": len(req.raw_content) if req.raw_content else 0,
+            },
+            "mimeType": req_mime,
+            "charset": req_charset,
+            "contentEncoding": req_encoding,
+            "header": {
+                "firstLine": f"{req.method} {req.path} {_http_version_string(req.http_version)}",
+                "headers": _headers_list(req),
+            },
+            "body": _body(req),
+        }
+
+        # Response side
+        if resp is not None:
+            resp_mime, resp_charset = _split_content_type(
+                resp.headers.get("Content-Type", "")
+            )
+            resp_encoding = resp.headers.get("Content-Encoding") or None
+            response_obj: dict[str, Any] | None = {
+                "status": resp.status_code,
+                "sizes": {
+                    "headers": len(str(resp.headers)),
+                    "body": len(resp.raw_content) if resp.raw_content else 0,
+                },
+                "mimeType": resp_mime,
+                "charset": resp_charset,
+                "contentEncoding": resp_encoding,
+                "header": {
+                    "firstLine": f"{_http_version_string(resp.http_version)} {resp.status_code} {resp.reason}",
+                    "headers": _headers_list(resp),
+                },
+                "body": _body(resp),
+            }
+        else:
+            response_obj = None
+
+        entry: dict[str, Any] = {
+            "status": status,
+            "method": req.method,
+            "protocolVersion": _http_version_string(req.http_version),
+            "scheme": req.scheme,
+            "host": req.pretty_host,
+            "actualPort": req.port,
+            "path": path,
+            "query": query,
+            "remoteAddress": remote_address,
+            "clientAddress": client_address,
+            "clientPort": client_port,
+            "times": times,
+            "timing": timing,
+            "tunnel": req.method == "CONNECT",
+            "keptAlive": False,
+            "webSocketMessages": [],
+            "request": request_obj,
+            "response": response_obj,
+        }
+
+        if f.error:
+            entry["failure"] = f.error.msg
+
+        if f.websocket is not None:
+            ws_messages = []
+            for m in f.websocket.messages:
+                if m.is_text:
+                    data = m.text
+                    binary = False
+                else:
+                    data = base64.b64encode(m.content).decode()
+                    binary = True
+                ws_messages.append(
+                    {
+                        "type": "Send" if m.from_client else "Receive",
+                        "time": _isofmt(m.timestamp),
+                        "opcode": m.type.value,
+                        "data": data,
+                        "binary": binary,
+                    }
+                )
+            entry["webSocketMessages"] = ws_messages
+
+        return entry

--- a/mitmproxy/addons/savecharles.py
+++ b/mitmproxy/addons/savecharles.py
@@ -72,9 +72,7 @@ def _headers_list(message: http.Message) -> list[dict[str, str]]:
 
 class SaveCharles:
     @command.command("save.charles")
-    def export_charles(
-        self, flows: Sequence[flow.Flow], path: types.Path
-    ) -> None:
+    def export_charles(self, flows: Sequence[flow.Flow], path: types.Path) -> None:
         """Export flows to a Charles Proxy JSON Session (.chlsj) file."""
         data = json.dumps(self.make_charles(flows), indent=4).encode()
         with open(path, "wb") as f:
@@ -180,9 +178,7 @@ class SaveCharles:
             client_port = int(f.client_conn.peername[1])
 
         # Request side
-        req_mime, req_charset = _split_content_type(
-            req.headers.get("Content-Type", "")
-        )
+        req_mime, req_charset = _split_content_type(req.headers.get("Content-Type", ""))
         req_encoding = req.headers.get("Content-Encoding") or None
         request_obj: dict[str, Any] = {
             "sizes": {

--- a/mitmproxy/tools/web/app.py
+++ b/mitmproxy/tools/web/app.py
@@ -535,6 +535,29 @@ class DumpFlows(RequestHandler):
         bio.close()
 
 
+class DumpFlowsCharles(RequestHandler):
+    def get(self) -> None:
+        self.set_header(
+            "Content-Disposition", "attachment; filename=flows.chlsj"
+        )
+        self.set_header("Content-Type", "application/json")
+
+        match: Callable[[mitmproxy.flow.Flow], bool]
+        try:
+            match = flowfilter.parse(self.request.arguments["filter"][0].decode())
+        except ValueError:
+            raise APIError(400, "Invalid filter argument / regex")
+        except (KeyError, IndexError):
+
+            def match(_) -> bool:
+                return True
+
+        from mitmproxy.addons.savecharles import SaveCharles
+
+        flows = [f for f in self.view if match(f)]
+        self.write(json.dumps(SaveCharles().make_charles(flows), indent=4))
+
+
 class ClearAll(RequestHandler):
     def post(self):
         self.view.clear()
@@ -893,6 +916,7 @@ handlers = [
     (r"/events(?:\.json)?", Events),
     (r"/flows(?:\.json)?", Flows),
     (r"/flows/dump", DumpFlows),
+    (r"/flows/dump.chlsj", DumpFlowsCharles),
     (r"/flows/resume", ResumeFlows),
     (r"/flows/kill", KillFlows),
     (r"/flows/(?P<flow_id>[0-9a-f\-]+)", FlowHandler),

--- a/mitmproxy/tools/web/app.py
+++ b/mitmproxy/tools/web/app.py
@@ -537,9 +537,7 @@ class DumpFlows(RequestHandler):
 
 class DumpFlowsCharles(RequestHandler):
     def get(self) -> None:
-        self.set_header(
-            "Content-Disposition", "attachment; filename=flows.chlsj"
-        )
+        self.set_header("Content-Disposition", "attachment; filename=flows.chlsj")
         self.set_header("Content-Type", "application/json")
 
         match: Callable[[mitmproxy.flow.Flow], bool]

--- a/test/mitmproxy/addons/test_savecharles.py
+++ b/test/mitmproxy/addons/test_savecharles.py
@@ -1,0 +1,153 @@
+import base64
+import json
+
+import pytest
+
+from mitmproxy import types
+from mitmproxy.addons import savecharles
+from mitmproxy.addons.savecharles import SaveCharles
+from mitmproxy.test import tflow
+from mitmproxy.test import tutils
+
+
+def test_make_charles_basic():
+    s = SaveCharles()
+    out = s.make_charles([tflow.tflow(resp=True)])
+    assert isinstance(out, list)
+    assert len(out) == 1
+    entry = out[0]
+    assert entry["method"] == "GET"
+    assert entry["status"] == "Complete"
+    assert entry["request"]["header"]["headers"]
+    assert entry["response"]["status"] == 200
+    assert entry["protocolVersion"].startswith("HTTP/")
+    # round-trip JSON serializable
+    json.dumps(out)
+
+
+def test_make_charles_skips_non_http(caplog):
+    s = SaveCharles()
+    out = s.make_charles([tflow.ttcpflow()])
+    assert out == []
+
+
+def test_make_charles_error_flow():
+    s = SaveCharles()
+    f = tflow.tflow(err=True)
+    entry = s.make_charles([f])[0]
+    assert entry["status"] == "Failed"
+    assert entry["response"] is None
+    assert entry["failure"]
+
+
+def test_make_charles_binary_body():
+    f = tflow.tflow(resp=tutils.tresp(content=b"foo" + b"\xff" * 10))
+    entry = SaveCharles().make_charles([f])[0]
+    body = entry["response"]["body"]
+    assert "encoded" in body
+    assert base64.b64decode(body["encoded"]) == b"foo" + b"\xff" * 10
+
+
+def test_make_charles_query_split():
+    f = tflow.tflow(resp=True)
+    f.request.path = "/path?x=1&y=2"
+    entry = SaveCharles().make_charles([f])[0]
+    assert entry["path"] == "/path"
+    assert entry["query"] == "x=1&y=2"
+
+
+def test_make_charles_websocket():
+    f = tflow.twebsocketflow()
+    entry = SaveCharles().make_charles([f])[0]
+    assert entry["webSocketMessages"]
+    assert entry["webSocketMessages"][0]["type"] in ("Send", "Receive")
+
+
+def test_export_charles_roundtrip(tmp_path):
+    out = tmp_path / "session.chlsj"
+    s = SaveCharles()
+    s.export_charles([tflow.tflow(resp=True)], types.Path(str(out)))
+    data = json.loads(out.read_bytes())
+    assert isinstance(data, list)
+    assert data[0]["method"] == "GET"
+
+
+def test_export_charles_write_error():
+    with pytest.raises(FileNotFoundError):
+        SaveCharles().export_charles(
+            [tflow.tflow(resp=True)], types.Path("unknown_dir/session.chlsj")
+        )
+
+
+def test_isofmt_none():
+    assert savecharles._isofmt(None) is None
+
+
+def test_ms_helpers():
+    assert savecharles._ms(None) == 0
+    assert savecharles._ms(-1) == 0
+    assert savecharles._ms(0.5) == 500
+
+
+def test_split_content_type():
+    assert savecharles._split_content_type("") == (None, None)
+    assert savecharles._split_content_type("text/html") == ("text/html", None)
+    assert savecharles._split_content_type(
+        'text/html; charset="utf-8"; foo=bar'
+    ) == ("text/html", "utf-8")
+
+
+def test_body_helpers():
+    assert savecharles._body(None) == {}
+    f = tflow.tflow(resp=True)
+    f.response.content = b""
+    assert savecharles._body(f.response) == {}
+
+
+def test_http_version_string_default():
+    assert savecharles._http_version_string("") == "HTTP/1.1"
+    assert savecharles._http_version_string("HTTP/2.0") == "HTTP/2.0"
+    assert savecharles._http_version_string("2.0") == "HTTP/2.0"
+
+
+def test_make_charles_active_status():
+    """No response and no error => Active."""
+    f = tflow.tflow()
+    f.request.timestamp_end = None
+    entry = SaveCharles().make_charles([f])[0]
+    assert entry["status"] == "Active"
+    assert entry["response"] is None
+    # end falls back to start
+    assert entry["times"]["end"] == entry["times"]["start"]
+
+
+def test_make_charles_no_timestamps_in_server_conn():
+    f = tflow.tflow(resp=True)
+    f.server_conn.timestamp_start = None
+    f.server_conn.timestamp_tcp_setup = None
+    f.server_conn.timestamp_tls_setup = None
+    entry = SaveCharles().make_charles([f])[0]
+    assert entry["timing"]["connectMs"] == 0
+    assert entry["timing"]["sslMs"] == 0
+
+
+def test_make_charles_request_only_no_end_ts():
+    f = tflow.tflow()
+    f.request.timestamp_end = None
+    entry = SaveCharles().make_charles([f])[0]
+    assert entry["timing"]["requestMs"] == 0
+    assert entry["timing"]["latencyMs"] == 0
+    # response timing branch
+    assert entry["timing"]["responseMs"] == 0
+
+
+def test_make_charles_text_decode_failure(monkeypatch):
+    """get_text returns None => fall back to encoded body."""
+    f = tflow.tflow(resp=True)
+    f.response.content = b"plain text"
+    monkeypatch.setattr(
+        type(f.response), "get_text", lambda self, strict=True: None
+    )
+    body = SaveCharles().make_charles([f])[0]["response"]["body"]
+    assert "encoded" in body
+    assert base64.b64decode(body["encoded"]) == b"plain text"

--- a/test/mitmproxy/addons/test_savecharles.py
+++ b/test/mitmproxy/addons/test_savecharles.py
@@ -92,9 +92,10 @@ def test_ms_helpers():
 def test_split_content_type():
     assert savecharles._split_content_type("") == (None, None)
     assert savecharles._split_content_type("text/html") == ("text/html", None)
-    assert savecharles._split_content_type(
-        'text/html; charset="utf-8"; foo=bar'
-    ) == ("text/html", "utf-8")
+    assert savecharles._split_content_type('text/html; charset="utf-8"; foo=bar') == (
+        "text/html",
+        "utf-8",
+    )
 
 
 def test_body_helpers():
@@ -145,9 +146,7 @@ def test_make_charles_text_decode_failure(monkeypatch):
     """get_text returns None => fall back to encoded body."""
     f = tflow.tflow(resp=True)
     f.response.content = b"plain text"
-    monkeypatch.setattr(
-        type(f.response), "get_text", lambda self, strict=True: None
-    )
+    monkeypatch.setattr(type(f.response), "get_text", lambda self, strict=True: None)
     body = SaveCharles().make_charles([f])[0]["response"]["body"]
     assert "encoded" in body
     assert base64.b64decode(body["encoded"]) == b"plain text"

--- a/test/mitmproxy/tools/web/test_app.py
+++ b/test/mitmproxy/tools/web/test_app.py
@@ -147,6 +147,18 @@ class TestApp(tornado.testing.AsyncHTTPTestCase):
         resp = self.fetch("/flows/dump?filter=[")
         assert resp.code == 400
 
+    def test_flows_dump_charles(self):
+        resp = self.fetch("/flows/dump.chlsj")
+        assert resp.code == 200
+        assert resp.headers.get("Content-Type") == "application/json"
+        data = json.loads(resp.body)
+        assert isinstance(data, list)
+        assert any(entry.get("method") for entry in data)
+
+    def test_flows_dump_charles_filter_error(self):
+        resp = self.fetch("/flows/dump.chlsj?filter=[")
+        assert resp.code == 400
+
     def test_clear(self):
         events = self.events.data.copy()
         flows = list(self.view)

--- a/web/src/js/components/Header/FileMenu.tsx
+++ b/web/src/js/components/Header/FileMenu.tsx
@@ -41,6 +41,10 @@ export default React.memo(function FileMenu() {
                 <i className="fa fa-fw fa-floppy-o" />
                 &nbsp;Save filtered
             </MenuItem>
+            <MenuItem onClick={() => location.replace("/flows/dump.chlsj")}>
+                <i className="fa fa-fw fa-file-code-o" />
+                &nbsp;Export as Charles JSON Session...
+            </MenuItem>
             <MenuItem
                 onClick={() =>
                     confirm("Delete all flows?") &&


### PR DESCRIPTION
## Summary

Adds the ability to export the current mitmweb session to the [Charles Proxy JSON Session (\`.chlsj\`) text format](https://www.charlesproxy.com/documentation/tools/import-export/).

## Changes

- New addon \`mitmproxy/addons/savecharles.py\` exposing a \`save.charles\` command that writes flows to a \`.chlsj\` file. Non-HTTP flows are skipped (matching \`save.har\` behavior). Binary bodies are base64-encoded; text bodies are emitted as-is. WebSocket messages and basic timing info are included.
- New web endpoint \`GET /flows/dump.chlsj\` (with optional \`?filter=\` argument) in \`mitmproxy/tools/web/app.py\`.
- New \"Export as Charles JSON Session...\" entry in the mitmweb **File** menu (\`web/src/js/components/Header/FileMenu.tsx\`).

## Tests

- \`test/mitmproxy/addons/test_savecharles.py\` — covers basic export, status mapping, query splitting, binary/text body encoding, websocket messages, error flows, server_conn timing edge cases (100% individual coverage).
- Two new cases in \`test/mitmproxy/tools/web/test_app.py\` exercising the new endpoint and its filter validation.

\`\`\`
uv run pytest test/mitmproxy/addons/test_savecharles.py test/mitmproxy/tools/web/  # 104 passed, 1 skipped
uv run tox -e individual_coverage -- mitmproxy/addons/savecharles.py            # OK
npx jest src/js/__tests__/components/Header/FileMenuSpec.tsx                    # 1 passed
\`\`\`