### PR TITLE
Fix ignored QUIC connections never relaying past the ClientHello

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
   `ignore_connection` in the `tls_clienthello` hook. The connection stalled
   after the ClientHello and mitmproxy raised
   `AssertionError: Unexpected event type at UDPLayer.start`.
+  ([#8339](https://github.com/mitmproxy/mitmproxy/pull/8339), @kasnder)
 - Bracket IPv6 target literals in the `CONNECT` request and `Host` header sent
   to an upstream proxy (`--mode upstream`), producing a valid `[2001:db8::1]:443`
   authority per RFC 3986 instead of the malformed `2001:db8::1:443`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 
 ## Unreleased: mitmproxy next
 
+- Fix QUIC connections never being relayed when an addon sets
+  `ignore_connection` in the `tls_clienthello` hook. The connection stalled
+  after the ClientHello and mitmproxy raised
+  `AssertionError: Unexpected event type at UDPLayer.start`.
 - Bracket IPv6 target literals in the `CONNECT` request and `Host` header sent
   to an upstream proxy (`--mode upstream`), producing a valid `[2001:db8::1]:443`
   authority per RFC 3986 instead of the malformed `2001:db8::1:443`.

--- a/mitmproxy/proxy/layers/quic/_stream_layers.py
+++ b/mitmproxy/proxy/layers/quic/_stream_layers.py
@@ -517,8 +517,23 @@ class ClientQuicLayer(QuicLayer):
                     address=None
                 )
             replacement_layer = UDPLayer(self.context, ignore=True)
-            parent_layer.handle_event = replacement_layer.handle_event  # type: ignore
-            parent_layer._handle_event = replacement_layer._handle_event  # type: ignore
+
+            # Only `_handle_event` may be replaced here. An outer layer may already hold a bound
+            # reference to `parent_layer.handle_event` -- `NextLayer._ask` caches one as
+            # `NextLayer._handle` when it decides the layer stack, which happens before the
+            # ClientHello is parsed -- so reassigning the attribute would not reach it, and the
+            # parent must keep owning blocking and pause handling. `Layer.handle_event` re-reads
+            # `self._handle_event` for every event, so dispatching dynamically here is what
+            # follows the UDP layer from its `start` state into `relay_messages`.
+            def handle_udp_event(event: events.Event) -> layer.CommandGenerator[None]:
+                if isinstance(event, events.CommandCompleted):
+                    # `parent_layer` pauses on the UDP layer's own blocking commands and resumes
+                    # them itself, so any reply that reaches here answers a command issued by a
+                    # layer this swap has just discarded, and there is nobody left to take it.
+                    return
+                yield from replacement_layer._handle_event(event)
+
+            parent_layer._handle_event = handle_udp_event  # type: ignore
             yield from parent_layer.handle_event(events.Start())
             for dgm in self.handshake_datagram_buf:
                 yield from parent_layer.handle_event(

--- a/test/mitmproxy/proxy/layers/quic/test__stream_layers.py
+++ b/test/mitmproxy/proxy/layers/quic/test__stream_layers.py
@@ -687,6 +687,23 @@ def make_client_tls_layer(
     return playbook, client_layer, tssl_client
 
 
+class CachedParentHandle:
+    """An outer layer that dispatches through a bound ``handle_event`` captured up front.
+
+    ``NextLayer._ask`` caches ``self.layer.handle_event`` into ``NextLayer._handle`` when it
+    decides the layer stack, so reassigning that attribute on the child afterwards does not
+    reach the cached reference. This stands in for that caching, which the playbook -- which
+    re-resolves ``self.layer.handle_event`` for every event -- does not otherwise exercise.
+    """
+
+    def __init__(self, inner: layer.Layer) -> None:
+        self.inner = inner
+        self._handle = inner.handle_event
+
+    def handle_event(self, event: events.Event) -> layer.CommandGenerator[None]:
+        yield from self._handle(event)
+
+
 class TestClientQuic:
     def test_http3_disabled(self, tctx: context.Context):
         """Test that we swallow QUIC packets if QUIC and HTTP/3 are disabled."""
@@ -861,6 +878,94 @@ class TestClientQuic:
                 tctx.server, b"ServerHello"
             )  # and the same for the serverhello.
             << commands.SendData(tctx.client, b"ServerHello")
+        )
+
+    @pytest.mark.parametrize("server_state", ["open", "closed"])
+    def test_passthrough_from_clienthello_cached_parent_handle(
+        self, tctx: context.Context, server_state: Literal["open", "closed"]
+    ):
+        """
+        Passthrough must keep relaying when events reach the parent layer through a reference
+        bound before the tls_clienthello hook ran, which is what happens in a real server run.
+
+        Reassigning ``parent_layer.handle_event`` cannot reach an outer layer's already-cached
+        bound method, so the ignore branch has to work through ``parent_layer._handle_event``,
+        which ``Layer.handle_event`` re-reads for every event.
+        """
+        if server_state == "open":
+            tctx.server.timestamp_start = time.time()
+            tctx.server.state = connection.ConnectionState.OPEN
+
+        playbook, client_layer, tssl_client = make_client_tls_layer(tctx, alpn=["quux"])
+        client_layer.child_layer = TlsEchoLayer(client_layer.context)
+        playbook.layer = CachedParentHandle(playbook.layer)
+
+        def make_passthrough(client_hello: tls.ClientHelloData) -> None:
+            client_hello.ignore_connection = True
+
+        client_hello = tssl_client.read()
+        (
+            playbook
+            >> events.DataReceived(tctx.client, client_hello)
+            << tls.TlsClienthelloHook(tutils.Placeholder())
+            >> tutils.reply(side_effect=make_passthrough)
+        )
+        passed_through = client_hello
+        if server_state == "closed":
+            playbook << commands.OpenConnection(tctx.server)
+            # A second client datagram arrives while OpenConnection is still pending. It must be
+            # queued and relayed once the connection opens, not dispatched into the UDP layer's
+            # start state. Both relays happen in one batch, so the playbook merges the sends.
+            playbook >> events.DataReceived(tctx.client, b"second datagram")
+            playbook >> tutils.reply(None, to=-2)
+            passed_through = client_hello + b"second datagram"
+        assert (
+            playbook
+            << commands.SendData(
+                tctx.server, passed_through
+            )  # passed through unmodified
+            >> events.DataReceived(
+                tctx.server, b"ServerHello"
+            )  # and the same for the serverhello.
+            << commands.SendData(tctx.client, b"ServerHello")
+            >> events.DataReceived(tctx.client, b"more client data")
+            << commands.SendData(tctx.server, b"more client data")
+        )
+
+    def test_passthrough_from_clienthello_stale_reply(self, tctx: context.Context):
+        """
+        A reply to a command that one of the replaced layers issued before the swap must be
+        dropped, not dispatched into the ignored UDP layer.
+
+        A real stack can have such a command in flight: ``RawQuicLayer(force_raw=True)`` builds a
+        datagram ``UDPLayer`` up front, whose ``UdpStartHook`` is still outstanding when the
+        ClientHello arrives. Nothing is left to receive that reply once the swap discards the
+        layers below.
+        """
+        tctx.server.timestamp_start = time.time()
+        tctx.server.state = connection.ConnectionState.OPEN
+
+        playbook, client_layer, tssl_client = make_client_tls_layer(tctx, alpn=["quux"])
+        client_layer.child_layer = TlsEchoLayer(client_layer.context)
+
+        def make_passthrough(client_hello: tls.ClientHelloData) -> None:
+            client_hello.ignore_connection = True
+
+        client_hello = tssl_client.read()
+        assert (
+            playbook
+            >> events.DataReceived(tctx.client, client_hello)
+            << tls.TlsClienthelloHook(tutils.Placeholder())
+            >> tutils.reply(side_effect=make_passthrough)
+            << commands.SendData(tctx.server, client_hello)
+            # The server connection is already open, so the UDP layer never issued this command.
+            >> events.OpenConnectionCompleted(
+                commands.OpenConnection(tctx.server), None
+            )
+            << None
+            # Relaying continues afterwards.
+            >> events.DataReceived(tctx.client, b"more client data")
+            << commands.SendData(tctx.server, b"more client data")
         )
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
#### Description

Fixes #8338: QUIC connections never relay past the ClientHello when an addon sets
`ignore_connection` in the `tls_clienthello` hook. The connection stalls in both directions
and mitmproxy raises `AssertionError: Unexpected event type at UDPLayer.start`.

`ClientQuicLayer.receive_handshake_data` swaps the QUIC layers for an ignored `UDPLayer`, and
two things go wrong, both because the swap does not account for the layers it replaces.

**The parent layer's dispatch is patched twice, and neither assignment holds.**
`parent_layer._handle_event = replacement_layer._handle_event` captures a bound method while
the UDP layer is still in its `start` state; `UDPLayer.start` later sets
`self._handle_event = self.relay_messages` on the replacement layer, which the parent never
re-reads. The accompanying `parent_layer.handle_event = replacement_layer.handle_event`
cannot compensate, because an outer layer may already hold a bound reference to the
original — `NextLayer._ask` caches exactly that as `NextLayer._handle` when it decides the
layer stack, which happens on the first datagram, before the ClientHello is parsed. Events
arrive through the cached method, find the parent unpaused, and dispatch into the frozen
`start` state.

This keeps `handle_event` untouched and replaces only `_handle_event`, with a dispatcher that
delegates to the UDP layer's *current* state function. `Layer.handle_event` re-reads
`self._handle_event` for every event, so that is the only assignment a stale cache cannot
defeat. The parent then keeps owning blocking and pause handling, and datagrams that arrive
while `OpenConnection` is pending are relayed in order once it completes.

**A command issued before the swap can still be in flight**, and its reply is routed to the
parent, which now dispatches it into the UDP layer. `RawQuicLayer(force_raw=True)` builds a
datagram `UDPLayer` in its constructor, so `--mode reverse:quic://` reliably has an
outstanding `UdpStartHook` when the ClientHello arrives. Such replies are now dropped: the
parent resumes the UDP layer's own blocking commands itself, so anything that reaches the
dispatcher answers a command from a layer that no longer exists.

Neither facet is a race, and neither depends on `connection_strategy`. Both fire in either
server state.

#### Why the existing test misses this

`test_passthrough_from_clienthello` passes today because `tutils.Playbook` re-resolves
`self.layer.handle_event` for every event, so it always reaches the patched attribute, and
`make_client_tls_layer` wires child layers by hand "to avoid NextLayer noise". The added
tests drive events through a reference bound up front, which is what a real server run does,
and feed back a reply the ignored layer never asked for.

#### Verification

End-to-end, with an `aioquic` echo server behind `mitmdump --mode reverse:quic://` and an
addon setting `ignore_connection`, driven by an `aioquic` client:

| | unmodified 12.2.3 / `main` | with this change |
| --- | --- | --- |
| client | `ConnectionError` (no handshake) | handshake completes, echo returned |
| target server | receives nothing | receives the stream data |
| `mitmproxy has crashed!` | 9 | 0 |

Test suite on `main` (`c69122b`), Python 3.13.14:

- `test/mitmproxy/proxy` + `test/mitmproxy/addons/test_next_layer.py`: 546 passed, 4 skipped.
- The three added test cases fail without the change, with the same assertion the
  end-to-end run produces.
- `ruff format --check`, `ruff check`, and `mypy` on the changed module are clean.

#### Checklist

- [x] I have updated tests where applicable.
- [x] I have added an entry to the CHANGELOG.
