### PR TITLE
Add Flowfilter description strings

### DIFF
--- a/mitmproxy/flowfilter.py
+++ b/mitmproxy/flowfilter.py
@@ -520,9 +520,7 @@ class FUrl(_StrRex):
         if isinstance(f, http.HTTPFlow):
             return bool(self.re.search(f.request.pretty_url))
         assert isinstance(f, dns.DNSFlow)
-        return bool(
-            f.request.questions and self.re.search(f.request.questions[0].name)
-        )
+        return bool(f.request.questions and self.re.search(f.request.questions[0].name))
 
     def __str__(self) -> str:
         return f"url matches {self.regex_str}"

--- a/mitmproxy/flowfilter.py
+++ b/mitmproxy/flowfilter.py
@@ -519,11 +519,10 @@ class FUrl(_StrRex):
             return False
         if isinstance(f, http.HTTPFlow):
             return bool(self.re.search(f.request.pretty_url))
-        elif isinstance(f, dns.DNSFlow):
-            return f.request.questions and bool(
-                self.re.search(f.request.questions[0].name)
-            )
-        return False
+        assert isinstance(f, dns.DNSFlow)
+        return bool(
+            f.request.questions and self.re.search(f.request.questions[0].name)
+        )
 
     def __str__(self) -> str:
         return f"url matches {self.regex_str}"

--- a/mitmproxy/flowfilter.py
+++ b/mitmproxy/flowfilter.py
@@ -520,7 +520,9 @@ class FUrl(_StrRex):
         if isinstance(f, http.HTTPFlow):
             return bool(self.re.search(f.request.pretty_url))
         elif isinstance(f, dns.DNSFlow):
-            return f.request.questions and bool(self.re.search(f.request.questions[0].name))
+            return f.request.questions and bool(
+                self.re.search(f.request.questions[0].name)
+            )
         return False
 
     def __str__(self) -> str:
@@ -641,6 +643,7 @@ class FCode(_Int):
 
     def __str__(self) -> str:
         return f"response code is {self.num}"
+
 
 def _parenthesize(t: _Token) -> str:
     if isinstance(t, (FAnd, FOr)):
@@ -792,6 +795,7 @@ class TFilter(Protocol):
     def __str__(self) -> str: ...  # pragma: no cover
 
     def dump(self, indent=0, fp=sys.stdout): ...  # pragma: no cover
+
 
 def parse(s: str) -> TFilter:
     """

--- a/mitmproxy/flowfilter.py
+++ b/mitmproxy/flowfilter.py
@@ -37,9 +37,14 @@ import functools
 import os
 import re
 import sys
+from abc import ABC
+from abc import abstractmethod
 from collections.abc import Sequence
+from typing import AnyStr
+from typing import cast
 from typing import Any
 from typing import ClassVar
+from typing import Generic
 from typing import Protocol
 
 import pyparsing as pp
@@ -50,8 +55,10 @@ from mitmproxy import http
 from mitmproxy import tcp
 from mitmproxy import udp
 
-maybe_ignore_case = (
-    re.IGNORECASE if os.environ.get("MITMPROXY_CASE_SENSITIVE_FILTERS") != "1" else 0
+maybe_ignore_case: re.RegexFlag = (
+    cast(re.RegexFlag, re.IGNORECASE)
+    if os.environ.get("MITMPROXY_CASE_SENSITIVE_FILTERS") != "1"
+    else re.NOFLAG
 )
 
 
@@ -68,8 +75,8 @@ def only(*types):
     return decorator
 
 
-class _Token:
-    def dump(self, indent=0, fp=sys.stdout):
+class _Token(ABC):
+    def dump(self, indent=0, fp=sys.stdout) -> None:
         print(
             "{spacing}{name}{expr}".format(
                 spacing="\t" * indent,
@@ -79,30 +86,39 @@ class _Token:
             file=fp,
         )
 
+    @abstractmethod
+    def __str__(self) -> str: ...
 
-class _Action(_Token):
+
+class _Action(_Token, ABC):
     code: ClassVar[str]
     help: ClassVar[str]
 
     @classmethod
-    def make(klass, s, loc, toks):
-        return klass(*toks[1:])
+    def make(cls, s, loc, toks):
+        return cls(*toks[1:])
 
 
 class FErr(_Action):
     code = "e"
     help = "Match error"
 
-    def __call__(self, f):
-        return True if f.error else False
+    def __call__(self, f) -> bool:
+        return bool(f.error)
+
+    def __str__(self) -> str:
+        return "has error"
 
 
 class FMarked(_Action):
     code = "marked"
     help = "Match marked flows"
 
-    def __call__(self, f):
+    def __call__(self, f) -> bool:
         return bool(f.marked)
+
+    def __str__(self) -> str:
+        return "is marked"
 
 
 class FHTTP(_Action):
@@ -110,8 +126,11 @@ class FHTTP(_Action):
     help = "Match HTTP flows"
 
     @only(http.HTTPFlow)
-    def __call__(self, f):
+    def __call__(self, f) -> bool:
         return True
+
+    def __str__(self) -> str:
+        return "is an HTTP Flow"
 
 
 class FWebSocket(_Action):
@@ -119,8 +138,11 @@ class FWebSocket(_Action):
     help = "Match WebSocket flows"
 
     @only(http.HTTPFlow)
-    def __call__(self, f: http.HTTPFlow):
+    def __call__(self, f: http.HTTPFlow) -> bool:
         return f.websocket is not None
+
+    def __str__(self) -> str:
+        return "is a Websocket Flow"
 
 
 class FTCP(_Action):
@@ -128,8 +150,11 @@ class FTCP(_Action):
     help = "Match TCP flows"
 
     @only(tcp.TCPFlow)
-    def __call__(self, f):
+    def __call__(self, f) -> bool:
         return True
+
+    def __str__(self) -> str:
+        return "is a TCP Flow"
 
 
 class FUDP(_Action):
@@ -137,8 +162,11 @@ class FUDP(_Action):
     help = "Match UDP flows"
 
     @only(udp.UDPFlow)
-    def __call__(self, f):
+    def __call__(self, f) -> bool:
         return True
+
+    def __str__(self) -> str:
+        return "is a UDP Flow"
 
 
 class FDNS(_Action):
@@ -146,8 +174,11 @@ class FDNS(_Action):
     help = "Match DNS flows"
 
     @only(dns.DNSFlow)
-    def __call__(self, f):
+    def __call__(self, f) -> bool:
         return True
+
+    def __str__(self) -> str:
+        return "is a DNS Flow"
 
 
 class FReq(_Action):
@@ -155,9 +186,12 @@ class FReq(_Action):
     help = "Match request with no response"
 
     @only(http.HTTPFlow, dns.DNSFlow)
-    def __call__(self, f):
+    def __call__(self, f) -> bool:
         if not f.response:
             return True
+
+    def __str__(self) -> str:
+        return "has no response"
 
 
 class FResp(_Action):
@@ -165,33 +199,60 @@ class FResp(_Action):
     help = "Match response"
 
     @only(http.HTTPFlow, dns.DNSFlow)
-    def __call__(self, f):
+    def __call__(self, f) -> bool:
         return bool(f.response)
+
+    def __str__(self) -> str:
+        return "has response"
 
 
 class FAll(_Action):
     code = "all"
     help = "Match all flows"
 
-    def __call__(self, f: flow.Flow):
+    def __call__(self, f: flow.Flow) -> bool:
         return True
 
+    def __str__(self) -> str:
+        return "all flows"
 
-class _Rex(_Action):
-    flags = 0
-    is_binary = True
 
-    def __init__(self, expr):
-        self.expr = expr
-        if self.is_binary:
-            expr = expr.encode()
+class _Rex(Generic[AnyStr], _Action, ABC):
+    flags: ClassVar[re.RegexFlag] = re.RegexFlag.NOFLAG
+
+    expr: str
+    re: re.Pattern[AnyStr]
+
+    def __init__(self, expr_str: str, expr: AnyStr):
+        self.expr = expr_str
         try:
             self.re = re.compile(expr, self.flags | maybe_ignore_case)
         except Exception:
             raise ValueError("Cannot compile expression.")
 
+    @property
+    def regex_str(self) -> str:
+        flags = ""
+        if self.re.flags & re.IGNORECASE:
+            flags += "i"
+        if self.re.flags & re.MULTILINE:
+            flags += "m"
+        if self.re.flags & re.DOTALL:
+            flags += "s"
+        return f"/{self.expr}/{flags}"
 
-def _check_content_type(rex, message):
+
+class _StrRex(_Rex[str], ABC):
+    def __init__(self, expr: str):
+        super().__init__(expr, expr)
+
+
+class _BinRex(_Rex[bytes], ABC):
+    def __init__(self, expr: str):
+        super().__init__(expr, expr.encode())
+
+
+def _check_content_type(rex: re.Pattern[bytes], message: http.Message) -> bool:
     return any(
         name.lower() == b"content-type" and rex.search(value)
         for name, value in message.headers.fields
@@ -215,90 +276,111 @@ class FAsset(_Action):
     ]
 
     @only(http.HTTPFlow)
-    def __call__(self, f):
+    def __call__(self, f) -> bool:
         if f.response:
             for i in self.ASSET_TYPES:
                 if _check_content_type(i, f.response):
                     return True
         return False
 
+    def __str__(self) -> str:
+        return "is asset"
 
-class FContentType(_Rex):
+
+class FContentType(_BinRex):
     code = "t"
     help = "Content-type header"
 
     @only(http.HTTPFlow)
-    def __call__(self, f):
+    def __call__(self, f) -> bool:
         if _check_content_type(self.re, f.request):
             return True
         elif f.response and _check_content_type(self.re, f.response):
             return True
         return False
 
+    def __str__(self) -> str:
+        return f"content type matches {self.regex_str}"
 
-class FContentTypeRequest(_Rex):
+
+class FContentTypeRequest(_BinRex):
     code = "tq"
     help = "Request Content-Type header"
 
     @only(http.HTTPFlow)
-    def __call__(self, f):
+    def __call__(self, f) -> bool:
         return _check_content_type(self.re, f.request)
 
+    def __str__(self) -> str:
+        return f"req. content type matches {self.regex_str}"
 
-class FContentTypeResponse(_Rex):
+
+class FContentTypeResponse(_BinRex):
     code = "ts"
     help = "Response Content-Type header"
 
     @only(http.HTTPFlow)
-    def __call__(self, f):
+    def __call__(self, f) -> bool:
         if f.response:
             return _check_content_type(self.re, f.response)
         return False
 
+    def __str__(self) -> str:
+        return f"resp. content type matches {self.regex_str}"
 
-class FHead(_Rex):
+
+class FHead(_BinRex):
     code = "h"
     help = "Header"
     flags = re.MULTILINE
 
     @only(http.HTTPFlow)
-    def __call__(self, f):
+    def __call__(self, f) -> bool:
         if f.request and self.re.search(bytes(f.request.headers)):
             return True
         if f.response and self.re.search(bytes(f.response.headers)):
             return True
         return False
 
+    def __str__(self) -> str:
+        return f"header matches {self.regex_str}"
 
-class FHeadRequest(_Rex):
+
+class FHeadRequest(_BinRex):
     code = "hq"
     help = "Request header"
     flags = re.MULTILINE
 
     @only(http.HTTPFlow)
-    def __call__(self, f):
+    def __call__(self, f) -> bool:
         if f.request and self.re.search(bytes(f.request.headers)):
             return True
 
+    def __str__(self) -> str:
+        return f"req. header matches {self.regex_str}"
 
-class FHeadResponse(_Rex):
+
+class FHeadResponse(_BinRex):
     code = "hs"
     help = "Response header"
     flags = re.MULTILINE
 
     @only(http.HTTPFlow)
-    def __call__(self, f):
+    def __call__(self, f) -> bool:
         if f.response and self.re.search(bytes(f.response.headers)):
             return True
 
+    def __str__(self) -> str:
+        return f"resp. header matches {self.regex_str}"
 
-class FBod(_Rex):
+
+class FBod(_BinRex):
     code = "b"
     help = "Body"
     flags = re.DOTALL
 
     @only(http.HTTPFlow, tcp.TCPFlow, udp.UDPFlow, dns.DNSFlow)
-    def __call__(self, f):
+    def __call__(self, f) -> bool:
         if isinstance(f, http.HTTPFlow):
             if (
                 f.request
@@ -327,14 +409,17 @@ class FBod(_Rex):
                 return True
         return False
 
+    def __str__(self) -> str:
+        return f"body matches {self.regex_str}"
 
-class FBodRequest(_Rex):
+
+class FBodRequest(_BinRex):
     code = "bq"
     help = "Request body"
     flags = re.DOTALL
 
     @only(http.HTTPFlow, tcp.TCPFlow, udp.UDPFlow, dns.DNSFlow)
-    def __call__(self, f):
+    def __call__(self, f) -> bool:
         if isinstance(f, http.HTTPFlow):
             if (
                 f.request
@@ -354,14 +439,17 @@ class FBodRequest(_Rex):
             if f.request and self.re.search(str(f.request).encode()):
                 return True
 
+    def __str__(self) -> str:
+        return f"body request matches {self.regex_str}"
 
-class FBodResponse(_Rex):
+
+class FBodResponse(_BinRex):
     code = "bs"
     help = "Response body"
     flags = re.DOTALL
 
     @only(http.HTTPFlow, tcp.TCPFlow, udp.UDPFlow, dns.DNSFlow)
-    def __call__(self, f):
+    def __call__(self, f) -> bool:
         if isinstance(f, http.HTTPFlow):
             if (
                 f.response
@@ -381,73 +469,87 @@ class FBodResponse(_Rex):
             if f.response and self.re.search(str(f.response).encode()):
                 return True
 
+    def __str__(self) -> str:
+        return f"body response matches {self.regex_str}"
 
-class FMethod(_Rex):
+
+class FMethod(_BinRex):
     code = "m"
     help = "Method"
 
     @only(http.HTTPFlow)
-    def __call__(self, f):
+    def __call__(self, f) -> bool:
         return bool(self.re.search(f.request.data.method))
 
+    def __str__(self) -> str:
+        return f"method matches {self.regex_str}"
 
-class FDomain(_Rex):
+
+class FDomain(_StrRex):
     code = "d"
     help = "Domain"
-    is_binary = False
 
     @only(http.HTTPFlow)
-    def __call__(self, f):
+    def __call__(self, f) -> bool:
         return bool(
             self.re.search(f.request.host) or self.re.search(f.request.pretty_host)
         )
 
+    def __str__(self) -> str:
+        return f"domain matches {self.regex_str}"
 
-class FUrl(_Rex):
+
+class FUrl(_StrRex):
     code = "u"
     help = "URL"
-    is_binary = False
 
     # FUrl is special, because it can be "naked".
 
     @classmethod
-    def make(klass, s, loc, toks):
+    def make(cls, s, loc, toks):
         if len(toks) > 1:
             toks = toks[1:]
-        return klass(*toks)
+        return cls(*toks)
 
     @only(http.HTTPFlow, dns.DNSFlow)
-    def __call__(self, f):
+    def __call__(self, f) -> bool:
         if not f or not f.request:
             return False
         if isinstance(f, http.HTTPFlow):
-            return self.re.search(f.request.pretty_url)
+            return bool(self.re.search(f.request.pretty_url))
         elif isinstance(f, dns.DNSFlow):
-            return f.request.questions and self.re.search(f.request.questions[0].name)
+            return f.request.questions and bool(self.re.search(f.request.questions[0].name))
+
+    def __str__(self) -> str:
+        return f"url matches {self.regex_str}"
 
 
-class FSrc(_Rex):
+class FSrc(_StrRex):
     code = "src"
     help = "Match source address"
-    is_binary = False
 
-    def __call__(self, f):
+    def __call__(self, f) -> bool:
         if not f.client_conn or not f.client_conn.peername:
             return False
         r = f"{f.client_conn.peername[0]}:{f.client_conn.peername[1]}"
-        return self.re.search(r)
+        return bool(self.re.search(r))
+
+    def __str__(self) -> str:
+        return f"source address matches {self.regex_str}"
 
 
-class FDst(_Rex):
+class FDst(_StrRex):
     code = "dst"
     help = "Match destination address"
-    is_binary = False
 
-    def __call__(self, f):
+    def __call__(self, f) -> bool:
         if not f.server_conn or not f.server_conn.address:
             return False
         r = f"{f.server_conn.address[0]}:{f.server_conn.address[1]}"
-        return self.re.search(r)
+        return bool(self.re.search(r))
+
+    def __str__(self) -> str:
+        return f"destination address matches {self.regex_str}"
 
 
 class FReplay(_Action):
@@ -457,6 +559,9 @@ class FReplay(_Action):
     def __call__(self, f):
         return f.is_replay is not None
 
+    def __str__(self) -> str:
+        return "flow has been replayed"
+
 
 class FReplayClient(_Action):
     code = "replayq"
@@ -464,6 +569,9 @@ class FReplayClient(_Action):
 
     def __call__(self, f):
         return f.is_replay == "request"
+
+    def __str__(self) -> str:
+        return "request has been replayed"
 
 
 class FReplayServer(_Action):
@@ -473,38 +581,47 @@ class FReplayServer(_Action):
     def __call__(self, f):
         return f.is_replay == "response"
 
+    def __str__(self) -> str:
+        return "response has been replayed"
 
-class FMeta(_Rex):
+
+class FMeta(_StrRex):
     code = "meta"
     help = "Flow metadata"
     flags = re.MULTILINE
-    is_binary = False
 
-    def __call__(self, f):
+    def __call__(self, f) -> bool:
         m = "\n".join([f"{key}: {value}" for key, value in f.metadata.items()])
-        return self.re.search(m)
+        return bool(self.re.search(m))
+
+    def __str__(self) -> str:
+        return f"flow metadata matches {self.regex_str}"
 
 
-class FMarker(_Rex):
+class FMarker(_StrRex):
     code = "marker"
     help = "Match marked flows with specified marker"
-    is_binary = False
 
-    def __call__(self, f):
-        return self.re.search(f.marked)
+    def __call__(self, f) -> bool:
+        return bool(self.re.search(f.marked))
+
+    def __str__(self) -> str:
+        return f"marker matches {self.regex_str}"
 
 
-class FComment(_Rex):
+class FComment(_StrRex):
     code = "comment"
     help = "Flow comment"
     flags = re.MULTILINE
-    is_binary = False
 
-    def __call__(self, f):
-        return self.re.search(f.comment)
+    def __call__(self, f) -> bool:
+        return bool(self.re.search(f.comment))
+
+    def __str__(self) -> str:
+        return f"comment matches {self.regex_str}"
 
 
-class _Int(_Action):
+class _Int(_Action, ABC):
     def __init__(self, num):
         self.num = int(num)
 
@@ -514,9 +631,18 @@ class FCode(_Int):
     help = "HTTP response code"
 
     @only(http.HTTPFlow)
-    def __call__(self, f):
+    def __call__(self, f) -> bool:
         if f.response and f.response.status_code == self.num:
             return True
+
+    def __str__(self) -> str:
+        return f"response code is {self.num}"
+
+def _parenthesize(t: _Token) -> str:
+    if isinstance(t, (FAnd, FOr)):
+        return f"({t})"
+    else:
+        return str(t)
 
 
 class FAnd(_Token):
@@ -528,8 +654,11 @@ class FAnd(_Token):
         for i in self.lst:
             i.dump(indent + 1, fp)
 
-    def __call__(self, f):
+    def __call__(self, f) -> bool:
         return all(i(f) for i in self.lst)
+
+    def __str__(self) -> str:
+        return " and ".join(_parenthesize(x) for x in self.lst)
 
 
 class FOr(_Token):
@@ -541,8 +670,11 @@ class FOr(_Token):
         for i in self.lst:
             i.dump(indent + 1, fp)
 
-    def __call__(self, f):
+    def __call__(self, f) -> bool:
         return any(i(f) for i in self.lst)
+
+    def __str__(self) -> str:
+        return " or ".join(_parenthesize(x) for x in self.lst)
 
 
 class FNot(_Token):
@@ -553,8 +685,11 @@ class FNot(_Token):
         super().dump(indent, fp)
         self.itm.dump(indent + 1, fp)
 
-    def __call__(self, f):
+    def __call__(self, f) -> bool:
         return not self.itm(f)
+
+    def __str__(self) -> str:
+        return f"not {_parenthesize(self.itm)}"
 
 
 filter_unary: Sequence[type[_Action]] = [
@@ -648,10 +783,11 @@ bnf = _make()
 class TFilter(Protocol):
     pattern: str
 
-    # TODO: This should be `-> bool`, but some filters aren't behaving correctly (requiring `bool()` by the caller).
-    #       Correct this when we properly type filters.
-    def __call__(self, f: flow.Flow) -> Any: ...  # pragma: no cover
+    def __call__(self, f: flow.Flow) -> bool: ...  # pragma: no cover
 
+    def __str__(self) -> str: ...  # pragma: no cover
+
+    def dump(self, indent=0, fp=sys.stdout): ...  # pragma: no cover
 
 def parse(s: str) -> TFilter:
     """
@@ -661,14 +797,14 @@ def parse(s: str) -> TFilter:
     if not s:
         raise ValueError("Empty filter expression")
     try:
-        flt = bnf.parseString(s, parseAll=True)[0]
+        flt = bnf.parse_string(s, parseAll=True)[0]
         flt.pattern = s
         return flt
     except (pp.ParseException, ValueError) as e:
         raise ValueError(f"Invalid filter expression: {s!r}") from e
 
 
-def match(flt: str | TFilter, flow: flow.Flow) -> bool:
+def match(flt: str | TFilter | None, flow: flow.Flow) -> bool:
     """
     Matches a flow against a compiled filter expression.
     Returns True if matched, False if not.

--- a/mitmproxy/flowfilter.py
+++ b/mitmproxy/flowfilter.py
@@ -42,7 +42,6 @@ from abc import abstractmethod
 from collections.abc import Sequence
 from typing import AnyStr
 from typing import cast
-from typing import Any
 from typing import ClassVar
 from typing import Generic
 from typing import Protocol
@@ -187,8 +186,7 @@ class FReq(_Action):
 
     @only(http.HTTPFlow, dns.DNSFlow)
     def __call__(self, f) -> bool:
-        if not f.response:
-            return True
+        return not f.response
 
     def __str__(self) -> str:
         return "has no response"
@@ -355,6 +353,7 @@ class FHeadRequest(_BinRex):
     def __call__(self, f) -> bool:
         if f.request and self.re.search(bytes(f.request.headers)):
             return True
+        return False
 
     def __str__(self) -> str:
         return f"req. header matches {self.regex_str}"
@@ -369,6 +368,7 @@ class FHeadResponse(_BinRex):
     def __call__(self, f) -> bool:
         if f.response and self.re.search(bytes(f.response.headers)):
             return True
+        return False
 
     def __str__(self) -> str:
         return f"resp. header matches {self.regex_str}"
@@ -438,6 +438,7 @@ class FBodRequest(_BinRex):
         elif isinstance(f, dns.DNSFlow):
             if f.request and self.re.search(str(f.request).encode()):
                 return True
+        return False
 
     def __str__(self) -> str:
         return f"body request matches {self.regex_str}"
@@ -468,6 +469,7 @@ class FBodResponse(_BinRex):
         elif isinstance(f, dns.DNSFlow):
             if f.response and self.re.search(str(f.response).encode()):
                 return True
+        return False
 
     def __str__(self) -> str:
         return f"body response matches {self.regex_str}"
@@ -519,6 +521,7 @@ class FUrl(_StrRex):
             return bool(self.re.search(f.request.pretty_url))
         elif isinstance(f, dns.DNSFlow):
             return f.request.questions and bool(self.re.search(f.request.questions[0].name))
+        return False
 
     def __str__(self) -> str:
         return f"url matches {self.regex_str}"
@@ -634,6 +637,7 @@ class FCode(_Int):
     def __call__(self, f) -> bool:
         if f.response and f.response.status_code == self.num:
             return True
+        return False
 
     def __str__(self) -> str:
         return f"response code is {self.num}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
     "msgpack>=1.0.0,<=1.1.2",
     "pydivert>=2.0.3,<=2.1.0; sys_platform == 'win32'",
     "pyOpenSSL>=24.3,<=27.0.0",
-    "pyparsing>=2.4.2,<=3.3.2",
+    "pyparsing>=3.3.2,<=3.3.2",
     "pyperclip>=1.9.0,<=1.11.0",
     "ruamel.yaml>=0.18.10,<=0.19.1",
     "sortedcontainers>=2.3,<=2.4.0",

--- a/test/mitmproxy/test_flowfilter.py
+++ b/test/mitmproxy/test_flowfilter.py
@@ -130,7 +130,10 @@ class TestParsing:
             ("~marker red", "marker matches /red/i"),
             ("~comment note", "comment matches /note/im"),
             ("~c 404", "response code is 404"),
-            ("(~u foobar & ~h voing)", "url matches /foobar/i and header matches /voing/im"),
+            (
+                "(~u foobar & ~h voing)",
+                "url matches /foobar/i and header matches /voing/im",
+            ),
             ("!~h test", "not header matches /test/im"),
             ("~u foo & ~c 200", "url matches /foo/i and response code is 200"),
             ("~u foo | ~c 200", "url matches /foo/i or response code is 200"),

--- a/test/mitmproxy/test_flowfilter.py
+++ b/test/mitmproxy/test_flowfilter.py
@@ -5,11 +5,13 @@ import pytest
 
 from mitmproxy import flowfilter
 from mitmproxy import http
+from mitmproxy.flowfilter import FAnd
+from mitmproxy.flowfilter import TFilter
 from mitmproxy.test import tflow
 
 
 class TestParsing:
-    def _dump(self, x):
+    def _dump(self, x: TFilter):
         c = io.StringIO()
         x.dump(fp=c)
         assert c.getvalue()
@@ -34,6 +36,7 @@ class TestParsing:
         assert flowfilter.parse("~comment .")
         p = flowfilter.parse("~q ~c 10")
         self._dump(p)
+        assert isinstance(p, FAnd)
         assert len(p.lst) == 2
 
     def test_non_ascii(self):
@@ -85,6 +88,57 @@ class TestParsing:
         a = flowfilter.parse("~hq 'header: qvalue'")
         assert isinstance(a, flowfilter.FHeadRequest)
         self._dump(a)
+
+    @pytest.mark.parametrize(
+        ("expr", "expected"),
+        [
+            ("~a", "is asset"),
+            ("~marked", "is marked"),
+            ("~http", "is an HTTP Flow"),
+            ("~websocket", "is a Websocket Flow"),
+            ("~tcp", "is a TCP Flow"),
+            ("~udp", "is a UDP Flow"),
+            ("~dns", "is a DNS Flow"),
+            ("~all", "all flows"),
+            ("~q", "has no response"),
+            ("~s", "has response"),
+            ("~e", "has error"),
+            ("~t content", "content type matches /content/i"),
+            ("~tq content", "req. content type matches /content/i"),
+            ("~ts content", "resp. content type matches /content/i"),
+            ("~h rex", "header matches /rex/im"),
+            ("~hq rex", "req. header matches /rex/im"),
+            ("~hs rex", "resp. header matches /rex/im"),
+            ("~h header", "header matches /header/im"),
+            ("~hq header", "req. header matches /header/im"),
+            ("~hs header", "resp. header matches /header/im"),
+            ("~b rex", "body matches /rex/is"),
+            ("~bq rex", "body request matches /rex/is"),
+            ("~bs rex", "body response matches /rex/is"),
+            ("~b content", "body matches /content/is"),
+            ("~bq content", "body request matches /content/is"),
+            ("~bs content", "body response matches /content/is"),
+            ("~m get", "method matches /get/i"),
+            ("~d example.com", "domain matches /example.com/i"),
+            ("~u foo", "url matches /foo/i"),
+            ("~src 127.0.0.1", "source address matches /127.0.0.1/i"),
+            ("~dst example.com:443", "destination address matches /example.com:443/i"),
+            ("~replay", "flow has been replayed"),
+            ("~replayq", "request has been replayed"),
+            ("~replays", "response has been replayed"),
+            ("~meta foo", "flow metadata matches /foo/im"),
+            ("~marker red", "marker matches /red/i"),
+            ("~comment note", "comment matches /note/im"),
+            ("~c 404", "response code is 404"),
+            ("(~u foobar & ~h voing)", "url matches /foobar/i and header matches /voing/im"),
+            ("!~h test", "not header matches /test/im"),
+            ("~u foo & ~c 200", "url matches /foo/i and response code is 200"),
+            ("~u foo | ~c 200", "url matches /foo/i or response code is 200"),
+            ("!(~u foo | ~c 200)", "not (url matches /foo/i or response code is 200)"),
+        ],
+    )
+    def test_str_implementations(self, expr: str, expected: str):
+        assert str(flowfilter.parse(expr)) == expected
 
 
 class TestMatchingHTTPFlow:
@@ -827,7 +881,7 @@ def test_pyparsing_bug(extract_tb):
 
 def test_match():
     with pytest.raises(ValueError):
-        flowfilter.match("[foobar", None)
+        flowfilter.match("[foobar", tflow.tflow())
 
-    assert flowfilter.match(None, None)
-    assert not flowfilter.match("foobar", None)
+    assert flowfilter.match(None, tflow.tflow())
+    assert not flowfilter.match("foobar", tflow.tflow())

--- a/uv.lock
+++ b/uv.lock
@@ -1047,7 +1047,7 @@ requires-dist = [
     { name = "publicsuffix2", specifier = ">=2.20190812,<=2.20191221" },
     { name = "pydivert", marker = "sys_platform == 'win32'", specifier = ">=2.0.3,<=2.1.0" },
     { name = "pyopenssl", specifier = ">=24.3,<=27.0.0" },
-    { name = "pyparsing", specifier = ">=2.4.2,<=3.3.2" },
+    { name = "pyparsing", specifier = "<=3.3.2,>=3.3.2" },
     { name = "pyperclip", specifier = ">=1.9.0,<=1.11.0" },
     { name = "ruamel-yaml", specifier = ">=0.18.10,<=0.19.1" },
     { name = "sortedcontainers", specifier = ">=2.3,<=2.4.0" },
@@ -1453,11 +1453,11 @@ wheels = [
 
 [[package]]
 name = "pyparsing"
-version = "3.3.1"
+version = "3.3.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/33/c1/1d9de9aeaa1b89b0186e5fe23294ff6517fce1bc69149185577cd31016b2/pyparsing-3.3.1.tar.gz", hash = "sha256:47fad0f17ac1e2cad3de3b458570fbc9b03560aa029ed5e16ee5554da9a2251c", size = 1550512, upload-time = "2025-12-23T03:14:04.391Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8b/40/2614036cdd416452f5bf98ec037f38a1afb17f327cb8e6b652d4729e0af8/pyparsing-3.3.1-py3-none-any.whl", hash = "sha256:023b5e7e5520ad96642e2c6db4cb683d3970bd640cdf7115049a6e9c3682df82", size = 121793, upload-time = "2025-12-23T03:14:02.103Z" },
+    { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
#### Description

This PR revives the old draft in [#7710](https://github.com/mitmproxy/mitmproxy/pull/7710) and completes the missing test coverage for the new __str__ implementations in flowfilter.py.

The broader goal behind this work is to move filter descriptions to the backend so that mitmweb can eventually stop relying on **filt.js**. I initially thought that backend descriptions plus the removal of filt.js could be done together in one PR, but after digging into the mitmweb flow I think that second step needs a bit more discussion. For that reason, I’d prefer to merge this first and follow up separately with the mitmweb changes.

One thing to note is that CI currently fails on old-dependencies (https://github.com/mitmproxy/mitmproxy/actions/runs/26331517591/job/77518316616?pr=8245). I guess we can't ignore that, but how should we fix that? never encountered this type of error.

#### General Discussion for next steps

This PR is only the first step. The remaining open design question is how mitmweb should validate filter expressions once filt.js is removed.

Today mitmweb has three places that use filter expressions:

1. Search
2. Highlight
3. Intercept

Search and Highlight are closely related: they use the websocket flow-filter path and already have dedicated update messages. Intercept is different: it is configured through the /options endpoint.

Because of that, moving validation from the frontend to the backend is not entirely straightforward. The main implementation options I see are:

1. Keep Search and Highlight on the existing websocket filter-update path, and add a separate backend validation path only for Intercept.
This avoids duplicated work for Search/Highlight, because validation and application are effectively the same operation there.

2. Introduce one unified backend validation channel for all three inputs (Search, Highlight, Intercept), and keep the existing websocket//options paths only for committing valid values.
This is more uniform conceptually, but it introduces some duplication for Search and Highlight, because the same expression may be parsed once for validation and again for application.

3. Enrich the existing Search/Highlight websocket messages with validation metadata, and extend the /options endpoint so that backend validation errors can be surfaced directly in the UI. The downside is that this changes the semantics of the general options update path, not only the intercept.

Thoughts?

#### Checklist

 - [x] I have updated tests where applicable.
 - [ ] I have added an entry to the CHANGELOG.
