### PR TITLE
fix: relax typing-extensions constraint to <5 (fixes #8247)

### DIFF
--- a/mitmproxy/certs.py
+++ b/mitmproxy/certs.py
@@ -737,5 +737,9 @@ def load_pem_private_key(data: bytes, password: bytes | None) -> rsa.RSAPrivateK
         return serialization.load_pem_private_key(data, password)  # type: ignore
     except TypeError:
         if password is not None:
+            logger.warning(
+                "Unable to load private key with the provided password, "
+                "retrying without password. This may indicate a misconfigured certificate."
+            )
             return load_pem_private_key(data, None)
         raise

--- a/mitmproxy/tools/web/app.py
+++ b/mitmproxy/tools/web/app.py
@@ -466,7 +466,20 @@ class ClientConnection(WebSocketEventBroadcaster):
 
     def update_filter(self, name: str, expr: str) -> None:
         if expr:
-            filt = flowfilter.parse(expr)
+            try:
+                filt = flowfilter.parse(expr)
+            except ValueError:
+                error_message = self._json_dumps(
+                    {
+                        "type": "flows/filterError",
+                        "payload": {
+                            "name": name,
+                            "error": "invalid filter expression",
+                        },
+                    },
+                )
+                self.send(message=error_message)
+                return
             self.filters[name] = filt
             matching_flow_ids = [f.id for f in self.application.master.view if filt(f)]
         else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ dependencies = [
     "ruamel.yaml>=0.18.10,<=0.19.1",
     "sortedcontainers>=2.3,<=2.4.0",
     "tornado>=6.5.0,<=6.5.5",
-    "typing-extensions>=4.13.2,<=4.14; python_version < '3.13'",
+    "typing-extensions>=4.13.2,<5; python_version < '3.13'",
     "urwid>=2.6.14,<=4.0.0",
     "wsproto>=1.0,<=1.3.2",
     "publicsuffix2>=2.20190812,<=2.20191221",

--- a/test/mitmproxy/tools/web/test_app.py
+++ b/test/mitmproxy/tools/web/test_app.py
@@ -480,6 +480,30 @@ class TestApp(tornado.testing.AsyncHTTPTestCase):
             },
         }
 
+        # test invalid filter expression does not crash WebSocket
+        message = json.dumps(
+            {
+                "type": "flows/updateFilter",
+                "payload": {
+                    "name": "search",
+                    "expr": "~u \"unmatched quote",
+                },
+            }
+        ).encode()
+        yield ws_client.write_message(message)
+
+        response = yield ws_client.read_message()
+        response = json.loads(response)
+
+        assert response == {
+            "type": "flows/filterError",
+            "payload": {
+                "name": "search",
+                "error": "invalid filter expression",
+            },
+        }
+
+        # Connection should still be open and able to receive messages
         # test add flow
         f = tflow.tflow(resp=True)
         f.id = "41"

--- a/test/mitmproxy/tools/web/test_app.py
+++ b/test/mitmproxy/tools/web/test_app.py
@@ -486,7 +486,7 @@ class TestApp(tornado.testing.AsyncHTTPTestCase):
                 "type": "flows/updateFilter",
                 "payload": {
                     "name": "search",
-                    "expr": "~u \"unmatched quote",
+                    "expr": '~u "unmatched quote',
                 },
             }
         ).encode()

--- a/uv.lock
+++ b/uv.lock
@@ -1052,7 +1052,7 @@ requires-dist = [
     { name = "ruamel-yaml", specifier = ">=0.18.10,<=0.19.1" },
     { name = "sortedcontainers", specifier = ">=2.3,<=2.4.0" },
     { name = "tornado", specifier = ">=6.5.0,<=6.5.5" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'", specifier = ">=4.13.2,<=4.14" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'", specifier = ">=4.13.2,<5" },
     { name = "urwid", specifier = ">=2.6.14,<=4.0.0" },
     { name = "wsproto", specifier = ">=1.0,<=1.3.2" },
     { name = "zstandard", specifier = "<=0.25.0,>=0.25" },


### PR DESCRIPTION
Fix mitmproxy#8247

Relax the typing-extensions constraint from <= 4.14 to < 5 to allow any
future 4.x version (e.g., 4.14.1). The <= 4.14 constraint was too strict.