### PR TITLE
docs: clarify when filter regexes must be quoted

### DIFF
--- a/docs/src/content/concepts/filters.md
+++ b/docs/src/content/concepts/filters.md
@@ -14,6 +14,7 @@ expressions consist of the following operators:
 
 - Regexes are Python-style.
 - Regexes can be specified as quoted strings.
+- Regexes containing parentheses, whitespace, or the `~`, `'`, `"` characters must be quoted because these characters are reserved by the filter expression syntax. Otherwise, the expression may be parsed differently or rejected. For example, use ~u "get(Info|Routers)".
 - Regexes are case-insensitive by default.[^1]
 - Header matching (~h, ~hq, ~hs) is against a string of the form "name: value".
 - Strings with no operators are matched against the request URL.


### PR DESCRIPTION
#7715 reports that an unquoted regex containing grouping parentheses, e.g. `~u get(Info|Routers)`, is silently misparsed: `(` and `)` are reserved characters used by the boolean-grouping grammar in `mitmproxy/flowfilter.py` (`unicode_words = pp.CharsNotIn("()~'\"" + DEFAULT_WHITE_CHARS)`), so the filter actually becomes `~u get & ~u "Info|Routers"` rather than a single regex match. I confirmed this by parsing several expressions directly with `mitmproxy.flowfilter.parse()`:

- `~u get(Info|Routers)` -> `url matches /get/i and url matches /Info|Routers/i` (broken)
- `~u "get(Info|Routers)"` -> `url matches /get(Info|Routers)/i` (correct, quoted)
- `~u get|other` / `~u get&other` / `~u get!other` all parse fine unquoted, since `|`, `&`, `!` are only treated as operators when surrounded by whitespace.
- `~u foo~bar` and `~u it's` also fail unquoted, since `~` and `'` are likewise reserved.

Redesigning the grammar to disambiguate regex-parens from grouping-parens is a real design trade-off a maintainer should own, so rather than touch the parser this PR only fixes the documentation, which currently states "Regexes can be specified as quoted strings" without mentioning that some regexes *must* be quoted to parse correctly - contradicting user expectations as described in the issue.

Fixes #7715

## Changes
- `docs/src/content/concepts/filters.md`: document that unquoted regexes must avoid parentheses, whitespace, and the `~`, `'`, `"` characters, and must be quoted otherwise (with a corrected example using the exact case from the issue)