### PR TITLE
ci: add name to macOS app build step for readability

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -101,7 +101,8 @@ jobs:
           keychain: ${{ runner.temp }}/temp
           p12-file-base64: ${{ secrets.APPLE_CERTIFICATE }}
           p12-password: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-      - if: runner.os == 'macOS' && github.repository == 'mitmproxy/mitmproxy'
+      - name: Build and notarize macOS app
+        if: runner.os == 'macOS' && github.repository == 'mitmproxy/mitmproxy'
             && (startsWith(github.ref, 'refs/heads/') || startsWith(github.ref, 'refs/tags/'))
         run: |
           python -u release/build.py macos-app \


### PR DESCRIPTION
## Problem

In `.github/workflows/main.yml`, the macOS app build `run` step is unnamed and longer than **300 characters**. In the GitHub Actions UI that collapses into a generic label, which hurts readability when scanning signed/notarized build failures.

## Changes

Semantics are unchanged: same `if` condition, same `release/build.py macos-app` command and arguments, and the preceding `id: keychain` step is untouched.

- Add `name: Build and notarize macOS app` to the existing macOS build step

## Test plan
- [ ] Confirm the macOS `if` guard and build command are unchanged
- [ ] Confirm the keychain import step still has `id: keychain`
