### PR TITLE
Fix #8239: mitmweb WebSocket crash on invalid filter expression

### DIFF
--- a/mitmproxy/tools/web/app.py
+++ b/mitmproxy/tools/web/app.py
@@ -466,7 +466,20 @@ class ClientConnection(WebSocketEventBroadcaster):
 
     def update_filter(self, name: str, expr: str) -> None:
         if expr:
-            filt = flowfilter.parse(expr)
+            try:
+                filt = flowfilter.parse(expr)
+            except ValueError:
+                error_message = self._json_dumps(
+                    {
+                        "type": "flows/filterError",
+                        "payload": {
+                            "name": name,
+                            "error": "invalid filter expression",
+                        },
+                    },
+                )
+                self.send(message=error_message)
+                return
             self.filters[name] = filt
             matching_flow_ids = [f.id for f in self.application.master.view if filt(f)]
         else:

--- a/test/mitmproxy/tools/web/test_app.py
+++ b/test/mitmproxy/tools/web/test_app.py
@@ -480,6 +480,30 @@ class TestApp(tornado.testing.AsyncHTTPTestCase):
             },
         }
 
+        # test invalid filter expression does not crash WebSocket
+        message = json.dumps(
+            {
+                "type": "flows/updateFilter",
+                "payload": {
+                    "name": "search",
+                    "expr": "~u \"unmatched quote",
+                },
+            }
+        ).encode()
+        yield ws_client.write_message(message)
+
+        response = yield ws_client.read_message()
+        response = json.loads(response)
+
+        assert response == {
+            "type": "flows/filterError",
+            "payload": {
+                "name": "search",
+                "error": "invalid filter expression",
+            },
+        }
+
+        # Connection should still be open and able to receive messages
         # test add flow
         f = tflow.tflow(resp=True)
         f.id = "41"

--- a/test/mitmproxy/tools/web/test_app.py
+++ b/test/mitmproxy/tools/web/test_app.py
@@ -486,7 +486,7 @@ class TestApp(tornado.testing.AsyncHTTPTestCase):
                 "type": "flows/updateFilter",
                 "payload": {
                     "name": "search",
-                    "expr": "~u \"unmatched quote",
+                    "expr": '~u "unmatched quote',
                 },
             }
         ).encode()


### PR DESCRIPTION
Fixes issue #8239: mitmweb disconnects on unmatched quote in filter.

When mitmweb receives an invalid filter expression (e.g., with unmatched quotes), the WebSocket connection would crash because flowfilter.parse() raises a ValueError that was not being caught in update_filter().