### PR TITLE
TLS: deliver buffered plaintext on unclean peer close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ## Unreleased: mitmproxy next
 
 - Fix HTTP response body being dropped when a TLS peer closes the connection without sending a `close_notify` alert.
+  ([#8272](https://github.com/mitmproxy/mitmproxy/pull/8272), @ravivasani75)
 - Fix contentview detection for XML files that start with CRLF.
   ([#8243](https://github.com/mitmproxy/mitmproxy/pull/8243), @ADiTyaRaj8969)
 - mitmweb: Fix the filter input losing half-typed text on unrelated parent re-renders.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ## Unreleased: mitmproxy next
 
+- Fix HTTP response body being dropped when a TLS peer closes the connection without sending a `close_notify` alert.
 - Fix contentview detection for XML files that start with CRLF.
   ([#8243](https://github.com/mitmproxy/mitmproxy/pull/8243), @ADiTyaRaj8969)
 - mitmweb: Fix the filter input losing half-typed text on unrelated parent re-renders.

--- a/mitmproxy/proxy/layers/tls.py
+++ b/mitmproxy/proxy/layers/tls.py
@@ -416,7 +416,7 @@ class TLSLayer(tunnel.TunnelLayer):
                 plaintext.extend(self.tls.recv(65535))
             except SSL.WantReadError:
                 break
-            except SSL.ZeroReturnError:
+            except (SSL.ZeroReturnError, SSL.SysCallError):
                 close = True
                 break
             except SSL.Error as e:

--- a/test/mitmproxy/proxy/layers/test_tls.py
+++ b/test/mitmproxy/proxy/layers/test_tls.py
@@ -337,6 +337,83 @@ class TestServerTLS:
             << None
         )
 
+    def test_unclean_close_preserves_buffered_data(self, tctx, monkeypatch):
+        """
+        When a TLS peer closes the underlying transport without sending a
+        close_notify alert, OpenSSL raises SSL.SysCallError(-1, 'Unexpected
+        EOF') from recv(). Any plaintext already buffered must still be
+        delivered to the child layer before the connection close event
+        propagates.
+        """
+        server_layer = tls.ServerTLSLayer(tctx)
+        playbook = tutils.Playbook(server_layer)
+        tctx.server.address = ("example.mitmproxy.org", 443)
+        tctx.server.state = ConnectionState.OPEN
+        tctx.server.sni = "example.mitmproxy.org"
+
+        tssl = SSLTest(server_side=True)
+
+        # Drive the handshake to completion.
+        data = tutils.Placeholder(bytes)
+        assert (
+            playbook
+            << tls.TlsStartServerHook(tutils.Placeholder())
+            >> reply_tls_start_server()
+            << commands.SendData(tctx.server, data)
+        )
+        tssl.bio_write(data())
+        with pytest.raises(ssl.SSLWantReadError):
+            tssl.do_handshake()
+
+        finish_handshake(playbook, tctx.server, tssl)
+
+        tssl.do_handshake()
+        playbook >> events.DataReceived(tctx.server, tssl.bio_read())
+        playbook << None
+        assert playbook
+        assert tctx.server.tls_established
+
+        # Establish a child layer that echoes received data back.
+        assert (
+            playbook
+            >> events.DataReceived(tctx.client, b"trigger")
+            << layer.NextLayerHook(tutils.Placeholder())
+            >> tutils.reply_next_layer(TlsEchoLayer)
+            << commands.SendData(tctx.client, b"trigger")
+        )
+
+        # The server delivers one record of plaintext, then the peer aborts
+        # the connection without close_notify. We simulate this by patching
+        # recv() to return the plaintext on the first call and raise
+        # SysCallError on subsequent calls.
+        tssl.obj.write(b"PARTIAL RESPONSE BODY")
+        ciphertext = tssl.bio_read()
+
+        assert server_layer.tls is not None
+        original_recv = server_layer.tls.recv
+        calls = {"n": 0}
+
+        def fake_recv(bufsize):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                return original_recv(bufsize)
+            raise SSL.SysCallError(-1, "Unexpected EOF")
+
+        monkeypatch.setattr(server_layer.tls, "recv", fake_recv)
+
+        # The buffered plaintext must be delivered to the child layer before
+        # the unclean close propagates. TlsEchoLayer echoes received data
+        # back, so SendData proves b"PARTIAL RESPONSE BODY" was not
+        # discarded. CloseConnection must then follow because the
+        # SysCallError is now treated like an EOF condition (close=True).
+        echoed_ciphertext = tutils.Placeholder(bytes)
+        assert (
+            playbook
+            >> events.DataReceived(tctx.server, ciphertext)
+            << commands.SendData(tctx.server, echoed_ciphertext)
+            << commands.CloseConnection(tctx.server)
+        )
+
     def test_untrusted_cert(self, tctx):
         """If the certificate is not trusted, we should fail."""
         playbook = tutils.Playbook(tls.ServerTLSLayer(tctx))


### PR DESCRIPTION
#### Summary

When a TLS peer closes the underlying transport without sending a `close_notify` alert, OpenSSL can raise `SSL.SysCallError(-1, 'Unexpected EOF')` from `recv()`.

Currently, `TLSLayer.receive_data` catches this in the generic `SSL.Error` branch, logs `TLS Error: (-1, 'Unexpected EOF')`, and breaks out of the receive loop without setting `close = True`. As a result, application data already buffered in that iteration can be dropped. For HTTP/1.1 responses that rely on `Connection: close` framing, this can show up as `200 OK (content missing)`.

This is the receive-side counterpart to commit [[efd2980](https://github.com/mitmproxy/mitmproxy/commit/efd2980b8)](https://github.com/mitmproxy/mitmproxy/commit/efd2980b8), which added similar handling in `send_data`.

#### Reproduction

The added test, `test_unclean_close_preserves_buffered_data`, reproduces this deterministically with no external dependencies. It drives a real TLS handshake and triggers the `SysCallError(-1, 'Unexpected EOF')` condition directly: it fails on `main` (playbook mismatch — `CloseConnection` is never emitted) and passes with this patch.

The underlying condition is generic: any TLS peer that closes the underlying transport without sending a `close_notify` alert. It surfaces user-visibly only when the HTTP response uses connection-close framing, since in that case the buffered data being dropped is the response body itself. With `Content-Length` or `Transfer-Encoding: chunked` responses the body is fully delivered before the close, so the same buggy code path runs but the dropped data is empty; HTTP/2 does not use connection-close framing and is unaffected.

I originally observed this with Burp Suite as the upstream proxy (`mitmdump --mode upstream:http://127.0.0.1:8080`): Burp closes responses without `close_notify` and converts `Transfer-Encoding: chunked` to close-framed, which makes the dropped data visible as a missing response body. mitmdump logs `TLS Error: (-1, 'Unexpected EOF')` followed by `<< 200 OK (content missing)`.

#### Fix

Catch `SSL.SysCallError` alongside `SSL.ZeroReturnError` in `TLSLayer.receive_data`.

Setting `close = True` allows the existing post-loop logic to forward buffered data via `DataReceived` and then emit `ConnectionClosed` normally.

#### Test

Added `test_unclean_close_preserves_buffered_data` to `TestServerTLS`.

The test drives a real TLS handshake, then monkeypatches `recv()` to simulate the `SysCallError(-1, 'Unexpected EOF')` that OpenSSL raises when the peer closes the transport without `close_notify`.

It asserts that:

1. Buffered data is delivered to the child layer, verified via the echo layer round-tripping `b"PARTIAL RESPONSE BODY"` back encrypted.
2. `CloseConnection` is subsequently emitted.

Before the fix, the test fails with a playbook mismatch because `CloseConnection` is never emitted. After the fix, the test passes. No other tests in `test_tls.py` regress.

Note on testing approach: I first tried to trigger `SysCallError` through `MemoryBIO.write_eof()` in the style of existing tests, but the test-side and mitmproxy-side BIOs are independent — `write_eof` on one doesn't raise on the other. Monkeypatching `recv()` was the only deterministic way I found to exercise this specific exception handler. Happy to revise if a more idiomatic approach is preferred.

#### Checklist

- [x] I have updated tests where applicable.
- [x] I have updated the `CHANGELOG.md`.
