### PR TITLE
Add SOCKS5 UDP ASSOCIATE support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 - Add SOCKS5 UDP support: mitmproxy now handles the `UDP ASSOCIATE` command and relays
   UDP datagrams, capturing them as regular UDP flows.
+  ([#8275](https://github.com/mitmproxy/mitmproxy/pull/8275), @pedro-cs-ribeiro)
 - Fix contentview detection for XML files that start with CRLF.
   ([#8243](https://github.com/mitmproxy/mitmproxy/pull/8243), @ADiTyaRaj8969)
 - mitmweb: Fix the filter input losing half-typed text on unrelated parent re-renders.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 ## Unreleased: mitmproxy next
 
+- Add SOCKS5 UDP support: mitmproxy now handles the `UDP ASSOCIATE` command and relays
+  UDP datagrams, capturing them as regular UDP flows.
 - Fix contentview detection for XML files that start with CRLF.
   ([#8243](https://github.com/mitmproxy/mitmproxy/pull/8243), @ADiTyaRaj8969)
 - mitmweb: Fix the filter input losing half-typed text on unrelated parent re-renders.

--- a/docs/src/content/concepts/modes.md
+++ b/docs/src/content/concepts/modes.md
@@ -439,6 +439,20 @@ In this mode, mitmproxy acts as a SOCKS5 proxy.
 This is similar to the regular proxy mode, but using SOCKS5 instead of HTTP for connection establishment
 with the proxy.
 
+mitmproxy supports the `CONNECT` (TCP) and `UDP ASSOCIATE` (UDP) commands.
+For UDP associations, mitmproxy listens for relayed datagrams on the SOCKS5 control connection port,
+forwards them to their destination, and records each as a regular UDP flow.
+Datagram reassembly using the `FRAG` field is not supported.
+
+{{% note %}}
+
+The UDP relay forwards datagrams using the SOCKS5 header without confirming prior source
+authentication. As a result, [`proxyauth`]({{< relref "/concepts/options" >}}#proxyauth)
+restricts only the TCP control connection. To maintain security when relaying UDP, bind the proxy
+to localhost or another trusted network.
+
+{{% /note %}}
+
 
 ## DNS Server
 

--- a/mitmproxy/proxy/layers/modes.py
+++ b/mitmproxy/proxy/layers/modes.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import socket
 import struct
 import sys
@@ -8,10 +9,12 @@ from collections.abc import Callable
 from dataclasses import dataclass
 
 from mitmproxy import connection
+from mitmproxy.connection import Address
 from mitmproxy.proxy import commands
 from mitmproxy.proxy import events
 from mitmproxy.proxy import layer
 from mitmproxy.proxy.commands import StartHook
+from mitmproxy.proxy.context import Context
 from mitmproxy.proxy.mode_specs import ReverseMode
 from mitmproxy.proxy.utils import expect
 
@@ -102,13 +105,82 @@ SOCKS5_METHOD_NO_AUTHENTICATION_REQUIRED = 0x00
 SOCKS5_METHOD_USER_PASSWORD_AUTHENTICATION = 0x02
 SOCKS5_METHOD_NO_ACCEPTABLE_METHODS = 0xFF
 
+SOCKS5_CMD_CONNECT = 0x01
+SOCKS5_CMD_BIND = 0x02
+SOCKS5_CMD_UDP_ASSOCIATE = 0x03
+
 SOCKS5_ATYP_IPV4_ADDRESS = 0x01
 SOCKS5_ATYP_DOMAINNAME = 0x03
 SOCKS5_ATYP_IPV6_ADDRESS = 0x04
 
+SOCKS5_REP_SUCCEEDED = 0x00
+SOCKS5_REP_GENERAL_FAILURE = 0x01
 SOCKS5_REP_HOST_UNREACHABLE = 0x04
 SOCKS5_REP_COMMAND_NOT_SUPPORTED = 0x07
 SOCKS5_REP_ADDRESS_TYPE_NOT_SUPPORTED = 0x08
+
+
+class Socks5Error(Exception):
+    """A SOCKS5 message could not be parsed."""
+
+    def __init__(self, message: str, reply_code: int | None = None) -> None:
+        super().__init__(message)
+        self.message = message
+        self.reply_code = reply_code
+
+
+def parse_socks5_address(data: bytes, offset: int = 0) -> tuple[str, int, int] | None:
+    """
+    Parse the ATYP + DST.ADDR + DST.PORT fields of a SOCKS5 message, starting at `offset`.
+
+    Returns a `(host, port, end_offset)` tuple where `end_offset` points just past the
+    parsed fields, or `None` if more data is needed to parse the address.
+    Raises `Socks5Error` if the address type is not supported.
+    """
+    if len(data) < offset + 1:
+        return None
+    atyp = data[offset]
+    if atyp == SOCKS5_ATYP_IPV4_ADDRESS:
+        length = 1 + 4 + 2
+    elif atyp == SOCKS5_ATYP_IPV6_ADDRESS:
+        length = 1 + 16 + 2
+    elif atyp == SOCKS5_ATYP_DOMAINNAME:
+        if len(data) < offset + 2:
+            return None
+        length = 1 + 1 + data[offset + 1] + 2
+    else:
+        raise Socks5Error(
+            f"Unknown address type: {atyp}", SOCKS5_REP_ADDRESS_TYPE_NOT_SUPPORTED
+        )
+
+    end = offset + length
+    if len(data) < end:
+        return None
+
+    if atyp == SOCKS5_ATYP_IPV4_ADDRESS:
+        host = socket.inet_ntop(socket.AF_INET, data[offset + 1 : offset + 5])
+    elif atyp == SOCKS5_ATYP_IPV6_ADDRESS:
+        host = socket.inet_ntop(socket.AF_INET6, data[offset + 1 : offset + 17])
+    else:
+        host = data[offset + 2 : end - 2].decode("ascii", "replace")
+    (port,) = struct.unpack("!H", data[end - 2 : end])
+    return host, port, end
+
+
+def pack_socks5_address(host: str, port: int) -> bytes:
+    """Encode an address as the SOCKS5 ATYP + ADDR + PORT fields."""
+    try:
+        packed = socket.inet_pton(socket.AF_INET, host)
+        atyp = SOCKS5_ATYP_IPV4_ADDRESS
+    except OSError:
+        try:
+            packed = socket.inet_pton(socket.AF_INET6, host)
+            atyp = SOCKS5_ATYP_IPV6_ADDRESS
+        except OSError:
+            encoded = host.encode("idna")
+            packed = bytes([len(encoded)]) + encoded
+            atyp = SOCKS5_ATYP_DOMAINNAME
+    return bytes([atyp]) + packed + struct.pack("!H", port)
 
 
 @dataclass
@@ -236,51 +308,38 @@ class Socks5Proxy(DestinationKnown):
         yield from self.state()
 
     def state_connect(self) -> layer.CommandGenerator[None]:
-        # Parse Connect Request
+        # Parse the request: VER CMD RSV ATYP DST.ADDR DST.PORT
         if len(self.buf) < 5:
             return
 
-        if self.buf[:3] != b"\x05\x01\x00":
+        cmd = self.buf[1]
+        supported_cmds = (SOCKS5_CMD_CONNECT, SOCKS5_CMD_UDP_ASSOCIATE)
+        if (
+            self.buf[0] != SOCKS5_VERSION
+            or self.buf[2] != 0x00
+            or cmd not in supported_cmds
+        ):
             yield from self.socks_err(
                 f"Unsupported SOCKS5 request: {self.buf!r}",
                 SOCKS5_REP_COMMAND_NOT_SUPPORTED,
             )
             return
 
-        # Determine message length
-        atyp = self.buf[3]
-        message_len: int
-        if atyp == SOCKS5_ATYP_IPV4_ADDRESS:
-            message_len = 4 + 4 + 2
-        elif atyp == SOCKS5_ATYP_IPV6_ADDRESS:
-            message_len = 4 + 16 + 2
-        elif atyp == SOCKS5_ATYP_DOMAINNAME:
-            message_len = 4 + 1 + self.buf[4] + 2
-        else:
-            yield from self.socks_err(
-                f"Unknown address type: {atyp}", SOCKS5_REP_ADDRESS_TYPE_NOT_SUPPORTED
-            )
+        try:
+            parsed = parse_socks5_address(self.buf, 3)
+        except Socks5Error as e:
+            yield from self.socks_err(e.message, e.reply_code)
+            return
+        if parsed is None:
+            return  # not enough bytes yet
+        host, port, offset = parsed
+        self.buf = self.buf[offset:]
+
+        if cmd == SOCKS5_CMD_UDP_ASSOCIATE:
+            yield from self.start_udp_associate()
             return
 
-        # Do we have enough bytes yet?
-        if len(self.buf) < message_len:
-            return
-
-        # Parse host and port
-        msg, self.buf = self.buf[:message_len], self.buf[message_len:]
-
-        host: str
-        if atyp == SOCKS5_ATYP_IPV4_ADDRESS:
-            host = socket.inet_ntop(socket.AF_INET, msg[4:-2])
-        elif atyp == SOCKS5_ATYP_IPV6_ADDRESS:
-            host = socket.inet_ntop(socket.AF_INET6, msg[4:-2])
-        else:
-            host_bytes = msg[5:-2]
-            host = host_bytes.decode("ascii", "replace")
-
-        (port,) = struct.unpack("!H", msg[-2:])
-
-        # We now have all we need, let's get going.
+        # CONNECT: We now have all we need, let's get going.
         self.context.server.address = (host, port)
         self.child_layer = layer.NextLayer(self.context)
 
@@ -301,3 +360,172 @@ class Socks5Proxy(DestinationKnown):
                     events.DataReceived(self.context.client, self.buf)
                 )
                 del self.buf
+
+    def start_udp_associate(self) -> layer.CommandGenerator[None]:
+        # Point the client at our UDP relay, which shares this connection's address:port.
+        assert self.context.client.sockname
+        host, port = self.context.client.sockname[:2]
+        yield commands.SendData(
+            self.context.client,
+            bytes([SOCKS5_VERSION, SOCKS5_REP_SUCCEEDED, 0x00])
+            + pack_socks5_address(host, port),
+        )
+        self.buf = b""
+        self.state = self.state_associated
+
+    def state_associated(self) -> layer.CommandGenerator[None]:
+        # The control connection is idle while associated; datagrams flow over the relay.
+        self.buf = b""
+        yield from ()
+
+
+class Socks5UdpStreamLayer(layer.Layer):
+    """
+    Virtual layer for a single destination of a SOCKS5 UDP association. Like
+    `QuicStreamLayer`, it owns virtual client/server connections and relays all events to
+    a child `NextLayer` stack.
+    """
+
+    client: connection.Client
+    server: connection.Server
+    child_layer: layer.Layer
+    header: bytes
+
+    def __init__(self, context: Context, address: Address, header: bytes) -> None:
+        self.client = context.client = context.client.copy()
+        self.client.transport_protocol = "udp"
+        self.client.state = connection.ConnectionState.OPEN
+        self.server = context.server = connection.Server(
+            address=address, transport_protocol="udp"
+        )
+        self.header = header
+        super().__init__(context)
+        self.child_layer = layer.NextLayer(context)
+
+        # we don't handle any events ourselves, everything goes to the child layer.
+        self.handle_event = self.child_layer.handle_event  # type: ignore
+        self._handle_event = self.child_layer._handle_event  # type: ignore
+
+    def _handle_event(self, event: events.Event) -> layer.CommandGenerator[None]:
+        raise AssertionError  # pragma: no cover
+
+
+class Socks5UdpProxy(layer.Layer):
+    """
+    Relay for SOCKS5 UDP ASSOCIATE datagrams, the receiving end of the relay that
+    `Socks5Proxy` advertises. Each datagram is prefixed with a SOCKS5 UDP request header
+    (RSV, FRAG, ATYP, DST.ADDR, DST.PORT). We strip the header, de-multiplex by destination
+    into a `Socks5UdpStreamLayer`, and re-encapsulate replies back to the client.
+    """
+
+    connections: dict[connection.Connection, layer.Layer]
+    destinations: dict[Address, Socks5UdpStreamLayer]
+    command_sources: dict[commands.Command, layer.Layer]
+
+    def __init__(self, context: Context) -> None:
+        super().__init__(context)
+        self.connections = {}
+        self.destinations = {}
+        self.command_sources = {}
+
+    def _handle_event(self, event: events.Event) -> layer.CommandGenerator[None]:
+        if isinstance(event, events.Start):
+            # destinations are discovered per datagram, so there is nothing to do yet.
+            yield from ()
+        elif isinstance(event, events.CommandCompleted):
+            yield from self.event_to_child(
+                self.command_sources.pop(event.command), event
+            )
+        elif isinstance(event, events.MessageInjected):
+            yield from self.event_to_child(
+                self.connections[event.flow.client_conn], event
+            )
+        elif (
+            isinstance(event, events.DataReceived)
+            and event.connection is self.context.client
+        ):
+            yield from self.handle_datagram(event.data)
+        elif (
+            isinstance(event, events.ConnectionClosed)
+            and event.connection is self.context.client
+        ):
+            for stream in list(self.destinations.values()):
+                yield from self.event_to_child(
+                    stream, events.ConnectionClosed(stream.client)
+                )
+            self._handle_event = self.done  # type: ignore
+        elif isinstance(event, events.ConnectionEvent):
+            yield from self.event_to_child(self.connections[event.connection], event)
+        else:
+            raise AssertionError(f"Unexpected event: {event!r}")
+
+    def handle_datagram(self, data: bytes) -> layer.CommandGenerator[None]:
+        if len(data) < 4 or data[:2] != b"\x00\x00":
+            yield commands.Log(
+                f"Received invalid SOCKS5 UDP datagram: {data!r}", logging.DEBUG
+            )
+            return
+        if data[2] != 0x00:
+            # FRAG != 0, datagram reassembly is not supported.
+            yield commands.Log(
+                f"Dropping fragmented SOCKS5 UDP datagram: {data!r}", logging.DEBUG
+            )
+            return
+        try:
+            parsed = parse_socks5_address(data, 3)
+        except Socks5Error as e:
+            yield commands.Log(
+                f"Dropping SOCKS5 UDP datagram: {e.message}", logging.DEBUG
+            )
+            return
+        if parsed is None:
+            yield commands.Log(
+                f"Received truncated SOCKS5 UDP datagram: {data!r}", logging.DEBUG
+            )
+            return
+        host, port, offset = parsed
+        address = (host, port)
+
+        stream = self.destinations.get(address)
+        if stream is None:
+            # the request header (data[:offset]) is reused to encapsulate replies.
+            stream = Socks5UdpStreamLayer(self.context.fork(), address, data[:offset])
+            self.destinations[address] = stream
+            self.connections[stream.client] = stream
+            self.connections[stream.server] = stream
+            yield from self.event_to_child(stream, events.Start())
+        yield from self.event_to_child(
+            stream, events.DataReceived(stream.client, data[offset:])
+        )
+
+    def event_to_child(
+        self, stream: layer.Layer, event: events.Event
+    ) -> layer.CommandGenerator[None]:
+        for command in stream.handle_event(event):
+            if (
+                isinstance(stream, Socks5UdpStreamLayer)
+                and isinstance(command, commands.ConnectionCommand)
+                and command.connection is stream.client
+            ):
+                if isinstance(command, commands.SendData):
+                    yield commands.SendData(
+                        self.context.client, stream.header + command.data
+                    )
+                elif isinstance(command, commands.CloseConnection):
+                    # there is no client close to forward, just forget this destination.
+                    self.destinations.pop(stream.server.address, None)  # type: ignore
+                    self.connections.pop(stream.client, None)
+                    self.connections.pop(stream.server, None)
+                else:
+                    raise AssertionError(
+                        f"Unexpected stream client command: {command!r}"
+                    )
+            else:
+                if command.blocking or isinstance(command, commands.RequestWakeup):
+                    self.command_sources[command] = stream
+                if isinstance(command, commands.OpenConnection):
+                    self.connections[command.connection] = stream
+                yield command
+
+    def done(self, _) -> layer.CommandGenerator[None]:  # pragma: no cover
+        yield from ()

--- a/mitmproxy/proxy/mode_servers.py
+++ b/mitmproxy/proxy/mode_servers.py
@@ -492,6 +492,8 @@ class ReverseInstance(AsyncioServerInstance[mode_specs.ReverseMode]):
 
 class Socks5Instance(AsyncioServerInstance[mode_specs.Socks5Mode]):
     def make_top_layer(self, context: Context) -> Layer:
+        if context.client.transport_protocol == "udp":
+            return layers.modes.Socks5UdpProxy(context)
         return layers.modes.Socks5Proxy(context)
 
 

--- a/mitmproxy/proxy/mode_specs.py
+++ b/mitmproxy/proxy/mode_specs.py
@@ -251,7 +251,7 @@ class Socks5Mode(ProxyMode):
 
     description = "SOCKS v5 proxy"
     default_port = 1080
-    transport_protocol = TCP
+    transport_protocol = BOTH
 
     def __post_init__(self) -> None:
         _check_empty(self.data)

--- a/test/mitmproxy/proxy/layers/test_modes.py
+++ b/test/mitmproxy/proxy/layers/test_modes.py
@@ -30,11 +30,13 @@ from mitmproxy.proxy.layers.tcp import TcpStartHook
 from mitmproxy.proxy.layers.tls import ClientTLSLayer
 from mitmproxy.proxy.layers.tls import TlsStartClientHook
 from mitmproxy.proxy.layers.tls import TlsStartServerHook
+from mitmproxy.proxy.layers.udp import UdpMessageInjected
 from mitmproxy.proxy.mode_specs import ProxyMode
 from mitmproxy.tcp import TCPFlow
 from mitmproxy.test import taddons
 from mitmproxy.test import tflow
 from mitmproxy.udp import UDPFlow
+from mitmproxy.udp import UDPMessage
 from test.mitmproxy.proxy.layers.test_tls import reply_tls_start_client
 from test.mitmproxy.proxy.layers.test_tls import reply_tls_start_server
 from test.mitmproxy.proxy.tutils import Placeholder
@@ -590,3 +592,168 @@ def test_socks5_premature_close(tctx: Context):
         << Log(r"Client closed connection before completing SOCKS5 handshake: b'\x05'")
         << CloseConnection(tctx.client)
     )
+
+
+# SOCKS5 UDP ASSOCIATE
+
+# RSV(0000) FRAG(00) ATYP(01=IPv4) DST.ADDR(1.2.3.4) DST.PORT(0005)
+UDP_HEADER = b"\x00\x00\x00\x01\x01\x02\x03\x04\x00\x05"
+
+
+def test_socks5_udp_associate(tctx: Context):
+    """The control connection accepts UDP ASSOCIATE and replies with the relay address."""
+    playbook = Playbook(modes.Socks5Proxy(tctx))
+    assert (
+        playbook
+        >> DataReceived(tctx.client, CLIENT_HELLO)
+        << SendData(tctx.client, SERVER_HELLO)
+        # VER=5 CMD=3 (UDP ASSOCIATE) RSV=0 ATYP=1 0.0.0.0:0
+        >> DataReceived(tctx.client, b"\x05\x03\x00\x01\x00\x00\x00\x00\x00\x00")
+        # The reply points the client at our relay, i.e. the proxy address it connected
+        # to (tctx.client.sockname == 127.0.0.1:8080, 8080 == 0x1f90).
+        << SendData(tctx.client, b"\x05\x00\x00\x01\x7f\x00\x00\x01\x1f\x90")
+    )
+    # The control connection stays open and idle; stray data is ignored, and closing it
+    # tears the association down.
+    assert (
+        playbook
+        >> DataReceived(tctx.client, b"ignored")
+        >> ConnectionClosed(tctx.client)
+        << CloseConnection(tctx.client)
+    )
+
+
+def test_socks5_udp_relay(tctx: Context):
+    """Socks5UdpProxy decapsulates a datagram, relays it, and re-encapsulates the reply."""
+    tctx.client.transport_protocol = "udp"
+    flow = Placeholder(UDPFlow)
+    server = Placeholder(Server)
+    assert (
+        Playbook(modes.Socks5UdpProxy(tctx))
+        >> DataReceived(tctx.client, UDP_HEADER + b"ping")
+        << NextLayerHook(Placeholder(NextLayer))
+        >> reply_next_layer(layers.UDPLayer)
+        << udp.UdpStartHook(flow)
+        >> reply()
+        << OpenConnection(server)
+        >> reply(None)
+        << udp.UdpMessageHook(flow)
+        >> reply()
+        << SendData(server, b"ping")
+        # The server's reply is wrapped back into a SOCKS5 UDP datagram for the client.
+        >> DataReceived(server, b"pong")
+        << udp.UdpMessageHook(flow)
+        >> reply()
+        << SendData(tctx.client, UDP_HEADER + b"pong")
+        # An injected client message is relayed onward as well.
+        >> UdpMessageInjected(flow, UDPMessage(True, b"inject"))
+        << udp.UdpMessageHook(flow)
+        >> reply()
+        << SendData(server, b"inject")
+        # When the server side closes, the destination is forgotten (no client close
+        # to forward over the connectionless relay).
+        >> ConnectionClosed(server)
+        << udp.UdpEndHook(flow)
+        >> reply()
+    )
+    assert server().address == ("1.2.3.4", 5)
+    assert [(m.from_client, m.content) for m in flow().messages] == [
+        (True, b"ping"),
+        (False, b"pong"),
+        (True, b"inject"),
+    ]
+
+
+def test_socks5_udp_relay_client_close(tctx: Context):
+    """Closing the relay (client) connection tears down all destinations."""
+    tctx.client.transport_protocol = "udp"
+    flow = Placeholder(UDPFlow)
+    server = Placeholder(Server)
+    assert (
+        Playbook(modes.Socks5UdpProxy(tctx))
+        >> DataReceived(tctx.client, UDP_HEADER + b"x")
+        << NextLayerHook(Placeholder(NextLayer))
+        >> reply_next_layer(layers.UDPLayer)
+        << udp.UdpStartHook(flow)
+        >> reply()
+        << OpenConnection(server)
+        >> reply(None)
+        << udp.UdpMessageHook(flow)
+        >> reply()
+        << SendData(server, b"x")
+        >> ConnectionClosed(tctx.client)
+        << CloseConnection(server)
+        << udp.UdpEndHook(flow)
+        >> reply()
+    )
+
+
+def test_socks5_udp_relay_multiple_destinations(tctx: Context):
+    """A single association fans out to multiple destinations, one flow each."""
+    tctx.client.transport_protocol = "udp"
+    flow1 = Placeholder(UDPFlow)
+    flow2 = Placeholder(UDPFlow)
+    server1 = Placeholder(Server)
+    server2 = Placeholder(Server)
+    header2 = b"\x00\x00\x00\x01\x05\x06\x07\x08\x00\x06"  # 5.6.7.8:6
+    assert (
+        Playbook(modes.Socks5UdpProxy(tctx))
+        >> DataReceived(tctx.client, UDP_HEADER + b"a")
+        << NextLayerHook(Placeholder(NextLayer))
+        >> reply_next_layer(layers.UDPLayer)
+        << udp.UdpStartHook(flow1)
+        >> reply()
+        << OpenConnection(server1)
+        >> reply(None)
+        << udp.UdpMessageHook(flow1)
+        >> reply()
+        << SendData(server1, b"a")
+        >> DataReceived(tctx.client, header2 + b"b")
+        << NextLayerHook(Placeholder(NextLayer))
+        >> reply_next_layer(layers.UDPLayer)
+        << udp.UdpStartHook(flow2)
+        >> reply()
+        << OpenConnection(server2)
+        >> reply(None)
+        << udp.UdpMessageHook(flow2)
+        >> reply()
+        << SendData(server2, b"b")
+    )
+    assert server1().address == ("1.2.3.4", 5)
+    assert server2().address == ("5.6.7.8", 6)
+    assert flow1() is not flow2()
+
+
+def test_socks5_udp_relay_invalid(tctx: Context):
+    """Malformed/fragmented datagrams are dropped without relaying anything."""
+    tctx.client.transport_protocol = "udp"
+    assert (
+        Playbook(modes.Socks5UdpProxy(tctx))
+        # too short
+        >> DataReceived(tctx.client, b"\x00")
+        # bad RSV
+        >> DataReceived(tctx.client, b"\xff\xff\x00\x01\x01\x02\x03\x04\x00\x05data")
+        # fragmented (FRAG != 0), unsupported
+        >> DataReceived(tctx.client, b"\x00\x00\x01\x01\x01\x02\x03\x04\x00\x05data")
+        # unknown address type
+        >> DataReceived(tctx.client, b"\x00\x00\x00\x07\x01\x02")
+        # truncated address
+        >> DataReceived(tctx.client, b"\x00\x00\x00\x01\x01\x02")
+    )
+
+
+@pytest.mark.parametrize(
+    "host,port",
+    [("1.2.3.4", 80), ("::1", 443), ("example.com", 8080)],
+)
+def test_socks5_address_roundtrip(host: str, port: int):
+    packed = modes.pack_socks5_address(host, port)
+    assert modes.parse_socks5_address(packed) == (host, port, len(packed))
+
+
+def test_socks5_address_incomplete():
+    assert modes.parse_socks5_address(b"") is None  # need ATYP byte
+    assert modes.parse_socks5_address(b"\x03") is None  # domain needs length byte
+    assert modes.parse_socks5_address(b"\x01\x01\x02") is None  # IPv4 truncated
+    with pytest.raises(modes.Socks5Error, match="Unknown address type: 9"):
+        modes.parse_socks5_address(b"\x09")

--- a/test/mitmproxy/proxy/layers/test_socks5_fuzz.py
+++ b/test/mitmproxy/proxy/layers/test_socks5_fuzz.py
@@ -6,6 +6,7 @@ from mitmproxy.connection import Client
 from mitmproxy.proxy.context import Context
 from mitmproxy.proxy.events import DataReceived
 from mitmproxy.proxy.layers.modes import Socks5Proxy
+from mitmproxy.proxy.layers.modes import Socks5UdpProxy
 
 opts = options.Options()
 tctx = Context(
@@ -21,4 +22,10 @@ tctx = Context(
 @given(binary())
 def test_socks5_fuzz(data):
     layer = Socks5Proxy(tctx)
+    list(layer.handle_event(DataReceived(tctx.client, data)))
+
+
+@given(binary())
+def test_socks5_udp_fuzz(data):
+    layer = Socks5UdpProxy(tctx)
     list(layer.handle_event(DataReceived(tctx.client, data)))

--- a/test/mitmproxy/proxy/test_mode_servers.py
+++ b/test/mitmproxy/proxy/test_mode_servers.py
@@ -45,6 +45,21 @@ def test_make():
         WireGuardServerInstance.make("regular", manager)
 
 
+def test_socks5_make_top_layer():
+    from mitmproxy.proxy.layers import modes
+
+    manager = Mock()
+    inst = ServerInstance.make("socks5", manager)
+
+    tcp_ctx = MagicMock()
+    tcp_ctx.client.transport_protocol = "tcp"
+    assert isinstance(inst.make_top_layer(tcp_ctx), modes.Socks5Proxy)
+
+    udp_ctx = MagicMock()
+    udp_ctx.client.transport_protocol = "udp"
+    assert isinstance(inst.make_top_layer(udp_ctx), modes.Socks5UdpProxy)
+
+
 async def test_last_exception_and_running(monkeypatch):
     manager = MagicMock()
     err = ValueError("something else")

--- a/test/mitmproxy/proxy/test_mode_specs.py
+++ b/test/mitmproxy/proxy/test_mode_specs.py
@@ -37,6 +37,11 @@ def test_parse_subclass():
         Socks5Mode.parse("regular")
 
 
+def test_socks5_dual_transport():
+    # SOCKS5 listens on both TCP (CONNECT) and UDP (the UDP ASSOCIATE relay).
+    assert Socks5Mode.parse("socks5").transport_protocol == "both"
+
+
 def test_listen_addr():
     assert ProxyMode.parse("regular").listen_port() == 8080
     assert ProxyMode.parse("regular@1234").listen_port() == 1234


### PR DESCRIPTION
# Add SOCKS5 UDP ASSOCIATE support

#### Description

Closes #6272.

Previously, mitmproxy’s SOCKS5 mode supported only the TCP `CONNECT` command and rejected `UDP ASSOCIATE` with `COMMAND_NOT_SUPPORTED`. As a result, clients that rely heavily on UDP, such as qBittorrent, could not be proxied. This update adds `UDP ASSOCIATE` support, so SOCKS5 UDP datagrams are relayed and captured as regular, inspectable, and modifiable `UDPFlow`s.

- `Socks5Mode` now listens on both TCP and UDP on the same port, similar to `DnsMode`. The `UDP ASSOCIATE` reply directs the client to the relay at the control connection’s address and port.
- `Socks5Proxy.state_connect` dispatches on the SOCKS5 command byte and handles `UDP ASSOCIATE` in addition to `CONNECT`.
- A new `Socks5UdpProxy` / `Socks5UdpStreamLayer` relay layer, modeled on the existing `RawQuicLayer` de-multiplexer, removes the SOCKS5 UDP header, de-multiplexes by destination into a child `NextLayer` stack (so DNS, QUIC, DTLS, and raw UDP are detected like any other UDP connection), and re-encapsulates replies. No changes to the proxy core (`server.py`) were required.

Fragmented datagrams (`FRAG != 0`) are dropped, as required by RFC 1928 for implementations that do not support reassembly. The relay forwards based on the SOCKS5 header and is not tied to prior authentication or association, consistent with mitmproxy’s open-by-default proxy model; this is noted in `modes.md`.

#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.