### PR TITLE
Honor opaque content view backgrounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ## Unreleased: mitmproxy next
 
 - Honor opaque console palettes for unstyled contentview text.
+  ([#8372](https://github.com/mitmproxy/mitmproxy/pull/8372), @tospakX)
 - Replace deprecated pyparsing APIs with their snake_case equivalents to avoid
   `PyparsingDeprecationWarning` during command and flow-filter parsing.
   ([#8344](https://github.com/mitmproxy/mitmproxy/pull/8344), @Dnsayhey)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ## Unreleased: mitmproxy next
 
+- Honor opaque console palettes for unstyled contentview text.
 - Replace deprecated pyparsing APIs with their snake_case equivalents to avoid
   `PyparsingDeprecationWarning` during command and flow-filter parsing.
   ([#8344](https://github.com/mitmproxy/mitmproxy/pull/8344), @Dnsayhey)

--- a/mitmproxy/tools/console/palettes.py
+++ b/mitmproxy/tools/console/palettes.py
@@ -102,22 +102,23 @@ class Palette:
                 highback = self.high["background"][1]
             lowback = self.low["background"][1]
 
-        for i in self._fields:
+        for i in ["", *self._fields]:
+            style = i or "text"
             if transparent and i == "background":
                 lst.append(["background", "default", "default"])
             else:
                 v: list[str | None] = [i]
-                low = list(self.low[i])
+                low = list(self.low[style])
                 if lowback and low[1] == "default":
                     low[1] = lowback
                 v.extend(low)
-                if self.high and i in self.high:
+                if self.high and style in self.high:
                     v.append(None)
-                    high: list[str | None] = list(self.high[i])
+                    high: list[str | None] = list(self.high[style])
                     if highback and high[1] == "default":
                         high[1] = highback
                     v.extend(high)
-                elif highback and self.low[i][1] == "default":
+                elif highback and self.low[style][1] == "default":
                     high = [None, low[0], highback]
                     v.extend(high)
                 lst.append(tuple(v))

--- a/test/mitmproxy/tools/console/test_palettes.py
+++ b/test/mitmproxy/tools/console/test_palettes.py
@@ -14,3 +14,16 @@ class TestPalette:
             palettes.Palette._fields
         )
         assert not missing, f"Missing styles for tags: {missing}"
+
+    def test_unstyled_content_background(self):
+        opaque = next(
+            entry for entry in palettes.SolarizedDark().palette(False) if not entry[0]
+        )
+        transparent = next(
+            entry for entry in palettes.SolarizedDark().palette(True) if not entry[0]
+        )
+
+        assert opaque[2] == "black"
+        assert opaque[5] == "h234"
+        assert transparent[2] == "default"
+        assert transparent[5] == "default"


### PR DESCRIPTION
#### Description

Fixes #8070.

Syntax-highlighted content contains unstyled segments represented by an empty attribute name. The console palette now maps that attribute to the normal text colors, so opaque palettes apply their configured background while transparent palettes continue using the terminal background.

Validation:

- `uv run pytest test/mitmproxy/tools/console/test_palettes.py test/mitmproxy/tools/console/test_flowview.py` (8 passed)
- `uv run tox -e lint`

#### Checklist

- [x] I have updated tests where applicable.
- [x] I have added an entry to the CHANGELOG.
