### PR TITLE
fix: apply server_replay_extra policy even after replay map is exhausted

### DIFF
--- a/mitmproxy/addons/serverplayback.py
+++ b/mitmproxy/addons/serverplayback.py
@@ -291,9 +291,7 @@ class ServerPlayback:
             or ctx.options.server_replay_extra == "kill"
         ):
             logging.warning(
-                "server_playback: killed non-replay request {}".format(
-                    f.request.url
-                )
+                "server_playback: killed non-replay request {}".format(f.request.url)
             )
             f.kill()
         elif ctx.options.server_replay_extra != "forward":

--- a/mitmproxy/addons/serverplayback.py
+++ b/mitmproxy/addons/serverplayback.py
@@ -285,21 +285,22 @@ class ServerPlayback:
                     response.refresh()
                 f.response = response
                 f.is_replay = "response"
-            elif (
-                ctx.options.server_replay_kill_extra
-                or ctx.options.server_replay_extra == "kill"
-            ):
-                logging.warning(
-                    "server_playback: killed non-replay request {}".format(
-                        f.request.url
-                    )
+                return
+        if (
+            ctx.options.server_replay_kill_extra
+            or ctx.options.server_replay_extra == "kill"
+        ):
+            logging.warning(
+                "server_playback: killed non-replay request {}".format(
+                    f.request.url
                 )
-                f.kill()
-            elif ctx.options.server_replay_extra != "forward":
-                logging.warning(
-                    "server_playback: returned {} non-replay request {}".format(
-                        ctx.options.server_replay_extra, f.request.url
-                    )
+            )
+            f.kill()
+        elif ctx.options.server_replay_extra != "forward":
+            logging.warning(
+                "server_playback: returned {} non-replay request {}".format(
+                    ctx.options.server_replay_extra, f.request.url
                 )
-                f.response = http.Response.make(int(ctx.options.server_replay_extra))
-                f.is_replay = "response"
+            )
+            f.response = http.Response.make(int(ctx.options.server_replay_extra))
+            f.is_replay = "response"

--- a/test/mitmproxy/addons/test_serverplayback.py
+++ b/test/mitmproxy/addons/test_serverplayback.py
@@ -419,7 +419,9 @@ async def test_server_playback_404(option, status):
         assert f.response.status_code == status
 
 
-@pytest.mark.parametrize("option,status", [("204", 204), ("400", 400), ("404", 404), ("500", 500)])
+@pytest.mark.parametrize(
+    "option,status", [("204", 204), ("400", 400), ("404", 404), ("500", 500)]
+)
 async def test_server_playback_extra_after_exhaustion(option, status):
     """
     The non-reusable replay map empties after the final saved flow is consumed.

--- a/test/mitmproxy/addons/test_serverplayback.py
+++ b/test/mitmproxy/addons/test_serverplayback.py
@@ -419,6 +419,33 @@ async def test_server_playback_404(option, status):
         assert f.response.status_code == status
 
 
+@pytest.mark.parametrize("option,status", [("204", 204), ("400", 400), ("404", 404), ("500", 500)])
+async def test_server_playback_extra_after_exhaustion(option, status):
+    """
+    The non-reusable replay map empties after the final saved flow is consumed.
+    The configured server_replay_extra policy must still be applied to the next
+    request instead of silently falling through to the upstream server.
+    """
+    s = serverplayback.ServerPlayback()
+    with taddons.context(s) as tctx:
+        tctx.configure(s, server_replay_refresh=True, server_replay_extra=option)
+
+        f = tflow.tflow()
+        f.response = mitmproxy.test.tutils.tresp(content=f.request.content)
+        s.load_flows([f])
+
+        # First request consumes the only saved flow.
+        f = tflow.tflow()
+        await tctx.cycle(s, f)
+        assert f.response.status_code == 200
+        assert not s.flowmap
+
+        # The replay map is now empty; the extra policy must still apply.
+        f = tflow.tflow()
+        s.request(f)
+        assert f.response.status_code == status
+
+
 def test_server_playback_response_deleted():
     """
     The server playback addon holds references to flows that can be modified by the user in the meantime.


### PR DESCRIPTION
## Description

When server replay is configured without `server_replay_reuse` (the default), consuming the final replayable response empties the replay map. Every later request then bypasses `server_replay_extra` because the extra-request policy is gated behind `if self.flowmap:`.

This contradicts the option's documented contract: `server_replay_extra` controls requests during replay for which no replayable response was found. It also makes numeric policies such as `404` stop applying silently after the last saved response is consumed.

## Changes

- **`mitmproxy/addons/serverplayback.py`**: Move the `server_replay_extra` handling (kill, return synthetic status code) outside the `if self.flowmap:` guard. After a matched replay flow is served, the function returns early. If no match is found (or the flowmap is empty), the configured extra-request policy is applied.

## Tests

- **`test/mitmproxy/addons/test_serverplayback.py`**: Add `test_server_playback_extra_after_exhaustion` — loads one flow, consumes it, then verifies that the configured `server_replay_extra` policy (204, 400, 404, 500) is still applied to the next request.

Closes #8363
