### PR TITLE
fix(web): preserve in-progress filter input across parent re-renders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ## Unreleased: mitmproxy next
 
 - mitmweb: Fix the filter input losing half-typed text on unrelated parent re-renders.
+  ([#8234](https://github.com/mitmproxy/mitmproxy/pull/8234), @ariel42)
 
 ## 12 May 2026: mitmproxy 12.2.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ## Unreleased: mitmproxy next
 
+- mitmweb: Fix the filter input losing half-typed text on unrelated parent re-renders.
 
 ## 12 May 2026: mitmproxy 12.2.3
 

--- a/web/src/js/__tests__/components/Header/FilterInputSpec.tsx
+++ b/web/src/js/__tests__/components/Header/FilterInputSpec.tsx
@@ -3,7 +3,7 @@ import FilterInput, {
     FilterIcon,
 } from "../../../components/Header/FilterInput";
 import FilterDocs from "../../../components/Header/FilterDocs";
-import { act, render } from "../../test-utils";
+import { act, fireEvent, render } from "../../test-utils";
 
 describe("FilterInput Component", () => {
     it("should render correctly", () => {
@@ -54,6 +54,37 @@ describe("FilterInput Component", () => {
             />,
         );
         expect(getByDisplayValue("bar")).toBeInTheDocument();
+    });
+
+    it("preserves user-typed text when the parent re-renders with an unchanged value prop", () => {
+        // `onChange` only propagates valid filters, so a half-typed
+        // invalid filter lives in local state while `props.value`
+        // remains the last valid filter. A parent re-render with the
+        // same `value` must not clobber the in-progress text.
+        const onChange = jest.fn();
+        const props = {
+            icon: FilterIcon.SEARCH,
+            color: "red",
+            placeholder: "Filter",
+            value: "",
+            onChange,
+        };
+        const { rerender, getByPlaceholderText } = render(
+            <FilterInput {...props} />,
+        );
+        const input = getByPlaceholderText("Filter") as HTMLInputElement;
+
+        // User types an invalid filter — `onChange` does not propagate
+        // it (see the existing `should handle isValid` test that
+        // asserts "~foo bar" is invalid).
+        act(() => fireEvent.change(input, { target: { value: "~foo bar" } }));
+        expect(input.value).toBe("~foo bar");
+        expect(onChange).not.toHaveBeenCalled();
+
+        // Parent re-renders with the same `value=""`. The input must
+        // retain the user's in-progress text.
+        rerender(<FilterInput {...props} />);
+        expect(input.value).toBe("~foo bar");
     });
 
     it("should handle isValid", () => {

--- a/web/src/js/components/Header/FilterInput.tsx
+++ b/web/src/js/components/Header/FilterInput.tsx
@@ -51,7 +51,13 @@ export default class FilterInput extends Component<
     }
 
     UNSAFE_componentWillReceiveProps(nextProps) {
-        this.setState({ value: nextProps.value });
+        // Local state intentionally diverges from props while typing
+        // (only valid filters reach the parent via `onChange`), so an
+        // unconditional sync would wipe the user's in-progress text on
+        // any unrelated parent re-render.
+        if (nextProps.value !== this.props.value) {
+            this.setState({ value: nextProps.value });
+        }
     }
 
     isValid(filt: string) {


### PR DESCRIPTION
#### Description

`FilterInput`'s `onChange` only propagates valid filters to the parent, so while the user is mid-typing an incomplete or invalid filter (e.g. `~foo bar`) the local `state.value` intentionally diverges from `props.value` — the parent still holds the last valid filter. Any unrelated parent re-render then fires `UNSAFE_componentWillReceiveProps`, which unconditionally called `this.setState({ value: nextProps.value })` and clobbered the user's in-progress text back to the last valid filter.

Gated the sync on `nextProps.value !== this.props.value` so the component only adopts an externally-changed value. When the parent re-renders without changing the value prop, the local state is preserved.

Added a `FilterInputSpec.tsx` regression test alongside the existing `should handle componentWillReceiveProps` test (which covers the positive path — external value change still wins). The new test types `~foo bar` (asserted invalid by the existing `should handle isValid` test), rerenders with the same value prop, and asserts the in-progress text survives. The test fails without the fix.

#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.