### PR TITLE
Handle comma-separated Content-Encoding in decode/encode

### DIFF
--- a/mitmproxy/net/encoding.py
+++ b/mitmproxy/net/encoding.py
@@ -48,6 +48,16 @@ def decode(
         return None
     encoding = encoding.lower()
 
+    # Content-Encoding can technically be a list like "sdch, gzip", so if we
+    # see commas we just peel off one codec at a time. decode order is the
+    # reverse of how it was applied, so handle the last token first.
+    # https://github.com/mitmproxy/mitmproxy/issues/2246
+    if "," in encoding:
+        encodings = [e.strip() for e in encoding.split(",") if e.strip()]
+        for e in reversed(encodings):
+            encoded = decode(encoded, e, errors)
+        return encoded
+
     global _cache
     cached = (
         isinstance(encoded, bytes)
@@ -61,7 +71,12 @@ def decode(
         try:
             decoded = custom_decode[encoding](encoded)
         except KeyError:
-            decoded = codecs.decode(encoded, encoding, errors)  # type: ignore
+            # sdch is a thing browsers used to advertise but we never actually
+            # decode it, so treat it like identity instead of choking on it.
+            if encoding == "sdch":
+                decoded = encoded
+            else:
+                decoded = codecs.decode(encoded, encoding, errors)  # type: ignore
         if encoding in ("gzip", "deflate", "deflateraw", "br", "zstd"):
             _cache = CachedDecode(encoded, encoding, errors, decoded)
         return decoded
@@ -106,6 +121,14 @@ def encode(
         return None
     encoding = encoding.lower()
 
+    # same deal as decode for a comma separated Content-Encoding, just in the
+    # forward order this time.
+    if "," in encoding:
+        encodings = [e.strip() for e in encoding.split(",") if e.strip()]
+        for e in encodings:
+            decoded = encode(decoded, e, errors)
+        return decoded
+
     global _cache
     cached = (
         isinstance(decoded, bytes)
@@ -119,7 +142,10 @@ def encode(
         try:
             encoded = custom_encode[encoding](decoded)
         except KeyError:
-            encoded = codecs.encode(decoded, encoding, errors)  # type: ignore
+            if encoding == "sdch":
+                encoded = decoded
+            else:
+                encoded = codecs.encode(decoded, encoding, errors)  # type: ignore
         if encoding in ("gzip", "deflate", "deflateraw", "br", "zstd"):
             _cache = CachedDecode(encoded, encoding, errors, decoded)
         return encoded

--- a/test/mitmproxy/net/test_encoding.py
+++ b/test/mitmproxy/net/test_encoding.py
@@ -66,6 +66,26 @@ def test_encoders_strings(encoder):
         encoding.decode("foobar", encoder)
 
 
+def test_multiple_encodings():
+    """https://github.com/mitmproxy/mitmproxy/issues/2246
+
+    Content-Encoding can be a comma separated list, so we should apply each
+    codec in turn instead of doing a single dict lookup that raises KeyError.
+    sdch is unsupported so it just passes through like identity.
+    """
+    # gzip body that was also tagged sdch should still decode fine
+    gzipped = encoding.encode(b"mitmproxy", "gzip")
+    assert encoding.decode(gzipped, "sdch, gzip") == b"mitmproxy"
+
+    # whitespace variations and casing shouldn't matter
+    assert encoding.decode(gzipped, "GZIP") == b"mitmproxy"
+    assert encoding.decode(gzipped, "sdch,gzip") == b"mitmproxy"
+
+    # round trip through two real codecs
+    both = encoding.encode(b"mitmproxy", "gzip, deflate")
+    assert encoding.decode(both, "gzip, deflate") == b"mitmproxy"
+
+
 class TestDecodeGzip:
     def test_regular_gzip(self):
         # generated with gzip.compress(b"mitmproxy")

--- a/test/mitmproxy/net/test_encoding.py
+++ b/test/mitmproxy/net/test_encoding.py
@@ -85,6 +85,9 @@ def test_multiple_encodings():
     both = encoding.encode(b"mitmproxy", "gzip, deflate")
     assert encoding.decode(both, "gzip, deflate") == b"mitmproxy"
 
+    # encoding sdch is a no-op too, so a sdch+gzip body is just the gzip
+    assert encoding.encode(b"mitmproxy", "sdch, gzip") == gzipped
+
 
 class TestDecodeGzip:
     def test_regular_gzip(self):


### PR DESCRIPTION
Content-Encoding can technically be a list like "sdch, gzip", and right now decode just does one dict lookup on the whole string and blows up with a KeyError/LookupError. so if a server sends something like that, decoding the body throws instead of working.

fixed it by splitting on commas and applying each codec in turn (reverse order for decode, forward for encode). also treat sdch as identity since we never actually decode it and it was the thing tripping people up here. went with handling it in encoding.py per the thread where mhils said we should just deal with this.

added a test covering the sdch, gzip case plus whitespace and casing, full suite passes locally. closes #2246
