### PR TITLE
fix: replace deprecated pyparsing API aliases with snake_case equivalents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 - Replace deprecated pyparsing APIs with their snake_case equivalents to avoid
   `PyparsingDeprecationWarning` during command and flow-filter parsing.
+  ([#8344](https://github.com/mitmproxy/mitmproxy/pull/8344), @Dnsayhey)
 - mitmweb: Replace the flow table's raster resource type icons with SVG icons so they follow the active theme.
   ([#8337](https://github.com/mitmproxy/mitmproxy/pull/8337), @sleeyax)
 - Bracket IPv6 target literals in the `CONNECT` request and `Host` header sent

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 ## Unreleased: mitmproxy next
 
+- Replace deprecated pyparsing APIs with their snake_case equivalents to avoid
+  `PyparsingDeprecationWarning` during command and flow-filter parsing.
 - mitmweb: Replace the flow table's raster resource type icons with SVG icons so they follow the active theme.
   ([#8337](https://github.com/mitmproxy/mitmproxy/pull/8337), @sleeyax)
 - Bracket IPv6 target literals in the `CONNECT` request and `Host` header sent

--- a/mitmproxy/command.py
+++ b/mitmproxy/command.py
@@ -200,8 +200,8 @@ class CommandManager:
         Parse a possibly partial command. Return a sequence of ParseResults and a sequence of remainder type help items.
         """
 
-        parts: pyparsing.ParseResults = command_lexer.expr.parseString(
-            cmdstr, parseAll=True
+        parts: pyparsing.ParseResults = command_lexer.expr.parse_string(
+            cmdstr, parse_all=True
         )
 
         parsed: list[ParseResult] = []

--- a/mitmproxy/command_lexer.py
+++ b/mitmproxy/command_lexer.py
@@ -21,7 +21,7 @@ expr = pyparsing.ZeroOrMore(
     PartialQuotedString
     | pyparsing.Word(" \r\n\t")
     | pyparsing.CharsNotIn("""'" \r\n\t""")
-).leaveWhitespace()
+).leave_whitespace()
 
 
 def quote(val: str) -> str:

--- a/mitmproxy/flowfilter.py
+++ b/mitmproxy/flowfilter.py
@@ -740,7 +740,7 @@ def _make():
     parts = []
     for cls in filter_unary:
         f = pp.Literal(f"~{cls.code}") + pp.WordEnd()
-        f.setParseAction(cls.make)
+        f.set_parse_action(cls.make)
         parts.append(f)
 
     # This is a bit of a hack to simulate Word(pyparsing_unicode.printables),
@@ -749,27 +749,27 @@ def _make():
     unicode_words.skipWhitespace = True
     regex = (
         unicode_words
-        | pp.QuotedString('"', escChar="\\")
-        | pp.QuotedString("'", escChar="\\")
+        | pp.QuotedString('"', esc_char="\\")
+        | pp.QuotedString("'", esc_char="\\")
     )
     for cls in filter_rex:
         f = pp.Literal(f"~{cls.code}") + pp.WordEnd() + regex.copy()
-        f.setParseAction(cls.make)
+        f.set_parse_action(cls.make)
         parts.append(f)
 
     for cls in filter_int:
         f = pp.Literal(f"~{cls.code}") + pp.WordEnd() + pp.Word(pp.nums)
-        f.setParseAction(cls.make)
+        f.set_parse_action(cls.make)
         parts.append(f)
 
     # A naked rex is a URL rex:
     f = regex.copy()
-    f.setParseAction(FUrl.make)
+    f.set_parse_action(FUrl.make)
     parts.append(f)
 
     atom = pp.MatchFirst(parts)
     expr = pp.OneOrMore(
-        pp.infixNotation(
+        pp.infix_notation(
             atom,
             [
                 (pp.Literal("!").suppress(), 1, pp.opAssoc.RIGHT, lambda x: FNot(*x)),
@@ -778,7 +778,7 @@ def _make():
             ],
         )
     )
-    return expr.setParseAction(lambda x: FAnd(x) if len(x) != 1 else x)
+    return expr.set_parse_action(lambda x: FAnd(x) if len(x) != 1 else x)
 
 
 bnf = _make()
@@ -802,7 +802,7 @@ def parse(s: str) -> TFilter:
     if not s:
         raise ValueError("Empty filter expression")
     try:
-        flt = bnf.parse_string(s, parseAll=True)[0]
+        flt = bnf.parse_string(s, parse_all=True)[0]
         flt.pattern = s
         return flt
     except (pp.ParseException, ValueError) as e:

--- a/test/mitmproxy/test_command_lexer.py
+++ b/test/mitmproxy/test_command_lexer.py
@@ -23,16 +23,14 @@ from mitmproxy import command_lexer
 def test_partial_quoted_string(test_input, valid):
     if valid:
         assert (
-            command_lexer.PartialQuotedString.parse_string(
-                test_input, parse_all=True
-            )[0]
+            command_lexer.PartialQuotedString.parse_string(test_input, parse_all=True)[
+                0
+            ]
             == test_input
         )
     else:
         with pytest.raises(pyparsing.ParseException):
-            command_lexer.PartialQuotedString.parse_string(
-                test_input, parse_all=True
-            )
+            command_lexer.PartialQuotedString.parse_string(test_input, parse_all=True)
 
 
 @pytest.mark.parametrize(

--- a/test/mitmproxy/test_command_lexer.py
+++ b/test/mitmproxy/test_command_lexer.py
@@ -23,12 +23,16 @@ from mitmproxy import command_lexer
 def test_partial_quoted_string(test_input, valid):
     if valid:
         assert (
-            command_lexer.PartialQuotedString.parseString(test_input, parseAll=True)[0]
+            command_lexer.PartialQuotedString.parse_string(
+                test_input, parse_all=True
+            )[0]
             == test_input
         )
     else:
         with pytest.raises(pyparsing.ParseException):
-            command_lexer.PartialQuotedString.parseString(test_input, parseAll=True)
+            command_lexer.PartialQuotedString.parse_string(
+                test_input, parse_all=True
+            )
 
 
 @pytest.mark.parametrize(
@@ -44,7 +48,7 @@ def test_partial_quoted_string(test_input, valid):
     ],
 )
 def test_expr(test_input, expected):
-    assert list(command_lexer.expr.parseString(test_input, parseAll=True)) == expected
+    assert list(command_lexer.expr.parse_string(test_input, parse_all=True)) == expected
 
 
 @given(text())


### PR DESCRIPTION
#### Description

Replace deprecated pyparsing camelCase methods and keyword arguments with their
snake_case equivalents in the command and flow-filter parsers and their tests.

The current `main` branch pins pyparsing 3.3.2, which supports all replacement
APIs, so no pyparsing 2.x compatibility layer is required. This removes
`PyparsingDeprecationWarning` without changing parser behavior.

This is a focused follow-up to #8133, which contained similar pyparsing changes
but was closed without merging as part of a much larger set of unrelated changes.

Validation:

- Strict pyparsing warning tests: `150 passed`.
- `uv run tox` (`2001 passed, 3 skipped`; lint, mypy, and py all passed)

#### Checklist

- [x] I have updated tests where applicable.
- [x] I have added an entry to the CHANGELOG.
