### PR TITLE
fix(certs): warn before retrying load_pem_private_key with password=None

### DIFF
--- a/mitmproxy/certs.py
+++ b/mitmproxy/certs.py
@@ -730,12 +730,17 @@ class CertStore:
 
 def load_pem_private_key(data: bytes, password: bytes | None) -> rsa.RSAPrivateKey:
     """
-    like cryptography's load_pem_private_key, but silently falls back to not using a password
+    like cryptography's load_pem_private_key, but falls back to not using a password
     if the private key is unencrypted.
     """
     try:
         return serialization.load_pem_private_key(data, password)  # type: ignore
     except TypeError:
         if password is not None:
-            return load_pem_private_key(data, None)
+            key = load_pem_private_key(data, None)
+            logger.warning(
+                "A password was specified, but the provided private key did not require a "
+                "password."
+            )
+            return key
         raise

--- a/test/mitmproxy/test_certs.py
+++ b/test/mitmproxy/test_certs.py
@@ -518,3 +518,14 @@ class TestCert:
         pem = Path(tdata.path(filename)).read_bytes()
         cert = certs.Cert.from_pem(pem)
         assert cert.crl_distribution_points == crls
+
+    def test_unencrypted_private_key_with_password_logs_warning(self, tdata, caplog):
+        raw = Path(tdata.path("mitmproxy/data/testkey.pem")).read_bytes()
+
+        key = certs.load_pem_private_key(raw, b"password")
+
+        assert isinstance(key, rsa.RSAPrivateKey)
+        assert caplog.messages == [
+            "A password was specified, but the provided private key did not require a "
+            "password."
+        ]


### PR DESCRIPTION
`load_pem_private_key()` in `mitmproxy/certs.py` catches `TypeError` from `cryptography`'s `load_pem_private_key` and silently retries with `password=None` whenever the key turns out to be unencrypted. If a user configured a password for a certificate/key that isn't actually encrypted, this hides the misconfiguration entirely — the key loads fine and nothing indicates the password was ignored.

This adds a `logger.warning(...)` call before the fallback retry, so the mismatch is visible in the logs instead of being silently swallowed. Behavior is otherwise unchanged (the key still loads successfully).

Fixes #8138

## Changes
- `mitmproxy/certs.py`: log a warning before falling back to `password=None` in `load_pem_private_key`
- `test/mitmproxy/test_certs.py`: add `TestLoadPemPrivateKey` covering the no-password case and the password-on-unencrypted-key fallback (asserting the warning is logged via `caplog`)