### PR TITLE
feat(web): add dark theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 - Remove the unused `msgpack` dependency. The msgpack contentview is
   implemented in Rust and shipped with `mitmproxy_rs` since mitmproxy 12.
   ([#8319](https://github.com/mitmproxy/mitmproxy/pull/8319), @lukehsiao)
+- mitmweb: Add a dark theme, selectable via the new `web_theme` option (`system`, `dark`, or `light`).
+  `system` follows the operating system's color-scheme preference.
 - mitmweb: Honor the `view_order_reversed` option for live flows. New flows are
   now placed at the top of the table when the option is set, instead of always
   being appended at the bottom.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
   ([#8319](https://github.com/mitmproxy/mitmproxy/pull/8319), @lukehsiao)
 - mitmweb: Add a dark theme, selectable via the new `web_theme` option (`system`, `dark`, or `light`).
   `system` follows the operating system's color-scheme preference.
+  ([#8317](https://github.com/mitmproxy/mitmproxy/pull/8317), @sleeyax)
 - mitmweb: Honor the `view_order_reversed` option for live flows. New flows are
   now placed at the top of the table when the option is set, instead of always
   being appended at the bottom.

--- a/mitmproxy/tools/web/webaddons.py
+++ b/mitmproxy/tools/web/webaddons.py
@@ -97,6 +97,13 @@ class WebAddon:
             ["tls", "icon", "path", "method", "status", "size", "time"],
             f"Columns to show in the flow list. Can be one of the following: {', '.join(AVAILABLE_WEB_COLUMNS)}",
         )
+        loader.add_option(
+            "web_theme",
+            str,
+            "system",
+            "Preferred color theme for the mitmweb user interface.",
+            choices=["system", "dark", "light"],
+        )
 
     def running(self):
         if hasattr(ctx.options, "web_open_browser") and ctx.options.web_open_browser:

--- a/test/mitmproxy/tools/web/test_webaddons.py
+++ b/test/mitmproxy/tools/web/test_webaddons.py
@@ -49,6 +49,17 @@ class TestWebAuth:
             assert not a.is_valid_password("")
             assert not a.is_valid_password("test")
 
+    def test_web_theme_option(self):
+        with taddons.context(webaddons.WebAddon()) as tctx:
+            assert tctx.options.web_theme == "system"
+            assert tctx.options._options["web_theme"].choices == [
+                "system",
+                "dark",
+                "light",
+            ]
+            tctx.options.web_theme = "dark"
+            assert tctx.options.web_theme == "dark"
+
     @pytest.mark.parametrize(
         "web_host,web_port,expected_web_url",
         [

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -10,6 +10,7 @@
                 "@codemirror/lang-html": "^6.4.9",
                 "@codemirror/lang-javascript": "^6.2.3",
                 "@codemirror/lang-yaml": "^6.1.2",
+                "@codemirror/theme-one-dark": "^6.1.2",
                 "@floating-ui/react-dom": "^2.1.2",
                 "@popperjs/core": "^2.11.8",
                 "@reduxjs/toolkit": "^2.8.1",

--- a/web/package.json
+++ b/web/package.json
@@ -13,6 +13,7 @@
         "@codemirror/lang-html": "^6.4.9",
         "@codemirror/lang-javascript": "^6.2.3",
         "@codemirror/lang-yaml": "^6.1.2",
+        "@codemirror/theme-one-dark": "^6.1.2",
         "@floating-ui/react-dom": "^2.1.2",
         "@popperjs/core": "^2.11.8",
         "@reduxjs/toolkit": "^2.8.1",

--- a/web/setup-jest.js
+++ b/web/setup-jest.js
@@ -3,3 +3,17 @@ console.warn = console.error = function () {
     err.apply(console, arguments);
     throw new Error(arguments[0]);
 };
+
+// jsdom does not implement matchMedia; provide a light-theme stub.
+if (typeof window.matchMedia !== "function") {
+    window.matchMedia = (query) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        addListener: () => {},
+        removeListener: () => {},
+        dispatchEvent: () => false,
+    });
+}

--- a/web/src/css/eventlog.less
+++ b/web/src/css/eventlog.less
@@ -33,7 +33,7 @@
         color: grey;
         margin-left: 6px;
         &:hover {
-            color: black;
+            color: var(--mitmweb-fg-strong);
         }
     }
 

--- a/web/src/css/eventlog.less
+++ b/web/src/css/eventlog.less
@@ -30,7 +30,7 @@
 
     .icon-close {
         cursor: pointer;
-        color: grey;
+        color: var(--mitmweb-fg-muted);
         margin-left: 6px;
         &:hover {
             color: var(--mitmweb-fg-strong);

--- a/web/src/css/flowdetail.less
+++ b/web/src/css/flowdetail.less
@@ -25,7 +25,7 @@
         margin-top: 2px;
         padding-left: 10px;
         padding-right: 7px;
-        color: grey;
+        color: var(--mitmweb-fg-muted);
         font-size: 15px;
         border: none;
         background: transparent;

--- a/web/src/css/flowdetail.less
+++ b/web/src/css/flowdetail.less
@@ -14,7 +14,7 @@
         padding: 5px 12px 10px;
 
         > footer {
-            box-shadow: 0 0 3px gray;
+            box-shadow: 0 0 3px var(--mitmweb-shadow);
             padding: 2px;
             margin: 0;
             height: 23px;

--- a/web/src/css/flowdetail.less
+++ b/web/src/css/flowdetail.less
@@ -34,7 +34,7 @@
     }
 
     .close-button:hover {
-        color: black;
+        color: var(--mitmweb-fg-strong);
     }
 
     .first-line {

--- a/web/src/css/flowdetail.less
+++ b/web/src/css/flowdetail.less
@@ -39,8 +39,8 @@
 
     .first-line {
         font-family: @font-family-monospace;
-        background-color: var(--mitmweb-accent);
-        color: white;
+        background-color: var(--mitmweb-first-line-bg);
+        color: var(--mitmweb-first-line-fg);
         margin: 0 -8px 2px;
         padding: 4px 8px;
         border-radius: 5px;

--- a/web/src/css/footer.less
+++ b/web/src/css/footer.less
@@ -1,5 +1,5 @@
 footer {
-    box-shadow: 0 -1px 3px lightgray;
+    box-shadow: 0 -1px 3px var(--mitmweb-shadow);
     padding: 0 0 4px 3px;
 
     .label {

--- a/web/src/css/global.less
+++ b/web/src/css/global.less
@@ -72,6 +72,17 @@
     // Alert
     --mitmweb-alert-warning-bg: #fcf8e3;
     --mitmweb-alert-warning-border: #faebcc;
+
+    // Response status codes, by class
+    --mitmweb-status-1xx: green;
+    --mitmweb-status-2xx: darkgreen;
+    --mitmweb-status-3xx: lightblue;
+    --mitmweb-status-4xx: red;
+    --mitmweb-status-5xx: red;
+    --mitmweb-status-other: darkred;
+
+    // Drop shadow cast by panel edges (footers)
+    --mitmweb-shadow: lightgray;
 }
 
 [data-theme="dark"] {
@@ -137,6 +148,17 @@
     // Alert
     --mitmweb-alert-warning-bg: #4d4327;
     --mitmweb-alert-warning-border: #6b5d2f;
+
+    // Response status codes — the light values are far too dark to read on a dark surface
+    --mitmweb-status-1xx: #7ec97e;
+    --mitmweb-status-2xx: #5cd65c;
+    --mitmweb-status-3xx: #7fc9e8;
+    --mitmweb-status-4xx: #ff7b7b;
+    --mitmweb-status-5xx: #ff7b7b;
+    --mitmweb-status-other: #e07b7b;
+
+    // Drop shadow cast by panel edges (footers)
+    --mitmweb-shadow: #000;
 }
 
 // www.paulirish.com/2012/box-sizing-border-box-ftw/

--- a/web/src/css/global.less
+++ b/web/src/css/global.less
@@ -57,6 +57,10 @@
     // Highlight (row hover / suggestion selection)
     --mitmweb-highlight: hsla(209, 52%, 84%, 0.5);
 
+    // Request/response first-line banner
+    --mitmweb-first-line-bg: #337ab7;
+    --mitmweb-first-line-fg: #fff;
+
     // Flow table row states (base rows reuse --mitmweb-bg / --mitmweb-bg-alt; -alt is the even-row shade)
     --mitmweb-row-highlight: hsl(48, 100%, 80%);
     --mitmweb-row-highlight-alt: hsl(48, 100%, 75%);
@@ -117,6 +121,10 @@
 
     // Highlight (row hover / suggestion selection)
     --mitmweb-highlight: hsla(209, 52%, 30%, 0.5);
+
+    // Request/response first-line banner — the accent blue is too bright to read monospace text on
+    --mitmweb-first-line-bg: #1c3a5e;
+    --mitmweb-first-line-fg: #dbe9fa;
 
     // Flow table row states (base rows reuse --mitmweb-bg / --mitmweb-bg-alt; -alt is the even-row shade)
     --mitmweb-row-highlight: hsl(48, 60%, 26%);

--- a/web/src/css/global.less
+++ b/web/src/css/global.less
@@ -83,6 +83,9 @@
 
     // Drop shadow cast by panel edges (footers)
     --mitmweb-shadow: lightgray;
+
+    // Applied to bitmap icons supplied by the OS, which we cannot recolor
+    --mitmweb-bitmap-icon-filter: none;
 }
 
 [data-theme="dark"] {
@@ -159,6 +162,11 @@
 
     // Drop shadow cast by panel edges (footers)
     --mitmweb-shadow: #000;
+
+    // The OS hands us light icons.
+    // The generic executable icon is a plain white square, which glares on a dark popover.
+    // Dimming knocks it back to grey while leaving colored app icons recognizable.
+    --mitmweb-bitmap-icon-filter: brightness(0.7);
 }
 
 // www.paulirish.com/2012/box-sizing-border-box-ftw/

--- a/web/src/css/global.less
+++ b/web/src/css/global.less
@@ -1,6 +1,6 @@
 // Semantic color tokens.
 // Light values below are byte-equal to the literals they replace, so this change is visually a no-op.
-// A future dark theme overrides these under a `[data-theme="dark"]` selector; colors that LESS functions
+// The dark theme overrides these under a `[data-theme="dark"]` selector; colors that LESS functions
 // (lighten/darken/fadeout) consume are left as literals here because those functions cannot operate on var().
 :root {
     // Match native controls (form inputs, scrollbars) to the active theme.
@@ -115,36 +115,17 @@
     --mitmweb-text-warning: #d0a95c;
     --mitmweb-text-danger: #e07b7b;
 
+    // Flow table row states (base rows reuse --mitmweb-bg / --mitmweb-bg-alt; -alt is the even-row shade)
+    --mitmweb-row-highlight: hsl(48, 60%, 26%);
+    --mitmweb-row-highlight-alt: hsl(48, 60%, 22%);
+    --mitmweb-row-selected: hsl(209, 45%, 26%);
+    --mitmweb-row-selected-alt: hsl(209, 45%, 22%);
+    --mitmweb-row-selected-highlight: hsl(209, 55%, 34%);
+    --mitmweb-row-selected-highlight-alt: hsl(209, 55%, 30%);
+
     // Alert
     --mitmweb-alert-warning-bg: #4d4327;
     --mitmweb-alert-warning-border: #6b5d2f;
-
-    // Flow-table row backgrounds are derived with LESS color functions
-    // (lighten/fadeout) that cannot operate on var(), so they are overridden here.
-    .flow-table tr {
-        background-color: hsl(0, 0%, 12%);
-        &:nth-child(even) {
-            background-color: hsl(0, 0%, 16%);
-        }
-        &.highlighted {
-            background-color: hsl(48, 60%, 26%);
-            &:nth-child(even) {
-                background-color: hsl(48, 60%, 22%);
-            }
-        }
-        &.selected {
-            background-color: hsl(209, 45%, 26%) !important;
-            &:nth-child(even) {
-                background-color: hsl(209, 45%, 22%) !important;
-            }
-        }
-        &.selected.highlighted {
-            background-color: hsl(209, 55%, 34%) !important;
-            &:nth-child(even) {
-                background-color: hsl(209, 55%, 30%) !important;
-            }
-        }
-    }
 }
 
 // www.paulirish.com/2012/box-sizing-border-box-ftw/

--- a/web/src/css/global.less
+++ b/web/src/css/global.less
@@ -67,6 +67,81 @@
     --mitmweb-alert-warning-border: #faebcc;
 }
 
+[data-theme="dark"] {
+    // Surfaces
+    --mitmweb-bg: #1e1e1e;
+    --mitmweb-bg-alt: #252526;
+    --mitmweb-bg-muted: #2d2d2d;
+    --mitmweb-bg-hover: #333333;
+    --mitmweb-bg-active: #3a3a3a;
+
+    // Text
+    --mitmweb-fg: #d4d4d4;
+    --mitmweb-fg-input: #cccccc;
+    --mitmweb-fg-muted: #9a9a9a;
+    --mitmweb-fg-strong: #ffffff;
+
+    // Borders
+    --mitmweb-border: #3c3c3c;
+    --mitmweb-border-light: #333333;
+    --mitmweb-border-lighter: #333333;
+    --mitmweb-border-strong: #555555;
+
+    // Accent (primary) — brightened for contrast on dark surfaces
+    --mitmweb-accent: #4a9eff;
+    --mitmweb-accent-hover: #6fb3ff;
+    --mitmweb-accent-active: #3a8ae0;
+    --mitmweb-accent-border: #3a8ae0;
+    --mitmweb-accent-border-active: #2f77c4;
+    --mitmweb-focus-ring: #4a9eff;
+
+    // State — solid backgrounds keep their vivid hues
+    --mitmweb-info: #5bc0de;
+    --mitmweb-info-hover: #31b0d5;
+    --mitmweb-info-border: #46b8da;
+    --mitmweb-info-border-hover: #269abc;
+    --mitmweb-success: #5cb85c;
+    --mitmweb-danger: #d9534f;
+    --mitmweb-warning: #f0ad4e;
+
+    // State — text lightened for dark background
+    --mitmweb-text-success: #6cc26c;
+    --mitmweb-text-info: #5bc0de;
+    --mitmweb-text-warning: #d0a95c;
+    --mitmweb-text-danger: #e07b7b;
+
+    // Alert
+    --mitmweb-alert-warning-bg: #4d4327;
+    --mitmweb-alert-warning-border: #6b5d2f;
+
+    // Flow-table row backgrounds are derived with LESS color functions
+    // (lighten/fadeout) that cannot operate on var(), so they are overridden here.
+    .flow-table tr {
+        background-color: hsl(0, 0%, 12%);
+        &:nth-child(even) {
+            background-color: hsl(0, 0%, 16%);
+        }
+        &.highlighted {
+            background-color: hsl(48, 60%, 26%);
+            &:nth-child(even) {
+                background-color: hsl(48, 60%, 22%);
+            }
+        }
+        &.selected {
+            background-color: hsl(209, 45%, 26%) !important;
+            &:nth-child(even) {
+                background-color: hsl(209, 45%, 22%) !important;
+            }
+        }
+        &.selected.highlighted {
+            background-color: hsl(209, 55%, 34%) !important;
+            &:nth-child(even) {
+                background-color: hsl(209, 55%, 30%) !important;
+            }
+        }
+    }
+}
+
 // www.paulirish.com/2012/box-sizing-border-box-ftw/
 html {
     box-sizing: border-box;

--- a/web/src/css/global.less
+++ b/web/src/css/global.less
@@ -86,6 +86,9 @@
 
     // Applied to bitmap icons supplied by the OS, which we cannot recolor
     --mitmweb-bitmap-icon-filter: none;
+
+    // `thumb track` for scrollbars
+    --mitmweb-scrollbar: auto;
 }
 
 [data-theme="dark"] {
@@ -167,6 +170,11 @@
     // The generic executable icon is a plain white square, which glares on a dark popover.
     // Dimming knocks it back to grey while leaving colored app icons recognizable.
     --mitmweb-bitmap-icon-filter: brightness(0.7);
+
+    // Panes such as the flow table reserve a scrollbar gutter permanently (`overflow-y: scroll`).
+    // Under `color-scheme: dark` the UA paints that gutter light, so an idle scrollbar reads as a stray vertical line against the pane divider.
+    // Sinking the track into the surface keeps it as invisible as it is on light backgrounds.
+    --mitmweb-scrollbar: var(--mitmweb-border-strong) var(--mitmweb-bg);
 }
 
 // www.paulirish.com/2012/box-sizing-border-box-ftw/
@@ -205,6 +213,7 @@ body {
     line-height: 1.42857143;
     color: var(--mitmweb-fg);
     background-color: var(--mitmweb-bg);
+    scrollbar-color: var(--mitmweb-scrollbar);
 }
 
 h1,

--- a/web/src/css/global.less
+++ b/web/src/css/global.less
@@ -137,7 +137,7 @@
     --mitmweb-text-danger: #e07b7b;
 
     // Highlight (row hover / suggestion selection)
-    --mitmweb-highlight: hsla(209, 52%, 30%, 0.5);
+    --mitmweb-highlight: hsla(209, 60%, 42%, 0.6);
 
     // Request/response first-line banner — the accent blue is too bright to read monospace text on
     --mitmweb-first-line-bg: #1c3a5e;

--- a/web/src/css/global.less
+++ b/web/src/css/global.less
@@ -115,6 +115,9 @@
     --mitmweb-text-warning: #d0a95c;
     --mitmweb-text-danger: #e07b7b;
 
+    // Highlight (row hover / suggestion selection)
+    --mitmweb-highlight: hsla(209, 52%, 30%, 0.5);
+
     // Flow table row states (base rows reuse --mitmweb-bg / --mitmweb-bg-alt; -alt is the even-row shade)
     --mitmweb-row-highlight: hsl(48, 60%, 26%);
     --mitmweb-row-highlight-alt: hsl(48, 60%, 22%);

--- a/web/src/css/global.less
+++ b/web/src/css/global.less
@@ -3,6 +3,9 @@
 // A future dark theme overrides these under a `[data-theme="dark"]` selector; colors that LESS functions
 // (lighten/darken/fadeout) consume are left as literals here because those functions cannot operate on var().
 :root {
+    // Match native controls (form inputs, scrollbars) to the active theme.
+    color-scheme: light;
+
     // Surfaces
     --mitmweb-bg: #fff;
     --mitmweb-bg-alt: #f2f2f2;
@@ -68,6 +71,8 @@
 }
 
 [data-theme="dark"] {
+    color-scheme: dark;
+
     // Surfaces
     --mitmweb-bg: #1e1e1e;
     --mitmweb-bg-alt: #252526;

--- a/web/src/css/header.less
+++ b/web/src/css/header.less
@@ -22,7 +22,7 @@
 header {
     padding-top: 6px;
     background-color: var(--mitmweb-bg);
-    @separator-color: lighten(grey, 15%);
+    @separator-color: var(--mitmweb-border-strong);
     > div:not(:empty) {
         display: block;
         margin: 0;
@@ -107,7 +107,7 @@ header {
     @space: 10px;
     margin-left: -(@menu-group-hmargin + 1px);
     content: " ";
-    border-left: solid 1px lighten(grey, 40%);
+    border-left: solid 1px var(--mitmweb-border-lighter);
     margin-top: @space;
     height: @menu-height - @space*2;
     position: absolute;

--- a/web/src/css/header.less
+++ b/web/src/css/header.less
@@ -93,6 +93,12 @@ header {
     input[type="checkbox"] {
         margin: 0;
     }
+    .theme-select {
+        font-size: 1.2rem;
+        padding: 1px 2px;
+        border: 1px solid var(--mitmweb-border);
+        border-radius: 3px;
+    }
 }
 
 .menu-legend {

--- a/web/src/css/mode.less
+++ b/web/src/css/mode.less
@@ -183,6 +183,7 @@
                 color: #5f6368;
                 width: 25px;
                 height: 25px;
+                filter: var(--mitmweb-bitmap-icon-filter);
             }
 
             .process-name {

--- a/web/src/css/mode.less
+++ b/web/src/css/mode.less
@@ -138,7 +138,7 @@
                 flex: 1;
                 min-width: 0;
                 outline: none;
-                color: black;
+                color: var(--mitmweb-fg);
             }
 
             .dropdown-list {

--- a/web/src/css/mode.less
+++ b/web/src/css/mode.less
@@ -139,6 +139,7 @@
                 min-width: 0;
                 outline: none;
                 color: var(--mitmweb-fg);
+                background: transparent;
             }
 
             .dropdown-list {

--- a/web/src/css/tabs.less
+++ b/web/src/css/tabs.less
@@ -1,5 +1,5 @@
 .nav-tabs {
-    @separator-color: lighten(grey, 15%);
+    @separator-color: var(--mitmweb-border-strong);
 
     border-bottom: solid @separator-color 1px;
 

--- a/web/src/js/__tests__/components/FlowTable/FlowColumnsSpec.tsx
+++ b/web/src/js/__tests__/components/FlowTable/FlowColumnsSpec.tsx
@@ -123,4 +123,41 @@ describe("Flowcolumns Components", () => {
         const tflow = TFlow();
         testFlowColumn(<FlowColumns.comment flow={tflow} rowNumber={0} />);
     });
+
+    it("should render the status column across all status code ranges", () => {
+        const statusCell = (status_code: number) => {
+            const tflow = TFlow();
+            tflow.response.status_code = status_code;
+            const { container } = render(
+                <table>
+                    <tbody>
+                        <tr>
+                            <FlowColumns.status flow={tflow} rowNumber={0} />
+                        </tr>
+                    </tbody>
+                </table>,
+            );
+            return container.querySelector(".col-status")!.textContent;
+        };
+
+        for (const status_code of [103, 200, 304, 404, 500]) {
+            expect(statusCell(status_code)).toContain(String(status_code));
+        }
+
+        // no response -> empty status cell
+        const noResponseFlow = { ...TFlow(), response: undefined };
+        const { container } = render(
+            <table>
+                <tbody>
+                    <tr>
+                        <FlowColumns.status
+                            flow={noResponseFlow}
+                            rowNumber={0}
+                        />
+                    </tr>
+                </tbody>
+            </table>,
+        );
+        expect(container.querySelector(".col-status")!.textContent).toBe("");
+    });
 });

--- a/web/src/js/__tests__/components/FlowTable/__snapshots__/FlowColumnsSpec.tsx.snap
+++ b/web/src/js/__tests__/components/FlowTable/__snapshots__/FlowColumnsSpec.tsx.snap
@@ -482,7 +482,6 @@ exports[`should render columns: status 1`] = `
       <tr>
         <td
           class="col-status"
-          style="color: darkgreen;"
         >
           200
         </td>

--- a/web/src/js/__tests__/components/FlowTable/__snapshots__/FlowRowSpec.tsx.snap
+++ b/web/src/js/__tests__/components/FlowTable/__snapshots__/FlowRowSpec.tsx.snap
@@ -83,7 +83,6 @@ exports[`FlowRow 1`] = `
         </td>
         <td
           class="col-status"
-          style="color: darkgreen;"
         >
           200
         </td>
@@ -177,7 +176,6 @@ exports[`FlowRow 1`] = `
         </td>
         <td
           class="col-status"
-          style="color: darkgreen;"
         >
           NOERROR
         </td>

--- a/web/src/js/__tests__/components/Header/OptionMenuSpec.tsx
+++ b/web/src/js/__tests__/components/Header/OptionMenuSpec.tsx
@@ -1,10 +1,32 @@
 import * as React from "react";
 import OptionMenu from "../../../components/Header/OptionMenu";
-import { render } from "../../test-utils";
+import { fireEvent, render, screen, waitFor } from "../../test-utils";
+import { enableFetchMocks } from "jest-fetch-mock";
+
+enableFetchMocks();
 
 describe("OptionMenu Component", () => {
     it("should render correctly", () => {
         const { asFragment } = render(<OptionMenu />);
         expect(asFragment()).toMatchSnapshot();
+    });
+
+    it("should update the web_theme option from the theme selector", async () => {
+        fetchMock.mockResponseOnce("");
+
+        render(<OptionMenu />);
+        fireEvent.change(screen.getByDisplayValue("system"), {
+            target: { value: "dark" },
+        });
+
+        await waitFor(() =>
+            expect(fetchMock).toHaveBeenCalledWith(
+                "./options",
+                expect.objectContaining({
+                    method: "PUT",
+                    body: JSON.stringify({ web_theme: "dark" }),
+                }),
+            ),
+        );
     });
 });

--- a/web/src/js/__tests__/components/Header/__snapshots__/MainMenuSpec.tsx.snap
+++ b/web/src/js/__tests__/components/Header/__snapshots__/MainMenuSpec.tsx.snap
@@ -17,9 +17,7 @@ exports[`MainMenu 1`] = `
           <span
             class="input-group-addon"
           >
-            <span
-              style="color: black;"
-            >
+            <span>
               <svg
                 aria-hidden="true"
                 class="lucide lucide-search icon icon-search"

--- a/web/src/js/__tests__/components/Header/__snapshots__/OptionMenuSpec.tsx.snap
+++ b/web/src/js/__tests__/components/Header/__snapshots__/OptionMenuSpec.tsx.snap
@@ -217,6 +217,45 @@ exports[`OptionMenu Component should render correctly 1`] = `
         View Options
       </div>
     </div>
+    <div
+      class="menu-group"
+    >
+      <div
+        class="menu-content"
+      >
+        <div
+          class="menu-entry"
+        >
+          <label>
+            Theme
+            <select
+              class="theme-select"
+            >
+              <option
+                value="system"
+              >
+                system
+              </option>
+              <option
+                value="dark"
+              >
+                dark
+              </option>
+              <option
+                value="light"
+              >
+                light
+              </option>
+            </select>
+          </label>
+        </div>
+      </div>
+      <div
+        class="menu-legend"
+      >
+        Appearance
+      </div>
+    </div>
   </div>
 </DocumentFragment>
 `;

--- a/web/src/js/__tests__/components/__snapshots__/FlowTableSpec.tsx.snap
+++ b/web/src/js/__tests__/components/__snapshots__/FlowTableSpec.tsx.snap
@@ -150,7 +150,6 @@ exports[`FlowTable Component should render correctly 1`] = `
           </td>
           <td
             class="col-status"
-            style="color: darkgreen;"
           >
             200
           </td>
@@ -396,7 +395,6 @@ exports[`FlowTable Component should scroll current selection into view 1`] = `
             </td>
             <td
               class="col-status"
-              style="color: darkgreen;"
             >
               200
             </td>
@@ -643,7 +641,6 @@ exports[`FlowTable Component should scroll current selection into view 2`] = `
             </td>
             <td
               class="col-status"
-              style="color: darkgreen;"
             >
               NOERROR
             </td>

--- a/web/src/js/__tests__/components/__snapshots__/HeaderSpec.tsx.snap
+++ b/web/src/js/__tests__/components/__snapshots__/HeaderSpec.tsx.snap
@@ -639,6 +639,45 @@ exports[`Header 2`] = `
             View Options
           </div>
         </div>
+        <div
+          class="menu-group"
+        >
+          <div
+            class="menu-content"
+          >
+            <div
+              class="menu-entry"
+            >
+              <label>
+                Theme
+                <select
+                  class="theme-select"
+                >
+                  <option
+                    value="system"
+                  >
+                    system
+                  </option>
+                  <option
+                    value="dark"
+                  >
+                    dark
+                  </option>
+                  <option
+                    value="light"
+                  >
+                    light
+                  </option>
+                </select>
+              </label>
+            </div>
+          </div>
+          <div
+            class="menu-legend"
+          >
+            Appearance
+          </div>
+        </div>
       </div>
     </div>
   </header>
@@ -1066,6 +1105,45 @@ exports[`Header 3`] = `
             class="menu-legend"
           >
             View Options
+          </div>
+        </div>
+        <div
+          class="menu-group"
+        >
+          <div
+            class="menu-content"
+          >
+            <div
+              class="menu-entry"
+            >
+              <label>
+                Theme
+                <select
+                  class="theme-select"
+                >
+                  <option
+                    value="system"
+                  >
+                    system
+                  </option>
+                  <option
+                    value="dark"
+                  >
+                    dark
+                  </option>
+                  <option
+                    value="light"
+                  >
+                    light
+                  </option>
+                </select>
+              </label>
+            </div>
+          </div>
+          <div
+            class="menu-legend"
+          >
+            Appearance
           </div>
         </div>
       </div>

--- a/web/src/js/__tests__/components/helpers/ThemeManagerSpec.tsx
+++ b/web/src/js/__tests__/components/helpers/ThemeManagerSpec.tsx
@@ -1,0 +1,54 @@
+import * as React from "react";
+import { render } from "../../test-utils";
+import { TStore } from "../../ducks/tutils";
+import ThemeManager from "../../../components/helpers/ThemeManager";
+import { defaultState as defaultOptions } from "../../../ducks/options";
+
+function storeWithTheme(web_theme: string) {
+    const state = TStore().getState();
+    return TStore({
+        ...state,
+        options: { ...defaultOptions, web_theme },
+    });
+}
+
+function mockMatchMedia(matches: boolean) {
+    window.matchMedia = ((query: string) => ({
+        matches,
+        media: query,
+        onchange: null,
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        addListener: () => {},
+        removeListener: () => {},
+        dispatchEvent: () => false,
+    })) as unknown as typeof window.matchMedia;
+}
+
+afterEach(() => {
+    document.documentElement.removeAttribute("data-theme");
+});
+
+test("system theme follows OS preference (light)", () => {
+    mockMatchMedia(false);
+    render(<ThemeManager />, { store: storeWithTheme("system") });
+    expect(document.documentElement.getAttribute("data-theme")).toBe("light");
+});
+
+test("system theme follows OS preference (dark)", () => {
+    mockMatchMedia(true);
+    render(<ThemeManager />, { store: storeWithTheme("system") });
+    expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
+});
+
+test("explicit dark overrides OS preference", () => {
+    mockMatchMedia(false);
+    render(<ThemeManager />, { store: storeWithTheme("dark") });
+    expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
+});
+
+test("explicit light overrides OS preference", () => {
+    mockMatchMedia(true);
+    render(<ThemeManager />, { store: storeWithTheme("light") });
+    expect(document.documentElement.getAttribute("data-theme")).toBe("light");
+});

--- a/web/src/js/components/FlowTable/FlowColumns.tsx
+++ b/web/src/js/components/FlowTable/FlowColumns.tsx
@@ -92,33 +92,33 @@ export const version: FlowColumn = ({ flow }) => (
 version.headerName = "Version";
 
 export const status: FlowColumn = ({ flow }) => {
-    let color = "darkred";
+    let color = "var(--mitmweb-status-other)";
 
     if ((flow.type !== "http" && flow.type != "dns") || !flow.response)
         return <td className="col-status" />;
 
     if (100 <= flow.response.status_code && flow.response.status_code < 200) {
-        color = "green";
+        color = "var(--mitmweb-status-1xx)";
     } else if (
         200 <= flow.response.status_code &&
         flow.response.status_code < 300
     ) {
-        color = "darkgreen";
+        color = "var(--mitmweb-status-2xx)";
     } else if (
         300 <= flow.response.status_code &&
         flow.response.status_code < 400
     ) {
-        color = "lightblue";
+        color = "var(--mitmweb-status-3xx)";
     } else if (
         400 <= flow.response.status_code &&
         flow.response.status_code < 500
     ) {
-        color = "red";
+        color = "var(--mitmweb-status-4xx)";
     } else if (
         500 <= flow.response.status_code &&
         flow.response.status_code < 600
     ) {
-        color = "red";
+        color = "var(--mitmweb-status-5xx)";
     }
 
     return (

--- a/web/src/js/components/Header/FlowListMenu.tsx
+++ b/web/src/js/components/Header/FlowListMenu.tsx
@@ -52,7 +52,7 @@ function FlowFilterInput() {
             value={value}
             placeholder="Search"
             icon={FilterIcon.SEARCH}
-            color="black"
+            color="var(--mitmweb-fg)"
             onChange={(expr) => dispatch(setFilter(expr))}
         />
     );

--- a/web/src/js/components/Header/OptionMenu.tsx
+++ b/web/src/js/components/Header/OptionMenu.tsx
@@ -4,9 +4,41 @@ import Button from "../common/Button";
 import DocsLink from "../common/DocsLink";
 import HideInStatic from "../common/HideInStatic";
 import * as modalActions from "../../ducks/ui/modal";
-import { useAppDispatch } from "../../ducks";
+import * as optionsActions from "../../ducks/options";
+import { useAppDispatch, useAppSelector } from "../../ducks";
 
 OptionMenu.title = "Options";
+
+function ThemeSelect() {
+    const dispatch = useAppDispatch();
+    const value = useAppSelector((state) => state.options.web_theme);
+    const choices = useAppSelector(
+        (state) => state.options_meta.web_theme?.choices,
+    ) ?? ["system", "dark", "light"];
+
+    return (
+        <div className="menu-entry">
+            <label>
+                Theme
+                <select
+                    className="theme-select"
+                    value={value}
+                    onChange={(e) =>
+                        dispatch(
+                            optionsActions.update("web_theme", e.target.value),
+                        )
+                    }
+                >
+                    {choices.map((choice) => (
+                        <option key={choice} value={choice}>
+                            {choice}
+                        </option>
+                    ))}
+                </select>
+            </label>
+        </div>
+    );
+}
 
 export default function OptionMenu() {
     const dispatch = useAppDispatch();
@@ -55,6 +87,15 @@ export default function OptionMenu() {
                 </div>
                 <div className="menu-legend">View Options</div>
             </div>
+
+            <HideInStatic>
+                <div className="menu-group">
+                    <div className="menu-content">
+                        <ThemeSelect />
+                    </div>
+                    <div className="menu-legend">Appearance</div>
+                </div>
+            </HideInStatic>
         </div>
     );
 }

--- a/web/src/js/components/ProxyApp.tsx
+++ b/web/src/js/components/ProxyApp.tsx
@@ -6,6 +6,7 @@ import CommandBar from "./CommandBar";
 import EventLog from "./EventLog";
 import Footer from "./Footer";
 import Modal from "./Modal/Modal";
+import ThemeManager from "./helpers/ThemeManager";
 import type { RootState } from "../ducks";
 import { connect } from "react-redux";
 
@@ -57,6 +58,7 @@ class ProxyAppMain extends Component<ProxyAppMainProps, ProxyAppMainState> {
 
         return (
             <div id="container" tabIndex={0}>
+                <ThemeManager />
                 <Header />
                 <MainView />
                 {showCommandBar && <CommandBar key="commandbar" />}

--- a/web/src/js/components/contentviews/CodeEditor.tsx
+++ b/web/src/js/components/contentviews/CodeEditor.tsx
@@ -5,7 +5,9 @@ import { css } from "@codemirror/lang-css";
 import { html } from "@codemirror/lang-html";
 import { javascript } from "@codemirror/lang-javascript";
 import { yaml } from "@codemirror/lang-yaml";
+import { oneDark } from "@codemirror/theme-one-dark";
 import { SyntaxHighlight } from "../../backends/consts";
+import { useResolvedTheme } from "../helpers/useTheme";
 
 type CodeEditorProps = {
     initialContent: string;
@@ -20,6 +22,7 @@ export default function CodeEditor({
     language,
     readonly = false,
 }: CodeEditorProps) {
+    const resolvedTheme = useResolvedTheme();
     const stopPropagation = useCallback(
         (e: React.KeyboardEvent<HTMLDivElement>) => e.stopPropagation(),
         [],
@@ -57,6 +60,7 @@ export default function CodeEditor({
                 onChange={onChange}
                 readOnly={readonly}
                 extensions={extensions}
+                theme={resolvedTheme === "dark" ? oneDark : "light"}
             />
         </div>
     );

--- a/web/src/js/components/helpers/ThemeManager.tsx
+++ b/web/src/js/components/helpers/ThemeManager.tsx
@@ -1,0 +1,16 @@
+import { useEffect } from "react";
+import { useResolvedTheme } from "./useTheme";
+
+/**
+ * Applies the resolved `web_theme` to the document by setting `data-theme`
+ * on the root element. Renders nothing.
+ */
+export default function ThemeManager() {
+    const resolved = useResolvedTheme();
+
+    useEffect(() => {
+        document.documentElement.setAttribute("data-theme", resolved);
+    }, [resolved]);
+
+    return null;
+}

--- a/web/src/js/components/helpers/useTheme.ts
+++ b/web/src/js/components/helpers/useTheme.ts
@@ -1,0 +1,38 @@
+import { useEffect, useState } from "react";
+import { useAppSelector } from "../../ducks/hooks";
+
+export type Theme = "system" | "dark" | "light";
+export type ResolvedTheme = "dark" | "light";
+
+function systemTheme(): ResolvedTheme {
+    return window.matchMedia("(prefers-color-scheme: dark)").matches
+        ? "dark"
+        : "light";
+}
+
+/**
+ * Resolves the `web_theme` option to a concrete "dark" or "light" value,
+ * following the OS preference (and its live changes) while set to "system".
+ */
+export function useResolvedTheme(): ResolvedTheme {
+    const theme = useAppSelector(
+        (state) => state.options.web_theme as Theme | undefined,
+    );
+    const [resolved, setResolved] = useState<ResolvedTheme>(() =>
+        !theme || theme === "system" ? systemTheme() : theme,
+    );
+
+    useEffect(() => {
+        if (theme && theme !== "system") {
+            setResolved(theme);
+            return;
+        }
+        const mql = window.matchMedia("(prefers-color-scheme: dark)");
+        const update = () => setResolved(mql.matches ? "dark" : "light");
+        update();
+        mql.addEventListener("change", update);
+        return () => mql.removeEventListener("change", update);
+    }, [theme]);
+
+    return resolved;
+}

--- a/web/src/js/ducks/_options_gen.ts
+++ b/web/src/js/ducks/_options_gen.ts
@@ -101,6 +101,7 @@ export interface OptionsState {
     web_password: string;
     web_port: number;
     web_static_viewer: string | undefined;
+    web_theme: string;
     websocket: boolean;
 }
 
@@ -208,5 +209,6 @@ export const defaultState: OptionsState = {
     web_password: "",
     web_port: 8081,
     web_static_viewer: "",
+    web_theme: "system",
     websocket: true,
 };


### PR DESCRIPTION
**Requires https://github.com/mitmproxy/mitmproxy/pull/8316 to be merged first.**

Adds a `web_theme` option (`system`/`dark`/`light`, default `system`) and a dark palette that overrides the color tokens under `[data-theme="dark"]`. `system` follows the OS `prefers-color-scheme` and reacts to live changes. The CodeMirror content editor uses the `one-dark` theme in dark mode. 

Historically, dark mode was declined on maintenance-cost grounds (#3886), but this implementation keeps the cost to a single token-override block plus only a handful of targeted overrides. Hopefully that's simple enough of an implementation to convince you to merge this :)

Closes #7828.

Part of #7789.

## Screenshots

<img width="1910" height="1006" alt="image" src="https://github.com/user-attachments/assets/6363fb43-b352-40f3-be2e-c26e88522b95" />

