### PR TITLE
fix: don't KeyError when a connection_id is reused before cleanup runs

### DIFF
--- a/mitmproxy/addons/proxyserver.py
+++ b/mitmproxy/addons/proxyserver.py
@@ -141,7 +141,12 @@ class Proxyserver(ServerManager):
         try:
             yield
         finally:
-            del self.connections[connection_id]
+            # Only remove our own entry: connection_id can be reused (e.g. a client
+            # address/port pair reconnecting quickly) before this handler's cleanup
+            # runs, in which case a newer registration has already overwritten ours
+            # here and a plain `del` would raise KeyError (#6405).
+            if self.connections.get(connection_id) is handler:
+                del self.connections[connection_id]
 
     def load(self, loader):
         loader.add_option(

--- a/test/mitmproxy/addons/test_proxyserver.py
+++ b/test/mitmproxy/addons/test_proxyserver.py
@@ -240,6 +240,29 @@ def test_options():
         tctx.configure(ps, mode=["regular", "local"], server=False)
 
 
+def test_register_connection_reused_id_does_not_raise():
+    # Regression test for #6405: if connection_id is reused (e.g. a client
+    # address/port pair reconnecting quickly) before an earlier handler's
+    # register_connection() context manager has unwound, a plain
+    # `del self.connections[connection_id]` in the finally block raises
+    # KeyError once the *newer* registration's cleanup runs and removes the
+    # entry the older one still thinks is its own.
+    ps = Proxyserver()
+    connection_id = ("tcp", ("127.0.0.1", 51356), ("127.0.0.1", 8080))
+    old_handler = Mock()
+    new_handler = Mock()
+
+    with ps.register_connection(connection_id, old_handler):
+        assert ps.connections[connection_id] is old_handler
+        with ps.register_connection(connection_id, new_handler):
+            assert ps.connections[connection_id] is new_handler
+        # inner cleanup must not remove the outer (different) registration
+        assert connection_id not in ps.connections
+
+    # outer cleanup must not raise even though its entry is already gone
+    assert connection_id not in ps.connections
+
+
 async def test_startup_err(monkeypatch, caplog) -> None:
     async def _raise(*_):
         raise OSError("cannot bind")


### PR DESCRIPTION
## Summary

`Proxyserver.register_connection()` unconditionally does
`del self.connections[connection_id]` in its `finally` block. `connection_id`
is a client address/port 4-tuple for connections that don't have a uuid
(per `ServerManager`'s own docstring: "temporary workaround"), so it can be
reused before an earlier handler's context manager has unwound — e.g. a
client reconnecting quickly on the same source port. When that happens, the
newer registration overwrites the dict entry, the newer handler's cleanup
deletes it, and the *older* handler's later cleanup then hits `KeyError` on
an entry that's already gone:

```
File ".../mitmproxy/addons/proxyserver.py", line 122, in register_connection
    del self.connections[connection_id]
KeyError: ('tcp', ('127.0.0.1', 51356), ('127.0.0.1', 8080))
```

Fixes #6405

## Changes

- `mitmproxy/addons/proxyserver.py`: only delete the dict entry in the
  `finally` block if it still points at this handler (i.e. hasn't been
  overwritten by a newer registration under the same id).
- `test/mitmproxy/addons/test_proxyserver.py`: regression test that
  simulates two overlapping `register_connection()` calls under the same
  `connection_id` and asserts neither raises (verified fails on current
  `main` with the exact reported `KeyError`, passes with the fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)