### PR TITLE
Add async `flow.request.stream` functions support

### DIFF
--- a/mitmproxy/http.py
+++ b/mitmproxy/http.py
@@ -4,6 +4,8 @@ import os
 import time
 import urllib.parse
 import warnings
+from collections.abc import AsyncIterable
+from collections.abc import Awaitable
 from collections.abc import Callable
 from collections.abc import Iterable
 from collections.abc import Iterator
@@ -34,6 +36,11 @@ from mitmproxy.utils import typecheck
 from mitmproxy.utils.strutils import always_bytes
 from mitmproxy.utils.strutils import always_str
 from mitmproxy.websocket import WebSocketData
+
+MessageStreamResult = bytes | Iterable[bytes] | AsyncIterable[bytes]
+MessageStreamCallable = Callable[
+    [bytes], MessageStreamResult | Awaitable[MessageStreamResult]
+]
 
 
 # While headers _should_ be ASCII, it's not uncommon for certain headers to be utf-8 encoded.
@@ -244,7 +251,7 @@ class Message(serializable.Serializable):
         self.data.set_state(state)
 
     data: MessageData
-    stream: Callable[[bytes], Iterable[bytes] | bytes] | bool = False
+    stream: MessageStreamCallable | bool = False
     """
     This attribute controls if the message body should be streamed.
 
@@ -254,6 +261,9 @@ class Message(serializable.Serializable):
     but immediately forwarded instead.
     Alternatively, a transformation function can be specified, which will be called for each chunk of data.
     Please note that packet boundaries generally should not be relied upon.
+
+    Transformation functions may be async, or decorated with
+    `mitmproxy.script.run_in_thread` if they perform blocking synchronous work.
 
     This attribute must be set in the `requestheaders` or `responseheaders` hook.
     Setting it in `request` or  `response` is already too late, mitmproxy has buffered the message body already.

--- a/mitmproxy/proxy/commands.py
+++ b/mitmproxy/proxy/commands.py
@@ -9,7 +9,12 @@ The counterpart to commands are events.
 
 import logging
 import warnings
+from collections.abc import Awaitable
+from collections.abc import Generator
+from typing import Generic
+from typing import Self
 from typing import TYPE_CHECKING
+from typing import TypeVar
 from typing import Union
 
 import mitmproxy.hooks
@@ -18,6 +23,8 @@ from mitmproxy.connection import Server
 
 if TYPE_CHECKING:
     import mitmproxy.proxy.layer
+
+R = TypeVar("R")
 
 
 class Command:
@@ -53,6 +60,23 @@ class RequestWakeup(Command):
 
     def __init__(self, delay: float):
         self.delay = delay
+
+
+class Await(Command, Generic[R]):
+    """Await a value without blocking unrelated proxy work."""
+
+    blocking = True
+    awaitable: Awaitable[R]
+
+    def __init__(self, awaitable: Awaitable[R]):
+        self.awaitable = awaitable
+
+    def unwrap(self) -> Generator[Self, tuple[R, None] | tuple[None, Exception], R]:
+        match (yield self):
+            case result, None:
+                return result
+            case None, error:
+                raise error
 
 
 class ConnectionCommand(Command):

--- a/mitmproxy/proxy/events.py
+++ b/mitmproxy/proxy/events.py
@@ -16,6 +16,8 @@ from mitmproxy import flow
 from mitmproxy.connection import Connection
 from mitmproxy.proxy import commands
 
+R = TypeVar("R")
+
 
 class Event:
     """
@@ -77,7 +79,8 @@ class CommandCompleted(Event):
         return super().__new__(cls)
 
     def __init_subclass__(cls, **kwargs):
-        command_cls = typing.get_type_hints(cls).get("command", None)
+        command_annotation = typing.get_type_hints(cls).get("command", None)
+        command_cls = typing.get_origin(command_annotation) or command_annotation
         valid_command_subclass = (
             isinstance(command_cls, type)
             and issubclass(command_cls, commands.Command)
@@ -114,6 +117,12 @@ class OpenConnectionCompleted(CommandCompleted):
 class HookCompleted(CommandCompleted):
     command: commands.StartHook
     reply: None = None
+
+
+@dataclass(repr=False)
+class AwaitCompleted(CommandCompleted, Generic[R]):
+    command: commands.Await[R]
+    reply: tuple[R, None] | tuple[None, Exception]
 
 
 T = TypeVar("T")

--- a/mitmproxy/proxy/layers/http/__init__.py
+++ b/mitmproxy/proxy/layers/http/__init__.py
@@ -1,6 +1,9 @@
 import collections
 import enum
+import inspect
 import time
+from collections.abc import AsyncIterable
+from collections.abc import Callable
 from dataclasses import dataclass
 from functools import cached_property
 from logging import DEBUG
@@ -309,37 +312,88 @@ class HttpStream(layer.Layer):
         yield commands.Log(f"Streaming request to {self.flow.request.host}.")
         self.client_state = self.state_stream_request_body
 
+    def read_message_stream(
+        self,
+        stream: http.MessageStreamCallable,
+        message_chunk: bytes,
+        write_message_stream: Callable[[bytes], layer.CommandGenerator[None]],
+    ) -> layer.CommandGenerator[None]:
+        chunks = stream(message_chunk)
+
+        if inspect.isawaitable(chunks):
+            chunks = yield from commands.Await(chunks).unwrap()
+
+        if isinstance(chunks, bytes):
+            chunks = [chunks]
+
+        if isinstance(chunks, AsyncIterable):
+            async_iterator = aiter(chunks)
+            while True:
+                try:
+                    chunk = yield from commands.Await(anext(async_iterator)).unwrap()
+                except StopAsyncIteration:
+                    break
+                yield from write_message_stream(chunk)
+        else:
+            for chunk in chunks:
+                yield from write_message_stream(chunk)
+
+    def read_request_stream(self, chunk: bytes) -> layer.CommandGenerator[None]:
+        assert callable(self.flow.request.stream)
+        yield from self.read_message_stream(
+            self.flow.request.stream,
+            chunk,
+            self.write_request_stream,
+        )
+
+    def write_request_stream(self, chunk: bytes) -> layer.CommandGenerator[None]:
+        if not isinstance(chunk, bytes):
+            raise TypeError(
+                f"Request.stream must yield bytes chunks, not {type(chunk).__name__}."
+            )
+        if chunk == b"":
+            return
+        if self.context.options.store_streamed_bodies:
+            self.request_body_buf += chunk
+        yield SendHttp(RequestData(self.stream_id, chunk), self.context.server)
+
+    def read_response_stream(self, chunk: bytes) -> layer.CommandGenerator[None]:
+        assert self.flow.response
+        assert callable(self.flow.response.stream)
+        yield from self.read_message_stream(
+            self.flow.response.stream,
+            chunk,
+            self.write_response_stream,
+        )
+
+    def write_response_stream(self, chunk: bytes) -> layer.CommandGenerator[None]:
+        if not isinstance(chunk, bytes):
+            raise TypeError(
+                f"Response.stream must yield bytes chunks, not {type(chunk).__name__}."
+            )
+        if chunk == b"":
+            return
+        if self.context.options.store_streamed_bodies:
+            self.response_body_buf += chunk
+        yield SendHttp(ResponseData(self.stream_id, chunk), self.context.client)
+
     @expect(RequestData, RequestTrailers, RequestEndOfMessage)
     def state_stream_request_body(
         self, event: RequestData | RequestEndOfMessage
     ) -> layer.CommandGenerator[None]:
         if isinstance(event, RequestData):
             if callable(self.flow.request.stream):
-                chunks = self.flow.request.stream(event.data)
-                if isinstance(chunks, bytes):
-                    chunks = [chunks]
+                yield from self.read_request_stream(event.data)
             else:
-                chunks = [event.data]
-            for chunk in chunks:
                 if self.context.options.store_streamed_bodies:
-                    self.request_body_buf += chunk
-                yield SendHttp(RequestData(self.stream_id, chunk), self.context.server)
+                    self.request_body_buf += event.data
+                yield SendHttp(event, self.context.server)
         elif isinstance(event, RequestTrailers):
             # we don't do anything further here, we wait for RequestEndOfMessage first to trigger the request hook.
             self.flow.request.trailers = event.trailers
         elif isinstance(event, RequestEndOfMessage):
             if callable(self.flow.request.stream):
-                chunks = self.flow.request.stream(b"")
-                if chunks == b"":
-                    chunks = []
-                elif isinstance(chunks, bytes):
-                    chunks = [chunks]
-                for chunk in chunks:
-                    if self.context.options.store_streamed_bodies:
-                        self.request_body_buf += chunk
-                    yield SendHttp(
-                        RequestData(self.stream_id, chunk), self.context.server
-                    )
+                yield from self.read_request_stream(b"")
 
             if self.context.options.store_streamed_bodies:
                 self.flow.request.data.content = bytes(self.request_body_buf)
@@ -445,31 +499,17 @@ class HttpStream(layer.Layer):
         assert self.flow.response
         if isinstance(event, ResponseData):
             if callable(self.flow.response.stream):
-                chunks = self.flow.response.stream(event.data)
-                if isinstance(chunks, bytes):
-                    chunks = [chunks]
+                yield from self.read_response_stream(event.data)
             else:
-                chunks = [event.data]
-            for chunk in chunks:
                 if self.context.options.store_streamed_bodies:
-                    self.response_body_buf += chunk
-                yield SendHttp(ResponseData(self.stream_id, chunk), self.context.client)
+                    self.response_body_buf += event.data
+                yield SendHttp(event, self.context.client)
         elif isinstance(event, ResponseTrailers):
             self.flow.response.trailers = event.trailers
             # will be sent in send_response() after the response hook.
         elif isinstance(event, ResponseEndOfMessage):
             if callable(self.flow.response.stream):
-                chunks = self.flow.response.stream(b"")
-                if chunks == b"":
-                    chunks = []
-                elif isinstance(chunks, bytes):
-                    chunks = [chunks]
-                for chunk in chunks:
-                    if self.context.options.store_streamed_bodies:
-                        self.response_body_buf += chunk
-                    yield SendHttp(
-                        ResponseData(self.stream_id, chunk), self.context.client
-                    )
+                yield from self.read_response_stream(b"")
             if self.context.options.store_streamed_bodies:
                 self.flow.response.data.content = bytes(self.response_body_buf)
                 self.response_body_buf.clear()

--- a/mitmproxy/proxy/server.py
+++ b/mitmproxy/proxy/server.py
@@ -19,6 +19,7 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 from types import TracebackType
 from typing import Literal
+from typing import TypeVar
 
 from OpenSSL import SSL
 
@@ -41,6 +42,8 @@ from mitmproxy.proxy.layers.http import HTTPMode
 from mitmproxy.utils import asyncio_utils
 from mitmproxy.utils import human
 from mitmproxy.utils.data import pkg_data
+
+R = TypeVar("R")
 
 logger = logging.getLogger(__name__)
 
@@ -102,12 +105,14 @@ class ConnectionHandler(metaclass=abc.ABCMeta):
     max_conns: collections.defaultdict[Address, asyncio.Semaphore]
     layer: "layer.Layer"
     wakeup_timer: set[asyncio.Task]
+    command_tasks: set[asyncio.Task]
 
     def __init__(self, context: Context) -> None:
         self.client = context.client
         self.transports = {}
         self.max_conns = collections.defaultdict(lambda: asyncio.Semaphore(5))
         self.wakeup_timer = set()
+        self.command_tasks = set()
 
         # Ask for the first layer right away.
         # In a reverse proxy scenario, this is necessary as we would otherwise hang
@@ -164,6 +169,9 @@ class ConnectionHandler(metaclass=abc.ABCMeta):
         while self.wakeup_timer:
             timer = self.wakeup_timer.pop()
             timer.cancel()
+        while self.command_tasks:
+            task = self.command_tasks.pop()
+            task.cancel()
 
         self.log("client disconnect")
         self.client.timestamp_end = time.time()
@@ -327,19 +335,22 @@ class ConnectionHandler(metaclass=abc.ABCMeta):
         if cancelled:
             raise cancelled
 
-    async def drain_writers(self):
+    async def drain_writers(self) -> None:
         """
         Drain all writers to create some backpressure. We won't continue reading until there's space available in our
         write buffers, so if we cannot write fast enough our own read buffers run full and the TCP recv stream is throttled.
         """
         async with self._drain_lock:
-            for transport in list(self.transports.values()):
-                if transport.writer is not None:
-                    try:
-                        await transport.writer.drain()
-                    except OSError as e:
-                        if transport.handler is not None:
-                            transport.handler.cancel(f"Error sending data: {e}")
+            await self._drain_writers()
+
+    async def _drain_writers(self) -> None:
+        for transport in list(self.transports.values()):
+            if transport.writer is not None:
+                try:
+                    await transport.writer.drain()
+                except OSError as e:
+                    if transport.handler is not None:
+                        transport.handler.cancel(f"Error sending data: {e}")
 
     async def on_timeout(self) -> None:
         try:
@@ -357,6 +368,18 @@ class ConnectionHandler(metaclass=abc.ABCMeta):
         await self.handle_hook(hook)
         if hook.blocking:
             await self.server_event(events.HookCompleted(hook))
+
+    async def await_command(self, command: commands.Await[R]) -> None:
+        reply: tuple[R, None] | tuple[None, Exception]
+        try:
+            result = await command.awaitable
+        except Exception as e:
+            reply = (None, e)
+        else:
+            reply = (result, None)
+        async with self._drain_lock:
+            await self.server_event(events.AwaitCompleted(command, reply))
+            await self._drain_writers()
 
     @abc.abstractmethod
     async def handle_hook(self, hook: commands.StartHook) -> None:
@@ -408,6 +431,15 @@ class ConnectionHandler(metaclass=abc.ABCMeta):
                         )
                         assert task is not None
                         self.wakeup_timer.add(task)
+                    elif isinstance(command, commands.Await):
+                        task = asyncio_utils.create_task(
+                            self.await_command(command),
+                            name="await_command",
+                            keep_ref=False,
+                            client=self.client.peername,
+                        )
+                        self.command_tasks.add(task)
+                        task.add_done_callback(self.command_tasks.discard)
                     elif (
                         isinstance(command, commands.ConnectionCommand)
                         and command.connection not in self.transports

--- a/mitmproxy/script/__init__.py
+++ b/mitmproxy/script/__init__.py
@@ -1,5 +1,7 @@
 from .concurrent import concurrent
+from .concurrent import run_in_thread
 
 __all__ = [
     "concurrent",
+    "run_in_thread",
 ]

--- a/mitmproxy/script/concurrent.py
+++ b/mitmproxy/script/concurrent.py
@@ -1,12 +1,71 @@
-"""
-This module provides a @concurrent decorator primitive to
-offload computations from mitmproxy's main master thread.
-"""
+"""Primitives for running callbacks outside the main event-loop thread."""
 
 import asyncio
 import inspect
+from collections.abc import AsyncGenerator
+from collections.abc import Awaitable
+from collections.abc import Callable
+from collections.abc import Generator
+from functools import wraps
+from typing import cast
+from typing import overload
+from typing import ParamSpec
+from typing import TypeVar
 
 from mitmproxy import hooks
+
+P = ParamSpec("P")
+T = TypeVar("T")
+
+
+@overload
+def run_in_thread(  # type: ignore[overload-overlap]
+    function: Callable[P, Generator[T, None, None]],
+) -> Callable[P, AsyncGenerator[T, None]]: ...
+
+
+@overload
+def run_in_thread(function: Callable[P, T]) -> Callable[P, Awaitable[T]]: ...
+
+
+def run_in_thread(
+    function: Callable[P, Generator[T, None, None]] | Callable[P, T],
+) -> Callable[P, AsyncGenerator[T, None]] | Callable[P, Awaitable[T]]:
+    """Run a synchronous function or generator function in worker threads."""
+    if inspect.iscoroutinefunction(function) or inspect.isasyncgenfunction(function):
+        raise ValueError("run_in_thread cannot be used with async functions.")
+
+    if inspect.isgeneratorfunction(function):
+        generator_function = cast(Callable[P, Generator[T, None, None]], function)
+
+        @wraps(function)
+        async def generator_wrapper(
+            *args: P.args, **kwargs: P.kwargs
+        ) -> AsyncGenerator[T, None]:
+            iterator = generator_function(*args, **kwargs)
+
+            # StopIteration can't be raised in an async generator,
+            # so we use a sentinel value to signal the end of the iterator.
+            class Done:
+                __slots__ = ()
+
+            done = Done()
+
+            while True:
+                item = await asyncio.to_thread(next, iterator, done)
+                if isinstance(item, Done):
+                    break
+                yield item
+
+        return generator_wrapper
+
+    sync_function = cast(Callable[P, T], function)
+
+    @wraps(function)
+    async def function_wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
+        return await asyncio.to_thread(sync_function, *args, **kwargs)
+
+    return function_wrapper
 
 
 def concurrent(fn):

--- a/test/mitmproxy/proxy/layers/http/test_http.py
+++ b/test/mitmproxy/proxy/layers/http/test_http.py
@@ -7,6 +7,7 @@ from mitmproxy.connection import ConnectionState
 from mitmproxy.connection import Server
 from mitmproxy.http import HTTPFlow
 from mitmproxy.http import Response
+from mitmproxy.proxy import commands
 from mitmproxy.proxy import layer
 from mitmproxy.proxy.commands import CloseConnection
 from mitmproxy.proxy.commands import Log
@@ -22,8 +23,10 @@ from mitmproxy.proxy.layers.tcp import TcpMessageInjected
 from mitmproxy.proxy.layers.tcp import TcpStartHook
 from mitmproxy.proxy.layers.websocket import WebsocketStartHook
 from mitmproxy.proxy.mode_specs import ProxyMode
+from mitmproxy.script import run_in_thread
 from mitmproxy.tcp import TCPFlow
 from mitmproxy.tcp import TCPMessage
+from mitmproxy.test import tflow
 from test.mitmproxy.proxy.tutils import BytesMatching
 from test.mitmproxy.proxy.tutils import Placeholder
 from test.mitmproxy.proxy.tutils import Playbook
@@ -531,6 +534,123 @@ def test_stream_modify(tctx):
         >> reply()
         << SendData(tctx.client, b"0\r\n\r\n")
     )
+
+
+async def run_message_stream(generator):
+    emitted = []
+    blocking = []
+    reply_value = None
+
+    while True:
+        try:
+            command = generator.send(reply_value)
+        except StopIteration:
+            return emitted, blocking
+
+        reply_value = None
+        if isinstance(command, commands.Await):
+            blocking.append(command)
+            try:
+                result = await command.awaitable
+            except Exception as error:
+                reply_value = (None, error)
+            else:
+                reply_value = (result, None)
+        else:
+            emitted.append(command)
+
+
+@pytest.mark.parametrize("direction", ["request", "response"])
+@pytest.mark.parametrize(
+    "style",
+    [
+        "sync_bytes",
+        "sync_list",
+        "threaded_bytes",
+        "threaded_list",
+        "threaded_generator",
+        "async_bytes",
+        "async_list",
+        "async_generator",
+    ],
+)
+async def test_message_stream_transformers(tctx, direction, style):
+    if style == "sync_bytes":
+
+        def transform(chunk):
+            return b"[" + chunk + b"]"
+
+    elif style == "sync_list":
+
+        def transform(chunk):
+            return [b"[", chunk, b"]"]
+
+    elif style == "threaded_bytes":
+
+        @run_in_thread
+        def transform(chunk):
+            return b"[" + chunk + b"]"
+
+    elif style == "threaded_list":
+
+        @run_in_thread
+        def transform(chunk):
+            return [b"[", chunk, b"]"]
+
+    elif style == "threaded_generator":
+
+        @run_in_thread
+        def transform(chunk):
+            yield b"["
+            yield chunk
+            yield b"]"
+
+    elif style == "async_bytes":
+
+        async def transform(chunk):
+            return b"[" + chunk + b"]"
+
+    elif style == "async_list":
+
+        async def transform(chunk):
+            return [b"[", chunk, b"]"]
+
+    else:
+
+        async def transform(chunk):
+            yield b"["
+            yield chunk
+            yield b"]"
+
+    stream = http.HttpStream(tctx, 1)
+    stream.flow = tflow.tflow(resp=True)
+    message = getattr(stream.flow, direction)
+    assert message is not None
+    message.stream = transform
+    tctx.options.store_streamed_bodies = True
+
+    if direction == "request":
+        generator = stream.read_request_stream(b"body")
+        expected_connection = tctx.server
+    else:
+        generator = stream.read_response_stream(b"body")
+        expected_connection = tctx.client
+
+    emitted, blocking = await run_message_stream(generator)
+
+    expected_chunks = [b"[body]"] if style.endswith("bytes") else [b"[", b"body", b"]"]
+    assert [command.event.data for command in emitted] == expected_chunks
+    assert all(command.connection is expected_connection for command in emitted)
+    if style.startswith(("threaded", "async")):
+        assert blocking
+        assert all(isinstance(command, commands.Await) for command in blocking)
+    else:
+        assert not blocking
+
+    body = (
+        stream.request_body_buf if direction == "request" else stream.response_body_buf
+    )
+    assert bytes(body) == b"[body]"
 
 
 @pytest.mark.parametrize("why", ["body_size=0", "body_size=3", "addon"])

--- a/test/mitmproxy/proxy/layers/http/test_http2.py
+++ b/test/mitmproxy/proxy/layers/http/test_http2.py
@@ -13,6 +13,7 @@ from mitmproxy.flow import Error
 from mitmproxy.http import Headers
 from mitmproxy.http import HTTPFlow
 from mitmproxy.http import Request
+from mitmproxy.proxy.commands import Await
 from mitmproxy.proxy.commands import CloseConnection
 from mitmproxy.proxy.commands import Log
 from mitmproxy.proxy.commands import OpenConnection
@@ -906,6 +907,70 @@ def test_stream_concurrency(tctx):
     assert [type(x) for x in frames] == [
         hyperframe.frame.HeadersFrame,
     ]
+
+
+def test_awaiting_stream_does_not_block_sibling_stream(
+    tctx: Context, open_h2_server_conn: Server
+):
+    """An awaiting stream must not pause other streams on the same H2 connection."""
+    playbook, cff = start_h2_client(tctx)
+    tctx.server = open_h2_server_conn
+
+    flow1 = Placeholder(HTTPFlow)
+    flow2 = Placeholder(HTTPFlow)
+    pending_awaitable = Placeholder()
+    await_command = Await(pending_awaitable)
+    stream1_headers = Placeholder(bytes)
+    stream2_request = Placeholder(bytes)
+    stream1_data = Placeholder(bytes)
+
+    async def transform(chunk: bytes) -> bytes:
+        return b"transformed: " + chunk
+
+    def enable_streaming(flow: HTTPFlow) -> None:
+        flow.request.stream = transform
+
+    assert (
+        playbook
+        # Start streaming request body data on stream 1.
+        >> DataReceived(
+            tctx.client,
+            cff.build_headers_frame(example_request_headers, stream_id=1).serialize(),
+        )
+        << http.HttpRequestHeadersHook(flow1)
+        >> reply(side_effect=enable_streaming)
+        << SendData(tctx.server, stream1_headers)
+        # The async transformer pauses only stream 1.
+        >> DataReceived(
+            tctx.client,
+            cff.build_data_frame(b"body", stream_id=1).serialize(),
+        )
+        << await_command
+        # Stream 3 shares both H2 connections and can still complete its request.
+        >> DataReceived(
+            tctx.client,
+            cff.build_headers_frame(
+                example_request_headers, flags=["END_STREAM"], stream_id=3
+            ).serialize(),
+        )
+        << http.HttpRequestHeadersHook(flow2)
+        >> reply()
+        << http.HttpRequestHook(flow2)
+        >> reply()
+        << SendData(tctx.server, stream2_request)
+        # Once stream 1 resumes, its transformed data is sent on the same connection.
+        >> reply((b"transformed: body", None), to=await_command)
+        << SendData(tctx.server, stream1_data)
+    )
+
+    assert decode_frames(stream1_headers())[-1].stream_id == 1
+    assert decode_frames(stream2_request())[-1].stream_id == 3
+    (data_frame,) = decode_frames(stream1_data())
+    assert isinstance(data_frame, hyperframe.frame.DataFrame)
+    assert data_frame.stream_id == 1
+    assert data_frame.data == b"transformed: body"
+
+    pending_awaitable().close()
 
 
 def test_max_concurrency(tctx):

--- a/test/mitmproxy/proxy/test_commands.py
+++ b/test/mitmproxy/proxy/test_commands.py
@@ -32,3 +32,34 @@ def test_start_hook():
     f = TestHook(b"foo")
     assert f.args() == [b"foo"]
     assert TestHook in all_hooks.values()
+
+
+def test_await_unwrap():
+    async def awaitable():
+        return 42
+
+    command = commands.Await(awaitable())
+    generator = command.unwrap()
+
+    assert next(generator) is command
+    with pytest.raises(StopIteration) as done:
+        generator.send((42, None))
+    assert done.value.value == 42
+
+    command.awaitable.close()
+
+
+def test_await_unwrap_error():
+    error = RuntimeError("test error")
+
+    async def awaitable():
+        return None
+
+    command = commands.Await(awaitable())
+
+    generator = command.unwrap()
+    assert next(generator) is command
+    with pytest.raises(RuntimeError, match="test error"):
+        generator.send((None, error))
+
+    command.awaitable.close()

--- a/test/mitmproxy/proxy/test_server.py
+++ b/test/mitmproxy/proxy/test_server.py
@@ -1,6 +1,7 @@
 import asyncio
 import collections
 import textwrap
+import threading
 from dataclasses import dataclass
 from typing import Callable
 from unittest import mock
@@ -10,6 +11,7 @@ import pytest
 from mitmproxy import options
 from mitmproxy.connection import Server
 from mitmproxy.proxy import commands
+from mitmproxy.proxy import events
 from mitmproxy.proxy import layer
 from mitmproxy.proxy import server
 from mitmproxy.proxy import server_hooks
@@ -17,6 +19,7 @@ from mitmproxy.proxy.events import Event
 from mitmproxy.proxy.events import HookCompleted
 from mitmproxy.proxy.events import Start
 from mitmproxy.proxy.mode_specs import ProxyMode
+from mitmproxy.script import run_in_thread
 
 
 class MockConnectionHandler(server.SimpleConnectionHandler):
@@ -30,6 +33,19 @@ class MockConnectionHandler(server.SimpleConnectionHandler):
             mode=ProxyMode.parse("regular"),
             hook_handlers=collections.defaultdict(lambda: mock.Mock()),
         )
+
+
+class AwaitCommandLayer(layer.Layer):
+    def __init__(self, context, command):
+        super().__init__(context)
+        self.command = command
+        self.completed = asyncio.Event()
+        self.result = None
+
+    def _handle_event(self, event: Event) -> layer.CommandGenerator[None]:
+        if isinstance(event, Start):
+            self.result = yield from self.command.unwrap()
+            self.completed.set()
 
 
 @pytest.mark.parametrize("result", ("success", "killed", "failed"))
@@ -104,3 +120,69 @@ async def test_no_reentrancy(capsys):
         Hook completed (must not happen before start is completed).
         """
     )
+
+
+@pytest.mark.parametrize("outcome", ["result", "exception"])
+async def test_await_completion(outcome):
+    handler = MockConnectionHandler()
+    handler.server_event = mock.AsyncMock()
+    handler._drain_writers = mock.AsyncMock()
+
+    async def awaitable():
+        if outcome == "exception":
+            raise RuntimeError("test error")
+        return "result"
+
+    command = commands.Await(awaitable())
+    await handler.await_command(command)
+
+    completed = handler.server_event.await_args.args[0]
+    assert isinstance(completed, events.AwaitCompleted)
+    assert completed.command is command
+    if outcome == "result":
+        assert completed.reply == ("result", None)
+    else:
+        assert completed.reply[0] is None
+        assert isinstance(completed.reply[1], RuntimeError)
+
+
+async def test_run_in_thread_does_not_block_other_connections():
+    started = threading.Event()
+    release = threading.Event()
+
+    @run_in_thread
+    def blocking():
+        started.set()
+        release.wait()
+        return "slow"
+
+    @run_in_thread
+    def fast():
+        return "fast"
+
+    first = MockConnectionHandler()
+    first.transports.clear()
+    first_layer = AwaitCommandLayer(first.layer.context, commands.Await(blocking()))
+    first.layer = first_layer
+
+    second = MockConnectionHandler()
+    second.transports.clear()
+    second_layer = AwaitCommandLayer(second.layer.context, commands.Await(fast()))
+    second.layer = second_layer
+
+    try:
+        await first.server_event(Start())
+        async with asyncio.timeout(5):
+            while not started.is_set():
+                await asyncio.sleep(0.01)
+
+        await second.server_event(Start())
+        await asyncio.wait_for(second_layer.completed.wait(), timeout=5)
+
+        assert second_layer.result == "fast"
+        assert not first_layer.completed.is_set()
+    finally:
+        release.set()
+
+    await asyncio.wait_for(first_layer.completed.wait(), timeout=5)
+    assert first_layer.result == "slow"

--- a/test/mitmproxy/script/test_concurrent.py
+++ b/test/mitmproxy/script/test_concurrent.py
@@ -1,9 +1,12 @@
 import asyncio
+import inspect
 import os
+import threading
 import time
 
 import pytest
 
+from mitmproxy.script.concurrent import run_in_thread
 from mitmproxy.test import taddons
 from mitmproxy.test import tflow
 
@@ -34,3 +37,45 @@ class TestConcurrent:
                 tdata.path("mitmproxy/data/addonscripts/concurrent_decorator_err.py")
             )
             assert "decorator not supported" in caplog.text
+
+
+async def test_run_in_thread_function():
+    event_loop_thread = threading.get_ident()
+
+    @run_in_thread
+    def plain(value: str) -> str:
+        assert threading.get_ident() != event_loop_thread
+        return value.upper()
+
+    assert inspect.iscoroutinefunction(plain)
+    assert await plain("value") == "VALUE"
+
+
+async def test_run_in_thread_generator():
+    event_loop_thread = threading.get_ident()
+
+    @run_in_thread
+    def generate():
+        assert threading.get_ident() != event_loop_thread
+        yield "one"
+        assert threading.get_ident() != event_loop_thread
+        yield "two"
+
+    assert inspect.isasyncgenfunction(generate)
+    assert [item async for item in generate()] == ["one", "two"]
+
+
+@pytest.mark.parametrize("kind", ["coroutine", "async_generator"])
+def test_run_in_thread_rejects_async_functions(kind):
+    if kind == "coroutine":
+
+        async def function():
+            return None
+
+    else:
+
+        async def function():
+            yield None
+
+    with pytest.raises(ValueError, match="cannot be used with async functions"):
+        run_in_thread(function)


### PR DESCRIPTION
#### Description

`Message.stream` transformers currently run synchronously while `HttpStream` processes request or response body data. If a transformer performs blocking work, it blocks mitmproxy’s main asyncio event loop. This pauses not only the affected HTTP stream, but also unrelated connections handled by that loop.

This PR adds explicit, opt-in concurrency for blocking stream transformers while preserving the existing synchronous fast path.

Existing transformers continue to work unchanged:

```python
def transform(chunk: bytes) -> bytes:
    return chunk.upper()

flow.request.stream = transform
```

Blocking synchronous transformers can now opt into worker-thread execution:

```python
from mitmproxy.script import run_in_thread

@run_in_thread
def transform(chunk: bytes) -> bytes:
    return blocking_operation(chunk)

flow.request.stream = transform
```

Native asynchronous transformers are also supported:

```python
async def transform(chunk: bytes) -> bytes:
    return await asynchronous_operation(chunk)

flow.response.stream = transform
```

This works for both `flow.request.stream` and `flow.response.stream`.

##### How asynchronous processing is integrated

The proxy layer command protocol now has a generic `Await` command and corresponding `AwaitCompleted` event. When an HTTP stream encounters an awaitable, it yields this blocking command and pauses only the layer that issued it.

The connection handler schedules the awaitable as an asyncio task instead of awaiting it inline. This allows the current `HttpStream` to remain paused while unrelated streams and connections continue to be processed. Results and exceptions are returned through the normal command-completion mechanism.

##### `run_in_thread`

`mitmproxy.script.run_in_thread` converts supported synchronous callables into regular asynchronous callables:

- A normal synchronous function becomes an async function whose invocation uses `asyncio.to_thread`.
- A synchronous generator function becomes an async generator. Each `next()` call runs through `asyncio.to_thread`, preserving incremental streaming and backpressure instead of consuming the complete generator in a worker thread.
- A normal function that manually returns a generator is intentionally not treated as a generator function. Supporting that would require inspecting arbitrary return values. Callers that need threaded incremental iteration should use an actual generator function.

##### Development history

The [stream-async-wip](https://github.com/hdk5/mitmproxy/tree/stream-async-wip) branch preserves the more detailed development history. It also contains several earlier designs that were rejected.

#### Checklist

- [x] I have updated tests where applicable.
- [ ] I have added an entry to the CHANGELOG.
