### PR TITLE
Use standard HTTP/2 version name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ## Unreleased: mitmproxy next
 
 - Report HTTP/2 messages as `HTTP/2` instead of `HTTP/2.0`.
+  ([#8371](https://github.com/mitmproxy/mitmproxy/pull/8371), @tospakX)
 - Replace deprecated pyparsing APIs with their snake_case equivalents to avoid
   `PyparsingDeprecationWarning` during command and flow-filter parsing.
   ([#8344](https://github.com/mitmproxy/mitmproxy/pull/8344), @Dnsayhey)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ## Unreleased: mitmproxy next
 
+- Report HTTP/2 messages as `HTTP/2` instead of `HTTP/2.0`.
 - Replace deprecated pyparsing APIs with their snake_case equivalents to avoid
   `PyparsingDeprecationWarning` during command and flow-filter parsing.
   ([#8344](https://github.com/mitmproxy/mitmproxy/pull/8344), @Dnsayhey)

--- a/docs/src/content/howto/ignore-domains.md
+++ b/docs/src/content/howto/ignore-domains.md
@@ -61,8 +61,8 @@ method to do so:
 Proxy server listening at http://*:8080
 127.0.0.1:57089: client connect
 127.0.0.1:57089: server connect example.com:443 (93.184.216.34:443)
-127.0.0.1:57089: GET https://example.com/ HTTP/2.0
-     << HTTP/2.0 200 OK 1.23k
+127.0.0.1:57089: GET https://example.com/ HTTP/2
+     << HTTP/2 200 OK 1.23k
 127.0.0.1:57089: client disconnect
 127.0.0.1:57089: server disconnect example.com:443 (93.184.216.34:443)
 ^C

--- a/mitmproxy/addons/asgiapp.py
+++ b/mitmproxy/addons/asgiapp.py
@@ -51,6 +51,7 @@ class WSGIApp(ASGIApp):
 HTTP_VERSION_MAP = {
     "HTTP/1.0": "1.0",
     "HTTP/1.1": "1.1",
+    "HTTP/2": "2",
     "HTTP/2.0": "2",
 }
 

--- a/mitmproxy/http.py
+++ b/mitmproxy/http.py
@@ -282,7 +282,7 @@ class Message(serializable.Serializable):
 
     @property
     def is_http2(self) -> bool:
-        return self.data.http_version == b"HTTP/2.0"
+        return self.data.http_version in (b"HTTP/2", b"HTTP/2.0")
 
     @property
     def is_http3(self) -> bool:
@@ -727,7 +727,7 @@ class Request(Message):
         The request's host/authority header.
 
         This property maps to either ``request.headers["Host"]`` or
-        ``request.authority``, depending on whether it's HTTP/1.x or HTTP/2.0.
+        ``request.authority``, depending on whether it's HTTP/1.x or HTTP/2.
 
         *See also:* `Request.authority`,`Request.host`, `Request.pretty_host`
         """

--- a/mitmproxy/proxy/layers/http/_http2.py
+++ b/mitmproxy/proxy/layers/http/_http2.py
@@ -453,7 +453,7 @@ class Http2Server(Http2Connection):
                 scheme=scheme,
                 authority=authority,
                 path=path,
-                http_version=b"HTTP/2.0",
+                http_version=b"HTTP/2",
                 headers=headers,
                 content=None,
                 trailers=None,
@@ -593,7 +593,7 @@ class Http2Client(Http2Connection):
                 return True
 
             response = http.Response(
-                http_version=b"HTTP/2.0",
+                http_version=b"HTTP/2",
                 status_code=status_code,
                 reason=b"",
                 headers=headers,

--- a/test/mitmproxy/proxy/layers/http/test_http2.py
+++ b/test/mitmproxy/proxy/layers/http/test_http2.py
@@ -142,6 +142,8 @@ def test_simple(tctx):
         )
     )
     assert flow().request.url == "http://example.com/"
+    assert flow().request.http_version == "HTTP/2"
+    assert flow().response.http_version == "HTTP/2"
     assert flow().response.text == "Hello, World!"
 
 

--- a/test/mitmproxy/test_http.py
+++ b/test/mitmproxy/test_http.py
@@ -216,7 +216,7 @@ class TestRequestCore:
         assert h1.host_header == "header.example.com"
 
         h2 = h1.copy()
-        h2.http_version = "HTTP/2.0"
+        h2.http_version = "HTTP/2"
         assert h2.host_header == "authority.example.com"
 
         h2_host_only = h2.copy()
@@ -235,7 +235,7 @@ class TestRequestCore:
         assert "host" not in h1.headers
         assert not h1.authority
 
-        h2 = treq(http_version=b"HTTP/2.0")
+        h2 = treq(http_version=b"HTTP/2")
         h2.host_header = "example.org"
         assert "host" not in h2.headers
         assert h2.authority == "example.org"
@@ -977,6 +977,7 @@ class TestMessage:
         _test_decoded_attr(tresp(), "http_version")
         assert tresp(http_version=b"HTTP/1.0").is_http10
         assert tresp(http_version=b"HTTP/1.1").is_http11
+        assert tresp(http_version=b"HTTP/2").is_http2
         assert tresp(http_version=b"HTTP/2.0").is_http2
 
 

--- a/web/src/js/components/FlowView/HttpMessages.tsx
+++ b/web/src/js/components/FlowView/HttpMessages.tsx
@@ -99,7 +99,7 @@ function ResponseLine({ flow }: ResponseLineProps) {
                 isValid={(code) => /^\d+$/.test(code)}
                 selectAllOnClick={true}
             />
-            {flow.response.http_version !== "HTTP/2.0" && (
+            {!flow.response.http_version.startsWith("HTTP/2") && (
                 <>
                     &nbsp;
                     <ValueEditor


### PR DESCRIPTION
#### Description

Fixes #7124.

New HTTP/2 requests and responses now use the standard `HTTP/2` version string. Existing `HTTP/2.0` flow data remains supported, and the ASGI adapter, web UI, and documentation accept the normalized value.

Validation:

- `uv run pytest test/mitmproxy/test_http.py test/mitmproxy/proxy/layers/http/test_http2.py test/mitmproxy/addons/test_asgiapp.py` (152 passed)
- `uv run tox -e lint`
- `npm test -- --runInBand` (82 suites, 338 tests)

#### Checklist

- [x] I have updated tests where applicable.
- [x] I have added an entry to the CHANGELOG.
