### PR TITLE
fix(wireguard): convert port-conflict RuntimeError to OSError with helpful message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 
 ## Unreleased: mitmproxy next
 
+- WireGuard mode now shows a helpful "port already in use" error with a port
+  hint when the UDP port is occupied, instead of the raw Rust error message.
+  ([#8291](https://github.com/mitmproxy/mitmproxy/pull/8291), @PhinehasNarh)
 - mitmweb: Honor the `view_order_reversed` option for live flows. New flows are
   now placed at the top of the table when the option is set, instead of always
   being appended at the bottom.

--- a/mitmproxy/proxy/mode_servers.py
+++ b/mitmproxy/proxy/mode_servers.py
@@ -381,14 +381,24 @@ class WireGuardServerInstance(AsyncioServerInstance[mode_specs.WireGuardMode]):
     async def start_udp_based_server(
         self, host, port
     ) -> mitmproxy_rs.wireguard.WireGuardServer:
-        return await mitmproxy_rs.wireguard.start_wireguard_server(
-            host,
-            port,
-            self.server_key,
-            [self.pubkey],
-            self.handle_stream,
-            self.handle_stream,
-        )
+        try:
+            return await mitmproxy_rs.wireguard.start_wireguard_server(
+                host,
+                port,
+                self.server_key,
+                [self.pubkey],
+                self.handle_stream,
+                self.handle_stream,
+            )
+        except RuntimeError as e:
+            # mitmproxy_rs raises RuntimeError (from Rust/PyO3) instead of OSError
+            # when the UDP port is already in use. Convert it so that the caller's
+            # OSError handler (which formats a helpful "port already in use" message)
+            # fires correctly.
+            msg = str(e).lower()
+            if "address already in use" in msg or "failed to bind" in msg:
+                raise OSError(errno.EADDRINUSE, str(e)) from e
+            raise
 
     def client_conf(self) -> str | None:
         if not self._servers:

--- a/test/mitmproxy/proxy/test_mode_servers.py
+++ b/test/mitmproxy/proxy/test_mode_servers.py
@@ -317,6 +317,32 @@ async def test_wireguard_port_conflict(tmp_path, monkeypatch):
             await inst.start()
 
 
+async def test_wireguard_unrelated_runtime_error(tmp_path, monkeypatch):
+    """RuntimeError from mitmproxy_rs that is not a bind failure is re-raised unchanged."""
+    import json
+
+    conf_file = tmp_path / "wireguard.conf"
+    conf_file.write_text(
+        json.dumps(
+            {
+                "server_key": mitmproxy_rs.wireguard.genkey(),
+                "client_key": mitmproxy_rs.wireguard.genkey(),
+            }
+        )
+    )
+
+    monkeypatch.setattr(
+        mitmproxy_rs.wireguard,
+        "start_wireguard_server",
+        AsyncMock(side_effect=RuntimeError("some unexpected wireguard error")),
+    )
+
+    with taddons.context(Proxyserver()):
+        inst = WireGuardServerInstance.make(f"wireguard:{conf_file}@51820", MagicMock())
+        with pytest.raises(RuntimeError, match="some unexpected wireguard error"):
+            await inst.start()
+
+
 async def test_tcp_start_error():
     manager = MagicMock()
 

--- a/test/mitmproxy/proxy/test_mode_servers.py
+++ b/test/mitmproxy/proxy/test_mode_servers.py
@@ -291,6 +291,32 @@ async def test_wireguard_invalid_conf(tmp_path):
         assert "Invalid configuration file" in repr(inst.last_exception)
 
 
+async def test_wireguard_port_conflict(tmp_path, monkeypatch):
+    """RuntimeError from mitmproxy_rs on port conflict is converted to OSError with a helpful message."""
+    import json
+
+    conf_file = tmp_path / "wireguard.conf"
+    conf_file.write_text(
+        json.dumps(
+            {
+                "server_key": mitmproxy_rs.wireguard.genkey(),
+                "client_key": mitmproxy_rs.wireguard.genkey(),
+            }
+        )
+    )
+
+    monkeypatch.setattr(
+        mitmproxy_rs.wireguard,
+        "start_wireguard_server",
+        AsyncMock(side_effect=RuntimeError("Address already in use (os error 98)")),
+    )
+
+    with taddons.context(Proxyserver()):
+        inst = WireGuardServerInstance.make(f"wireguard:{conf_file}@51820", MagicMock())
+        with pytest.raises(OSError, match="51820"):
+            await inst.start()
+
+
 async def test_tcp_start_error():
     manager = MagicMock()
 


### PR DESCRIPTION
#### Description

Fixes #7650.

When the WireGuard UDP port is already in use, `mitmproxy_rs` raises a `RuntimeError` (from the Rust/PyO3 layer) rather than an `OSError`. This means the existing error handler in `AsyncioServerInstance._start()` - which catches `OSError(EADDRINUSE)` and appends a helpful port hint - never fires for WireGuard mode. Users instead see the raw Rust error with no context:

```
Address already in use (os error 48)
Error logged during startup, exiting...
```

**After this fix**, `WireGuardServerInstance.start_udp_based_server()` catches `RuntimeError` on bind failures and re-raises as `OSError(EADDRINUSE)`, so the parent handler produces:

```
WireGuard proxy failed to listen on *:51820 with [Errno 98] Address already in use
Try specifying a different port by using `--mode wireguard@51822`.
```

#### Changes

- `mitmproxy/proxy/mode_servers.py`: wrap `start_wireguard_server()` in `WireGuardServerInstance` to catch `RuntimeError` containing 'address already in use' or 'failed to bind' and re-raise as `OSError(EADDRINUSE)`
- `test/mitmproxy/proxy/test_mode_servers.py`: add `test_wireguard_port_conflict` - monkeypatches `start_wireguard_server` to raise `RuntimeError` and asserts the result is `OSError` containing the port number

#### Checklist

- [x] I have updated tests where applicable.
- [x] I have added an entry to the CHANGELOG.