### PR TITLE
Fix resource leak in proxy server connection cleanup

### DIFF
--- a/mitmproxy/proxy/server.py
+++ b/mitmproxy/proxy/server.py
@@ -325,8 +325,7 @@ class ConnectionHandler(metaclass=abc.ABCMeta):
             writer.close()
         except OSError:
             pass
-        finally:
-            self.transports.pop(connection, None)
+        self.transports.pop(connection, None)
 
         if cancelled:
             raise cancelled
@@ -612,3 +611,4 @@ if __name__ == "__main__":  # pragma: no cover
     server.close()
     loop.run_until_complete(server.wait_closed())
     loop.close()
+

--- a/mitmproxy/proxy/server.py
+++ b/mitmproxy/proxy/server.py
@@ -142,7 +142,10 @@ class ConnectionHandler(metaclass=abc.ABCMeta):
             self.log("client kill connection")
             writer = self.transports.pop(self.client).writer
             assert writer
-            writer.close()
+            try:
+                writer.close()
+            except OSError:
+                pass
         else:
             await self.server_event(events.Start())
             handler = asyncio_utils.create_task(
@@ -322,7 +325,8 @@ class ConnectionHandler(metaclass=abc.ABCMeta):
             writer.close()
         except OSError:
             pass
-        self.transports.pop(connection)
+        finally:
+            self.transports.pop(connection, None)
 
         if cancelled:
             raise cancelled

--- a/mitmproxy/proxy/server.py
+++ b/mitmproxy/proxy/server.py
@@ -611,4 +611,3 @@ if __name__ == "__main__":  # pragma: no cover
     server.close()
     loop.run_until_complete(server.wait_closed())
     loop.close()
-

--- a/test/mitmproxy/proxy/test_server.py
+++ b/test/mitmproxy/proxy/test_server.py
@@ -8,6 +8,7 @@ from unittest import mock
 import pytest
 
 from mitmproxy import options
+from mitmproxy.connection import ConnectionState
 from mitmproxy.connection import Server
 from mitmproxy.proxy import commands
 from mitmproxy.proxy import layer
@@ -136,7 +137,7 @@ async def test_handle_connection_cleanup_with_oserror():
 
     # Create a mock connection
     connection = Server(address=("server", 1234))
-    connection.state = 0  # ConnectionState.CLOSED
+    connection.state = ConnectionState.CLOSED
 
     # Set up a transport with a writer that raises OSError on close
     mock_writer = mock.Mock()
@@ -169,7 +170,7 @@ async def test_handle_connection_cleanup_success():
 
     # Create a mock connection
     connection = Server(address=("server", 1234))
-    connection.state = 0  # ConnectionState.CLOSED
+    connection.state = ConnectionState.CLOSED
 
     # Set up a transport with a normal writer
     mock_writer = mock.Mock()

--- a/test/mitmproxy/proxy/test_server.py
+++ b/test/mitmproxy/proxy/test_server.py
@@ -104,3 +104,92 @@ async def test_no_reentrancy(capsys):
         Hook completed (must not happen before start is completed).
         """
     )
+
+
+async def test_handle_client_writer_close_oserror():
+    """Test that handle_client handles OSError when closing writer."""
+    handler = MockConnectionHandler()
+    handler.client.error = "test error"
+
+    # Set up a transport with a writer that raises OSError on close
+    mock_writer = mock.Mock()
+    mock_writer.close.side_effect = OSError("Connection reset")
+    handler.transports[handler.client] = server.ConnectionIO(
+        handler=None,
+        reader=mock.Mock(),
+        writer=mock_writer,
+    )
+
+    # Mock the hooks to avoid actual execution
+    handler.handle_hook = mock.AsyncMock()
+
+    # This should not raise an exception
+    await handler.handle_client()
+
+    # Verify writer.close() was called
+    mock_writer.close.assert_called_once()
+
+
+async def test_handle_connection_cleanup_with_oserror():
+    """Test that handle_connection properly cleans up transports even when writer.close() raises OSError."""
+    handler = MockConnectionHandler()
+
+    # Create a mock connection
+    connection = Server(address=("server", 1234))
+    connection.state = 0  # ConnectionState.CLOSED
+
+    # Set up a transport with a writer that raises OSError on close
+    mock_writer = mock.Mock()
+    mock_writer.close.side_effect = OSError("Connection reset")
+    mock_reader = mock.AsyncMock()
+    mock_reader.read.side_effect = OSError("Connection closed")
+
+    handler.transports[connection] = server.ConnectionIO(
+        handler=None,
+        reader=mock_reader,
+        writer=mock_writer,
+    )
+
+    # Mock the hooks to avoid actual execution
+    handler.handle_hook = mock.AsyncMock()
+    handler.server_event = mock.AsyncMock()
+
+    # This should not raise an exception
+    await handler.handle_connection(connection)
+
+    # Verify writer.close() was called
+    mock_writer.close.assert_called_once()
+    # Verify transport was removed even though close() raised OSError
+    assert connection not in handler.transports
+
+
+async def test_handle_connection_cleanup_success():
+    """Test that handle_connection properly cleans up transports on success path."""
+    handler = MockConnectionHandler()
+
+    # Create a mock connection
+    connection = Server(address=("server", 1234))
+    connection.state = 0  # ConnectionState.CLOSED
+
+    # Set up a transport with a normal writer
+    mock_writer = mock.Mock()
+    mock_reader = mock.AsyncMock()
+    mock_reader.read.side_effect = OSError("Connection closed")
+
+    handler.transports[connection] = server.ConnectionIO(
+        handler=None,
+        reader=mock_reader,
+        writer=mock_writer,
+    )
+
+    # Mock the hooks to avoid actual execution
+    handler.handle_hook = mock.AsyncMock()
+    handler.server_event = mock.AsyncMock()
+
+    # This should complete successfully
+    await handler.handle_connection(connection)
+
+    # Verify writer.close() was called
+    mock_writer.close.assert_called_once()
+    # Verify transport was removed
+    assert connection not in handler.transports


### PR DESCRIPTION
## Motivation

The proxy server has resource leaks in connection cleanup code. When exceptions occur during writer cleanup, connection objects can leak because \	ransports.pop()\ is not in a finally block, and \writer.close()\ lacks exception protection.

## Changes

- Added \OSError\ protection for \writer.close()\ in \handle_client\
- Moved \	ransports.pop()\ to finally block to ensure cleanup
- Used \pop(connection, None)\ to avoid KeyError on missing connections

## Testing

- [x] Code passes existing tests
- [x] Resource cleanup works correctly even when exceptions occur
- [x] No KeyError when connections are already removed

## Checklist

- [x] Code follows the project's coding standards
- [x] Changes are minimal and focused on the specific issue
- [x] Commit messages follow conventional format
- [x] No unrelated changes included

These changes prevent connection object leaks when exceptions occur during writer cleanup, improving resource management and stability.