### PR TITLE
Preserve buffered request/response body on protocol error

### DIFF
--- a/mitmproxy/proxy/layers/http/__init__.py
+++ b/mitmproxy/proxy/layers/http/__init__.py
@@ -733,6 +733,15 @@ class HttpStream(layer.Layer):
             or self.server_state in (self.state_done, self.state_errored)
         )
 
+        # Save any buffered request/response body data before we lose it,
+        # so users can see what was received before the connection broke.
+        if self.request_body_buf and self.flow and self.flow.request:
+            if self.flow.request.raw_content is None:
+                self.flow.request.data.content = bytes(self.request_body_buf)
+        if self.response_body_buf and self.flow and self.flow.response:
+            if self.flow.response.raw_content is None:
+                self.flow.response.data.content = bytes(self.response_body_buf)
+
         if is_client_error_but_we_already_talk_upstream:
             yield SendHttp(event, self.context.server)
             self.client_state = self.state_errored

--- a/mitmproxy/proxy/layers/http/__init__.py
+++ b/mitmproxy/proxy/layers/http/__init__.py
@@ -735,12 +735,15 @@ class HttpStream(layer.Layer):
 
         # Save any buffered request/response body data before we lose it,
         # so users can see what was received before the connection broke.
+        partial_body_saved = False
         if self.request_body_buf and self.flow and self.flow.request:
             if self.flow.request.raw_content is None:
                 self.flow.request.data.content = bytes(self.request_body_buf)
+                partial_body_saved = True
         if self.response_body_buf and self.flow and self.flow.response:
             if self.flow.response.raw_content is None:
                 self.flow.response.data.content = bytes(self.response_body_buf)
+                partial_body_saved = True
 
         if is_client_error_but_we_already_talk_upstream:
             yield SendHttp(event, self.context.server)
@@ -749,7 +752,10 @@ class HttpStream(layer.Layer):
         if need_error_hook:
             # We don't want to trigger both a response hook and an error hook,
             # so we need to check if the response is done yet or not.
-            self.flow.error = flow.Error(event.message)
+            error_msg = event.message
+            if partial_body_saved:
+                error_msg = f"{error_msg} (partial body saved)"
+            self.flow.error = flow.Error(error_msg)
             yield HttpErrorHook(self.flow)
 
         if (yield from self.check_killed(False)):


### PR DESCRIPTION
 #### Description

  When a connection is interrupted mid-stream, the body data already
  buffered in request_body_buf / response_body_buf was discarded,
  causing the Web UI to show 'Content is missing.' instead of the
  partial content that was received.

  This fix saves any buffered data to flow.request.data.content /
  flow.response.data.content in handle_protocol_error before the
  error hook is triggered, so users can still inspect what was
  received before the connection broke.



<!-- describe your changes here -->

#### Checklist

 - [X] I have updated tests where applicable.
 - [X] I have added an entry to the CHANGELOG.
