### PR TITLE
docs: mention Microsoft Store install on Windows

### DIFF
--- a/docs/src/content/overview/installation.md
+++ b/docs/src/content/overview/installation.md
@@ -34,6 +34,9 @@ the repository maintainers directly for issues with native packages.
 ## Windows
 
 To install mitmproxy on Windows, download the installer from [mitmproxy.org](https://mitmproxy.org/). 
+Alternatively, mitmproxy is also available on the
+[Microsoft Store](https://apps.microsoft.com/detail/9NWNDLQMNZD7), which installs
+updates automatically.
 We also provide standalone binaries, they take significantly longer to start
 as some files need to be extracted to temporary directories first.
 After installation, mitmproxy, mitmdump and mitmweb are also added to your PATH and can be invoked from the command line.


### PR DESCRIPTION
#### Description

The Windows section of the installation docs only mentions the installer and the
standalone binaries from mitmproxy.org, even though every release is also published
to the Microsoft Store by CI (`release/deploy-microsoft-store.py`, `msix-installer`
in `.github/workflows/main.yml`). The store listing is not discoverable from the docs
today.

This adds one sentence linking to it, next to the existing download options:

> To install mitmproxy on Windows, download the installer from [mitmproxy.org](https://mitmproxy.org/).
> **Alternatively, mitmproxy is also available on the [Microsoft Store](https://apps.microsoft.com/detail/9NWNDLQMNZD7), which installs updates automatically.**
> We also provide standalone binaries, [...]

The product ID `9NWNDLQMNZD7` is the one already recorded in [`release/README.md`](https://github.com/mitmproxy/mitmproxy/blob/main/release/README.md); I verified the listing resolves and is published by `mitmproxy.org`. I used the short `apps.microsoft.com/detail/...` form, which is what the older `/store/detail/mitmproxy/...` URL now redirects to.

The automatic-updates note seemed worth including because the docs otherwise state that
mitmproxy never does update checks itself.

This covers the docs half of #6053; the downloads.mitmproxy.org side lives in the
`mitmproxy/www` repo, so it is out of scope here.

#### Checklist

 - [x] I have updated tests where applicable. <!-- docs-only change, no tests apply -->
 - [x] I have added an entry to the CHANGELOG. <!-- skipped: docs-only, matching #7990 and other docs-only PRs -->
