### PR TITLE
fix(web): avoid infinite componentDidUpdate loop in FlowTable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ## Unreleased: mitmproxy next
 
+- mitmweb: Fix an infinite update cycle in `FlowTable` by only recomputing the virtual-scroll window in `componentDidUpdate` when `flowView` or `rowHeight` actually change.
 
 ## 12 May 2026: mitmproxy 12.2.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ## Unreleased: mitmproxy next
 
 - mitmweb: Fix an infinite update cycle in `FlowTable` by only recomputing the virtual-scroll window in `componentDidUpdate` when `flowView` or `rowHeight` actually change.
+  ([#8233](https://github.com/mitmproxy/mitmproxy/pull/8233), @ariel42)
 
 ## 12 May 2026: mitmproxy 12.2.3
 

--- a/web/src/js/__tests__/components/FlowTableSpec.tsx
+++ b/web/src/js/__tests__/components/FlowTableSpec.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import FlowTable, { PureFlowTable } from "../../components/FlowTable";
 
 import { act, render } from "../test-utils";
-import { select } from "../../ducks/flows";
+import { FLOWS_REMOVE, select } from "../../ducks/flows";
 
 window.addEventListener = jest.fn();
 
@@ -23,5 +23,43 @@ describe("FlowTable Component", () => {
 
         act(() => store.dispatch(select([store.getState().flows.view[3]])));
         expect(asFragment()).toMatchSnapshot();
+    });
+
+    it("does not call onViewportUpdate when flowView and rowHeight are unchanged", () => {
+        // Regression guard for an infinite componentDidUpdate -> setState
+        // cycle. Before the FlowTableProps-comparison gate in
+        // componentDidUpdate, onViewportUpdate was called on EVERY update —
+        // including the setState the previous call itself produced — so
+        // setState could feed itself indefinitely when state.viewportTop
+        // and viewport.scrollTop never converged.
+        const spy = jest.spyOn(PureFlowTable.prototype, "onViewportUpdate");
+        const { store } = render(<FlowTable />);
+        spy.mockClear(); // ignore the componentDidMount call
+
+        // A `select` dispatch changes connect-mapped props that reach
+        // FlowTable (onlySelectedId, firstSelectedIndex) and triggers
+        // componentDidUpdate, but does NOT change flowView or rowHeight —
+        // so onViewportUpdate must not run.
+        act(() => store.dispatch(select([store.getState().flows.view[0]])));
+        expect(spy).not.toHaveBeenCalled();
+
+        spy.mockRestore();
+    });
+
+    it("calls onViewportUpdate when flowView changes", () => {
+        // Complement of the previous test: removing a flow changes
+        // `state.flows.view`, so the connect-mapped `flowView` prop differs
+        // from `prevProps.flowView` on the resulting componentDidUpdate.
+        // The gate must let onViewportUpdate run in this branch — otherwise
+        // adding/removing flows would not refresh the virtual-scroll window.
+        const spy = jest.spyOn(PureFlowTable.prototype, "onViewportUpdate");
+        const { store } = render(<FlowTable />);
+        spy.mockClear();
+
+        const firstFlowId = store.getState().flows.view[0].id;
+        act(() => store.dispatch(FLOWS_REMOVE(firstFlowId)));
+        expect(spy).toHaveBeenCalled();
+
+        spy.mockRestore();
     });
 });

--- a/web/src/js/components/FlowTable.tsx
+++ b/web/src/js/components/FlowTable.tsx
@@ -65,7 +65,22 @@ export class PureFlowTable extends React.Component<
         if (snapshot) {
             autoscroll.adjustScrollTop(this.viewport);
         }
-        this.onViewportUpdate();
+        // Only recompute the virtual-scroll window when the flow list
+        // or the row height actually changed. Other call sites still
+        // drive onViewportUpdate as needed (componentDidMount, the
+        // resize listener, the viewport onScroll, the post-scroll-into-
+        // view call). Calling it unconditionally from here let
+        // setState -> componentDidUpdate -> setState spin whenever
+        // vScroll.end * rowHeight was less than scrollTop: the capped
+        // Math.min(scrollTop, vScroll.end * rowHeight) stayed strictly
+        // below scrollTop and the `state.viewportTop !== scrollTop`
+        // setState condition kept re-firing.
+        if (
+            prevProps.flowView !== this.props.flowView ||
+            prevProps.rowHeight !== this.props.rowHeight
+        ) {
+            this.onViewportUpdate();
+        }
 
         const { onlySelectedId } = this.props;
 


### PR DESCRIPTION
#### Description

`FlowTable.componentDidUpdate` calls `this.onViewportUpdate()` on every update, even when the inputs to `calcVScroll` (the flow list and the row height) did not change. `onViewportUpdate` reads the current `viewport.scrollTop`, recomputes `vScroll`, and `setState`s when `state.viewportTop !== scrollTop` or `vScroll` shape changed. The new `state.viewportTop` is `Math.min(scrollTop, vScroll.end * rowHeight)`, so when `vScroll.end * rowHeight < scrollTop` the new state stays strictly below `scrollTop`, the inequality holds on the next iteration, and the cycle spins until the browser kills the JS thread.

Gated the call on `prevProps.flowView !== this.props.flowView || prevProps.rowHeight !== this.props.rowHeight`. The other `onViewportUpdate` call sites — `componentDidMount`, the window resize listener, the viewport `onScroll` handler, and the post-scroll-into-view call — are unchanged, so user scrolling and resizing still drive the virtual-scroll window normally.

Added a `FlowTableSpec.tsx` regression test that spies on `PureFlowTable.prototype.onViewportUpdate` and asserts it is NOT called after a `select` dispatch (which changes connect-mapped props but leaves `flowView` and `rowHeight` alone). The test fails without the fix.

#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.