### PR TITLE
net/http/url: bracket IPv6 literals in hostport() per RFC 3986

### DIFF
--- a/mitmproxy/net/http/url.py
+++ b/mitmproxy/net/http/url.py
@@ -148,9 +148,9 @@ def hostport(scheme: AnyStr, host: AnyStr, port: int) -> AnyStr:
     """
     # IPv6 addresses contain colons and must be bracketed in URIs (RFC 3986 §3.2.2).
     if isinstance(host, bytes):
-        host_in_uri: AnyStr = (b"[" + host + b"]") if b":" in host else host
+        host_in_uri: AnyStr = (b"[" + host + b"]") if (host and b":" in host) else host
     else:
-        host_in_uri = f"[{host}]" if ":" in host else host
+        host_in_uri = f"[{host}]" if (host and ":" in host) else host
 
     if default_port(scheme) == port:
         return host_in_uri

--- a/mitmproxy/net/http/url.py
+++ b/mitmproxy/net/http/url.py
@@ -143,14 +143,22 @@ def unquote(s: str) -> str:
 def hostport(scheme: AnyStr, host: AnyStr, port: int) -> AnyStr:
     """
     Returns the host component, with a port specification if needed.
+
+    IPv6 literals are always wrapped in square brackets as required by RFC 3986 §3.2.2.
     """
+    # IPv6 addresses contain colons and must be bracketed in URIs (RFC 3986 §3.2.2).
+    if isinstance(host, bytes):
+        host_in_uri: AnyStr = (b"[" + host + b"]") if b":" in host else host
+    else:
+        host_in_uri = f"[{host}]" if ":" in host else host
+
     if default_port(scheme) == port:
-        return host
+        return host_in_uri
     else:
         if isinstance(host, bytes):
-            return b"%s:%d" % (host, port)
+            return b"%s:%d" % (host_in_uri, port)
         else:
-            return "%s:%d" % (host, port)
+            return f"{host_in_uri}:{port}"
 
 
 def default_port(scheme: AnyStr) -> int | None:

--- a/test/mitmproxy/net/http/test_url.py
+++ b/test/mitmproxy/net/http/test_url.py
@@ -76,6 +76,20 @@ def test_unparse():
     assert url.unparse("https", "foo.com", 80, "") == "https://foo.com:80"
     assert url.unparse("https", "foo.com", 443, "") == "https://foo.com"
     assert url.unparse(b"http", b"foo.com", 99, b"") == b"http://foo.com:99"
+    # IPv6: brackets required in URI host component (RFC 3986 §3.2.2)
+    assert url.unparse("http", "::1", 8080, "/path") == "http://[::1]:8080/path"
+    assert url.unparse("http", "::1", 80, "/") == "http://[::1]/"
+    assert url.unparse(b"https", b"2001:db8::1", 443, b"/") == b"https://[2001:db8::1]/"
+    # parse → unparse roundtrip for IPv6 URLs
+    assert (
+        url.unparse(
+            *[
+                x.decode() if isinstance(x, bytes) else x
+                for x in url.parse("http://[::1]:8080/path")
+            ]
+        )
+        == "http://[::1]:8080/path"
+    )
 
 
 # We ignore the byte 126: '~' because of an incompatibility in Python 3.6 and 3.7
@@ -164,6 +178,15 @@ def test_unquote():
 
 def test_hostport():
     assert url.hostport(b"https", b"foo.com", 8080) == b"foo.com:8080"
+    # default port — no port suffix
+    assert url.hostport("http", "foo.com", 80) == "foo.com"
+    assert url.hostport(b"https", b"foo.com", 443) == b"foo.com"
+    # IPv6: must be bracketed per RFC 3986 §3.2.2
+    assert url.hostport("http", "::1", 8080) == "[::1]:8080"
+    assert url.hostport(b"http", b"::1", 8080) == b"[::1]:8080"
+    # IPv6 at default port — bracketed but no port suffix
+    assert url.hostport("http", "::1", 80) == "[::1]"
+    assert url.hostport(b"https", b"2001:db8::1", 443) == b"[2001:db8::1]"
 
 
 def test_default_port():


### PR DESCRIPTION
## Bug

`url.hostport()` returns bare IPv6 addresses (e.g. `::1:8080`) instead of the bracketed form (`[::1]:8080`) required by RFC 3986 §3.2.2. This means `url.unparse()` produces malformed URIs and the `parse() → unparse()` roundtrip is broken for IPv6 hosts:

```python
url.parse('http://[::1]:8080/path')
# → (b'http', b'::1', 8080, b'/path')   (host stored without brackets — correct)

url.unparse('http', '::1', 8080, '/path')
# was: 'http://::1:8080/path'   ← invalid URI
# now: 'http://[::1]:8080/path' ← correct
```

## Fix

Detect IPv6 hosts in `hostport()` (any host containing `:`) and wrap them in square brackets before building the authority component. Works for both `str` and `bytes` paths, with and without a non-default port.

## Verification

```
uv run pytest test/mitmproxy/net/http/test_url.py -v
# 23 passed
```

New test assertions cover:
- `hostport()` str/bytes × non-default / default port × IPv6
- `unparse()` str/bytes IPv6 URLs
- `parse() → unparse()` roundtrip for IPv6

> Note: assisted with AI tooling during development.