### PR TITLE
Guard QUIC datagram flushing when no network path is available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
   ([#8232](https://github.com/mitmproxy/mitmproxy/pull/8232), @ariel42)
 - mitmweb: Fix correctly displaying multiple blank lines in content renderer.
   ([#8248](https://github.com/mitmproxy/mitmproxy/pull/8248), @vincentdehaan)
+- Guard QUIC datagram flushing when no network path is available.
+  ([#8277](https://github.com/mitmproxy/mitmproxy/pull/8277), @lups2000)
 
 ## 12 May 2026: mitmproxy 12.2.3
 

--- a/mitmproxy/proxy/layers/quic/_stream_layers.py
+++ b/mitmproxy/proxy/layers/quic/_stream_layers.py
@@ -170,11 +170,11 @@ class QuicLayer(tunnel.TunnelLayer):
 
         # send all queued datagrams
         assert self.quic
-        
+
         # aioquic 1.2.0 raises IndexError in datagrams_to_send() if no network path exists yet.
         if not self.quic._network_paths:
             return
-        
+
         now = self._time()
 
         for data, addr in self.quic.datagrams_to_send(now=now):

--- a/mitmproxy/proxy/layers/quic/_stream_layers.py
+++ b/mitmproxy/proxy/layers/quic/_stream_layers.py
@@ -170,6 +170,11 @@ class QuicLayer(tunnel.TunnelLayer):
 
         # send all queued datagrams
         assert self.quic
+        
+        # aioquic 1.2.0 raises IndexError in datagrams_to_send() if no network path exists yet.
+        if not self.quic._network_paths:
+            return
+        
         now = self._time()
 
         for data, addr in self.quic.datagrams_to_send(now=now):

--- a/test/mitmproxy/proxy/layers/quic/test__stream_layers.py
+++ b/test/mitmproxy/proxy/layers/quic/test__stream_layers.py
@@ -1008,6 +1008,36 @@ class TestClientQuic:
             << tls.TlsFailedClientHook(tutils.Placeholder())
         )
 
+    def test_post_handshake_close_without_network_path(self, tctx: context.Context):
+        # We want to exercise the post-handshake `receive_data()` path directly
+        tctx.client.state = connection.ConnectionState.CLOSED
+        client_layer = ClientQuicLayer(tctx, time=lambda: 0)
+        client_layer.child_layer = TlsEchoLayer(tctx)
+        client_layer.tunnel_state = tls.tunnel.TunnelState.CLOSED
+
+        playbook = tutils.Playbook(client_layer, expected=[])
+
+        quic_buf = QuicBuffer(data=client_hello)
+        header = pull_quic_header(quic_buf, host_cid_length=8)
+        config = QuicConfiguration(is_client=False)
+        config.load_cert_chain(
+            tdata.path("mitmproxy/net/data/verificationcerts/trusted-leaf.crt"),
+            tdata.path("mitmproxy/net/data/verificationcerts/trusted-leaf.key"),
+        )
+        client_layer.quic = QuicConnection(
+            configuration=config,
+            original_destination_connection_id=header.destination_cid,
+        )
+
+        # This reproduces the problematic aioquic state: server-side QUIC has been
+        # created, but no datagram was processed yet, so no network path exists.
+        assert client_layer.quic._network_paths == []
+
+        # A late empty read after handshake failure must not try to drain
+        # datagrams from aioquic before a network path was established.
+        assert playbook >> events.DataReceived(tctx.client, b"")
+        assert playbook
+
     def test_no_server_tls(self, tctx: context.Context):
         playbook, client_layer, tssl_client = make_client_tls_layer(
             tctx, no_server=True


### PR DESCRIPTION
#### Description

This PR prevents a QUIC crash when mitmproxy calls `aioquic.datagrams_to_send()` before the QUIC connection has learned any network path. Fixes #8161.

In some handshake failure races, mitmproxy can still reach `QuicLayer.tls_interact()` after the client-side QUIC setup has already failed. 


#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
