### PR TITLE
Modernize mitmweb tabs and footer

### DIFF
--- a/web/src/css/badges.less
+++ b/web/src/css/badges.less
@@ -45,3 +45,27 @@
     text-transform: uppercase;
     color: var(--mitmweb-fg-muted);
 }
+
+.footer-badge {
+    padding: 0 6px;
+    font-size: 11px;
+    font-weight: 600;
+    white-space: nowrap;
+
+    &.footer-badge-neutral {
+        color: var(--mitmweb-neutral-soft-fg);
+        background-color: var(--mitmweb-neutral-soft-bg);
+    }
+    &.footer-badge-info {
+        color: var(--mitmweb-info-soft-fg);
+        background-color: var(--mitmweb-info-soft-bg);
+    }
+    &.footer-badge-success {
+        color: var(--mitmweb-success-soft-fg);
+        background-color: var(--mitmweb-success-soft-bg);
+    }
+    &.footer-badge-danger {
+        color: var(--mitmweb-danger-soft-fg);
+        background-color: var(--mitmweb-danger-soft-bg);
+    }
+}

--- a/web/src/css/footer.less
+++ b/web/src/css/footer.less
@@ -1,8 +1,16 @@
 footer {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 3px;
     box-shadow: 0 -1px 3px var(--mitmweb-shadow);
-    padding: 0 0 4px 3px;
+    padding: 3px;
+    background-color: var(--mitmweb-bg);
 
-    .label {
-        margin-right: 3px;
+    .footer-meta {
+        display: flex;
+        flex: 0 0 auto;
+        gap: 3px;
+        margin-left: auto;
     }
 }

--- a/web/src/css/global.less
+++ b/web/src/css/global.less
@@ -466,38 +466,6 @@ textarea {
     border-radius: 3px;
 }
 
-.label {
-    display: inline;
-    padding: 0.2em 0.6em 0.3em;
-    font-size: 75%;
-    font-weight: 700;
-    line-height: 1;
-    color: #fff;
-    text-align: center;
-    white-space: nowrap;
-    vertical-align: baseline;
-    border-radius: 0.25em;
-}
-
-.label-default {
-    color: var(--mitmweb-neutral-soft-fg);
-    background-color: var(--mitmweb-neutral-soft-bg);
-}
-
-.label-primary {
-    background-color: var(--mitmweb-accent);
-}
-
-.label-success {
-    color: var(--mitmweb-success-soft-fg);
-    background-color: var(--mitmweb-success-soft-bg);
-}
-
-.label-danger {
-    color: var(--mitmweb-danger-soft-fg);
-    background-color: var(--mitmweb-danger-soft-bg);
-}
-
 .alert {
     padding: 15px;
     margin-bottom: 20px;

--- a/web/src/css/tabs.less
+++ b/web/src/css/tabs.less
@@ -12,7 +12,7 @@
         //font-family: Lato;
 
         &:hover,
-        &:focus {
+        &:focus-visible {
             color: var(--mitmweb-accent-hover);
         }
 
@@ -44,16 +44,12 @@
             border-color 120ms ease;
 
         &:not(.active):not(.special):hover,
-        &:not(.active):not(.special):focus {
+        &:not(.active):not(.special):focus-visible {
             background-color: var(--mitmweb-bg-alt);
             border-bottom-color: var(--mitmweb-border-strong);
         }
 
-        &.active {
-            background-color: var(--mitmweb-bg);
-        }
-
-        &.special:focus {
+        &.special:focus-visible {
             background-color: var(--mitmweb-accent-active);
         }
     }

--- a/web/src/css/tabs.less
+++ b/web/src/css/tabs.less
@@ -43,25 +43,18 @@
             background-color 120ms ease,
             border-color 120ms ease;
 
-        &:hover,
-        &:focus {
+        &:not(.active):not(.special):hover,
+        &:not(.active):not(.special):focus {
             background-color: var(--mitmweb-bg-alt);
+            border-bottom-color: var(--mitmweb-border-strong);
         }
 
         &.active {
             background-color: var(--mitmweb-bg);
-            border-bottom-color: var(--mitmweb-bg);
         }
 
-        &.special {
-            border-color: var(--mitmweb-accent);
-            border-bottom-color: var(--mitmweb-accent);
-
-            &:hover,
-            &:focus {
-                background-color: var(--mitmweb-accent-active);
-                border-color: var(--mitmweb-accent-active);
-            }
+        &.special:focus {
+            background-color: var(--mitmweb-accent-active);
         }
     }
 }

--- a/web/src/css/tabs.less
+++ b/web/src/css/tabs.less
@@ -35,8 +35,34 @@
 
 .nav-tabs-lg {
     > a {
-        padding: 3px 14px;
+        padding: 4px 14px;
         margin: 0 2px -1px;
+        border-radius: 4px 4px 0 0;
+        transition:
+            color 120ms ease,
+            background-color 120ms ease,
+            border-color 120ms ease;
+
+        &:hover,
+        &:focus {
+            background-color: var(--mitmweb-bg-alt);
+        }
+
+        &.active {
+            background-color: var(--mitmweb-bg);
+            border-bottom-color: var(--mitmweb-bg);
+        }
+
+        &.special {
+            border-color: var(--mitmweb-accent);
+            border-bottom-color: var(--mitmweb-accent);
+
+            &:hover,
+            &:focus {
+                background-color: var(--mitmweb-accent-active);
+                border-color: var(--mitmweb-accent-active);
+            }
+        }
     }
 }
 

--- a/web/src/js/__tests__/components/FooterSpec.tsx
+++ b/web/src/js/__tests__/components/FooterSpec.tsx
@@ -1,14 +1,13 @@
 import * as React from "react";
 import { render, screen } from "../test-utils";
 import Footer from "../../components/Footer";
-import { TStore } from "../ducks/tutils";
+import { testState, TStore } from "../ducks/tutils";
 
 test("renders active options as badges", () => {
-    const state = TStore().getState();
     const store = TStore({
-        ...state,
+        ...testState,
         options: {
-            ...state.options,
+            ...testState.options,
             mode: ["regular", "upstream:https://example.com"],
             intercept: "~q",
             ssl_insecure: true,
@@ -48,4 +47,22 @@ test("renders active options as badges", () => {
         "127.0.0.1:9090",
         "mitmproxy 1.2.3",
     ].forEach((text) => expect(screen.getByText(text)).toBeVisible());
+
+    expect(screen.getByText("ssl_insecure")).toHaveClass("footer-badge-danger");
+    expect(screen.getByText("anticache")).toHaveClass("footer-badge-success");
+    expect(screen.getByText("127.0.0.1:9090")).toHaveClass("footer-badge-info");
+});
+
+test("does not render a badge for an enabled option", () => {
+    const store = TStore({
+        ...testState,
+        options: {
+            ...testState.options,
+            http2: true,
+        },
+    });
+
+    render(<Footer />, { store });
+
+    expect(screen.queryByText("no-http2")).not.toBeInTheDocument();
 });

--- a/web/src/js/__tests__/components/FooterSpec.tsx
+++ b/web/src/js/__tests__/components/FooterSpec.tsx
@@ -1,0 +1,51 @@
+import * as React from "react";
+import { render, screen } from "../test-utils";
+import Footer from "../../components/Footer";
+import { TStore } from "../ducks/tutils";
+
+test("renders active options as badges", () => {
+    const state = TStore().getState();
+    const store = TStore({
+        ...state,
+        options: {
+            ...state.options,
+            mode: ["regular", "upstream:https://example.com"],
+            intercept: "~q",
+            ssl_insecure: true,
+            showhost: true,
+            upstream_cert: false,
+            rawtcp: false,
+            http2: false,
+            websocket: false,
+            anticache: true,
+            anticomp: true,
+            stickyauth: "~u example.com",
+            stickycookie: "~d example.com",
+            stream_large_bodies: "1048576",
+            listen_host: "127.0.0.1",
+            listen_port: 9090,
+            server: true,
+        },
+    });
+
+    render(<Footer />, { store });
+
+    [
+        "regular,upstream:https://example.com",
+        "Intercept: ~q",
+        "ssl_insecure",
+        "showhost",
+        "no-upstream-cert",
+        "no-raw-tcp",
+        "no-http2",
+        "no-websocket",
+        "anticache",
+        "anticomp",
+        "stickyauth: ~u example.com",
+        "stickycookie: ~d example.com",
+        "stream: 1mb",
+        "1 of 5 flows selected",
+        "127.0.0.1:9090",
+        "mitmproxy 1.2.3",
+    ].forEach((text) => expect(screen.getByText(text)).toBeVisible());
+});

--- a/web/src/js/__tests__/components/ProxyAppSpec.tsx
+++ b/web/src/js/__tests__/components/ProxyAppSpec.tsx
@@ -18,6 +18,10 @@ test("ProxyApp", async () => {
         JSON.stringify(cv),
     );
     render(<ProxyApp />);
-    expect(screen.getByTitle("Mitmproxy Version")).toBeDefined();
+    expect(screen.getByTitle("Mitmproxy Version")).toHaveClass(
+        "badge",
+        "footer-badge",
+        "footer-badge-neutral",
+    );
     await waitFor(() => screen.getByText("my data"));
 });

--- a/web/src/js/__tests__/components/ProxyAppSpec.tsx
+++ b/web/src/js/__tests__/components/ProxyAppSpec.tsx
@@ -18,10 +18,6 @@ test("ProxyApp", async () => {
         JSON.stringify(cv),
     );
     render(<ProxyApp />);
-    expect(screen.getByTitle("Mitmproxy Version")).toHaveClass(
-        "badge",
-        "footer-badge",
-        "footer-badge-neutral",
-    );
+    expect(screen.getByTitle("Mitmproxy Version")).toBeVisible();
     await waitFor(() => screen.getByText("my data"));
 });

--- a/web/src/js/components/Footer.tsx
+++ b/web/src/js/components/Footer.tsx
@@ -4,6 +4,19 @@ import HideInStatic from "../components/common/HideInStatic";
 import { useAppSelector } from "../ducks";
 import Badge from "./common/Badge";
 
+type FooterBadgeProps = Omit<
+    React.ComponentProps<typeof Badge>,
+    "className"
+> & {
+    variant: "neutral" | "info" | "success" | "danger";
+};
+
+function FooterBadge({ variant, ...props }: FooterBadgeProps) {
+    return (
+        <Badge {...props} className={`footer-badge footer-badge-${variant}`} />
+    );
+}
+
 export default function Footer() {
     const version = useAppSelector((state) => state.backendState.version);
     const {
@@ -33,92 +46,63 @@ export default function Footer() {
     return (
         <footer>
             {mode && (mode.length !== 1 || mode[0] !== "regular") && (
-                <Badge className="footer-badge footer-badge-success">
-                    {mode.join(",")}
-                </Badge>
+                <FooterBadge variant="success">{mode.join(",")}</FooterBadge>
             )}
             {intercept && (
-                <Badge className="footer-badge footer-badge-success">
+                <FooterBadge variant="success">
                     Intercept: {intercept}
-                </Badge>
+                </FooterBadge>
             )}
             {ssl_insecure && (
-                <Badge className="footer-badge footer-badge-danger">
-                    ssl_insecure
-                </Badge>
+                <FooterBadge variant="danger">ssl_insecure</FooterBadge>
             )}
-            {showhost && (
-                <Badge className="footer-badge footer-badge-success">
-                    showhost
-                </Badge>
-            )}
+            {showhost && <FooterBadge variant="success">showhost</FooterBadge>}
             {!upstream_cert && (
-                <Badge className="footer-badge footer-badge-success">
-                    no-upstream-cert
-                </Badge>
+                <FooterBadge variant="success">no-upstream-cert</FooterBadge>
             )}
-            {!rawtcp && (
-                <Badge className="footer-badge footer-badge-success">
-                    no-raw-tcp
-                </Badge>
-            )}
-            {!http2 && (
-                <Badge className="footer-badge footer-badge-success">
-                    no-http2
-                </Badge>
-            )}
+            {!rawtcp && <FooterBadge variant="success">no-raw-tcp</FooterBadge>}
+            {!http2 && <FooterBadge variant="success">no-http2</FooterBadge>}
             {!websocket && (
-                <Badge className="footer-badge footer-badge-success">
-                    no-websocket
-                </Badge>
+                <FooterBadge variant="success">no-websocket</FooterBadge>
             )}
             {anticache && (
-                <Badge className="footer-badge footer-badge-success">
-                    anticache
-                </Badge>
+                <FooterBadge variant="success">anticache</FooterBadge>
             )}
-            {anticomp && (
-                <Badge className="footer-badge footer-badge-success">
-                    anticomp
-                </Badge>
-            )}
+            {anticomp && <FooterBadge variant="success">anticomp</FooterBadge>}
             {stickyauth && (
-                <Badge className="footer-badge footer-badge-success">
+                <FooterBadge variant="success">
                     stickyauth: {stickyauth}
-                </Badge>
+                </FooterBadge>
             )}
             {stickycookie && (
-                <Badge className="footer-badge footer-badge-success">
+                <FooterBadge variant="success">
                     stickycookie: {stickycookie}
-                </Badge>
+                </FooterBadge>
             )}
             {stream_large_bodies && (
-                <Badge className="footer-badge footer-badge-success">
+                <FooterBadge variant="success">
                     stream: {formatSize(stream_large_bodies)}
-                </Badge>
+                </FooterBadge>
             )}
             {totalFlowsLength > 0 && (
-                <Badge className="footer-badge footer-badge-neutral">
+                <FooterBadge variant="neutral">
                     {selectedFlowsLength} of {totalFlowsLength} flows selected
-                </Badge>
+                </FooterBadge>
             )}
             <div className="footer-meta">
                 <HideInStatic>
                     {server && (
-                        <Badge
-                            className="footer-badge footer-badge-info"
+                        <FooterBadge
+                            variant="info"
                             title="HTTP Proxy Server Address"
                         >
                             {listen_host || "*"}:{listen_port || 8080}
-                        </Badge>
+                        </FooterBadge>
                     )}
                 </HideInStatic>
-                <Badge
-                    className="footer-badge footer-badge-neutral"
-                    title="Mitmproxy Version"
-                >
+                <FooterBadge variant="neutral" title="Mitmproxy Version">
                     mitmproxy {version}
-                </Badge>
+                </FooterBadge>
             </div>
         </footer>
     );

--- a/web/src/js/components/Footer.tsx
+++ b/web/src/js/components/Footer.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import { formatSize } from "../utils";
 import HideInStatic from "../components/common/HideInStatic";
 import { useAppSelector } from "../ducks";
+import Badge from "./common/Badge";
 
 export default function Footer() {
     const version = useAppSelector((state) => state.backendState.version);
@@ -32,63 +33,92 @@ export default function Footer() {
     return (
         <footer>
             {mode && (mode.length !== 1 || mode[0] !== "regular") && (
-                <span className="label label-success">{mode.join(",")}</span>
+                <Badge className="footer-badge footer-badge-success">
+                    {mode.join(",")}
+                </Badge>
             )}
             {intercept && (
-                <span className="label label-success">
+                <Badge className="footer-badge footer-badge-success">
                     Intercept: {intercept}
-                </span>
+                </Badge>
             )}
             {ssl_insecure && (
-                <span className="label label-danger">ssl_insecure</span>
+                <Badge className="footer-badge footer-badge-danger">
+                    ssl_insecure
+                </Badge>
             )}
-            {showhost && <span className="label label-success">showhost</span>}
+            {showhost && (
+                <Badge className="footer-badge footer-badge-success">
+                    showhost
+                </Badge>
+            )}
             {!upstream_cert && (
-                <span className="label label-success">no-upstream-cert</span>
+                <Badge className="footer-badge footer-badge-success">
+                    no-upstream-cert
+                </Badge>
             )}
-            {!rawtcp && <span className="label label-success">no-raw-tcp</span>}
-            {!http2 && <span className="label label-success">no-http2</span>}
+            {!rawtcp && (
+                <Badge className="footer-badge footer-badge-success">
+                    no-raw-tcp
+                </Badge>
+            )}
+            {!http2 && (
+                <Badge className="footer-badge footer-badge-success">
+                    no-http2
+                </Badge>
+            )}
             {!websocket && (
-                <span className="label label-success">no-websocket</span>
+                <Badge className="footer-badge footer-badge-success">
+                    no-websocket
+                </Badge>
             )}
             {anticache && (
-                <span className="label label-success">anticache</span>
+                <Badge className="footer-badge footer-badge-success">
+                    anticache
+                </Badge>
             )}
-            {anticomp && <span className="label label-success">anticomp</span>}
+            {anticomp && (
+                <Badge className="footer-badge footer-badge-success">
+                    anticomp
+                </Badge>
+            )}
             {stickyauth && (
-                <span className="label label-success">
+                <Badge className="footer-badge footer-badge-success">
                     stickyauth: {stickyauth}
-                </span>
+                </Badge>
             )}
             {stickycookie && (
-                <span className="label label-success">
+                <Badge className="footer-badge footer-badge-success">
                     stickycookie: {stickycookie}
-                </span>
+                </Badge>
             )}
             {stream_large_bodies && (
-                <span className="label label-success">
+                <Badge className="footer-badge footer-badge-success">
                     stream: {formatSize(stream_large_bodies)}
-                </span>
+                </Badge>
             )}
             {totalFlowsLength > 0 && (
-                <span className="label label-default">
+                <Badge className="footer-badge footer-badge-neutral">
                     {selectedFlowsLength} of {totalFlowsLength} flows selected
-                </span>
+                </Badge>
             )}
-            <div className="float-right">
+            <div className="footer-meta">
                 <HideInStatic>
                     {server && (
-                        <span
-                            className="label label-primary"
+                        <Badge
+                            className="footer-badge footer-badge-info"
                             title="HTTP Proxy Server Address"
                         >
                             {listen_host || "*"}:{listen_port || 8080}
-                        </span>
+                        </Badge>
                     )}
                 </HideInStatic>
-                <span className="label label-default" title="Mitmproxy Version">
+                <Badge
+                    className="footer-badge footer-badge-neutral"
+                    title="Mitmproxy Version"
+                >
                     mitmproxy {version}
-                </span>
+                </Badge>
             </div>
         </footer>
     );

--- a/web/src/js/components/common/Badge.tsx
+++ b/web/src/js/components/common/Badge.tsx
@@ -1,16 +1,8 @@
 import * as React from "react";
 import classnames from "classnames";
 
-type BadgeProps = {
-    className?: string;
-    children: React.ReactNode;
-    title?: string;
-};
+type BadgeProps = React.ComponentPropsWithoutRef<"span">;
 
-export default function Badge({ className, children, title }: BadgeProps) {
-    return (
-        <span className={classnames("badge", className)} title={title}>
-            {children}
-        </span>
-    );
+export default function Badge({ className, ...props }: BadgeProps) {
+    return <span {...props} className={classnames("badge", className)} />;
 }

--- a/web/src/js/components/common/Badge.tsx
+++ b/web/src/js/components/common/Badge.tsx
@@ -4,8 +4,13 @@ import classnames from "classnames";
 type BadgeProps = {
     className?: string;
     children: React.ReactNode;
+    title?: string;
 };
 
-export default function Badge({ className, children }: BadgeProps) {
-    return <span className={classnames("badge", className)}>{children}</span>;
+export default function Badge({ className, children, title }: BadgeProps) {
+    return (
+        <span className={classnames("badge", className)} title={title}>
+            {children}
+        </span>
+    );
 }


### PR DESCRIPTION
#### Description

This PR slightly updates the mitmweb interface without changing its overall structure:

1. Adds subtle rounded corners and clearer hover states to the main tabs.
2. Reuses the existing `Badge` component, introduced in #8335, for footer status indicators.
3. Improves footer spacing, wrapping, and colors in dark mode.

<img width="1512" height="827" alt="Screenshot 2026-08-05 at 10 34 00" src="https://github.com/user-attachments/assets/1a6c928d-7369-42e0-8507-f854305d6868" />
<img width="1512" height="828" alt="Screenshot 2026-08-05 at 10 34 19" src="https://github.com/user-attachments/assets/0c2c1fd5-6405-4da1-9a99-ec610c6f18bb" />


#### Checklist

 - [x] I have updated tests where applicable.
 - [ ] I have added an entry to the CHANGELOG.
