### PR TITLE
Add machine-readable Code enum to flow.Error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 
 ## Unreleased: mitmproxy next
 
+- Add a machine-readable `code` to `mitmproxy.flow.Error` (a `flow.Error.Code`
+  enum: `GENERIC`, `KILLED`, `CONNECTION`, `TIMEOUT`, `PROTOCOL`) so error
+  categories can be determined without parsing the human-readable `msg`.
 - mitmweb: Honor the `view_order_reversed` option for live flows. New flows are
   now placed at the top of the table when the option is set, instead of always
   being appended at the bottom.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Add a machine-readable `code` to `mitmproxy.flow.Error` (a `flow.Error.Code`
   enum: `GENERIC`, `KILLED`, `CONNECTION`, `TIMEOUT`, `PROTOCOL`) so error
   categories can be determined without parsing the human-readable `msg`.
+  ([#8321](https://github.com/mitmproxy/mitmproxy/pull/8321), @youdie006)
 - mitmweb: Honor the `view_order_reversed` option for live flows. New flows are
   now placed at the top of the table when the option is set, instead of always
   being appended at the bottom.

--- a/mitmproxy/flow.py
+++ b/mitmproxy/flow.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import copy
+import enum
 import time
 import uuid
 from dataclasses import dataclass
@@ -26,11 +27,34 @@ class Error(serializable.SerializableDataclass):
     communications, like interrupted connections, timeouts, or protocol errors.
     """
 
+    class Code(enum.Enum):
+        """
+        Machine-readable category of an `Error`.
+
+        Unlike `Error.msg`, which is a human-readable description that may change
+        at any time, these values are stable and safe to branch on. This
+        enumeration also documents which kinds of errors mitmproxy can produce.
+        """
+
+        GENERIC = "generic"
+        """An error that does not fit any of the more specific categories."""
+        KILLED = "killed"
+        """The flow was killed by the user or an addon."""
+        CONNECTION = "connection"
+        """A connection could not be established or was interrupted."""
+        TIMEOUT = "timeout"
+        """An operation timed out."""
+        PROTOCOL = "protocol"
+        """The peer violated the protocol or sent data mitmproxy could not process."""
+
     msg: str
     """Message describing the error."""
 
     timestamp: float = field(default_factory=time.time)
     """Unix timestamp of when this error happened."""
+
+    code: Code = Code.GENERIC
+    """Machine-readable error category. See `Error.Code`."""
 
     KILLED_MESSAGE: ClassVar[str] = "Connection killed."
 
@@ -237,7 +261,7 @@ class Flow(serializable.Serializable):
         #  flows in transit (https://github.com/mitmproxy/mitmproxy/issues/4711), even though they are advertised
         #  as killable. An alternative approach would be to introduce a `KillInjected` event similar to
         #  `MessageInjected`, which should fix this issue.
-        self.error = Error(Error.KILLED_MESSAGE)
+        self.error = Error(Error.KILLED_MESSAGE, code=Error.Code.KILLED)
         self.intercepted = False
         self.live = False
 

--- a/mitmproxy/io/compat.py
+++ b/mitmproxy/io/compat.py
@@ -433,6 +433,15 @@ def convert_20_21(data):
     return data
 
 
+def convert_21_22(data):
+    data["version"] = 22
+    # flow.Error gained a machine-readable `code`. Existing errors predate the
+    # categorization, so they default to flow.Error.Code.GENERIC.
+    if data["error"] is not None:
+        data["error"]["code"] = "generic"
+    return data
+
+
 def _convert_dict_keys(o: Any) -> Any:
     if isinstance(o, dict):
         return {strutils.always_str(k): _convert_dict_keys(v) for k, v in o.items()}
@@ -498,6 +507,7 @@ converters = {
     18: convert_18_19,
     19: convert_19_20,
     20: convert_20_21,
+    21: convert_21_22,
 }
 
 

--- a/mitmproxy/proxy/layers/http/__init__.py
+++ b/mitmproxy/proxy/layers/http/__init__.py
@@ -668,7 +668,7 @@ class HttpStream(layer.Layer):
                 )
 
         if err:
-            self.flow.error = flow.Error(err)
+            self.flow.error = flow.Error(err, code=flow.Error.Code.PROTOCOL)
 
             if request:
                 # flow has not been seen yet, register it.
@@ -707,7 +707,9 @@ class HttpStream(layer.Layer):
 
         if killed_by_remote:
             if not self.flow.error:
-                self.flow.error = flow.Error(killed_by_remote)
+                self.flow.error = flow.Error(
+                    killed_by_remote, code=flow.Error.Code.CONNECTION
+                )
         if killed_by_us or killed_by_remote:
             if emit_error_hook:
                 yield HttpErrorHook(self.flow)
@@ -740,7 +742,7 @@ class HttpStream(layer.Layer):
         if need_error_hook:
             # We don't want to trigger both a response hook and an error hook,
             # so we need to check if the response is done yet or not.
-            self.flow.error = flow.Error(event.message)
+            self.flow.error = flow.Error(event.message, code=flow.Error.Code.PROTOCOL)
             yield HttpErrorHook(self.flow)
 
         if (yield from self.check_killed(False)):

--- a/mitmproxy/proxy/layers/tcp.py
+++ b/mitmproxy/proxy/layers/tcp.py
@@ -81,7 +81,9 @@ class TCPLayer(layer.Layer):
             err = yield commands.OpenConnection(self.context.server)
             if err:
                 if self.flow:
-                    self.flow.error = flow.Error(str(err))
+                    self.flow.error = flow.Error(
+                        str(err), code=flow.Error.Code.CONNECTION
+                    )
                     yield TcpErrorHook(self.flow)
                 yield commands.CloseConnection(self.context.client)
                 self._handle_event = self.done

--- a/mitmproxy/proxy/layers/udp.py
+++ b/mitmproxy/proxy/layers/udp.py
@@ -80,7 +80,9 @@ class UDPLayer(layer.Layer):
             err = yield commands.OpenConnection(self.context.server)
             if err:
                 if self.flow:
-                    self.flow.error = flow.Error(str(err))
+                    self.flow.error = flow.Error(
+                        str(err), code=flow.Error.Code.CONNECTION
+                    )
                     yield UdpErrorHook(self.flow)
                 yield commands.CloseConnection(self.context.client)
                 self._handle_event = self.done

--- a/mitmproxy/version.py
+++ b/mitmproxy/version.py
@@ -7,7 +7,7 @@ MITMPROXY = "mitmproxy " + VERSION
 
 # Serialization format version. This is displayed nowhere, it just needs to be incremented by one
 # for each change in the file format.
-FLOW_FORMAT_VERSION = 21
+FLOW_FORMAT_VERSION = 22
 
 
 def get_dev_version() -> str:

--- a/test/mitmproxy/io/test_compat.py
+++ b/test/mitmproxy/io/test_compat.py
@@ -2,6 +2,7 @@ import pytest
 
 from mitmproxy import exceptions
 from mitmproxy import io
+from mitmproxy.io import compat
 
 
 @pytest.mark.parametrize(
@@ -29,3 +30,16 @@ def test_cannot_convert(tdata):
         flow_reader = io.FlowReader(f)
         with pytest.raises(exceptions.FlowReadException):
             list(flow_reader.stream())
+
+
+def test_convert_21_22():
+    # Flows with an error gain the new machine-readable error code, defaulting
+    # to GENERIC for pre-existing flows.
+    with_error = {"version": 21, "error": {"msg": "boom", "timestamp": 1.0}}
+    assert compat.convert_21_22(with_error) == {
+        "version": 22,
+        "error": {"msg": "boom", "timestamp": 1.0, "code": "generic"},
+    }
+    # Flows without an error are left untouched apart from the version bump.
+    no_error = {"version": 21, "error": None}
+    assert compat.convert_21_22(no_error) == {"version": 22, "error": None}

--- a/test/mitmproxy/test_flow.py
+++ b/test/mitmproxy/test_flow.py
@@ -168,3 +168,28 @@ class TestError:
         e = flow.Error("yay")
         assert repr(e)
         assert str(e)
+
+    def test_code_default(self):
+        # The machine-readable code defaults to GENERIC, and the
+        # human-readable message is unaffected.
+        e = flow.Error("something went wrong")
+        assert e.code == flow.Error.Code.GENERIC
+        assert e.msg == "something went wrong"
+
+    def test_code_explicit(self):
+        e = flow.Error(flow.Error.KILLED_MESSAGE, code=flow.Error.Code.KILLED)
+        assert e.code == flow.Error.Code.KILLED
+        assert e.msg == flow.Error.KILLED_MESSAGE
+
+    def test_code_roundtrip(self):
+        e = flow.Error("boom", code=flow.Error.Code.PROTOCOL)
+        state = e.get_state()
+        # The code is serialized by its (stable) string value.
+        assert state["code"] == "protocol"
+        assert flow.Error.from_state(state).code == flow.Error.Code.PROTOCOL
+
+        e2 = flow.Error("other")
+        assert e2.code == flow.Error.Code.GENERIC
+        e2.set_state(e.get_state())
+        assert e2.code == flow.Error.Code.PROTOCOL
+        assert e2.get_state() == e.get_state()

--- a/web/src/js/__tests__/ducks/_tflow.ts
+++ b/web/src/js/__tests__/ducks/_tflow.ts
@@ -24,6 +24,7 @@ export function THTTPFlow(): Required<HTTPFlow> {
         },
         "comment": "I'm a comment!",
         "error": {
+            "code": "generic",
             "msg": "error",
             "timestamp": 946681207.0
         },
@@ -184,6 +185,7 @@ export function TTCPFlow(): Required<TCPFlow> {
         },
         "comment": "",
         "error": {
+            "code": "generic",
             "msg": "error",
             "timestamp": 946681207.0
         },
@@ -250,6 +252,7 @@ export function TUDPFlow(): Required<UDPFlow> {
         },
         "comment": "",
         "error": {
+            "code": "generic",
             "msg": "error",
             "timestamp": 946681207.0
         },
@@ -316,6 +319,7 @@ export function TDNSFlow(): Required<DNSFlow> {
         },
         "comment": "",
         "error": {
+            "code": "generic",
             "msg": "error",
             "timestamp": 946681207.0
         },


### PR DESCRIPTION
Closes #4554.

Adds a machine-readable category to `flow.Error` so consumers can distinguish interrupted connections, timeouts, and protocol errors, while the human-facing `msg` is unchanged (as the issue requests).

- New nested `Error.Code` enum: `GENERIC` (default) / `KILLED` / `CONNECTION` / `TIMEOUT` / `PROTOCOL`. Nested to avoid colliding with the existing HTTP `ErrorCode` int enum.
- The `code` field is placed after `timestamp` to preserve positional back-compat (`Error(msg, ts)`), and `kill()` sets `KILLED`. Codes are set at categorizable construction sites (connection-open failures -> CONNECTION, header validation / protocol errors -> PROTOCOL); GENERIC elsewhere.
- Flow format bumped 21 -> 22 with a `convert_21_22` migration so existing `.mitm` files still load.

Design follows the issue and the review on the earlier (abandoned) #5662: a GENERIC default instead of a required arg (no breaking change), KILLED unified into the enum, and the format migration.

## Test plan
Added `test_flow.py::TestError` cases (default/explicit/round-trip) and `test_compat.py::test_convert_21_22` (red->green). `test_flow.py` + `test_compat.py` + `test_io.py` -> 33 passed; proxy layer tests -> 259 passed. ruff + mypy clean.

---

*AI disclosure: this PR was drafted with Claude Code (AI-assisted). Tests were run red->green locally (test_flow + test_compat independently re-verified: 21 passed).*