### PR TITLE
scripts: fix crash when loading addon scripts that define a dataclass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Fix a crash when loading an addon script that defines a `@dataclass`. Script
   modules are now registered in `sys.modules` before execution, as required by
   the standard library's import machinery.
+  ([#8293](https://github.com/mitmproxy/mitmproxy/pull/8293), @gaurav0107)
 - mitmweb: Honor the `view_order_reversed` option for live flows. New flows are
   now placed at the top of the table when the option is set, instead of always
   being appended at the bottom.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@
 - Remove the unused `msgpack` dependency. The msgpack contentview is
   implemented in Rust and shipped with `mitmproxy_rs` since mitmproxy 12.
   ([#8319](https://github.com/mitmproxy/mitmproxy/pull/8319), @lukehsiao)
+- Fix a crash when loading an addon script that defines a `@dataclass`. Script
+  modules are now registered in `sys.modules` before execution, as required by
+  the standard library's import machinery.
 - mitmweb: Honor the `view_order_reversed` option for live flows. New flows are
   now placed at the top of the table when the option is set, instead of always
   being appended at the bottom.

--- a/mitmproxy/addons/script.py
+++ b/mitmproxy/addons/script.py
@@ -35,7 +35,18 @@ def load_script(path: str) -> types.ModuleType | None:
         spec = importlib.util.spec_from_loader(fullname, loader=loader)
         assert spec
         m = importlib.util.module_from_spec(spec)
-        loader.exec_module(m)
+        # Register the module in sys.modules before executing it, as recommended
+        # by the importlib docs. Parts of the standard library (e.g. dataclasses,
+        # pickling, typing.get_type_hints) look the defining module up in
+        # sys.modules by its __module__ name while the module body runs. Without
+        # this, a script that defines a @dataclass fails to load.
+        sys.modules[fullname] = m
+        try:
+            loader.exec_module(m)
+        except BaseException:
+            # Don't leave a half-initialized module behind on failure.
+            sys.modules.pop(fullname, None)
+            raise
         if not getattr(m, "name", None):
             m.name = path  # type: ignore
         return m

--- a/test/mitmproxy/addons/test_script.py
+++ b/test/mitmproxy/addons/test_script.py
@@ -32,6 +32,19 @@ def test_load_script(tmp_path, tdata, caplog):
     assert "invalid syntax" in caplog.text
 
 
+def test_load_script_with_dataclass(tdata, caplog):
+    """
+    Regression test for #8279: a script that defines a @dataclass must load.
+    dataclasses looks the defining module up in sys.modules while the class
+    body runs, so this only works if load_script registers the module first.
+    """
+    ns = script.load_script(tdata.path("mitmproxy/data/addonscripts/dataclass.py"))
+    assert ns is not None
+    assert "error in script" not in caplog.text
+    # The dataclass is usable from the loaded module.
+    assert ns.C(2).x == 2
+
+
 def test_load_fullname(tdata):
     """
     Test that loading two scripts at locations a/foo.py and b/foo.py works.

--- a/test/mitmproxy/data/addonscripts/dataclass.py
+++ b/test/mitmproxy/data/addonscripts/dataclass.py
@@ -1,0 +1,23 @@
+"""Regression fixture for #8279.
+
+A script that defines a ``@dataclass``. dataclasses looks the defining module
+up in ``sys.modules`` by its ``__module__`` name while the class body runs, so
+loading this script fails unless ``load_script`` registers the module in
+``sys.modules`` before executing it. The ``ClassVar`` field combined with
+deferred annotations forces dataclasses down the string-based type-resolution
+path that performs the lookup.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import ClassVar
+
+
+@dataclass
+class C:
+    x: int
+    counter: ClassVar[int] = 0
+
+
+addons = [C(1)]


### PR DESCRIPTION
#### Description

Loading an addon script that defines a `@dataclass` currently crashes:

```
@dataclass
  File ".../dataclasses.py", line ..., in _process_class
    ... = sys.modules.get(cls.__module__).__dict__
AttributeError: 'NoneType' object has no attribute '__dict__'
```

The root cause is in `mitmproxy.addons.script.load_script`: it builds the
module with `importlib.util.module_from_spec(spec)` and then calls
`loader.exec_module(m)` **without first registering the module in
`sys.modules`**. Python's import documentation recommends inserting the module
into `sys.modules` before executing it, because parts of the standard library
(`dataclasses`, pickling, `typing.get_type_hints`, ...) look the defining
module up in `sys.modules` by its `__module__` name while the class body runs.
When the entry is missing the lookup returns `None` and the decorator raises.

This registers the module in `sys.modules` before execution and removes it
again if execution fails, so a failed load still leaves nothing behind. The
existing `sys.modules.pop(fullname, None)` at the top of `load_script` keeps
guaranteeing uniqueness across reloads.

Closes #8279

#### Checklist

- [x] I have updated tests where applicable.
- [x] I have added an entry to the CHANGELOG.

#### Summary

- Register addon-script modules in `sys.modules` before `exec_module`, and
  unregister on failure.
- Add a regression test (`test_load_script_with_dataclass`) and a
  `dataclass.py` addon fixture that fails to load without the fix.
- Add a CHANGELOG entry.
