### PR TITLE
Treat carriage return as whitespace in strutils.is_xml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Treat carriage return as whitespace in `strutils.is_xml`, so XML response
   bodies that arrive with a leading CR or CRLF before the root element are
   still detected by the XML/HTML content view.
+  ([#8243](https://github.com/mitmproxy/mitmproxy/pull/8243), @ADiTyaRaj8969)
 - mitmweb: Fix the filter input losing half-typed text on unrelated parent re-renders.
   ([#8234](https://github.com/mitmproxy/mitmproxy/pull/8234), @ariel42)
 - mitmweb: Fix an infinite update cycle in `FlowTable` by only recomputing the virtual-scroll window in `componentDidUpdate` when `flowView` or `rowHeight` actually change.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 
 ## Unreleased: mitmproxy next
 
+- Treat carriage return as whitespace in `strutils.is_xml`, so XML response
+  bodies that arrive with a leading CR or CRLF before the root element are
+  still detected by the XML/HTML content view.
 - mitmweb: Fix the filter input losing half-typed text on unrelated parent re-renders.
   ([#8234](https://github.com/mitmproxy/mitmproxy/pull/8234), @ariel42)
 - mitmweb: Fix an infinite update cycle in `FlowTable` by only recomputing the virtual-scroll window in `componentDidUpdate` when `flowView` or `rowHeight` actually change.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,7 @@
 
 ## Unreleased: mitmproxy next
 
-- Treat carriage return as whitespace in `strutils.is_xml`, so XML response
-  bodies that arrive with a leading CR or CRLF before the root element are
-  still detected by the XML/HTML content view.
+- Fix contentview detection for XML files that start with CRLF.
   ([#8243](https://github.com/mitmproxy/mitmproxy/pull/8243), @ADiTyaRaj8969)
 - mitmweb: Fix the filter input losing half-typed text on unrelated parent re-renders.
   ([#8234](https://github.com/mitmproxy/mitmproxy/pull/8234), @ariel42)

--- a/mitmproxy/utils/strutils.py
+++ b/mitmproxy/utils/strutils.py
@@ -163,8 +163,10 @@ def is_mostly_bin(s: bytes) -> bool:
 
 
 def is_xml(s: bytes) -> bool:
+    # XML 1.0 §2.3 defines whitespace as (#x20 | #x9 | #xD | #xA), so a
+    # leading \r before "<" should also be skipped here.
     for char in s:
-        if char in (9, 10, 32):  # is space?
+        if char in (9, 10, 13, 32):  # is whitespace?
             continue
         return char == 60  # is a "<"?
     return False

--- a/test/mitmproxy/utils/test_strutils.py
+++ b/test/mitmproxy/utils/test_strutils.py
@@ -106,6 +106,11 @@ def test_is_xml():
     assert not strutils.is_xml(b"foo")
     assert strutils.is_xml(b"<foo")
     assert strutils.is_xml(b"  \n<foo")
+    # XML 1.0 §2.3 lists CR as whitespace, so bodies that arrive with
+    # CRLF (or a stray \r) before the root element must still be detected.
+    assert strutils.is_xml(b"\r<foo")
+    assert strutils.is_xml(b"\r\n<foo")
+    assert not strutils.is_xml(b"\r\nfoo")
 
 
 def test_clean_hanging_newline():


### PR DESCRIPTION
## Summary

`strutils.is_xml` walks the input bytes skipping `(9, 10, 32)` — tab, LF, space — before checking for an opening `<`. CR (`\r`, `0x0D`) is also XML whitespace per [XML 1.0 §2.3](https://www.w3.org/TR/REC-xml/#NT-S), but it's missing from that tuple. So a response body that begins with a stray `\r` or `\r\n` before the root element returned `False`, and the XML/HTML content view auto-detection score (`mitmproxy/contentviews/_view_xml_html.py:273`) dropped from 0.4 to 0.

## Reproduction

```python
>>> from mitmproxy.utils import strutils
>>> strutils.is_xml(b"\r<foo>")
False
>>> strutils.is_xml(b"\r\n<foo>")
False
```

Both should be `True`. After the change:

```python
>>> strutils.is_xml(b"\r<foo>")
True
>>> strutils.is_xml(b"\r\n<foo>")
True
>>> strutils.is_xml(b"\r\nfoo")   # still rejected
False
```

## Change

One byte added to the whitespace tuple in `is_xml`, and a short comment pointing at the spec so the next reader doesn't reintroduce the gap. Test additions cover the two CR cases plus a negative case that confirms the "must be `<`" check still rejects non-XML.

```diff
-        if char in (9, 10, 32):  # is space?
+        if char in (9, 10, 13, 32):  # is whitespace?
```

## Verification

```
$ uv run pytest test/mitmproxy/utils/test_strutils.py::test_is_xml -v
test/mitmproxy/utils/test_strutils.py::test_is_xml PASSED
```

Ruff lint + format both clean on the touched files.