### PR TITLE
Don't stall QUIC flows when host ignoring is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@
   ([#8232](https://github.com/mitmproxy/mitmproxy/pull/8232), @ariel42)
 - mitmweb: Fix correctly displaying multiple blank lines in content renderer.
   ([#8248](https://github.com/mitmproxy/mitmproxy/pull/8248), @vincentdehaan)
+- Fix QUIC connections never starting if --allow-hosts or --ignore-hosts is set.
+  ([#8295](https://github.com/mitmproxy/mitmproxy/pull/8295), @tbodt)
 
 ## 12 May 2026: mitmproxy 12.2.3
 

--- a/mitmproxy/addons/next_layer.py
+++ b/mitmproxy/addons/next_layer.py
@@ -320,19 +320,21 @@ class NextLayer:
                         return ch
                 return None
             case "udp":
-                try:
-                    return quic_parse_client_hello_from_datagrams([data_client])
-                except ValueError:
-                    pass
+                if _starts_like_quic(data_client, context.server.address):
+                    try:
+                        return quic_parse_client_hello_from_datagrams([data_client])
+                    except ValueError:
+                        pass
 
-                try:
-                    ch = dtls_parse_client_hello(data_client)
-                except ValueError:
-                    pass
-                else:
-                    if ch is None:
-                        raise NeedsMoreData
-                    return ch
+                if starts_like_dtls_record(data_client):
+                    try:
+                        ch = dtls_parse_client_hello(data_client)
+                    except ValueError:
+                        pass
+                    else:
+                        if ch is None:
+                            raise NeedsMoreData
+                        return ch
                 return None
             case _:  # pragma: no cover
                 assert_never(context.client.transport_protocol)

--- a/test/mitmproxy/addons/test_next_layer.py
+++ b/test/mitmproxy/addons/test_next_layer.py
@@ -32,6 +32,7 @@ from mitmproxy.proxy.layers import UDPLayer
 from mitmproxy.proxy.layers.http import HTTPMode
 from mitmproxy.proxy.layers.http import HttpStream
 from mitmproxy.proxy.layers.tls import HTTP1_ALPNS
+from mitmproxy.proxy.layers.tls import HTTP3_ALPN
 from mitmproxy.proxy.mode_specs import ProxyMode
 from mitmproxy.test import taddons
 
@@ -98,6 +99,8 @@ quic_short_header_packet = bytes.fromhex(
     "7d0720be075fce3126de3f0d54dc059150e0f80f1a8db5e542eb03240b0a1db44a322fb4fd3c6f2e054b369e14"
     "5a5ff925db617d187ec65a7f00d77651968e74c1a9ddc3c7fab57e8df821b07e103264244a3a03d17984e29933"
 )
+
+invalid_quic = bytes.fromhex("806b3343cf00000000000000000000000000")
 
 dns_query = bytes.fromhex("002a01000001000000000000076578616d706c6503636f6d0000010001")
 
@@ -277,6 +280,15 @@ class TestNextLayer:
                 quic_client_hello,
                 True,
                 id="quic sni",
+            ),
+            pytest.param(
+                ["example.com"],
+                [],
+                "udp",
+                "192.0.2.1",
+                invalid_quic,
+                False,
+                id="invalid quic",
             ),
             # allow
             pytest.param(
@@ -755,6 +767,16 @@ transparent_proxy_configs = [
         id=f"transparent proxy: http via ALPN",
     ),
     pytest.param(
+        http3 := TConf(
+            before=[modes.TransparentProxy, ServerQuicLayer, ClientQuicLayer],
+            after=[modes.TransparentProxy, ServerQuicLayer, ClientQuicLayer, HttpLayer],
+            server_address=("192.0.2.1", 443),
+            transport_protocol="udp",
+            alpn=HTTP3_ALPN,
+        ),
+        id=f"transparent proxy: http3 via ALPN",
+    ),
+    pytest.param(
         TConf(
             before=[modes.TransparentProxy],
             after=[modes.TransparentProxy, TCPLayer],
@@ -848,6 +870,13 @@ transparent_proxy_configs = [
             tls_version="QUICv1",
         ),
         id=f"transparent proxy: non-http quic",
+    ),
+    pytest.param(
+        dataclasses.replace(
+            http3,
+            ignore_hosts=["$^"],
+        ),
+        id="transparent proxy: http3 not ignored but with ignoring active",
     ),
 ]
 


### PR DESCRIPTION
If allow_hosts or ignore_hosts was set, any QUIC connections would stall forever after TLS handshake and never get assigned an HttpLayer or e.g. appear in the flow list in mitmweb. The codepath goes like this:

1. After client TLS handshake completes, next layer hook is invoked with data_client = b'', i.e. the data so far inside the QUIC stream
2. _next_layer first checks using _ignore_connection
3. _ignore_connection uses _get_client_hello, passing b'' data_client
4. quick_parse_client_hello_from_datagram raises a type of ValueError because b'' is definitely not a valid QUIC packet
5. ValueError is skipped, so dtls_parse_client_hello is tried, which also raises a type of ValueError for about the same reason
6. This is now converted into NeedsMoreData, which bails out of the entire _next_layer process.

This repeats each time next_layer is called and never makes progress, even if data is read on the QUIC stream, it's still not going to be a valid QUIC or DTLS packet.

This fix matches the tcp case and only tries to parse the packet as quic or dtls if it heuristically looks like that.

#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
