### PR TITLE
fix(test): call configure() on script addons in taddons.context.configure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 
 ## Unreleased: mitmproxy next
 
+- `mitmproxy.test.taddons.context.configure()` now calls `configure()` on
+  addons obtained via `context.script()`, which are registered but not part
+  of the addon chain and previously never received the `options.changed`
+  broadcast that normally triggers it for chained addons.
+  ([#3402](https://github.com/mitmproxy/mitmproxy/issues/3402), @citizen204)
 - Replace deprecated pyparsing APIs with their snake_case equivalents to avoid
   `PyparsingDeprecationWarning` during command and flow-filter parsing.
   ([#8344](https://github.com/mitmproxy/mitmproxy/pull/8344), @Dnsayhey)

--- a/mitmproxy/test/taddons.py
+++ b/mitmproxy/test/taddons.py
@@ -59,11 +59,23 @@ class context:
         Options object with the given keyword arguments, then calls the
         configure method on the addon with the updated value.
         """
+        # Options changes are normally broadcast to addons via the
+        # `options.changed` signal, which only reaches addons that are part
+        # of `self.master.addons.chain` (i.e. added with `.add()`, as the
+        # constructor does for `context(*addons)`). Addons obtained via
+        # `context.script()` are only `.register()`-ed, not chained, so that
+        # broadcast never reaches them and `configure()` is silently never
+        # called for them. Invoke it directly in that case.
+        chained = addon in self.master.addons.chain
         if addon not in self.master.addons:
             self.master.addons.register(addon)
         with self.options.rollback(kwargs.keys(), reraise=True):
             if kwargs:
                 self.options.update(**kwargs)
+                if not chained:
+                    self.master.addons.invoke_addon_sync(
+                        addon, hooks.ConfigureHook(set(kwargs.keys()))
+                    )
             else:
                 self.master.addons.invoke_addon_sync(addon, hooks.ConfigureHook(set()))
 

--- a/test/mitmproxy/data/addonscripts/configure_recorder.py
+++ b/test/mitmproxy/data/addonscripts/configure_recorder.py
@@ -1,0 +1,21 @@
+class ConfigureRecorder:
+    """
+    Records every `updated` set passed to `configure()`, so tests can check
+    whether `configure()` was actually invoked after an option change.
+    """
+
+    call_log = []
+
+    def load(self, loader):
+        loader.add_option(
+            name="recorder_option",
+            typespec=str,
+            default="default",
+            help="A custom option for testing that configure() gets called.",
+        )
+
+    def configure(self, updated):
+        self.call_log.append(set(updated))
+
+
+addons = [ConfigureRecorder()]

--- a/test/mitmproxy/test_taddons.py
+++ b/test/mitmproxy/test_taddons.py
@@ -5,3 +5,26 @@ def test_load_script(tdata):
     with taddons.context() as tctx:
         s = tctx.script(tdata.path("mitmproxy/data/addonscripts/recorder/recorder.py"))
         assert s
+
+
+def test_configure_calls_configure_on_script_addon(tdata):
+    """
+    https://github.com/mitmproxy/mitmproxy/issues/3402
+
+    `context.script()` returns an addon that is registered but not part of
+    the addon chain, so the `options.changed` broadcast that normally
+    triggers `configure()` for chained addons never reaches it.
+    `context.configure()` must invoke `configure()` on it directly instead.
+    """
+    with taddons.context() as tctx:
+        addon = tctx.script(
+            tdata.path("mitmproxy/data/addonscripts/configure_recorder.py")
+        )
+        inner = addon.addons[0]
+        # `configure()` is always called once at load time, with every
+        # currently-set option.
+        assert len(inner.call_log) == 1
+
+        tctx.configure(addon, recorder_option="changed")
+        assert tctx.options.recorder_option == "changed"
+        assert inner.call_log[-1] == {"recorder_option"}


### PR DESCRIPTION
## Summary

`context.script()` returns an addon that is `register()`-ed but never added to `AddonManager.chain`. The `options.changed` -> `_configure_all` -> `trigger()` broadcast that normally calls `configure()` after an option change only walks `self.chain`, so a script addon's `configure()` is silently never called again after the initial load — even though `context.configure(addon, some_option=...)` updates the option value itself just fine. This makes it impossible to write a test that exercises a script addon's `configure()` reaction to an option change.

Reproduced on current `main` with a minimal script addon that records its `configure()` calls: after `tctx.configure(addon, foo='bar')`, the option updates but `configure()` is never invoked a second time.

## Changes

- `mitmproxy/test/taddons.py`: `context.configure()` now explicitly invokes `ConfigureHook` on the target addon after updating options, but only when that addon isn't already part of `self.master.addons.chain` — chained addons (the common case, e.g. `context(some_addon)`) already receive the hook via the existing `options.changed` broadcast, so this avoids calling `configure()` twice for them.
- `test/mitmproxy/data/addonscripts/configure_recorder.py`: new fixture script addon that records every `updated` set passed to its `configure()`.
- `test/mitmproxy/test_taddons.py`: regression test loading the fixture via `context.script()` and asserting `configure()` is called with the changed option key after `context.configure()`. Verified the test fails on unpatched `taddons.py` and passes with the fix.

Fixes #3402