### PR TITLE
feat: add termlog_colors option to force/disable color output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@
   now placed at the top of the table when the option is set, instead of always
   being appended at the bottom.
   ([#8288](https://github.com/mitmproxy/mitmproxy/pull/8288), @hexbinoct)
+- Add a `termlog_colors` option (`auto`/`always`/`never`) to force-enable or
+  force-disable ANSI color output for log and mitmdump flow output. Useful
+  for piping `mitmdump` output to a pager (e.g. `mitmdump | less -R`) while
+  keeping colors.
+  ([#8280](https://github.com/mitmproxy/mitmproxy/pull/8280), @gaurav0107)
 - Fix contentview detection for XML files that start with CRLF.
   ([#8243](https://github.com/mitmproxy/mitmproxy/pull/8243), @ADiTyaRaj8969)
 - mitmweb: Fix the filter input losing half-typed text on unrelated parent re-renders.

--- a/mitmproxy/addons/dumper.py
+++ b/mitmproxy/addons/dumper.py
@@ -85,6 +85,13 @@ class Dumper:
                     raise exceptions.OptionsError(str(e)) from e
             else:
                 self.filter = None
+        if "termlog_colors" in updated:
+            # Re-detect VT-code support honoring the user's color override
+            # (auto/always/never). Keeps `mitmdump | less -R` colorized.
+            self.out_has_vt_codes = vt_codes.ensure_supported(
+                self.outfp,
+                override=ctx.options.termlog_colors,  # type: ignore[arg-type]
+            )
 
     def style(self, text: str, **style) -> str:
         if style and self.out_has_vt_codes:

--- a/mitmproxy/addons/errorcheck.py
+++ b/mitmproxy/addons/errorcheck.py
@@ -2,9 +2,23 @@ import asyncio
 import logging
 import sys
 
+from mitmproxy import ctx
 from mitmproxy import log
 from mitmproxy.contrib import click as miniclick
 from mitmproxy.utils import vt_codes
+
+
+def _resolve_color_override(raw: object) -> vt_codes.ColorOverride:
+    """Coerce the raw ``termlog_colors`` option value into a known literal.
+
+    Defaults to ``"auto"`` for any unexpected value so the type narrows to
+    ``vt_codes.ColorOverride`` without requiring callers to validate.
+    """
+    if raw == "always":
+        return "always"
+    if raw == "never":
+        return "never"
+    return "auto"
 
 
 class ErrorCheck:
@@ -32,7 +46,15 @@ class ErrorCheck:
             plural = "s" if len(self.logger.has_errored) > 1 else ""
             if self.repeat_errors_on_stderr:
                 message = f"Error{plural} logged during startup:"
-                if vt_codes.ensure_supported(sys.stderr):  # pragma: no cover
+                # `ctx.options` may not be loaded yet if errorcheck fires
+                # before option registration; default to "auto" in that case.
+                opts = getattr(ctx, "options", None)
+                color_override = _resolve_color_override(
+                    getattr(opts, "termlog_colors", "auto") if opts else "auto"
+                )
+                if vt_codes.ensure_supported(
+                    sys.stderr, override=color_override
+                ):  # pragma: no cover
                     message = miniclick.style(message, fg="red")
                 details = "\n".join(
                     self.logger.format(r) for r in self.logger.has_errored

--- a/mitmproxy/addons/termlog.py
+++ b/mitmproxy/addons/termlog.py
@@ -21,11 +21,26 @@ class TermLog:
         loader.add_option(
             "termlog_verbosity", str, "info", "Log verbosity.", choices=log.LogLevels
         )
+        loader.add_option(
+            "termlog_colors",
+            str,
+            "auto",
+            """
+            Force-enable or force-disable ANSI color output for log and
+            mitmdump flow output. "auto" (default) emits colors only when
+            the destination is a TTY. "always" forces colors on, useful when
+            piping output to a pager (e.g. `mitmdump | less -R`). "never"
+            disables colors unconditionally.
+            """,
+            choices=("auto", "always", "never"),
+        )
         self.logger.setLevel(logging.INFO)
 
     def configure(self, updated):
         if "termlog_verbosity" in updated:
             self.logger.setLevel(ctx.options.termlog_verbosity.upper())
+        if "termlog_colors" in updated:
+            self.logger.refresh_color_support(ctx.options.termlog_colors)
 
     def uninstall(self) -> None:
         # uninstall the log dumper.
@@ -39,6 +54,19 @@ class TermLogHandler(log.MitmLogHandler):
         super().__init__()
         self.file: IO[str] = out or sys.stdout
         self.has_vt_codes = vt_codes.ensure_supported(self.file)
+        self.formatter = log.MitmFormatter(self.has_vt_codes)
+
+    def refresh_color_support(self, override: str) -> None:
+        """Re-evaluate VT-code support honoring the user's color override.
+
+        Called from TermLog.configure when termlog_colors changes so the
+        formatter reflects the new setting without restarting the addon.
+        """
+        # Validated by the option's `choices` tuple, so the cast is safe.
+        self.has_vt_codes = vt_codes.ensure_supported(
+            self.file,
+            override=override,  # type: ignore[arg-type]
+        )
         self.formatter = log.MitmFormatter(self.has_vt_codes)
 
     def emit(self, record: logging.LogRecord) -> None:

--- a/mitmproxy/utils/vt_codes.py
+++ b/mitmproxy/utils/vt_codes.py
@@ -5,6 +5,9 @@ This module provides a method to detect if a given file object supports virtual 
 import os
 import sys
 from typing import IO
+from typing import Literal
+
+ColorOverride = Literal["auto", "always", "never"]
 
 if os.name == "nt":
     from ctypes import byref  # type: ignore
@@ -33,7 +36,7 @@ if os.name == "nt":
     SetConsoleMode.argtypes = [HANDLE, DWORD]
     SetConsoleMode.restype = BOOL
 
-    def ensure_supported(f: IO[str]) -> bool:
+    def _ensure_supported_native(f: IO[str]) -> bool:
         if not f.isatty():
             return False
         if f == sys.stdout:
@@ -56,5 +59,25 @@ if os.name == "nt":
 
 else:
 
-    def ensure_supported(f: IO[str]) -> bool:
+    def _ensure_supported_native(f: IO[str]) -> bool:
         return f.isatty()
+
+
+def ensure_supported(f: IO[str], override: ColorOverride = "auto") -> bool:
+    """Return whether ``f`` supports virtual terminal escape codes.
+
+    The ``override`` parameter mirrors the well-known ``--color={auto,always,never}``
+    flag from coreutils (``ls``, ``grep``):
+
+    - ``"auto"`` (default): probe the file via ``isatty()`` (and on Windows, the
+      console mode ioctl). This preserves the historical behavior.
+    - ``"always"``: unconditionally return ``True``, e.g. when piping mitmdump
+      output to a pager (``mitmdump | less -R``) and you want to keep colors.
+    - ``"never"``: unconditionally return ``False``, e.g. when redirecting to a
+      log file or running in a CI environment that mishandles ANSI codes.
+    """
+    if override == "always":
+        return True
+    if override == "never":
+        return False
+    return _ensure_supported_native(f)

--- a/test/mitmproxy/addons/test_dumper.py
+++ b/test/mitmproxy/addons/test_dumper.py
@@ -7,6 +7,7 @@ import pytest
 import mitmproxy_rs.syntax_highlight
 from mitmproxy import exceptions
 from mitmproxy.addons import dumper
+from mitmproxy.addons import termlog
 from mitmproxy.addons.dumper import CONTENTVIEW_STYLES
 from mitmproxy.http import Headers
 from mitmproxy.net.dns import response_codes
@@ -336,6 +337,38 @@ def test_styling():
     with taddons.context(d):
         d.response(tflow.tflow(resp=True))
         assert "\x1b[" in sio.getvalue()
+
+
+def test_force_color():
+    """termlog_colors=always forces colored mitmdump output even on a non-TTY."""
+    sio = io.StringIO()
+    t = termlog.TermLog()
+    d = dumper.Dumper(sio)
+    try:
+        with taddons.context(t, d) as tctx:
+            assert d.out_has_vt_codes is False
+            tctx.configure(d, termlog_colors="always")
+            assert d.out_has_vt_codes is True
+            d.response(tflow.tflow(resp=True))
+            assert "\x1b[" in sio.getvalue()
+    finally:
+        t.uninstall()
+
+
+def test_disable_color():
+    """termlog_colors=never disables colored mitmdump output unconditionally."""
+    sio = io.StringIO()
+    t = termlog.TermLog()
+    d = dumper.Dumper(sio)
+    d.out_has_vt_codes = True  # simulate prior auto-detection
+    try:
+        with taddons.context(t, d) as tctx:
+            tctx.configure(d, termlog_colors="never")
+            assert d.out_has_vt_codes is False
+            d.response(tflow.tflow(resp=True))
+            assert "\x1b[" not in sio.getvalue()
+    finally:
+        t.uninstall()
 
 
 def test_has_styles_for_tags():

--- a/test/mitmproxy/addons/test_errorcheck.py
+++ b/test/mitmproxy/addons/test_errorcheck.py
@@ -2,8 +2,23 @@ import logging
 
 import pytest
 
+from mitmproxy.addons.errorcheck import _resolve_color_override
 from mitmproxy.addons.errorcheck import ErrorCheck
 from mitmproxy.tools import main
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("always", "always"),
+        ("never", "never"),
+        ("auto", "auto"),
+        ("unexpected", "auto"),
+        (None, "auto"),
+    ],
+)
+def test_resolve_color_override(raw, expected):
+    assert _resolve_color_override(raw) == expected
 
 
 @pytest.mark.parametrize("run_main", [main.mitmdump, main.mitmproxy])

--- a/test/mitmproxy/addons/test_termlog.py
+++ b/test/mitmproxy/addons/test_termlog.py
@@ -46,6 +46,34 @@ async def test_styling(monkeypatch) -> None:
     t.uninstall()
 
 
+async def test_force_color() -> None:
+    """termlog_colors=always emits ANSI codes even on a non-TTY (StringIO)."""
+    f = io.StringIO()
+    t = termlog.TermLog(out=f)
+    with taddons.context(t) as tctx:
+        tctx.configure(t, termlog_colors="always")
+        logging.warning("hello")
+
+    assert "\x1b[33mhello\x1b[0m" in f.getvalue()
+    t.uninstall()
+
+
+async def test_disable_color(monkeypatch) -> None:
+    """termlog_colors=never disables ANSI codes even when isatty() is True."""
+    monkeypatch.setattr(vt_codes, "_ensure_supported_native", lambda _: True)
+
+    f = io.StringIO()
+    t = termlog.TermLog(out=f)
+    with taddons.context(t) as tctx:
+        tctx.configure(t, termlog_colors="never")
+        logging.warning("hello")
+
+    out = f.getvalue()
+    assert "hello" in out
+    assert "\x1b[" not in out  # no ANSI escapes
+    t.uninstall()
+
+
 async def test_cannot_print(monkeypatch) -> None:
     def _raise(*args, **kwargs):
         raise OSError

--- a/test/mitmproxy/utils/test_vt_codes.py
+++ b/test/mitmproxy/utils/test_vt_codes.py
@@ -5,3 +5,25 @@ from mitmproxy.utils.vt_codes import ensure_supported
 
 def test_simple():
     assert not ensure_supported(io.StringIO())
+
+
+def test_override_always():
+    """`override="always"` returns True even for non-TTY file objects."""
+    assert ensure_supported(io.StringIO(), override="always") is True
+
+
+def test_override_never():
+    """`override="never"` returns False even when isatty() reports True."""
+
+    class FakeTTY:
+        def isatty(self) -> bool:
+            return True
+
+    assert ensure_supported(FakeTTY(), override="never") is False
+
+
+def test_override_auto_default():
+    """`override="auto"` keeps the historical isatty()-based behavior."""
+    # Default (no override) — equivalent to "auto".
+    assert not ensure_supported(io.StringIO())
+    assert not ensure_supported(io.StringIO(), override="auto")

--- a/web/src/js/ducks/_options_gen.ts
+++ b/web/src/js/ducks/_options_gen.ts
@@ -80,6 +80,7 @@ export interface OptionsState {
     strip_ech: boolean;
     tcp_hosts: string[];
     tcp_timeout: number;
+    termlog_colors: string;
     termlog_verbosity: string;
     tls_ecdh_curve_client: string | undefined;
     tls_ecdh_curve_server: string | undefined;
@@ -187,6 +188,7 @@ export const defaultState: OptionsState = {
     strip_ech: true,
     tcp_hosts: [],
     tcp_timeout: 600,
+    termlog_colors: "auto",
     termlog_verbosity: "info",
     tls_ecdh_curve_client: undefined,
     tls_ecdh_curve_server: undefined,


### PR DESCRIPTION
### Description

Adds a `termlog_colors` option (`auto`/`always`/`never`) so users can override mitmproxy's automatic `isatty()`-based color detection. The primary motivation is to keep colored output when piping `mitmdump` through a pager:

```bash
mitmdump --set termlog_colors=always | less -R
```

This mirrors the well-known `--color={auto,always,never}` flag from coreutils (`ls`, `grep`).

The override threads through `vt_codes.ensure_supported(f, override=...)`, which is called from:

- `termlog` (logging output)
- `dumper` (mitmdump flow output)
- `errorcheck` (startup-error stderr printing)

Default behavior is unchanged: `"auto"` preserves the existing `isatty()` / Windows console-mode detection. The new option is keyword-only on `ensure_supported`, so any third-party callers continue to work without modification.

### Checklist

- [x] I have updated tests where applicable.
- [x] I have added an entry to the CHANGELOG (or this change does not need one).

### Summary

Closes #7824.

Tests added:

- `test/mitmproxy/utils/test_vt_codes.py` — `test_override_always`, `test_override_never`, `test_override_auto_default`
- `test/mitmproxy/addons/test_termlog.py` — `test_force_color`, `test_disable_color`
- `test/mitmproxy/addons/test_dumper.py` — `test_force_color`, `test_disable_color`

Local verification:

- `uv run pytest test/mitmproxy/utils/test_vt_codes.py test/mitmproxy/addons/test_termlog.py test/mitmproxy/addons/test_dumper.py test/mitmproxy/addons/test_errorcheck.py` — 31 passed
- `uv run pytest test/mitmproxy/addons/` — 533 passed, 1 skipped
- `uv run mypy` — 288 source files, no issues
- `uv run ruff check . && uv run ruff format --check .` — clean