### PR TITLE
fix(web): theme the sorted flow table header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Remove the unused `msgpack` dependency. The msgpack contentview is
   implemented in Rust and shipped with `mitmproxy_rs` since mitmproxy 12.
   ([#8319](https://github.com/mitmproxy/mitmproxy/pull/8319), @lukehsiao)
+- mitmweb: Fix the flow table header of the sorted column keeping a light background and hiding its sort chevron under the dark theme.
 - mitmweb: Add a dark theme, selectable via the new `web_theme` option (`system`, `dark`, or `light`).
   `system` follows the operating system's color-scheme preference.
   ([#8317](https://github.com/mitmproxy/mitmproxy/pull/8317), @sleeyax)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
   implemented in Rust and shipped with `mitmproxy_rs` since mitmproxy 12.
   ([#8319](https://github.com/mitmproxy/mitmproxy/pull/8319), @lukehsiao)
 - mitmweb: Fix the flow table header of the sorted column keeping a light background and hiding its sort chevron under the dark theme.
+  ([#8336](https://github.com/mitmproxy/mitmproxy/pull/8336), @sleeyax)
 - mitmweb: Add a dark theme, selectable via the new `web_theme` option (`system`, `dark`, or `light`).
   `system` follows the operating system's color-scheme preference.
   ([#8317](https://github.com/mitmproxy/mitmproxy/pull/8317), @sleeyax)

--- a/web/src/css/flowtable.less
+++ b/web/src/css/flowtable.less
@@ -36,7 +36,7 @@
 
         &.sort-asc,
         &.sort-desc {
-            background-color: lighten(#f2f2f2, 3%);
+            background-color: var(--mitmweb-th-sorted-bg);
             padding-right: 18px;
         }
 
@@ -51,7 +51,11 @@
             top: 4px;
             width: 14px;
             height: 14px;
-            background-color: fadeout(lighten(#f2f2f2, 3%), 20%);
+            background-color: color-mix(
+                in srgb,
+                var(--mitmweb-th-sorted-bg) 80%,
+                transparent
+            );
         }
     }
 

--- a/web/src/css/global.less
+++ b/web/src/css/global.less
@@ -1,7 +1,6 @@
 // Semantic color tokens.
 // Light values below are byte-equal to the literals they replace, so this change is visually a no-op.
-// The dark theme overrides these under a `[data-theme="dark"]` selector; colors that LESS functions
-// (lighten/darken/fadeout) consume are left as literals here because those functions cannot operate on var().
+// The dark theme overrides these under a `[data-theme="dark"]` selector.
 :root {
     // Match native controls (form inputs, scrollbars) to the active theme.
     color-scheme: light;
@@ -60,6 +59,9 @@
     // Request/response first-line banner
     --mitmweb-first-line-bg: #337ab7;
     --mitmweb-first-line-fg: #fff;
+
+    // Flow table header cell the flows are sorted by, one shade off the header row
+    --mitmweb-th-sorted-bg: #fafafa;
 
     // Flow table row states (base rows reuse --mitmweb-bg / --mitmweb-bg-alt; -alt is the even-row shade)
     --mitmweb-row-highlight: hsl(48, 100%, 80%);
@@ -142,6 +144,9 @@
     // Request/response first-line banner — the accent blue is too bright to read monospace text on
     --mitmweb-first-line-bg: #1c3a5e;
     --mitmweb-first-line-fg: #dbe9fa;
+
+    // Flow table header cell the flows are sorted by, one shade off the header row
+    --mitmweb-th-sorted-bg: #2d2d2d;
 
     // Flow table row states (base rows reuse --mitmweb-bg / --mitmweb-bg-alt; -alt is the even-row shade)
     --mitmweb-row-highlight: hsl(48, 60%, 26%);


### PR DESCRIPTION
#### Description

In dark mode the flow table header of the sorted column stayed near-white and its sort chevron was invisible.

The two colors involved were the last ones left as literals after #8316 introduced the semantic token layer: `lighten()`/`fadeout()` cannot operate on `var()`, so the sorted `th` background and the chevron's mask kept a hardcoded `#fafafa`. The chevron is stroked in `--mitmweb-fg` (light grey in dark mode), so it vanished against its own mask.

Both now read a new `--mitmweb-th-sorted-bg` token, and the mask derives its alpha with `color-mix` instead. The light value is byte-equal to what `lighten(#f2f2f2, 3%)` compiled to, so the light theme is unchanged.

No LESS color functions remain in the stylesheets, so the note about them in the token header comment is dropped as well.

#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.