### PR TITLE
Uds support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ## Unreleased: mitmproxy next
 
+- Add support for listening to, and forwarding to, unix domain sockets.
 - mitmweb: Honor the `view_order_reversed` option for live flows. New flows are
   now placed at the top of the table when the option is set, instead of always
   being appended at the bottom.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
 
 ## Unreleased: mitmproxy next
 
-- Add support for listening to, and forwarding to, unix domain sockets. 
+- Add support for listening to, and forwarding to, unix domain sockets.
+  ([#8320](https://github.com/mitmproxy/mitmproxy/pull/8320), @yyweiss) 
 - mitmweb: Honor the `view_order_reversed` option for live flows. New flows are
   now placed at the top of the table when the option is set, instead of always
   being appended at the bottom.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 ## Unreleased: mitmproxy next
 
-- Add support for listening to, and forwarding to, unix domain sockets.
+- Add support for listening to, and forwarding to, unix domain sockets. 
 - mitmweb: Honor the `view_order_reversed` option for live flows. New flows are
   now placed at the top of the table when the option is set, instead of always
   being appended at the bottom.

--- a/mitmproxy/addons/block.py
+++ b/mitmproxy/addons/block.py
@@ -27,6 +27,8 @@ class Block:
         )
 
     def client_connected(self, client):
+        if isinstance(client.peername, str):
+            return
         parts = client.peername[0].rsplit("%", 1)
         address = ipaddress.ip_address(parts[0])
         if isinstance(address, ipaddress.IPv6Address):

--- a/mitmproxy/addons/next_layer.py
+++ b/mitmproxy/addons/next_layer.py
@@ -343,11 +343,11 @@ class NextLayer:
         stack = tunnel.LayerStack()
 
         match spec.scheme:
-            case "http":
+            case "http" | "http+unix":
                 if starts_like_tls_record(data_client):
                     stack /= ClientTLSLayer(context)
                 stack /= HttpLayer(context, HTTPMode.transparent)
-            case "https":
+            case "https" | "https+unix":
                 if context.client.transport_protocol == "udp":
                     stack /= ServerQuicLayer(context)
                     stack /= ClientQuicLayer(context)
@@ -358,7 +358,7 @@ class NextLayer:
                         stack /= ClientTLSLayer(context)
                     stack /= HttpLayer(context, HTTPMode.transparent)
 
-            case "tcp":
+            case "tcp" | "unix":
                 if starts_like_tls_record(data_client):
                     stack /= ClientTLSLayer(context)
                 stack /= TCPLayer(context)

--- a/mitmproxy/net/server_spec.py
+++ b/mitmproxy/net/server_spec.py
@@ -9,7 +9,7 @@ from typing import Literal
 from mitmproxy.net import check
 
 ServerSpec = tuple[
-    Literal["http", "https", "http3", "tls", "dtls", "tcp", "udp", "dns", "quic"],
+    Literal["http", "https", "http3", "tls", "dtls", "tcp", "udp", "dns", "quic", "unix", "http+unix", "https+unix"],
     tuple[str, int],
 ]
 
@@ -48,6 +48,8 @@ def parse(server_spec: str, default_scheme: str) -> ServerSpec:
 
     if m.group("scheme"):
         scheme = m.group("scheme")
+    elif m.group("uds"):
+        scheme = "http+unix"
     else:
         scheme = default_scheme
     if scheme not in (
@@ -60,15 +62,30 @@ def parse(server_spec: str, default_scheme: str) -> ServerSpec:
         "udp",
         "dns",
         "quic",
+        "unix",
+        "http+unix",
+        "https+unix",
     ):
         raise ValueError(f"Invalid server scheme: {scheme}")
 
-    host = m.group("host")
-    # IPv6 brackets
-    if host.startswith("[") and host.endswith("]"):
-        host = host[1:-1]
-    if not check.is_valid_host(host):
-        raise ValueError(f"Invalid hostname: {host}")
+    if m.group("uds"):
+        uds = m.group("uds")
+    else:
+        uds = None
+    if uds and "unix" not in scheme:
+        raise ValueError(f"Invalid server scheme for uds mode: {scheme}")
+    elif not uds and "unix" in scheme:
+        raise ValueError(f"Invalid server scheme for network mode: {scheme}")
+
+    if uds:
+        host = uds
+    else:
+        host = m.group("host")
+        # IPv6 brackets
+        if host.startswith("[") and host.endswith("]"):
+            host = host[1:-1]
+        if not check.is_valid_host(host):
+            raise ValueError(f"Invalid hostname: {host}")
 
     if m.group("port"):
         port = int(m.group("port"))
@@ -80,6 +97,9 @@ def parse(server_spec: str, default_scheme: str) -> ServerSpec:
                 "quic": 443,
                 "http3": 443,
                 "dns": 53,
+                "unix": 0,
+                "http+unix": 0,
+                "https+unix": 0,
             }[scheme]
         except KeyError:
             raise ValueError(f"Port specification missing.")

--- a/mitmproxy/net/server_spec.py
+++ b/mitmproxy/net/server_spec.py
@@ -16,10 +16,14 @@ ServerSpec = tuple[
 server_spec_re = re.compile(
     r"""
         ^
-        (?:(?P<scheme>\w+)://)?  # scheme is optional
-        (?P<host>[^:/]+|\[.+\])  # hostname can be DNS name, IPv4, or IPv6 address.
-        (?::(?P<port>\d+))?  #  port is optional
-        /?  #  we allow a trailing backslash, but no path
+        (?:(?P<scheme>[\w+]+)://)?  # scheme is optional
+        (?:
+            (?P<host>[^:/]+|\[.+\])  # hostname can be DNS name, IPv4, or IPv6 address.
+            (?::(?P<port>\d+))?  #  port is optional
+            /?  #  we allow a trailing backslash, but no path
+            |
+            (?P<uds>/.*)
+        )
         $
         """,
     re.VERBOSE,

--- a/mitmproxy/net/server_spec.py
+++ b/mitmproxy/net/server_spec.py
@@ -9,7 +9,20 @@ from typing import Literal
 from mitmproxy.net import check
 
 ServerSpec = tuple[
-    Literal["http", "https", "http3", "tls", "dtls", "tcp", "udp", "dns", "quic", "unix", "http+unix", "https+unix"],
+    Literal[
+        "http",
+        "https",
+        "http3",
+        "tls",
+        "dtls",
+        "tcp",
+        "udp",
+        "dns",
+        "quic",
+        "unix",
+        "http+unix",
+        "https+unix",
+    ],
     tuple[str, int],
 ]
 

--- a/mitmproxy/options.py
+++ b/mitmproxy/options.py
@@ -108,7 +108,7 @@ class Options(optmanager.OptManager):
             "listen_uds",
             Optional[str],
             None,
-            "Unix domain socket to listen to (may be overridden for individual modes, see `mode`). "
+            "Unix domain socket to listen to (may be overridden for individual modes, see `mode`). ",
         )
         self.add_option(
             "mode",

--- a/mitmproxy/options.py
+++ b/mitmproxy/options.py
@@ -105,6 +105,12 @@ class Options(optmanager.OptManager):
             "By default, the port is mode-specific. The default regular HTTP proxy spawns on port 8080.",
         )
         self.add_option(
+            "listen_uds",
+            Optional[str],
+            None,
+            "Unix domain socket to listen to (may be overridden for individual modes, see `mode`). "
+        )
+        self.add_option(
             "mode",
             Sequence[str],
             ["regular"],

--- a/mitmproxy/proxy/layers/modes.py
+++ b/mitmproxy/proxy/layers/modes.py
@@ -73,10 +73,10 @@ class ReverseProxy(DestinationKnown):
 
         # For secure protocols, set SNI if keep_host_header is false
         match spec.scheme:
-            case "http3" | "quic" | "https" | "tls" | "dtls":
+            case "http3" | "quic" | "https" | "tls" | "dtls" | "https+unix":
                 if not self.context.options.keep_host_header:
                     self.context.server.sni = spec.address[0]
-            case "tcp" | "http" | "udp" | "dns":
+            case "tcp" | "http" | "udp" | "dns" | "unix" | "http+unix":
                 pass
             case _:  # pragma: no cover
                 assert_never(spec.scheme)

--- a/mitmproxy/proxy/mode_servers.py
+++ b/mitmproxy/proxy/mode_servers.py
@@ -253,9 +253,10 @@ class AsyncioServerInstance(ServerInstance[M], metaclass=ABCMeta):
         assert not self._servers
         host = self.mode.listen_host(ctx.options.listen_host)
         port = self.mode.listen_port(ctx.options.listen_port)
+        uds = self.mode.listen_uds(ctx.options.listen_uds)
         assert port is not None
         try:
-            self._servers = await self.listen(host, port)
+            self._servers = await self.listen(host, port, uds)
         except OSError as e:
             message = f"{self.mode.description} failed to listen on {host or '*'}:{port} with {e}"
             if e.errno == errno.EADDRINUSE and self.mode.custom_listen_port is None:
@@ -277,7 +278,7 @@ class AsyncioServerInstance(ServerInstance[M], metaclass=ABCMeta):
             self._servers = []
 
     async def listen(
-        self, host: str, port: int
+        self, host: str, port: int, uds: str | None = None
     ) -> list[
         asyncio.Server
         | mitmproxy_rs.udp.UdpServer
@@ -303,9 +304,11 @@ class AsyncioServerInstance(ServerInstance[M], metaclass=ABCMeta):
             | mitmproxy_rs.udp.UdpServer
             | mitmproxy_rs.wireguard.WireGuardServer
         ] = []
-        if self.mode.transport_protocol in ("tcp", "both"):
+        if uds and self.mode.transport_protocol in ("tcp", "both"):
+            servers.append(await asyncio.start_unix_server(self.handle_stream, uds))
+        if self.mode.transport_protocol in ("tcp", "both") and not uds:
             servers.append(await asyncio.start_server(self.handle_stream, host, port))
-        if self.mode.transport_protocol in ("udp", "both"):
+        if self.mode.transport_protocol in ("udp", "both") and not uds:
             # we start two servers for dual-stack support.
             # On Linux, this would also be achievable by toggling IPV6_V6ONLY off, but this here works cross-platform.
             if host == "":

--- a/mitmproxy/proxy/mode_specs.py
+++ b/mitmproxy/proxy/mode_specs.py
@@ -170,7 +170,7 @@ class ProxyMode(Serializable, metaclass=ABCMeta):
         else:
             return self.default_port
 
-    def listen_uds(self, default: str | None = None) -> str:
+    def listen_uds(self, default: str | None = None) -> str | None:
         """
         Return the unix domain socket this mode should listen on. This can be either directly
         specified in the spec or taken from a user-configured global default (`options.listen_uds`).

--- a/mitmproxy/proxy/mode_specs.py
+++ b/mitmproxy/proxy/mode_specs.py
@@ -140,7 +140,11 @@ class ProxyMode(Serializable, metaclass=ABCMeta):
             raise ValueError(f"{mode!r} is not a spec for a {cls.type_name} mode")
 
         return mode_cls(
-            full_spec=spec, data=data, custom_listen_host=host, custom_listen_port=port, custom_listen_uds=uds
+            full_spec=spec,
+            data=data,
+            custom_listen_host=host,
+            custom_listen_port=port,
+            custom_listen_uds=uds,
         )
 
     def listen_host(self, default: str | None = None) -> str:
@@ -248,7 +252,18 @@ class ReverseMode(ProxyMode):
     description = "reverse proxy"
     transport_protocol = TCP
     scheme: Literal[
-        "http", "https", "http3", "tls", "dtls", "tcp", "udp", "dns", "quic", 'unix', 'http+unix', 'https+unix'
+        "http",
+        "https",
+        "http3",
+        "tls",
+        "dtls",
+        "tcp",
+        "udp",
+        "dns",
+        "quic",
+        "unix",
+        "http+unix",
+        "https+unix",
     ]
     address: tuple[str, int]
 

--- a/mitmproxy/proxy/mode_specs.py
+++ b/mitmproxy/proxy/mode_specs.py
@@ -179,10 +179,10 @@ class ProxyMode(Serializable, metaclass=ABCMeta):
         """
         if self.custom_listen_uds is not None:
             return self.custom_listen_uds
-        elif default is not None and self.custom_listen_host is None and self.custom_listen_port is None:
+        elif self.custom_listen_host is None and self.custom_listen_port is None:
             return default
         else:
-            return ""
+            return None
 
     @classmethod
     def from_state(cls, state):

--- a/mitmproxy/proxy/mode_specs.py
+++ b/mitmproxy/proxy/mode_specs.py
@@ -58,6 +58,8 @@ class ProxyMode(Serializable, metaclass=ABCMeta):
     """A custom listen host, if specified in the spec."""
     custom_listen_port: int | None
     """A custom listen port, if specified in the spec."""
+    custom_listen_uds: str | None
+    """A custom listen uds, if specified in the spec."""
 
     type_name: ClassVar[
         str
@@ -107,7 +109,11 @@ class ProxyMode(Serializable, metaclass=ABCMeta):
 
         mode, _, data = head.partition(":")
 
-        if listen_at:
+        if listen_at.startswith("/"):
+            host = None
+            port = None
+            uds = listen_at
+        elif listen_at:
             if ":" in listen_at:
                 host, _, port_str = listen_at.rpartition(":")
             else:
@@ -119,9 +125,11 @@ class ProxyMode(Serializable, metaclass=ABCMeta):
                     raise ValueError
             except ValueError:
                 raise ValueError(f"invalid port: {port_str}")
+            uds = None
         else:
             host = None
             port = None
+            uds = None
 
         try:
             mode_cls = ProxyMode.__types[mode.lower()]
@@ -132,7 +140,7 @@ class ProxyMode(Serializable, metaclass=ABCMeta):
             raise ValueError(f"{mode!r} is not a spec for a {cls.type_name} mode")
 
         return mode_cls(
-            full_spec=spec, data=data, custom_listen_host=host, custom_listen_port=port
+            full_spec=spec, data=data, custom_listen_host=host, custom_listen_port=port, custom_listen_uds=uds
         )
 
     def listen_host(self, default: str | None = None) -> str:

--- a/mitmproxy/proxy/mode_specs.py
+++ b/mitmproxy/proxy/mode_specs.py
@@ -170,6 +170,20 @@ class ProxyMode(Serializable, metaclass=ABCMeta):
         else:
             return self.default_port
 
+    def listen_uds(self, default: str | None = None) -> str:
+        """
+        Return the unix domain socket this mode should listen on. This can be either directly
+        specified in the spec or taken from a user-configured global default (`options.listen_uds`).
+        May be `None` for not listening on a UDS.
+        Returns `None` instead of the default if a custom host or port are set.
+        """
+        if self.custom_listen_uds is not None:
+            return self.custom_listen_uds
+        elif default is not None and self.custom_listen_host is None and self.custom_listen_port is None:
+            return default
+        else:
+            return ""
+
     @classmethod
     def from_state(cls, state):
         return ProxyMode.parse(state)

--- a/mitmproxy/proxy/mode_specs.py
+++ b/mitmproxy/proxy/mode_specs.py
@@ -248,7 +248,7 @@ class ReverseMode(ProxyMode):
     description = "reverse proxy"
     transport_protocol = TCP
     scheme: Literal[
-        "http", "https", "http3", "tls", "dtls", "tcp", "udp", "dns", "quic"
+        "http", "https", "http3", "tls", "dtls", "tcp", "udp", "dns", "quic", 'unix', 'http+unix', 'https+unix'
     ]
     address: tuple[str, int]
 

--- a/mitmproxy/proxy/server.py
+++ b/mitmproxy/proxy/server.py
@@ -208,7 +208,11 @@ class ConnectionHandler(metaclass=abc.ABCMeta):
             writer: asyncio.StreamWriter | mitmproxy_rs.Stream
             try:
                 command.connection.timestamp_start = time.time()
-                if command.connection.transport_protocol == "tcp":
+                if command.connection.transport_protocol == "tcp" and command.connection.address[0].startswith("/"):
+                    reader, writer = await asyncio.open_unix_connection(
+                        command.connection.address[0],
+                    )
+                elif command.connection.transport_protocol == "tcp":
                     reader, writer = await asyncio.open_connection(
                         *command.connection.address,
                         local_addr=command.connection.sockname,

--- a/mitmproxy/proxy/server.py
+++ b/mitmproxy/proxy/server.py
@@ -208,7 +208,10 @@ class ConnectionHandler(metaclass=abc.ABCMeta):
             writer: asyncio.StreamWriter | mitmproxy_rs.Stream
             try:
                 command.connection.timestamp_start = time.time()
-                if command.connection.transport_protocol == "tcp" and command.connection.address[0].startswith("/"):
+                if (
+                    command.connection.transport_protocol == "tcp"
+                    and command.connection.address[0].startswith("/")
+                ):
                     reader, writer = await asyncio.open_unix_connection(
                         command.connection.address[0],
                     )

--- a/mitmproxy/tools/cmdline.py
+++ b/mitmproxy/tools/cmdline.py
@@ -61,6 +61,7 @@ def common_options(parser, opts):
     group = parser.add_argument_group("Proxy Options")
     opts.make_parser(group, "listen_host", metavar="HOST")
     opts.make_parser(group, "listen_port", metavar="PORT", short="p")
+    opts.make_parser(group, "listen_uds")
     opts.make_parser(group, "server", short="n")
     opts.make_parser(group, "ignore_hosts", metavar="HOST")
     opts.make_parser(group, "allow_hosts", metavar="HOST")

--- a/mitmproxy/utils/human.py
+++ b/mitmproxy/utils/human.py
@@ -78,13 +78,15 @@ def format_timestamp_with_milli(s):
 
 
 @functools.lru_cache
-def format_address(address: tuple | None) -> str:
+def format_address(address: tuple | str | None) -> str:
     """
     This function accepts IPv4/IPv6 tuples and
     returns the formatted address string with port number
     """
     if address is None:
         return "<no address>"
+    if isinstance(address, str):
+        return address
     try:
         host = ipaddress.ip_address(address[0])
         if host.is_unspecified:

--- a/test/mitmproxy/addons/test_block.py
+++ b/test/mitmproxy/addons/test_block.py
@@ -51,6 +51,11 @@ from mitmproxy.test import taddons
         (False, True, False, ("::ffff:216.58.207.174",)),
         (False, True, False, (r"::ffff:216.58.207.174%scope",)),
         (False, True, False, ("2001:4860:4860::8888",)),
+        # uds: never block
+        (False, True, False, "/tmp/mitmproxy.sock"),
+        (False, False, False, "/tmp/mitmproxy.sock"),
+        (True, True, False, "/tmp/mitmproxy.sock"),
+        (True, False, False, "/tmp/mitmproxy.sock"),
     ],
 )
 async def test_block_global(block_global, block_private, should_be_killed, address):

--- a/test/mitmproxy/net/test_server_spec.py
+++ b/test/mitmproxy/net/test_server_spec.py
@@ -38,3 +38,9 @@ def test_parse_err():
 
     with pytest.raises(ValueError, match="Port specification missing"):
         server_spec.parse("example.com", "tcp")
+
+    with pytest.raises(ValueError, match="Invalid server scheme for uds mode"):
+        server_spec.parse("tcp:///tmp/mitmproxy.sock", "https")
+
+    with pytest.raises(ValueError, match="Invalid server scheme for network mode"):
+        server_spec.parse("unix://example.com", "https")

--- a/test/mitmproxy/net/test_server_spec.py
+++ b/test/mitmproxy/net/test_server_spec.py
@@ -14,6 +14,9 @@ from mitmproxy.net import server_spec
         ("http://[::1]/", "https", ("http", ("::1", 80))),
         ("https://[::1]/", "https", ("https", ("::1", 443))),
         ("http://[::1]:8080", "https", ("http", ("::1", 8080))),
+        ("http+unix:///tmp/mitmproxy.sock", "https", ("http+unix", ("/tmp/mitmproxy.sock", 0))),
+        ("unix:///tmp/mitmproxy.sock", "https", ("unix", ("/tmp/mitmproxy.sock", 0))),
+        ("/tmp/mitmproxy.sock", "https", ("http+unix", ("/tmp/mitmproxy.sock", 0))),
     ],
 )
 def test_parse(spec, default_scheme, out):

--- a/test/mitmproxy/net/test_server_spec.py
+++ b/test/mitmproxy/net/test_server_spec.py
@@ -14,7 +14,11 @@ from mitmproxy.net import server_spec
         ("http://[::1]/", "https", ("http", ("::1", 80))),
         ("https://[::1]/", "https", ("https", ("::1", 443))),
         ("http://[::1]:8080", "https", ("http", ("::1", 8080))),
-        ("http+unix:///tmp/mitmproxy.sock", "https", ("http+unix", ("/tmp/mitmproxy.sock", 0))),
+        (
+            "http+unix:///tmp/mitmproxy.sock",
+            "https",
+            ("http+unix", ("/tmp/mitmproxy.sock", 0)),
+        ),
         ("unix:///tmp/mitmproxy.sock", "https", ("unix", ("/tmp/mitmproxy.sock", 0))),
         ("/tmp/mitmproxy.sock", "https", ("http+unix", ("/tmp/mitmproxy.sock", 0))),
     ],

--- a/test/mitmproxy/proxy/test_mode_servers.py
+++ b/test/mitmproxy/proxy/test_mode_servers.py
@@ -98,6 +98,7 @@ async def test_tcp_start_stop(caplog_async):
         assert await caplog_async.await_log("stopped")
 
 
+@pytest.mark.skipif(not hasattr(asyncio, "start_unix_server"), reason="Unix sockets not supported")
 async def test_uds_start_stop(caplog_async):
     caplog_async.set_level("INFO")
     manager = MagicMock()

--- a/test/mitmproxy/proxy/test_mode_servers.py
+++ b/test/mitmproxy/proxy/test_mode_servers.py
@@ -98,13 +98,17 @@ async def test_tcp_start_stop(caplog_async):
         assert await caplog_async.await_log("stopped")
 
 
-@pytest.mark.skipif(not hasattr(asyncio, "start_unix_server"), reason="Unix sockets not supported")
+@pytest.mark.skipif(
+    not hasattr(asyncio, "start_unix_server"), reason="Unix sockets not supported"
+)
 async def test_uds_start_stop(caplog_async):
     caplog_async.set_level("INFO")
     manager = MagicMock()
 
     with taddons.context():
-        inst = ServerInstance.make("regular@/tmp/mitmproxy_test_uds_start_stop.sock", manager)
+        inst = ServerInstance.make(
+            "regular@/tmp/mitmproxy_test_uds_start_stop.sock", manager
+        )
         await inst.start()
         assert inst.last_exception is None
         assert await caplog_async.await_log("proxy listening")

--- a/test/mitmproxy/proxy/test_mode_servers.py
+++ b/test/mitmproxy/proxy/test_mode_servers.py
@@ -98,6 +98,28 @@ async def test_tcp_start_stop(caplog_async):
         assert await caplog_async.await_log("stopped")
 
 
+async def test_uds_start_stop(caplog_async):
+    caplog_async.set_level("INFO")
+    manager = MagicMock()
+
+    with taddons.context():
+        inst = ServerInstance.make("regular@/tmp/mitmproxy_test_uds_start_stop.sock", manager)
+        await inst.start()
+        assert inst.last_exception is None
+        assert await caplog_async.await_log("proxy listening")
+
+        path = inst.listen_addrs[0]
+        reader, writer = await asyncio.open_unix_connection(path)
+        assert await caplog_async.await_log("client connect")
+
+        writer.close()
+        await writer.wait_closed()
+        assert await caplog_async.await_log("client disconnect")
+
+        await inst.stop()
+        assert await caplog_async.await_log("stopped")
+
+
 async def test_tcp_timeout(caplog_async):
     """Test that TCP connections are closed after the configured timeout period."""
     caplog_async.set_level("INFO")

--- a/test/mitmproxy/proxy/test_mode_specs.py
+++ b/test/mitmproxy/proxy/test_mode_specs.py
@@ -55,6 +55,9 @@ def test_listen_addr():
     assert ProxyMode.parse("reverse:https://1.2.3.4").listen_port() == 8080
     assert ProxyMode.parse("reverse:dns://8.8.8.8").listen_port() == 53
 
+    assert ProxyMode.parse("regular").listen_uds() is None
+    assert ProxyMode.parse("regular@1234").listen_uds() is None
+    assert ProxyMode.parse("regular@/tmp/test.sock").listen_uds() == "/tmp/test.sock"
 
 def test_parse_specific_modes():
     assert ProxyMode.parse("regular")

--- a/test/mitmproxy/proxy/test_mode_specs.py
+++ b/test/mitmproxy/proxy/test_mode_specs.py
@@ -59,6 +59,7 @@ def test_listen_addr():
     assert ProxyMode.parse("regular@1234").listen_uds() is None
     assert ProxyMode.parse("regular@/tmp/test.sock").listen_uds() == "/tmp/test.sock"
 
+
 def test_parse_specific_modes():
     assert ProxyMode.parse("regular")
     # assert ProxyMode.parse("http3")

--- a/test/mitmproxy/proxy/test_server.py
+++ b/test/mitmproxy/proxy/test_server.py
@@ -73,7 +73,9 @@ async def test_open_connection(result, monkeypatch):
     assert server_disconnected.called == (result == "success")
 
 
-@pytest.mark.skipif(not hasattr(asyncio, "start_unix_server"), reason="Unix sockets not supported")
+@pytest.mark.skipif(
+    not hasattr(asyncio, "start_unix_server"), reason="Unix sockets not supported"
+)
 @pytest.mark.parametrize("result", ("success", "killed", "failed"))
 async def test_open_unix_connection(result, monkeypatch):
     handler = MockConnectionHandler()

--- a/test/mitmproxy/proxy/test_server.py
+++ b/test/mitmproxy/proxy/test_server.py
@@ -73,6 +73,48 @@ async def test_open_connection(result, monkeypatch):
     assert server_disconnected.called == (result == "success")
 
 
+@pytest.mark.skipif(not hasattr(asyncio, "start_unix_server"), reason="Unix sockets not supported")
+@pytest.mark.parametrize("result", ("success", "killed", "failed"))
+async def test_open_unix_connection(result, monkeypatch):
+    handler = MockConnectionHandler()
+    server_connect = handler.hook_handlers["server_connect"]
+    server_connected = handler.hook_handlers["server_connected"]
+    server_connect_error = handler.hook_handlers["server_connect_error"]
+    server_disconnected = handler.hook_handlers["server_disconnected"]
+
+    match result:
+        case "success":
+            monkeypatch.setattr(
+                asyncio,
+                "open_unix_connection",
+                mock.AsyncMock(return_value=(mock.MagicMock(), mock.MagicMock())),
+            )
+            monkeypatch.setattr(
+                MockConnectionHandler, "handle_connection", mock.AsyncMock()
+            )
+        case "failed":
+            monkeypatch.setattr(
+                asyncio, "open_unix_connection", mock.AsyncMock(side_effect=OSError)
+            )
+        case "killed":
+
+            def _kill(d: server_hooks.ServerConnectionHookData) -> None:
+                d.server.error = "do not connect"
+
+            server_connect.side_effect = _kill
+
+    await handler.open_connection(
+        commands.OpenConnection(connection=Server(address=("/sock", 0)))
+    )
+
+    assert server_connect.call_args[0][0].server.address == ("/sock", 0)
+
+    assert server_connected.called == (result == "success")
+    assert server_connect_error.called == (result != "success")
+
+    assert server_disconnected.called == (result == "success")
+
+
 async def test_no_reentrancy(capsys):
     class ReentrancyTestLayer(layer.Layer):
         def handle_event(self, event: Event) -> layer.CommandGenerator[None]:

--- a/test/mitmproxy/utils/test_human.py
+++ b/test/mitmproxy/utils/test_human.py
@@ -64,3 +64,4 @@ def test_format_address():
     assert human.format_address(("::", "8080")) == "*:8080"
     assert human.format_address(("0.0.0.0", "8080")) == "*:8080"
     assert human.format_address(None) == "<no address>"
+    assert human.format_address("/tmp/mitmproxy.sock") == "/tmp/mitmproxy.sock"

--- a/web/gen/backend_consts.py
+++ b/web/gen/backend_consts.py
@@ -15,7 +15,7 @@ filename = here / "../src/js/backends/consts.ts"
 async def make() -> str:
     protocols = typing.get_args(typing.get_type_hints(ReverseMode)["scheme"])
     protocol_enum = ",\n    ".join(
-        f'{protocol.upper()} = "{protocol.lower()}"' for protocol in protocols
+        f'{protocol.upper().replace("+", "_PLUS_")} = "{protocol.lower()}"' for protocol in protocols
     )
 
     langs = typing.get_args(SyntaxHighlight.__value__)

--- a/web/gen/backend_consts.py
+++ b/web/gen/backend_consts.py
@@ -15,7 +15,8 @@ filename = here / "../src/js/backends/consts.ts"
 async def make() -> str:
     protocols = typing.get_args(typing.get_type_hints(ReverseMode)["scheme"])
     protocol_enum = ",\n    ".join(
-        f'{protocol.upper().replace("+", "_PLUS_")} = "{protocol.lower()}"' for protocol in protocols
+        f'{protocol.upper().replace("+", "_PLUS_")} = "{protocol.lower()}"'
+        for protocol in protocols
     )
 
     langs = typing.get_args(SyntaxHighlight.__value__)

--- a/web/src/js/backends/consts.ts
+++ b/web/src/js/backends/consts.ts
@@ -10,8 +10,8 @@ export enum ReverseProxyProtocols {
     DNS = "dns",
     QUIC = "quic",
     UNIX = "unix",
-    HTTP+UNIX = "http+unix",
-    HTTPS+UNIX = "https+unix",
+    HTTP_PLUS_UNIX = "http+unix",
+    HTTPS_PLUS_UNIX = "https+unix",
 }
 
 export enum SyntaxHighlight {

--- a/web/src/js/backends/consts.ts
+++ b/web/src/js/backends/consts.ts
@@ -9,6 +9,9 @@ export enum ReverseProxyProtocols {
     UDP = "udp",
     DNS = "dns",
     QUIC = "quic",
+    UNIX = "unix",
+    HTTP+UNIX = "http+unix",
+    HTTPS+UNIX = "https+unix",
 }
 
 export enum SyntaxHighlight {

--- a/web/src/js/ducks/_options_gen.ts
+++ b/web/src/js/ducks/_options_gen.ts
@@ -37,6 +37,7 @@ export interface OptionsState {
     key_size: number;
     listen_host: string;
     listen_port: number | undefined;
+    listen_uds: string | undefined;
     map_local: string[];
     map_remote: string[];
     mode: string[];
@@ -144,6 +145,7 @@ export const defaultState: OptionsState = {
     key_size: 2048,
     listen_host: "",
     listen_port: undefined,
+    listen_uds: undefined,
     map_local: [],
     map_remote: [],
     mode: ["regular"],


### PR DESCRIPTION
#### Description

Adds support for listening to a unix domain socket (issue #7072) and forwarding to a uds (issue #1936)

The changes do not change any existing behaviors, except for some invalid inputs becoming valid.

No existing tests had to be changed. I added some new test cases, though more should probably be added.

#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
