### PR TITLE
fix: correctly detect flow-list/single-flow command results in the console

### DIFF
--- a/mitmproxy/tools/console/commandexecutor.py
+++ b/mitmproxy/tools/console/commandexecutor.py
@@ -19,11 +19,16 @@ class CommandExecutor:
                 logging.error(str(e))
             else:
                 if ret is not None:
-                    if type(ret) == Sequence[flow.Flow]:  # noqa: E721
+                    if (
+                        isinstance(ret, Sequence)
+                        and not isinstance(ret, (str, bytes))
+                        and ret
+                        and all(isinstance(x, flow.Flow) for x in ret)
+                    ):
                         signals.status_message.send(
                             message="Command returned %s flows" % len(ret)
                         )
-                    elif type(ret) is flow.Flow:
+                    elif isinstance(ret, flow.Flow):
                         signals.status_message.send(message="Command returned 1 flow")
                     else:
                         self.master.overlay(

--- a/test/mitmproxy/tools/console/test_commandexecutor.py
+++ b/test/mitmproxy/tools/console/test_commandexecutor.py
@@ -1,0 +1,62 @@
+from unittest.mock import Mock
+
+from mitmproxy.test import tflow
+from mitmproxy.tools.console import signals
+from mitmproxy.tools.console.commandexecutor import CommandExecutor
+
+
+def test_command_returning_flow_list_shows_status_message(console):
+    # A command that returns Sequence[flow.Flow] (e.g. `view.flows.resolve`) must not
+    # be routed to the DataViewerOverlay: rendering it there deepcopies the flows,
+    # which crashes with `TypeError: cannot pickle 'Context' object` for any flow
+    # that carries a live connection context (mitmproxy/mitmproxy#4916). Regression
+    # test for the `type(ret) == Sequence[flow.Flow]` dead-code check, which never
+    # matched at runtime because Python erases generic parameters.
+    executor = CommandExecutor(console)
+    console.commands.execute = Mock(return_value=[tflow.tflow(), tflow.tflow()])
+    console.overlay = Mock()
+
+    messages = []
+
+    def on_status_message(message, expire=5):
+        messages.append(message)
+
+    # connect() only keeps a weak reference, so on_status_message must stay alive
+    # for the duration of the test.
+    signals.status_message.connect(on_status_message)
+
+    executor("view.flows.resolve @all")
+
+    console.overlay.assert_not_called()
+    assert messages == ["Command returned 2 flows"]
+
+
+def test_command_returning_single_flow_shows_status_message(console):
+    # Same dead-code class of bug: `type(ret) is flow.Flow` never matches a concrete
+    # subclass like HTTPFlow, so a command returning exactly one flow also used to
+    # fall through to the DataViewerOverlay instead of a short status message.
+    executor = CommandExecutor(console)
+    console.commands.execute = Mock(return_value=tflow.tflow())
+    console.overlay = Mock()
+
+    messages = []
+
+    def on_status_message(message, expire=5):
+        messages.append(message)
+
+    signals.status_message.connect(on_status_message)
+
+    executor("view.flows.resolve @focus")
+
+    console.overlay.assert_not_called()
+    assert messages == ["Command returned 1 flow"]
+
+
+def test_command_returning_other_value_uses_overlay(console):
+    executor = CommandExecutor(console)
+    console.commands.execute = Mock(return_value=["not", "flows"])
+    console.overlay = Mock()
+
+    executor("some.command")
+
+    console.overlay.assert_called_once()


### PR DESCRIPTION
## Summary

`CommandExecutor` decides whether a command's return value should be shown as a
short status message using `type(ret) == Sequence[flow.Flow]` and
`type(ret) is flow.Flow`. Neither check can ever be true at runtime: Python
erases generic parameters, so no concrete type ever equals the subscripted
`Sequence[flow.Flow]`, and `type(x) is flow.Flow` only matches the exact base
class, never a concrete subclass like `HTTPFlow`/`TCPFlow`/`UDPFlow`/`DNSFlow`
— which is what every real command actually returns.

As a result, any command returning a list of flows (e.g.
`view.flows.resolve @focus`) or a single flow always fell through to the
`DataViewerOverlay` branch instead of the intended status message. That
overlay's grid editor deepcopies its input, which is how the original report
crashed with `TypeError: cannot pickle 'Context' object`. I could no longer
reproduce the exact pickling crash with current flow/connection objects (it
may have been incidentally fixed by unrelated refactors), but the dead
type-check itself is still very much present and still routes flow-list
results to the wrong UI — confirmed with a regression test that fails against
current `main` (the overlay mock is called when it shouldn't be) and passes
after this fix.

Fixes #4916

## Changes

- `mitmproxy/tools/console/commandexecutor.py`: replace the dead `type() ==`/
  `type() is` checks with `isinstance()`-based checks that actually match at
  runtime, plus an explicit non-empty/non-str guard for the sequence case.
- `test/mitmproxy/tools/console/test_commandexecutor.py`: new regression
  tests covering flow-list, single-flow, and non-flow command results
  (verified fail-before / pass-after via `git stash`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)