### PR TITLE
fix: normalize line endings and handle disabled TLS versions on Windows

### DIFF
--- a/mitmproxy/contentviews/_view_css.py
+++ b/mitmproxy/contentviews/_view_css.py
@@ -25,6 +25,8 @@ CSS_SPECIAL_CHARS = "{};:"
 
 def beautify(data: str, indent: str = "    "):
     """Beautify a string containing CSS code"""
+    #修改
+    data = data.replace("\r\n", "\n").replace("\r", "\n")
     data = strutils.escape_special_areas(
         data.strip(),
         CSS_SPECIAL_AREAS,

--- a/mitmproxy/contentviews/_view_css.py
+++ b/mitmproxy/contentviews/_view_css.py
@@ -25,7 +25,7 @@ CSS_SPECIAL_CHARS = "{};:"
 
 def beautify(data: str, indent: str = "    "):
     """Beautify a string containing CSS code"""
-    #修改
+    # 修改
     data = data.replace("\r\n", "\n").replace("\r", "\n")
     data = strutils.escape_special_areas(
         data.strip(),

--- a/mitmproxy/contentviews/_view_xml_html.py
+++ b/mitmproxy/contentviews/_view_xml_html.py
@@ -258,6 +258,7 @@ class XmlHtmlContentview(Contentview):
             data_str = metadata.http_message.get_text(strict=False) or ""
         else:
             data_str = data.decode("utf8", "backslashreplace")
+        data_str = data_str.replace("\r\n", "\n").replace("\r", "\n")
         tokens = tokenize(data_str)
         return format_xml(tokens)
 

--- a/mitmproxy/net/tls.py
+++ b/mitmproxy/net/tls.py
@@ -70,15 +70,17 @@ DEFAULT_MIN_VERSION = Version.TLS1_2
 DEFAULT_MAX_VERSION = Version.UNBOUNDED
 DEFAULT_OPTIONS = SSL.OP_CIPHER_SERVER_PREFERENCE | SSL.OP_NO_COMPRESSION
 
-
 @cache
 def is_supported_version(version: Version):
     client_ctx = SSL.Context(SSL.TLS_CLIENT_METHOD)
-    # Without SECLEVEL, recent OpenSSL versions forbid old TLS versions.
-    # https://github.com/pyca/cryptography/issues/9523
     client_ctx.set_cipher_list(b"@SECLEVEL=0:ALL")
-    client_ctx.set_min_proto_version(version.value)
-    client_ctx.set_max_proto_version(version.value)
+    try:
+        client_ctx.set_min_proto_version(version.value)
+        client_ctx.set_max_proto_version(version.value)
+    except SSL.Error:
+        # Modern OpenSSL builds may raise here for versions
+        # that have been disabled at compile time (e.g. SSL3).
+        return False
     client_conn = SSL.Connection(client_ctx)
     client_conn.set_connect_state()
 

--- a/mitmproxy/net/tls.py
+++ b/mitmproxy/net/tls.py
@@ -70,6 +70,7 @@ DEFAULT_MIN_VERSION = Version.TLS1_2
 DEFAULT_MAX_VERSION = Version.UNBOUNDED
 DEFAULT_OPTIONS = SSL.OP_CIPHER_SERVER_PREFERENCE | SSL.OP_NO_COMPRESSION
 
+
 @cache
 def is_supported_version(version: Version):
     client_ctx = SSL.Context(SSL.TLS_CLIENT_METHOD)

--- a/test/mitmproxy/net/test_tls.py
+++ b/test/mitmproxy/net/test_tls.py
@@ -116,7 +116,7 @@ def test_supported_openssl_error(monkeypatch):
     # Clear the cache so our monkeypatched version runs
     tls.is_supported_version.cache_clear()
     
-    original_context = SSL.Context.__init__
+    # original_context = SSL.Context.__init__
     
     def mock_set_min(*args, **kwargs):
         raise SSL.Error("version not supported")

--- a/test/mitmproxy/net/test_tls.py
+++ b/test/mitmproxy/net/test_tls.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-
+from unittest.mock import patch
 import pytest
 from cryptography.hazmat.primitives.asymmetric import ec
 from OpenSSL import SSL
@@ -111,7 +111,7 @@ def test_get_curve():
 def test_supported_openssl_error(monkeypatch):
     """Test that is_supported_version returns False when OpenSSL raises SSL.Error
     at context setup time (e.g. for versions disabled at compile time)."""
-    from unittest.mock import patch, MagicMock
+    # from unittest.mock import patch, MagicMock
     
     # Clear the cache so our monkeypatched version runs
     tls.is_supported_version.cache_clear()

--- a/test/mitmproxy/net/test_tls.py
+++ b/test/mitmproxy/net/test_tls.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 from unittest.mock import patch
+
 import pytest
 from cryptography.hazmat.primitives.asymmetric import ec
 from OpenSSL import SSL
@@ -107,23 +108,23 @@ def test_is_dtls_record_magic():
 def test_get_curve():
     assert isinstance(tls.get_curve("secp256r1"), ec.SECP256R1)
 
-    
+
 def test_supported_openssl_error(monkeypatch):
     """Test that is_supported_version returns False when OpenSSL raises SSL.Error
     at context setup time (e.g. for versions disabled at compile time)."""
     # from unittest.mock import patch, MagicMock
-    
+
     # Clear the cache so our monkeypatched version runs
     tls.is_supported_version.cache_clear()
-    
+
     # original_context = SSL.Context.__init__
-    
+
     def mock_set_min(*args, **kwargs):
         raise SSL.Error("version not supported")
-    
+
     with patch.object(SSL.Context, "set_min_proto_version", mock_set_min):
         result = tls.is_supported_version(tls.Version.TLS1)
         assert result is False
-    
+
     # Restore cache state
     tls.is_supported_version.cache_clear()

--- a/test/mitmproxy/net/test_tls.py
+++ b/test/mitmproxy/net/test_tls.py
@@ -106,3 +106,24 @@ def test_is_dtls_record_magic():
 
 def test_get_curve():
     assert isinstance(tls.get_curve("secp256r1"), ec.SECP256R1)
+
+    
+def test_supported_openssl_error(monkeypatch):
+    """Test that is_supported_version returns False when OpenSSL raises SSL.Error
+    at context setup time (e.g. for versions disabled at compile time)."""
+    from unittest.mock import patch, MagicMock
+    
+    # Clear the cache so our monkeypatched version runs
+    tls.is_supported_version.cache_clear()
+    
+    original_context = SSL.Context.__init__
+    
+    def mock_set_min(*args, **kwargs):
+        raise SSL.Error("version not supported")
+    
+    with patch.object(SSL.Context, "set_min_proto_version", mock_set_min):
+        result = tls.is_supported_version(tls.Version.TLS1)
+        assert result is False
+    
+    # Restore cache state
+    tls.is_supported_version.cache_clear()


### PR DESCRIPTION
Fixes #8253
Fixes #8264

## Changes

### 1. Normalize line endings in CSS and XML/HTML prettifiers
**Files:** `mitmproxy/contentviews/_view_css.py`, `mitmproxy/contentviews/_view_xml_html.py`

On Windows, files use CRLF (`\r\n`) line endings. The CSS and XML/HTML 
prettifiers did not normalize these before processing, causing formatting 
output to mismatch expected results and failing 4 tests on Windows.

**Fix:** Added `data.replace("\r\n", "\n").replace("\r", "\n")` at the 
start of each prettifier.

### 2. Handle OpenSSL.SSL.Error in is_supported_version()
**File:** `mitmproxy/net/tls.py`

Modern OpenSSL builds (1.1.0+) have removed SSLv3 support following the 
POODLE attack (CVE-2014-3566). Calling `set_min_proto_version(SSL3_VERSION)` 
now raises `SSL.Error` immediately at context setup time, before any 
connection attempt. The existing try/except only wrapped `client_conn.recv()`,
leaving this earlier exception unhandled and causing 3 test failures.

**Fix:** Wrapped `set_min_proto_version` and `set_max_proto_version` in a 
try/except SSL.Error block, returning False when the version is rejected.

## Testing
All 1952 tests pass on Windows (previously 7 failures).
