### PR TITLE
Make per-address connection concurrency limit configurable

### DIFF
--- a/mitmproxy/options.py
+++ b/mitmproxy/options.py
@@ -245,5 +245,15 @@ class Options(optmanager.OptManager):
             Timeout in seconds for inactive TCP connections. Connections will be closed after this period of inactivity.
             """,
         )
+        self.add_option(
+            "connection_max_per_address",
+            int,
+            5,
+            """
+            Maximum number of concurrent connections mitmproxy will hold open to any single
+            destination address. A destination that already has this many connections open
+            will delay new ones until one of the existing connections closes.
+            """,
+        )
 
         self.update(**kwargs)

--- a/mitmproxy/proxy/server.py
+++ b/mitmproxy/proxy/server.py
@@ -106,7 +106,9 @@ class ConnectionHandler(metaclass=abc.ABCMeta):
     def __init__(self, context: Context) -> None:
         self.client = context.client
         self.transports = {}
-        self.max_conns = collections.defaultdict(lambda: asyncio.Semaphore(5))
+        self.max_conns = collections.defaultdict(
+            lambda: asyncio.Semaphore(context.options.connection_max_per_address)
+        )
         self.wakeup_timer = set()
 
         # Ask for the first layer right away.

--- a/test/mitmproxy/proxy/test_server.py
+++ b/test/mitmproxy/proxy/test_server.py
@@ -22,11 +22,11 @@ from mitmproxy.proxy.mode_specs import ProxyMode
 class MockConnectionHandler(server.SimpleConnectionHandler):
     hook_handlers: dict[str, mock.Mock | Callable]
 
-    def __init__(self):
+    def __init__(self, opts: options.Options | None = None):
         super().__init__(
             reader=mock.Mock(),
             writer=mock.Mock(),
-            options=options.Options(),
+            options=opts or options.Options(),
             mode=ProxyMode.parse("regular"),
             hook_handlers=collections.defaultdict(lambda: mock.Mock()),
         )
@@ -71,6 +71,33 @@ async def test_open_connection(result, monkeypatch):
     assert server_connect_error.called == (result != "success")
 
     assert server_disconnected.called == (result == "success")
+
+
+async def test_max_conns_defaults_to_five():
+    handler = MockConnectionHandler()
+    semaphore = handler.max_conns[("server", 1234)]
+
+    await asyncio.wait_for(
+        asyncio.gather(*(semaphore.acquire() for _ in range(5))), timeout=0.05
+    )
+    assert semaphore.locked()
+
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(semaphore.acquire(), timeout=0.05)
+
+
+async def test_max_conns_respects_connection_max_per_address_option():
+    opts = options.Options(connection_max_per_address=8)
+    handler = MockConnectionHandler(opts)
+    semaphore = handler.max_conns[("server", 1234)]
+
+    await asyncio.wait_for(
+        asyncio.gather(*(semaphore.acquire() for _ in range(8))), timeout=0.05
+    )
+    assert semaphore.locked()
+
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(semaphore.acquire(), timeout=0.05)
 
 
 async def test_no_reentrancy(capsys):

--- a/web/src/js/ducks/_options_gen.ts
+++ b/web/src/js/ducks/_options_gen.ts
@@ -18,6 +18,7 @@ export interface OptionsState {
     command_history: boolean;
     confdir: string;
     connect_addr: string | undefined;
+    connection_max_per_address: number;
     connection_strategy: string;
     console_focus_follow: boolean;
     content_view_lines_cutoff: number;
@@ -125,6 +126,7 @@ export const defaultState: OptionsState = {
     command_history: true,
     confdir: "~/.mitmproxy",
     connect_addr: undefined,
+    connection_max_per_address: 5,
     connection_strategy: "eager",
     console_focus_follow: false,
     content_view_lines_cutoff: 512,


### PR DESCRIPTION
Fixes #8322

## Summary

`ConnectionHandler.__init__` hardcoded `asyncio.Semaphore(5)` as the concurrency cap for connections to any single destination address, held for the connection's entire lifetime (`open_connection()` wraps `handle_connection()` inside the `async with self.max_conns[address]:` block). There was no `Options` field or `--set` flag for this value anywhere — a 6th concurrent connection to the same address just queues indefinitely behind whichever of the 5 stays open longest.

This adds `connection_max_per_address` (default `5`, so behavior is unchanged unless a user opts in) and reads it in `ConnectionHandler.__init__` instead of the hardcoded literal.

## Changes

- `mitmproxy/options.py`: new `connection_max_per_address` option, default `5`.
- `mitmproxy/proxy/server.py`: `ConnectionHandler.__init__` reads the option instead of the hardcoded `5`.
- `test/mitmproxy/proxy/test_server.py`: two new tests asserting the *behavior* (the Nth+1 connection actually blocks / doesn't block) via the public `Semaphore` API (`acquire`/`locked`), not by inspecting private state. One pins the existing default-5 behavior, the other confirms a custom `connection_max_per_address` is honored.

## Testing

- `pytest test/mitmproxy/proxy/test_server.py test/mitmproxy/test_options.py` — all pass.
- `ruff check` / `ruff format --check` / `mypy` on the changed files — all clean.