### PR TITLE
http1: don't emit chunked terminator for empty data events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ## Unreleased: mitmproxy next
 
+- Fix `Http1Server`/`Http1Client` emitting the chunked-encoding body-end terminator `0\r\n\r\n` when a `ResponseData`/`RequestData` event carries an empty payload. Previously, a `response.stream` addon callable that returned `b""` (e.g. while buffering for a later flush) would make the client treat the response as complete and stop reading mid-stream.
 - mitmweb: Fix the filter input losing half-typed text on unrelated parent re-renders.
   ([#8234](https://github.com/mitmproxy/mitmproxy/pull/8234), @ariel42)
 - mitmweb: Fix an infinite update cycle in `FlowTable` by only recomputing the virtual-scroll window in `componentDidUpdate` when `flowView` or `rowHeight` actually change.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ## Unreleased: mitmproxy next
 
 - Fix `Http1Server`/`Http1Client` emitting the chunked-encoding body-end terminator `0\r\n\r\n` when a `ResponseData`/`RequestData` event carries an empty payload. Previously, a `response.stream` addon callable that returned `b""` (e.g. while buffering for a later flush) would make the client treat the response as complete and stop reading mid-stream.
+  ([#8242](https://github.com/mitmproxy/mitmproxy/pull/8242), @Osezno-byte)
 - mitmweb: Fix the filter input losing half-typed text on unrelated parent re-renders.
   ([#8234](https://github.com/mitmproxy/mitmproxy/pull/8234), @ariel42)
 - mitmweb: Fix an infinite update cycle in `FlowTable` by only recomputing the virtual-scroll window in `componentDidUpdate` when `flowView` or `rowHeight` actually change.

--- a/mitmproxy/proxy/layers/http/_http1.py
+++ b/mitmproxy/proxy/layers/http/_http1.py
@@ -250,6 +250,14 @@ class Http1Server(Http1Connection):
             yield commands.SendData(self.conn, raw)
         elif isinstance(event, ResponseData):
             assert self.response
+            if not event.data:
+                # Empty ResponseData is a no-op. Under chunked transfer-encoding
+                # we must NOT emit a zero-length chunk — `0\r\n\r\n` is the
+                # body-end terminator and would make the client treat the
+                # response as complete mid-stream. See: stream callable in a
+                # response.stream addon returning b"" while buffering for a
+                # later flush.
+                return
             if "chunked" in self.response.headers.get("transfer-encoding", "").lower():
                 raw = b"%x\r\n%s\r\n" % (len(event.data), event.data)
             else:
@@ -378,6 +386,13 @@ class Http1Client(Http1Connection):
             yield commands.SendData(self.conn, raw)
         elif isinstance(event, RequestData):
             assert self.request
+            if not event.data:
+                # Empty RequestData is a no-op. Under chunked transfer-encoding
+                # we must NOT emit a zero-length chunk — `0\r\n\r\n` is the
+                # body-end terminator and would make the upstream treat the
+                # request body as complete mid-stream. Same reasoning as
+                # Http1Server.send for ResponseData.
+                return
             if "chunked" in self.request.headers.get("transfer-encoding", "").lower():
                 raw = b"%x\r\n%s\r\n" % (len(event.data), event.data)
             else:

--- a/test/mitmproxy/proxy/layers/http/test_http1.py
+++ b/test/mitmproxy/proxy/layers/http/test_http1.py
@@ -111,7 +111,6 @@ class TestServer:
             << ReceiveHttp(RequestEndOfMessage(3))
         )
 
-
     def test_chunked_response_empty_data_no_terminator(self, tctx):
         """Empty ResponseData(b"") on a chunked response must NOT emit the
         chunked-encoding body-end terminator `0\r\n\r\n`.
@@ -132,9 +131,7 @@ class TestServer:
             << ReceiveHttp(RequestEndOfMessage(1))
             >> ResponseHeaders(
                 1,
-                http.Response.make(
-                    200, b"", headers={"transfer-encoding": "chunked"}
-                ),
+                http.Response.make(200, b"", headers={"transfer-encoding": "chunked"}),
             )
             << SendData(
                 tctx.client,

--- a/test/mitmproxy/proxy/layers/http/test_http1.py
+++ b/test/mitmproxy/proxy/layers/http/test_http1.py
@@ -112,7 +112,78 @@ class TestServer:
         )
 
 
+    def test_chunked_response_empty_data_no_terminator(self, tctx):
+        """Empty ResponseData(b"") on a chunked response must NOT emit the
+        chunked-encoding body-end terminator `0\r\n\r\n`.
+
+        Before this fix, a `response.stream` callable returning `b""` (e.g. a
+        rehydrator buffering events for a later flush) caused
+        `b"%x\r\n%s\r\n" % (0, b"") == b"0\r\n\r\n"` to be sent, which the
+        client parses as end-of-body and stops reading mid-stream.
+        """
+        playbook = Playbook(Http1Server(tctx))
+        (
+            playbook
+            >> DataReceived(
+                tctx.client,
+                b"GET http://example.com/ HTTP/1.1\r\nHost: example.com\r\n\r\n",
+            )
+            << ReceiveHttp(Placeholder(RequestHeaders))
+            << ReceiveHttp(RequestEndOfMessage(1))
+            >> ResponseHeaders(
+                1,
+                http.Response.make(
+                    200, b"", headers={"transfer-encoding": "chunked"}
+                ),
+            )
+            << SendData(
+                tctx.client,
+                b"HTTP/1.1 200 OK\r\ntransfer-encoding: chunked\r\n\r\n",
+            )
+            >> ResponseData(1, b"hello")
+            << SendData(tctx.client, b"5\r\nhello\r\n")
+            # Empty ResponseData must produce no SendData. Playbook is strict:
+            # any unexpected SendData here would fail the test.
+            >> ResponseData(1, b"")
+            >> ResponseData(1, b"world")
+            << SendData(tctx.client, b"5\r\nworld\r\n")
+            >> ResponseEndOfMessage(1)
+            << SendData(tctx.client, b"0\r\n\r\n")
+        )
+        assert playbook
+
+
 class TestClient:
+    def test_chunked_request_empty_data_no_terminator(self, tctx):
+        """Empty RequestData(b"") on a chunked request must NOT emit the
+        chunked-encoding body-end terminator. Same bug as
+        TestServer.test_chunked_response_empty_data_no_terminator, just on
+        the request side.
+        """
+        req = http.Request.make(
+            "POST",
+            "http://example.com/",
+            headers={"transfer-encoding": "chunked"},
+        )
+        playbook = Playbook(Http1Client(tctx))
+        (
+            playbook
+            >> RequestHeaders(1, req, False)
+            << SendData(
+                tctx.server,
+                b"POST / HTTP/1.1\r\ntransfer-encoding: chunked\r\n\r\n",
+            )
+            >> RequestData(1, b"hello")
+            << SendData(tctx.server, b"5\r\nhello\r\n")
+            # Empty RequestData → no SendData. Playbook is strict.
+            >> RequestData(1, b"")
+            >> RequestData(1, b"world")
+            << SendData(tctx.server, b"5\r\nworld\r\n")
+            >> RequestEndOfMessage(1)
+            << SendData(tctx.server, b"0\r\n\r\n")
+        )
+        assert playbook
+
     @pytest.mark.parametrize("pipeline", ["pipeline", None])
     def test_simple(self, tctx, pipeline):
         req = http.Request.make("GET", "http://example.com/")


### PR DESCRIPTION
## Summary

`Http1Server.send` and `Http1Client.send` format every `ResponseData` /
`RequestData` event into a chunked-encoding frame via:

```python
raw = b"%x\r\n%s\r\n" % (len(event.data), event.data)
```

When `event.data == b""` and the response/request uses
`transfer-encoding: chunked`, the format string produces `b"0\r\n\r\n"`
— the HTTP/1.1 body-end terminator. The peer parses it as end-of-body
and stops reading. Anything emitted afterwards (legitimate chunks, the
real `0\r\n\r\n` from `ResponseEndOfMessage`) is silently discarded.

This bites `response.stream` / `request.stream` addons that buffer
incoming chunks and emit `b""` while waiting for a later flush — a
natural pattern when an addon needs to re-frame across event boundaries
(e.g. SSE rehydration that joins split tokens spanning multiple deltas).

On HTTP/2 and HTTP/3 the same `b""` is harmless: hyper-h2 / aioquic
emit a zero-byte `DATA` frame without `END_STREAM`, which the peer
ignores. The bug is HTTP/1.1-specific.

## Fix

Skip empty `ResponseData` / `RequestData` events early in
`Http1Server.send` / `Http1Client.send`, before any framing decision.

## Tests

Two new tests in `test/mitmproxy/proxy/layers/http/test_http1.py`:
- `TestServer.test_chunked_response_empty_data_no_terminator`: empty
  `ResponseData` between two real chunked-encoded chunks must produce
  no `SendData`.
- `TestClient.test_chunked_request_empty_data_no_terminator`: same on
  the request side.

Both fail without the fix (Playbook strict-mismatch on the unexpected
`SendData(b"0\r\n\r\n")`) and pass with it.

## How I found this

`response.stream` addon for a custom SSE-format PII rehydrator was
buffering events while waiting for a partial `[[LABEL` token to close.
While buffering, the callable returned `b""`. Through mitmproxy, the
upstream-side stream truncated at exactly the first `b""` return
(client only saw the chunks emitted before that point). Through a
direct connection to the same upstream, the full stream came through.

I narrowed it via:
1. tcpdump on the upstream interface: mitmproxy initiated the FIN.
2. ALPN logger via a `tls_established_server` hook: upstream ALPN
   `b''` → HTTP/1.1.
3. Variant return-value sweep: `b""` truncates, `b"\n"` (single byte)
   works fine. That isolates the bug to the empty-event chunked-encode
   path.

The `\n` chunk gets encoded as `b"1\r\n\n\r\n"` — a valid 1-byte chunk.
The `b""` chunk gets encoded as `b"0\r\n\r\n"` — the body terminator.