### PR TITLE
Fix for modified reason phrase not being sent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
   ([#8295](https://github.com/mitmproxy/mitmproxy/pull/8295), @tbodt)
 - Correctly read the SNI hostname from fragmented QUIC client hellos.
   ([#8296](https://github.com/mitmproxy/mitmproxy/pull/8296), @tbodt)
+- mitmweb: Fix for modified reason phrase not being sent
 
 ## 12 May 2026: mitmproxy 12.2.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 - Correctly read the SNI hostname from fragmented QUIC client hellos.
   ([#8296](https://github.com/mitmproxy/mitmproxy/pull/8296), @tbodt)
 - mitmweb: Fix for modified reason phrase not being sent
+  ([#8333](https://github.com/mitmproxy/mitmproxy/pull/8333), @grusski)
 
 ## 12 May 2026: mitmproxy 12.2.3
 

--- a/mitmproxy/tools/web/app.py
+++ b/mitmproxy/tools/web/app.py
@@ -608,8 +608,10 @@ class FlowHandler(RequestHandler):
                 elif a == "response" and hasattr(flow, "response"):
                     response: mitmproxy.http.Response = flow.response
                     for k, v in b.items():
-                        if k in ["msg", "http_version"]:
-                            setattr(response, k, str(v))
+                        if k == "reason":
+                            response.reason = str(v)
+                        elif k == "http_version":
+                            response.http_version = str(v)
                         elif k == "code":
                             response.status_code = int(v)
                         elif k == "headers":

--- a/test/mitmproxy/tools/web/test_app.py
+++ b/test/mitmproxy/tools/web/test_app.py
@@ -207,7 +207,7 @@ class TestApp(tornado.testing.AsyncHTTPTestCase):
                 "content": "req",
             },
             "response": {
-                "msg": "Non-Authorisé",
+                "reason": "Non-Authorisé",
                 "code": 404,
                 "headers": [("bar", "baz")],
                 "trailers": [("foo", "bar")],
@@ -221,7 +221,7 @@ class TestApp(tornado.testing.AsyncHTTPTestCase):
         assert f.request.port == 123
         assert f.request.headers["foo"] == "bar"
         assert f.request.text == "req"
-        assert f.response.msg == "Non-Authorisé"
+        assert f.response.reason == "Non-Authorisé"
         assert f.response.status_code == 404
         assert f.response.headers["bar"] == "baz"
         assert f.response.text == "resp"

--- a/test/mitmproxy/tools/web/test_app.py
+++ b/test/mitmproxy/tools/web/test_app.py
@@ -254,12 +254,12 @@ class TestApp(tornado.testing.AsyncHTTPTestCase):
             == 400
         )
 
-    def test_flow_update_reason_only(self):
+    def test_flow_update_http_version_only(self):
         f = self.view.get_by_id("42")
         f.backup()
-        resp = self.put_json("/flows/42", {"response": {"reason": "Non-Authorisé"}})
+        resp = self.put_json("/flows/42", {"response": {"http_version": "2.0"}})
         assert resp.code == 200
-        assert f.response.reason == "Non-Authorisé"
+        assert f.response.http_version == "2.0"
         f.revert()
 
     def test_flow_duplicate(self):

--- a/test/mitmproxy/tools/web/test_app.py
+++ b/test/mitmproxy/tools/web/test_app.py
@@ -254,6 +254,14 @@ class TestApp(tornado.testing.AsyncHTTPTestCase):
             == 400
         )
 
+    def test_flow_update_reason_only(self):
+        f = self.view.get_by_id("42")
+        f.backup()
+        resp = self.put_json("/flows/42", {"response": {"reason": "Non-Authorisé"}})
+        assert resp.code == 200
+        assert f.response.reason == "Non-Authorisé"
+        f.revert()
+
     def test_flow_duplicate(self):
         resp = self.fetch("/flows/42/duplicate", method="POST")
         assert resp.code == 200

--- a/web/src/js/components/FlowView/HttpMessages.tsx
+++ b/web/src/js/components/FlowView/HttpMessages.tsx
@@ -104,9 +104,9 @@ function ResponseLine({ flow }: ResponseLineProps) {
                     &nbsp;
                     <ValueEditor
                         content={flow.response.reason}
-                        onEditDone={(msg) =>
+                        onEditDone={(reason) =>
                             dispatch(
-                                flowActions.update(flow, { response: { msg } }),
+                                flowActions.update(flow, { response: { reason } }),
                             )
                         }
                         selectAllOnClick={true}

--- a/web/src/js/components/FlowView/HttpMessages.tsx
+++ b/web/src/js/components/FlowView/HttpMessages.tsx
@@ -106,7 +106,9 @@ function ResponseLine({ flow }: ResponseLineProps) {
                         content={flow.response.reason}
                         onEditDone={(reason) =>
                             dispatch(
-                                flowActions.update(flow, { response: { reason } }),
+                                flowActions.update(flow, {
+                                    response: { reason },
+                                }),
                             )
                         }
                         selectAllOnClick={true}


### PR DESCRIPTION
#### Description

It looks like there was mismatch between `msg` being sent form the frontend and being passed to the response object but this object does not know about a `msg` attribute, it only knows about a `reason` attribute.
This mismatch has been corrected by sending the correct `reason` attribute in the frontend and properly dispatching it.

I already reported the issue here:
https://github.com/mitmproxy/mitmproxy/issues/8332

#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.