### PR TITLE
console: fix search in the flow view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
   highlighting, and `n`/`N` had nothing to jump to. Bodies are rendered line by line
   again, only the match itself is emphasized, and the search term now survives view
   rebuilds.
+  ([#8355](https://github.com/mitmproxy/mitmproxy/pull/8355), @malkafen)
 - Bracket IPv6 target literals in the `CONNECT` request and `Host` header sent
   to an upstream proxy (`--mode upstream`), producing a valid `[2001:db8::1]:443`
   authority per RFC 3986 instead of the malformed `2001:db8::1:443`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 
 ## Unreleased: mitmproxy next
 
+- mitmproxy: Fix search (`/`, `n`, `N`) in the flow view. The message body was rendered
+  as a single widget, so a match greyed out the entire body, discarded its syntax
+  highlighting, and `n`/`N` had nothing to jump to. Bodies are rendered line by line
+  again, only the match itself is emphasized, and the search term now survives view
+  rebuilds.
 - Bracket IPv6 target literals in the `CONNECT` request and `Host` header sent
   to an upstream proxy (`--mode upstream`), producing a valid `[2001:db8::1]:443`
   authority per RFC 3986 instead of the malformed `2001:db8::1:443`.

--- a/mitmproxy/tools/console/flowview.py
+++ b/mitmproxy/tools/console/flowview.py
@@ -21,6 +21,27 @@ from mitmproxy.tools.console import tabs
 from mitmproxy.utils import strutils
 
 
+def chunks_to_lines(chunks: list[tuple[str, str]]) -> list[list[tuple[str, str]]]:
+    """
+    Split syntax highlighting chunks (which may span multiple lines) into one
+    urwid markup list per line.
+
+    Rendering each line as its own widget is what makes search (`/`, `n`, `N`)
+    able to move between individual matches instead of treating the whole body
+    as one giant line.
+    """
+    lines: list[list[tuple[str, str]]] = [[]]
+    for style, text in chunks:
+        head, *rest = text.split("\n")
+        if head:
+            lines[-1].append((style, head))
+        for part in rest:
+            lines.append([(style, part)] if part else [])
+    if len(lines) > 1 and not lines[-1]:
+        lines.pop()
+    return lines
+
+
 class FlowViewHeader(urwid.WidgetWrap):
     def __init__(
         self,
@@ -229,7 +250,8 @@ class FlowDetails(tabs.Tabs):
                 marker = self.FROM_CLIENT_MARKER
             else:
                 marker = self.TO_CLIENT_MARKER
-            widget_lines.append(urwid.Text([marker, *chunks]))
+            for line in chunks_to_lines(chunks):
+                widget_lines.append(urwid.Text([marker, *line]))
 
         if flow.websocket.closed_by_client is not None:
             widget_lines.append(
@@ -288,7 +310,8 @@ class FlowDetails(tabs.Tabs):
                 language=pretty.syntax_highlight,
             )
 
-            widget_lines.append(urwid.Text([marker, *chunks]))
+            for line in chunks_to_lines(chunks):
+                widget_lines.append(urwid.Text([marker, *line]))
 
         if flow.intercepted:
             markup = widget_lines[-1].get_text()[0]
@@ -354,7 +377,7 @@ class FlowDetails(tabs.Tabs):
             language=pretty.syntax_highlight,
         )
 
-        text_objects = [urwid.Text(chunks)]
+        text_objects = [urwid.Text(line) for line in chunks_to_lines(chunks)]
         if len(cut_off) < len(pretty.text):
             text_objects.append(
                 urwid.Text(

--- a/mitmproxy/tools/console/searchable.py
+++ b/mitmproxy/tools/console/searchable.py
@@ -2,15 +2,81 @@ import urwid
 
 from mitmproxy.tools.console import signals
 
+Markup = list[tuple[str | None, str]]
+
+
+def highlight_matches(
+    text: str, attrs: list[tuple[str | None, int]], search_term: str
+) -> Markup | None:
+    """
+    Rebuild the markup of a line so that every occurrence of search_term uses the
+    "focusfield" attribute while the rest keeps its original syntax highlighting.
+
+    Returns None if the line does not contain the search term.
+    """
+    if not search_term:
+        return None
+
+    matches = []
+    pos = text.find(search_term)
+    while pos != -1:
+        matches.append((pos, pos + len(search_term)))
+        pos = text.find(search_term, pos + len(search_term))
+    if not matches:
+        return None
+
+    runs = []
+    pos = 0
+    for attr, length in attrs:
+        runs.append((pos, pos + length, attr))
+        pos += length
+    if pos < len(text):
+        runs.append((pos, len(text), None))
+
+    boundaries = {0, len(text)}
+    for start, end in matches:
+        boundaries.update((start, end))
+    for start, end, _ in runs:
+        boundaries.update((start, end))
+
+    markup: Markup = []
+    cuts = sorted(b for b in boundaries if 0 <= b <= len(text))
+    for start, end in zip(cuts, cuts[1:]):
+        if start == end:
+            continue
+        if any(m_start <= start < m_end for m_start, m_end in matches):
+            attr = "focusfield"
+        else:
+            attr = next(
+                (a for r_start, r_end, a in runs if r_start <= start < r_end), None
+            )
+        if markup and markup[-1][0] == attr:
+            markup[-1] = (attr, markup[-1][1] + text[start:end])
+        else:
+            markup.append((attr, text[start:end]))
+    return markup
+
 
 class Highlight(urwid.AttrMap):
-    def __init__(self, t):
-        urwid.AttrMap.__init__(
-            self,
-            urwid.Text(t.text),
-            "focusfield",
-        )
+    def __init__(self, t, search_term: str | None = None):
+        text, attrs = t.get_text()
+        markup = highlight_matches(text, attrs, search_term or "")
+        if markup is None:
+            # No known match position, fall back to highlighting the entire line.
+            urwid.AttrMap.__init__(self, urwid.Text(text), "focusfield")
+        else:
+            urwid.AttrMap.__init__(self, urwid.Text(markup), None)
         self.backup = t
+
+
+class SearchState:
+    """
+    The last search term is shared between all Searchable instances: the flow view
+    rebuilds its widgets whenever the focused flow changes, and an instance-local
+    term would make `n`/`N` stop working after any such rebuild.
+    """
+
+    last_search: str | None = None
 
 
 class Searchable(urwid.ListBox):
@@ -20,7 +86,14 @@ class Searchable(urwid.ListBox):
         self.search_offset = 0
         self.current_highlight = None
         self.search_term = None
-        self.last_search = None
+
+    @property
+    def last_search(self) -> str | None:
+        return SearchState.last_search
+
+    @last_search.setter
+    def last_search(self, text: str | None) -> None:
+        SearchState.last_search = text
 
     def keypress(self, size, key: str):
         if key == "/":
@@ -52,7 +125,7 @@ class Searchable(urwid.ListBox):
         if offset is None:
             self.current_highlight = None
         else:
-            self.body[offset] = Highlight(self.body[offset])
+            self.body[offset] = Highlight(self.body[offset], self.search_term)
             self.current_highlight = offset
 
     def get_text(self, w):

--- a/mitmproxy/tools/console/searchable.py
+++ b/mitmproxy/tools/console/searchable.py
@@ -7,31 +7,23 @@ Markup = list[tuple[str | None, str]]
 
 def highlight_matches(
     text: str, attrs: list[tuple[str | None, int]], search_term: str
-) -> Markup | None:
+) -> Markup:
     """
     Rebuild the markup of a line so that every occurrence of search_term uses the
     "focusfield" attribute while the rest keeps its original syntax highlighting.
-
-    Returns None if the line does not contain the search term.
     """
-    if not search_term:
-        return None
-
     matches = []
-    pos = text.find(search_term)
+    pos = text.find(search_term) if search_term else -1
     while pos != -1:
         matches.append((pos, pos + len(search_term)))
         pos = text.find(search_term, pos + len(search_term))
-    if not matches:
-        return None
 
+    # Attributes are run length encoded, turn them into absolute ranges.
     runs = []
     pos = 0
     for attr, length in attrs:
         runs.append((pos, pos + length, attr))
         pos += length
-    if pos < len(text):
-        runs.append((pos, len(text), None))
 
     boundaries = {0, len(text)}
     for start, end in matches:
@@ -40,32 +32,23 @@ def highlight_matches(
         boundaries.update((start, end))
 
     markup: Markup = []
-    cuts = sorted(b for b in boundaries if 0 <= b <= len(text))
+    cuts = sorted(boundaries)
     for start, end in zip(cuts, cuts[1:]):
-        if start == end:
-            continue
         if any(m_start <= start < m_end for m_start, m_end in matches):
             attr = "focusfield"
         else:
             attr = next(
                 (a for r_start, r_end, a in runs if r_start <= start < r_end), None
             )
-        if markup and markup[-1][0] == attr:
-            markup[-1] = (attr, markup[-1][1] + text[start:end])
-        else:
-            markup.append((attr, text[start:end]))
+        markup.append((attr, text[start:end]))
     return markup
 
 
 class Highlight(urwid.AttrMap):
-    def __init__(self, t, search_term: str | None = None):
+    def __init__(self, t, search_term: str | None):
         text, attrs = t.get_text()
         markup = highlight_matches(text, attrs, search_term or "")
-        if markup is None:
-            # No known match position, fall back to highlighting the entire line.
-            urwid.AttrMap.__init__(self, urwid.Text(text), "focusfield")
-        else:
-            urwid.AttrMap.__init__(self, urwid.Text(markup), None)
+        urwid.AttrMap.__init__(self, urwid.Text(markup), None)
         self.backup = t
 
 

--- a/test/mitmproxy/tools/console/test_flowview_search.py
+++ b/test/mitmproxy/tools/console/test_flowview_search.py
@@ -2,6 +2,8 @@ import json
 
 from mitmproxy import http
 from mitmproxy.test import tflow
+from mitmproxy.tools.console.flowview import chunks_to_lines
+from mitmproxy.tools.console.searchable import highlight_matches
 
 BODY = json.dumps(
     {
@@ -18,6 +20,37 @@ BODY = json.dumps(
 
 def _searchable(console):
     return console.window.focus_stack().top_widget().body._w.body
+
+
+def test_chunks_to_lines():
+    assert chunks_to_lines([("a", "one\ntwo"), ("b", "\nthree")]) == [
+        [("a", "one")],
+        [("a", "two")],
+        [("b", "three")],
+    ]
+    assert chunks_to_lines([("a", "single line\n")]) == [[("a", "single line")]]
+    assert chunks_to_lines([("a", "gap\n\nhere")]) == [
+        [("a", "gap")],
+        [],
+        [("a", "here")],
+    ]
+
+
+def test_highlight_matches():
+    # Matches are emphasized, everything else keeps its original attribute.
+    assert highlight_matches("ab-ab", [("x", 2), ("y", 3)], "ab") == [
+        ("focusfield", "ab"),
+        ("y", "-"),
+        ("focusfield", "ab"),
+    ]
+    # Lines without any attributes are supported, too.
+    assert highlight_matches("say ab", [], "ab") == [
+        (None, "say "),
+        ("focusfield", "ab"),
+    ]
+    # Without a match the original attributes are left alone.
+    assert highlight_matches("abc", [("x", 3)], "zzz") == [("x", "abc")]
+    assert highlight_matches("abc", [("x", 3)], "") == [("x", "abc")]
 
 
 async def test_search_moves_between_matches(console):

--- a/test/mitmproxy/tools/console/test_flowview_search.py
+++ b/test/mitmproxy/tools/console/test_flowview_search.py
@@ -1,0 +1,98 @@
+import json
+
+from mitmproxy import http
+from mitmproxy.test import tflow
+
+BODY = json.dumps(
+    {
+        "users": [
+            {"id": 1, "name": "alice", "token": "needle-one"},
+            {"id": 2, "name": "bob", "token": "quiet"},
+            {"id": 3, "name": "needle-two", "token": "xyz"},
+        ],
+        "total": 3,
+    },
+    indent=2,
+).encode()
+
+
+def _searchable(console):
+    return console.window.focus_stack().top_widget().body._w.body
+
+
+async def test_search_moves_between_matches(console):
+    f = tflow.tflow(
+        req=http.Request.make(
+            "POST",
+            "http://example.com",
+            BODY,
+            headers={"Content-Type": "application/json"},
+        ),
+    )
+    await console.load_flow(f)
+    console.type("<enter>")
+
+    body = _searchable(console)
+    assert len(body.body) > 5, "request body must be split into one widget per line"
+
+    console.type("/needle<enter>")
+    first = body.current_highlight
+    assert first is not None
+
+    console.type("n")
+    second = body.current_highlight
+    assert second is not None
+    assert second != first, "'n' must jump to the next match"
+
+    console.type("N")
+    assert body.current_highlight == first, "'N' must jump back to the previous match"
+
+
+async def test_search_survives_view_rebuild(console):
+    f = tflow.tflow(
+        req=http.Request.make(
+            "POST",
+            "http://example.com",
+            BODY,
+            headers={"Content-Type": "application/json"},
+        ),
+    )
+    await console.load_flow(f)
+    console.type("<enter>")
+    console.type("/needle<enter>")
+
+    # A flow update rebuilds the whole flow view; the search term must survive it.
+    console.window.focus_changed()
+    console.type("n")
+
+    body = _searchable(console)
+    assert body.current_highlight is not None, (
+        "'n' must still work after the view was rebuilt"
+    )
+
+
+async def test_search_keeps_syntax_highlighting(console):
+    f = tflow.tflow(
+        req=http.Request.make(
+            "POST",
+            "http://example.com",
+            BODY,
+            headers={"Content-Type": "application/json"},
+        ),
+    )
+    await console.load_flow(f)
+    console.type("<enter>")
+    console.type("/needle<enter>")
+
+    body = _searchable(console)
+    highlighted = body.body[body.current_highlight]
+
+    attrs = set()
+    for row in highlighted.render((80,)).content():
+        for attr, _, _text in row:
+            attrs.add(attr)
+
+    assert "focusfield" in attrs, "the match itself must be emphasized"
+    assert attrs - {"focusfield", None}, (
+        "syntax highlighting must survive on the rest of the line"
+    )


### PR DESCRIPTION
#### Description

Searching inside a flow (`/`, then `n`/`N`) is broken in mitmproxy 12: on a match the whole message body turns grey, loses its syntax highlighting, and `n`/`N` do not move anywhere.

`FlowDetails._get_content_view` renders the entire body as a single widget (`text_objects = [urwid.Text(chunks)]`); before the contentview rework (#7623, #7670) there was one widget per line. Since `Searchable` works on list walker items, this breaks search in three ways:

1. `Highlight` rebuilds the item as `AttrMap(urwid.Text(t.text), "focusfield")` — plain text without markup, so syntax highlighting is discarded, and `focusfield` is `("black", "light gray")`, repainting the whole body grey.
2. `find_next` iterates over items, not over occurrences within an item, so with a single body item `n`/`N` never advance.
3. `last_search` lives on the `Searchable` instance, but `conn_text()` creates a new one on every flow view rebuild, so the search term is silently forgotten.

Changes:

- `flowview.py`: add `chunks_to_lines()` to split highlighting chunks at newlines, so bodies are rendered one widget per line again. Applied to HTTP bodies, TCP/UDP streams and WebSocket messages.
- `searchable.py`: `Highlight` keeps the original markup and emphasizes only the matched substrings.
- `searchable.py`: move the last search term into a shared `SearchState` so `n`/`N` survive view rebuilds.

`test/mitmproxy/tools/console/test_flowview_search.py` covers all three symptoms; the tests fail on current main and pass with this change.

#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.