### PR TITLE
fix: improve error message for WireGuard port conflicts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-﻿# Release History
+﻿﻿# Release History
 
 <!--
 ✨ Please add a bullet point describing your change.                                                             ✨

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Release History
+﻿# Release History
 
 <!--
 ✨ Please add a bullet point describing your change.                                                             ✨

--- a/mitmproxy/proxy/mode_servers.py
+++ b/mitmproxy/proxy/mode_servers.py
@@ -1,4 +1,4 @@
-"""
+﻿"""
 This module defines "server instances", which manage
 the TCP/UDP servers spawned by mitmproxy as specified by the proxy mode.
 
@@ -381,14 +381,19 @@ class WireGuardServerInstance(AsyncioServerInstance[mode_specs.WireGuardMode]):
     async def start_udp_based_server(
         self, host, port
     ) -> mitmproxy_rs.wireguard.WireGuardServer:
-        return await mitmproxy_rs.wireguard.start_wireguard_server(
-            host,
-            port,
-            self.server_key,
-            [self.pubkey],
-            self.handle_stream,
-            self.handle_stream,
-        )
+        try:
+            return await mitmproxy_rs.wireguard.start_wireguard_server(
+                host,
+                port,
+                self.server_key,
+                [self.pubkey],
+                self.handle_stream,
+                self.handle_stream,
+            )
+        except RuntimeError as e:
+            if 'Address already in use' in str(e):
+                raise OSError(errno.EADDRINUSE, str(e)) from e
+            raise
 
     def client_conf(self) -> str | None:
         if not self._servers:

--- a/mitmproxy/proxy/mode_servers.py
+++ b/mitmproxy/proxy/mode_servers.py
@@ -1,4 +1,4 @@
-﻿"""
+"""
 This module defines "server instances", which manage
 the TCP/UDP servers spawned by mitmproxy as specified by the proxy mode.
 
@@ -391,7 +391,7 @@ class WireGuardServerInstance(AsyncioServerInstance[mode_specs.WireGuardMode]):
                 self.handle_stream,
             )
         except RuntimeError as e:
-            if 'Address already in use' in str(e):
+            if "Address already in use" in str(e):
                 raise OSError(errno.EADDRINUSE, str(e)) from e
             raise
 

--- a/test/mitmproxy/proxy/test_mode_servers.py
+++ b/test/mitmproxy/proxy/test_mode_servers.py
@@ -3,6 +3,7 @@ import platform
 import socket
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
+import errno
 from unittest.mock import Mock
 
 import pytest
@@ -289,6 +290,32 @@ async def test_wireguard_invalid_conf(tmp_path):
             await inst.start()
 
         assert "Invalid configuration file" in repr(inst.last_exception)
+
+
+async def test_wireguard_eaddrinuse_error():
+    """Test that WireGuard EADDRINUSE errors are converted to OSError with helpful message."""
+    manager = MagicMock()
+    import mitmproxy_rs.wireguard as wg_mod
+
+    with taddons.context():
+        inst = WireGuardServerInstance.make("wireguard@0", manager)
+        original = wg_mod.start_wireguard_server
+        wg_mod.start_wireguard_server = AsyncMock(
+            side_effect=RuntimeError(
+                "Failed to bind UDP socket to 0.0.0.0:51820\n"
+                "Caused by:\n"
+                "    Address already in use (os error 98)"
+            )
+        )
+        try:
+            with pytest.raises(OSError) as excinfo:
+                await inst.start()
+            assert excinfo.value.errno == errno.EADDRINUSE
+            assert "Address already in use" in str(excinfo.value)
+            assert "Try specifying a different port" in str(excinfo.value)
+        finally:
+            wg_mod.start_wireguard_server = original
+
 
 
 async def test_tcp_start_error():

--- a/test/mitmproxy/proxy/test_mode_servers.py
+++ b/test/mitmproxy/proxy/test_mode_servers.py
@@ -1,9 +1,9 @@
 import asyncio
+import errno
 import platform
 import socket
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
-import errno
 from unittest.mock import Mock
 
 import pytest
@@ -315,7 +315,6 @@ async def test_wireguard_eaddrinuse_error():
             assert "Try specifying a different port" in str(excinfo.value)
         finally:
             wg_mod.start_wireguard_server = original
-
 
 
 async def test_tcp_start_error():


### PR DESCRIPTION
## Description

When running two mitmproxy instances in WireGuard mode simultaneously, the second instance fails with a raw Rust error message:

`
Address already in use (os error 48)
Error logged during startup, exiting...
`

This is confusing compared to the helpful error message shown for web UI port conflicts (which suggests a different port).

## Changes

The root cause is that mitmproxy_rs.wireguard.start_wireguard_server() raises a RuntimeError (from Rust), but the existing error handler in AsyncioServerInstance._start() only catches OSError. This fix:

1. **mitmproxy/proxy/mode_servers.py**: Wraps the Rust start_wireguard_server() call in WireGuardServerInstance.start_udp_based_server() with a try/except that catches RuntimeError and converts "Address already in use" errors to OSError(errno.EADDRINUSE). This allows the existing handler in _start() to produce the nice message:

    `
    WireGuard server failed to listen on 0.0.0.0:51820 with Address already in use (os error 98)
    Try specifying a different port by using --mode wireguard@51822.
    `

2. **	est/mitmproxy/proxy/test_mode_servers.py**: Adds 	est_wireguard_eaddrinuse_error() that mocks the Rust binding to verify the error conversion and helpful message.

Fixes #7650