### PR TITLE
Fix resource leaks in proxy server and save addon

### DIFF
--- a/mitmproxy/addons/save.py
+++ b/mitmproxy/addons/save.py
@@ -98,8 +98,12 @@ class Save:
         new_log_file.parent.mkdir(parents=True, exist_ok=True)
 
         f = new_log_file.open(_mode(ctx.options.save_stream_file))
-        self.stream = io.FilteredFlowWriter(f, self.filt)
-        self.current_path = path
+        try:
+            self.stream = io.FilteredFlowWriter(f, self.filt)
+            self.current_path = path
+        except Exception:
+            f.close()
+            raise
 
     def save_flow(self, flow: flow.Flow) -> None:
         """

--- a/mitmproxy/net/free_port.py
+++ b/mitmproxy/net/free_port.py
@@ -15,11 +15,11 @@ def get_free_port() -> int:
             tcp.bind(("", 0))
             port: int = tcp.getsockname()[1]
             udp.bind(("", port))
-            udp.close()
             return port
         except OSError:
             pass
         finally:
             tcp.close()
+            udp.close()
 
     return 0

--- a/mitmproxy/proxy/server.py
+++ b/mitmproxy/proxy/server.py
@@ -136,34 +136,35 @@ class ConnectionHandler(metaclass=abc.ABCMeta):
             client=self.client.peername,
         )
 
-        self.log("client connect")
-        await self.handle_hook(server_hooks.ClientConnectedHook(self.client))
-        if self.client.error:
-            self.log("client kill connection")
-            writer = self.transports.pop(self.client).writer
-            assert writer
-            writer.close()
-        else:
-            await self.server_event(events.Start())
-            handler = asyncio_utils.create_task(
-                self.handle_connection(self.client),
-                name=f"client connection handler",
-                keep_ref=False,
-                client=self.client.peername,
-            )
-            self.transports[self.client].handler = handler
-            await asyncio.wait([handler])
-            if not handler.cancelled() and (e := handler.exception()):
-                self.log(
-                    f"connection handler has crashed: {e}",
-                    logging.ERROR,
-                    exc_info=(type(e), e, e.__traceback__),
+        try:
+            self.log("client connect")
+            await self.handle_hook(server_hooks.ClientConnectedHook(self.client))
+            if self.client.error:
+                self.log("client kill connection")
+                writer = self.transports.pop(self.client).writer
+                assert writer
+                writer.close()
+            else:
+                await self.server_event(events.Start())
+                handler = asyncio_utils.create_task(
+                    self.handle_connection(self.client),
+                    name=f"client connection handler",
+                    keep_ref=False,
+                    client=self.client.peername,
                 )
-
-        watch.cancel()
-        while self.wakeup_timer:
-            timer = self.wakeup_timer.pop()
-            timer.cancel()
+                self.transports[self.client].handler = handler
+                await asyncio.wait([handler])
+                if not handler.cancelled() and (e := handler.exception()):
+                    self.log(
+                        f"connection handler has crashed: {e}",
+                        logging.ERROR,
+                        exc_info=(type(e), e, e.__traceback__),
+                    )
+        finally:
+            watch.cancel()
+            while self.wakeup_timer:
+                timer = self.wakeup_timer.pop()
+                timer.cancel()
 
         self.log("client disconnect")
         self.client.timestamp_end = time.time()
@@ -252,7 +253,13 @@ class ConnectionHandler(metaclass=abc.ABCMeta):
                 else:
                     addr = human.format_address(command.connection.address)
                 self.log(f"server connect {addr}")
-                await self.handle_hook(server_hooks.ServerConnectedHook(hook_data))
+                try:
+                    await self.handle_hook(server_hooks.ServerConnectedHook(hook_data))
+                except Exception:
+                    self.log(f"ServerConnectedHook failed, closing connection", logging.ERROR, exc_info=True)
+                    writer.close()
+                    self.transports.pop(command.connection, None)
+                    raise
                 await self.server_event(events.OpenConnectionCompleted(command, None))
 
                 try:

--- a/mitmproxy/proxy/server.py
+++ b/mitmproxy/proxy/server.py
@@ -256,7 +256,11 @@ class ConnectionHandler(metaclass=abc.ABCMeta):
                 try:
                     await self.handle_hook(server_hooks.ServerConnectedHook(hook_data))
                 except Exception:
-                    self.log(f"ServerConnectedHook failed, closing connection", logging.ERROR, exc_info=True)
+                    self.log(
+                        f"ServerConnectedHook failed, closing connection",
+                        logging.ERROR,
+                        exc_info=True,
+                    )
                     writer.close()
                     self.transports.pop(command.connection, None)
                     raise

--- a/test/mitmproxy/addons/test_save.py
+++ b/test/mitmproxy/addons/test_save.py
@@ -197,3 +197,26 @@ def test_disk_full(tmp_path, monkeypatch, capsys):
             sa.response(f)
 
         assert "Error while writing" in capsys.readouterr().err
+
+
+def test_filtered_flow_writer_init_failure(tmp_path, monkeypatch):
+    """Test that file handle is closed when FilteredFlowWriter initialization fails."""
+    sa = save.Save()
+    with taddons.context(sa) as tctx:
+        tctx.configure(sa, save_stream_file=str(tmp_path / "foo.txt"))
+
+        f1 = tflow.tflow(resp=True)
+        sa.request(f1)
+        sa.response(f1)
+
+        def failing_init(self, *args, **kwargs):
+            raise RuntimeError("Simulated initialization failure")
+
+        monkeypatch.setattr(io.FilteredFlowWriter, "__init__", failing_init)
+
+        sa.current_path = str(tmp_path / "different.txt")
+
+        with pytest.raises(RuntimeError, match="Simulated initialization failure"):
+            sa.maybe_rotate_to_new_file()
+
+        assert sa.stream is None

--- a/test/mitmproxy/proxy/test_server.py
+++ b/test/mitmproxy/proxy/test_server.py
@@ -132,7 +132,7 @@ async def test_client_connected_hook_failure_cleanup(monkeypatch):
 
     monkeypatch.setattr(
         "mitmproxy.proxy.server.asyncio_utils.create_task",
-        lambda coro, *args, **kwargs: (coro.close(), watch_task)[1]
+        lambda coro, *args, **kwargs: (coro.close(), watch_task)[1],
     )
 
     with pytest.raises(RuntimeError, match="ClientConnectedHook failed"):
@@ -157,14 +157,14 @@ async def test_server_connected_hook_failure_cleanup(monkeypatch):
     monkeypatch.setattr(
         asyncio,
         "open_connection",
-        mock.AsyncMock(return_value=(mock.MagicMock(), mock.MagicMock()))
+        mock.AsyncMock(return_value=(mock.MagicMock(), mock.MagicMock())),
     )
 
     writer_mock = mock.MagicMock()
     monkeypatch.setattr(
         asyncio,
         "open_connection",
-        mock.AsyncMock(return_value=(mock.MagicMock(), writer_mock))
+        mock.AsyncMock(return_value=(mock.MagicMock(), writer_mock)),
     )
 
     conn = Server(address=("example.com", 8080))

--- a/test/mitmproxy/proxy/test_server.py
+++ b/test/mitmproxy/proxy/test_server.py
@@ -225,3 +225,54 @@ async def test_handle_client_normal_path_cleanup(monkeypatch):
     assert watch_cancelled
     timer_mock.cancel.assert_called()
     assert len(handler.wakeup_timer) == 0
+
+
+async def test_handle_client_connection_handler_crash_logs_error(monkeypatch, caplog):
+    """Test that handle_client logs a connection-handler crash and still cleans up.
+
+    Covers the `if not handler.cancelled() and (e := handler.exception()):`
+    branch in `handle_client` (mitmproxy/proxy/server.py).
+    """
+    handler = MockConnectionHandler()
+
+    async def dummy_watch():
+        try:
+            await asyncio.sleep(10)
+        except asyncio.CancelledError:
+            raise
+
+    watch_task = asyncio.create_task(dummy_watch())
+
+    async def crashing_handle_connection():
+        await asyncio.sleep(0)
+        raise RuntimeError("connection handler crashed")
+
+    handler_task = asyncio.create_task(crashing_handle_connection())
+
+    def mock_create_task(coro, *args, **kwargs):
+        name = kwargs.get("name", "")
+        if "timeout" in name:
+            coro.close()
+            return watch_task
+        else:
+            coro.close()
+            return handler_task
+
+    monkeypatch.setattr(
+        "mitmproxy.proxy.server.asyncio_utils.create_task",
+        mock_create_task,
+    )
+
+    import logging
+
+    with caplog.at_level(logging.ERROR):
+        await handler.handle_client()
+
+    await asyncio.sleep(0)
+
+    assert any(
+        "connection handler has crashed" in rec.message
+        and "connection handler crashed" in rec.message
+        for rec in caplog.records
+    ), f"Expected crash log, got: {[r.message for r in caplog.records]}"
+    assert len(handler.wakeup_timer) == 0

--- a/test/mitmproxy/proxy/test_server.py
+++ b/test/mitmproxy/proxy/test_server.py
@@ -175,3 +175,53 @@ async def test_server_connected_hook_failure_cleanup(monkeypatch):
 
     writer_mock.close.assert_called_once()
     assert conn not in handler.transports
+
+
+async def test_handle_client_normal_path_cleanup(monkeypatch):
+    """Test that watchdog and timers are cleaned up in normal execution path."""
+    handler = MockConnectionHandler()
+
+    timer_mock = mock.Mock()
+    handler.wakeup_timer.add(timer_mock)
+
+    watch_cancelled = False
+
+    async def dummy_watch():
+        nonlocal watch_cancelled
+        try:
+            await asyncio.sleep(10)
+        except asyncio.CancelledError:
+            watch_cancelled = True
+            raise
+
+    watch_task = asyncio.create_task(dummy_watch())
+
+    async def dummy_handle_connection():
+        await asyncio.sleep(0)
+
+    handler_task = asyncio.create_task(dummy_handle_connection())
+
+    call_count = [0]
+
+    def mock_create_task(coro, *args, **kwargs):
+        call_count[0] += 1
+        name = kwargs.get("name", "")
+        if "timeout" in name:
+            coro.close()
+            return watch_task
+        else:
+            coro.close()
+            return handler_task
+
+    monkeypatch.setattr(
+        "mitmproxy.proxy.server.asyncio_utils.create_task",
+        mock_create_task,
+    )
+
+    await handler.handle_client()
+
+    await asyncio.sleep(0)
+
+    assert watch_cancelled
+    timer_mock.cancel.assert_called()
+    assert len(handler.wakeup_timer) == 0

--- a/test/mitmproxy/proxy/test_server.py
+++ b/test/mitmproxy/proxy/test_server.py
@@ -104,3 +104,74 @@ async def test_no_reentrancy(capsys):
         Hook completed (must not happen before start is completed).
         """
     )
+
+
+async def test_client_connected_hook_failure_cleanup(monkeypatch):
+    """Test that watchdog and timers are cleaned up when ClientConnectedHook fails."""
+    handler = MockConnectionHandler()
+
+    def failing_hook(*args, **kwargs):
+        raise RuntimeError("ClientConnectedHook failed")
+
+    handler.hook_handlers["client_connected"] = failing_hook
+
+    timer_mock = mock.Mock()
+    handler.wakeup_timer.add(timer_mock)
+
+    watch_cancelled = False
+
+    async def dummy_watch():
+        nonlocal watch_cancelled
+        try:
+            await asyncio.sleep(10)
+        except asyncio.CancelledError:
+            watch_cancelled = True
+            raise
+
+    watch_task = asyncio.create_task(dummy_watch())
+
+    monkeypatch.setattr(
+        "mitmproxy.proxy.server.asyncio_utils.create_task",
+        lambda coro, *args, **kwargs: (coro.close(), watch_task)[1]
+    )
+
+    with pytest.raises(RuntimeError, match="ClientConnectedHook failed"):
+        await handler.handle_client()
+
+    await asyncio.sleep(0)
+
+    assert watch_cancelled
+    timer_mock.cancel.assert_called()
+    assert len(handler.wakeup_timer) == 0
+
+
+async def test_server_connected_hook_failure_cleanup(monkeypatch):
+    """Test that connection is closed when ServerConnectedHook fails."""
+    handler = MockConnectionHandler()
+
+    def failing_hook(*args, **kwargs):
+        raise RuntimeError("ServerConnectedHook failed")
+
+    handler.hook_handlers["server_connected"] = failing_hook
+
+    monkeypatch.setattr(
+        asyncio,
+        "open_connection",
+        mock.AsyncMock(return_value=(mock.MagicMock(), mock.MagicMock()))
+    )
+
+    writer_mock = mock.MagicMock()
+    monkeypatch.setattr(
+        asyncio,
+        "open_connection",
+        mock.AsyncMock(return_value=(mock.MagicMock(), writer_mock))
+    )
+
+    conn = Server(address=("example.com", 8080))
+    command = commands.OpenConnection(connection=conn)
+
+    with pytest.raises(RuntimeError, match="ServerConnectedHook failed"):
+        await handler.open_connection(command)
+
+    writer_mock.close.assert_called_once()
+    assert conn not in handler.transports


### PR DESCRIPTION
## Problem

This PR fixes three resource leak issues in mitmproxy that can occur when hooks raise exceptions during connection establishment.

### Issue 1: File handle leak in save.py

**Location:** `mitmproxy/addons/save.py:100`

**Problem:** When `FilteredFlowWriter` initialization fails after opening a file, the file handle is not closed, leading to resource leaks.

**Fix:** Wrap the initialization in a try-except block to close the file handle if initialization fails.

### Issue 2: Watchdog task leak in server.py

**Location:** `mitmproxy/proxy/server.py:127-180`

**Problem:** If `ClientConnectedHook` raises an exception, the watchdog task and wakeup timers are not cancelled, leading to task leaks.

**Fix:** Wrap the connection handling logic in a try-finally block to ensure cleanup.

### Issue 3: Connection leak in server.py

**Location:** `mitmproxy/proxy/server.py:255`

**Problem:** If `ServerConnectedHook` raises an exception after a connection is established, the connection is not closed and the transport is not cleaned up, leading to connection leaks.

**Fix:** Wrap the hook call in a try-except block to close the connection and clean up the transport if the hook fails.

## Impact

These resource leaks can accumulate over time in long-running mitmproxy instances, especially when custom addons raise exceptions in connection hooks, file system errors occur during stream rotation, or network conditions cause frequent connection failures.

The fixes ensure proper resource cleanup in error paths, improving mitmproxy's stability and preventing potential file descriptor exhaustion.

## Testing

The changes are minimal and focused on error handling paths. Existing tests should continue to pass as the normal execution flow is unchanged. The fixes only affect behavior when exceptions occur.