### PR TITLE
Preserve quoted filter regex escapes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ## Unreleased: mitmproxy next
 
 - Preserve backslashes in quoted flow-filter regular expressions.
+  ([#8373](https://github.com/mitmproxy/mitmproxy/pull/8373), @tospakX)
 - Replace deprecated pyparsing APIs with their snake_case equivalents to avoid
   `PyparsingDeprecationWarning` during command and flow-filter parsing.
   ([#8344](https://github.com/mitmproxy/mitmproxy/pull/8344), @Dnsayhey)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ## Unreleased: mitmproxy next
 
+- Preserve backslashes in quoted flow-filter regular expressions.
 - Replace deprecated pyparsing APIs with their snake_case equivalents to avoid
   `PyparsingDeprecationWarning` during command and flow-filter parsing.
   ([#8344](https://github.com/mitmproxy/mitmproxy/pull/8344), @Dnsayhey)

--- a/mitmproxy/flowfilter.py
+++ b/mitmproxy/flowfilter.py
@@ -747,11 +747,15 @@ def _make():
     # which has a horrible performance with len(pyparsing.pyparsing_unicode.printables) == 1114060
     unicode_words = pp.CharsNotIn("()~'\"" + pp.ParserElement.DEFAULT_WHITE_CHARS)
     unicode_words.skipWhitespace = True
-    regex = (
-        unicode_words
-        | pp.QuotedString('"', esc_char="\\")
-        | pp.QuotedString("'", esc_char="\\")
-    )
+    def quoted_regex(quote: str):
+        def unquote(toks):
+            return re.sub(r"\\([\\'\"])", r"\1", toks[0][1:-1])
+
+        return pp.QuotedString(
+            quote, esc_char="\\", unquote_results=False
+        ).set_parse_action(unquote)
+
+    regex = unicode_words | quoted_regex('"') | quoted_regex("'")
     for cls in filter_rex:
         f = pp.Literal(f"~{cls.code}") + pp.WordEnd() + regex.copy()
         f.set_parse_action(cls.make)

--- a/mitmproxy/flowfilter.py
+++ b/mitmproxy/flowfilter.py
@@ -747,6 +747,7 @@ def _make():
     # which has a horrible performance with len(pyparsing.pyparsing_unicode.printables) == 1114060
     unicode_words = pp.CharsNotIn("()~'\"" + pp.ParserElement.DEFAULT_WHITE_CHARS)
     unicode_words.skipWhitespace = True
+
     def quoted_regex(quote: str):
         def unquote(toks):
             return re.sub(r"\\([\\'\"])", r"\1", toks[0][1:-1])

--- a/test/mitmproxy/test_flowfilter.py
+++ b/test/mitmproxy/test_flowfilter.py
@@ -63,6 +63,11 @@ class TestParsing:
         a = flowfilter.parse(r'~u "foo \'bar"')
         assert a.expr == "foo 'bar"
 
+    @pytest.mark.parametrize("quote", ['"', "'"])
+    def test_quoted_regex_preserves_escapes(self, quote):
+        a = flowfilter.parse(f"~u {quote}\\.sign\\({quote}")
+        assert a.expr == r"\.sign\("
+
     def test_nesting(self):
         a = flowfilter.parse("(~u foobar & ~h voing)")
         assert a.lst[0].expr == "foobar"


### PR DESCRIPTION
#### Description

Fixes #6688.

Quoted flow-filter regexes previously lost backslashes during parsing, so patterns such as `\.sign\(` became invalid. Quoted regex parsing now preserves regex escapes while retaining support for escaped quotes and backslashes.

Validation:

- `uv run pytest test/mitmproxy/test_flowfilter.py` (125 passed)
- `uv run tox -e lint`

#### Checklist

- [x] I have updated tests where applicable.
- [x] I have added an entry to the CHANGELOG.
