### PR TITLE
Add vim-style :q and :q! command aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 ## Unreleased: mitmproxy next
 
+- Add vim-style `:q` and `:q!` command aliases as shortcuts for
+  `console.view.pop` and `console.exit` in the console command prompt.
 - Replace deprecated pyparsing APIs with their snake_case equivalents to avoid
   `PyparsingDeprecationWarning` during command and flow-filter parsing.
   ([#8344](https://github.com/mitmproxy/mitmproxy/pull/8344), @Dnsayhey)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 - Add vim-style `:q` and `:q!` command aliases as shortcuts for
   `console.view.pop` and `console.exit` in the console command prompt.
+  ([#8366](https://github.com/mitmproxy/mitmproxy/pull/8366), @nkbeast)
 - Replace deprecated pyparsing APIs with their snake_case equivalents to avoid
   `PyparsingDeprecationWarning` during command and flow-filter parsing.
   ([#8344](https://github.com/mitmproxy/mitmproxy/pull/8344), @Dnsayhey)

--- a/mitmproxy/tools/console/consoleaddons.py
+++ b/mitmproxy/tools/console/consoleaddons.py
@@ -364,6 +364,16 @@ class ConsoleAddon:
         """
         signals.pop_view_state.send()
 
+    @command.command("q")
+    def quit(self) -> None:
+        """Vim-style alias for `console.view.pop`."""
+        self.view_pop()
+
+    @command.command("q!")
+    def quit_force(self) -> None:
+        """Vim-style alias for `console.exit`."""
+        self.exit()
+
     @command.command("console.bodyview")
     @command.argument("part", type=mitmproxy.types.Choice("console.bodyview.options"))
     def bodyview(self, flow: flow.Flow, part: str) -> None:

--- a/test/mitmproxy/tools/console/test_commander.py
+++ b/test/mitmproxy/tools/console/test_commander.py
@@ -3,6 +3,8 @@ import pytest
 from mitmproxy import options
 from mitmproxy.addons import command_history
 from mitmproxy.test import taddons
+from mitmproxy.tools.console import consoleaddons
+from mitmproxy.tools.console import signals
 from mitmproxy.tools.console.commander import commander
 
 
@@ -380,3 +382,28 @@ class TestCommandBuffer:
                 ("commander_hint", "option "),
                 ("commander_hint", "*value "),
             ]
+
+
+class TestQuitAliases:
+    def test_aliases_registered(self, commander_tctx):
+        ca = consoleaddons.ConsoleAddon(commander_tctx.master)
+        commander_tctx.master.addons.add(ca)
+        cmds = commander_tctx.master.commands.commands
+        assert "q" in cmds
+        assert "q!" in cmds
+
+    def test_quit_alias(self, commander_tctx, monkeypatch):
+        ca = consoleaddons.ConsoleAddon(commander_tctx.master)
+        commander_tctx.master.addons.add(ca)
+        rec = []
+        monkeypatch.setattr(signals.pop_view_state, "send", lambda: rec.append(1))
+        commander_tctx.master.commands.execute("q")
+        assert rec
+
+    def test_quit_force_alias(self, commander_tctx, monkeypatch):
+        ca = consoleaddons.ConsoleAddon(commander_tctx.master)
+        commander_tctx.master.addons.add(ca)
+        rec = []
+        monkeypatch.setattr(commander_tctx.master, "shutdown", lambda: rec.append(1))
+        commander_tctx.master.commands.execute("q!")
+        assert rec


### PR DESCRIPTION
## Description

Closes https://github.com/mitmproxy/mitmproxy/issues/8071

Adds vim-style `:q` and `:q!` aliases to the console command prompt:

| Alias | Maps to | Behavior |
|-------|---------|----------|
| `:q` | `console.view.pop` | Pop view / prompt to quit at top level |
| `:q!` | `console.exit` | Exit immediately without prompt |

The existing `q`/`Q` keybindings are unchanged. The aliases are registered as regular commands, so they also appear in command completion and the command list.

## Checklist

- [x] I have updated tests where applicable.
- [x] I have added an entry to the CHANGELOG.