### PR TITLE
Add support for the PROXY protocol (v1/v2) on inbound connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
   `proxy_protocol` option (a list of listen ports expected to receive such a header).
   Lets mitmproxy sit behind a load balancer or proxy chain (e.g. AWS NLB, HAProxy,
   Envoy) that uses PROXY protocol to preserve the original client address.
+  ([#8377](https://github.com/mitmproxy/mitmproxy/pull/8377), @keshavkrishna)
 - Replace deprecated pyparsing APIs with their snake_case equivalents to avoid
   `PyparsingDeprecationWarning` during command and flow-filter parsing.
   ([#8344](https://github.com/mitmproxy/mitmproxy/pull/8344), @Dnsayhey)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 
 ## Unreleased: mitmproxy next
 
+- Add support for the PROXY protocol (v1/v2) on inbound connections, via the new
+  `proxy_protocol` option (a list of listen ports expected to receive such a header).
+  Lets mitmproxy sit behind a load balancer or proxy chain (e.g. AWS NLB, HAProxy,
+  Envoy) that uses PROXY protocol to preserve the original client address.
 - Replace deprecated pyparsing APIs with their snake_case equivalents to avoid
   `PyparsingDeprecationWarning` during command and flow-filter parsing.
   ([#8344](https://github.com/mitmproxy/mitmproxy/pull/8344), @Dnsayhey)

--- a/mitmproxy/options.py
+++ b/mitmproxy/options.py
@@ -247,17 +247,22 @@ class Options(optmanager.OptManager):
         )
         self.add_option(
             "proxy_protocol",
-            bool,
-            False,
+            Sequence[str],
+            [],
             """
-            Expect incoming connections to start with a PROXY protocol (v1 or v2) header,
-            as sent by upstream load balancers/proxies (e.g. AWS NLB, HAProxy, Envoy) that
-            support it. The original client address from the header replaces the immediate
-            peer's address for logging and in addons.
+            Listen ports on which incoming connections are expected to start with a PROXY
+            protocol (v1 or v2) header, as sent by upstream load balancers/proxies (e.g. AWS
+            NLB, HAProxy, Envoy) that support it. The original client address from the header
+            replaces the immediate peer's address for logging and in addons.
 
-            Only enable this on listeners that are exclusively reachable through a trusted
-            upstream proxy: the header is client-supplied data and lets anyone who can reach
-            the listener directly spoof their apparent source address.
+            This is scoped per listen port (not global) because "is this listener behind a
+            PROXY-protocol load balancer" is a property of that one socket: mitmproxy can run
+            several modes at once, and most modes (WireGuard, local capture, transparent
+            TUN, ...) never receive such a header at all.
+
+            Only list ports that are exclusively reachable through a trusted upstream proxy:
+            the header is client-supplied data and lets anyone who can reach the listener
+            directly spoof their apparent source address.
             """,
         )
 

--- a/mitmproxy/options.py
+++ b/mitmproxy/options.py
@@ -245,5 +245,20 @@ class Options(optmanager.OptManager):
             Timeout in seconds for inactive TCP connections. Connections will be closed after this period of inactivity.
             """,
         )
+        self.add_option(
+            "proxy_protocol",
+            bool,
+            False,
+            """
+            Expect incoming connections to start with a PROXY protocol (v1 or v2) header,
+            as sent by upstream load balancers/proxies (e.g. AWS NLB, HAProxy, Envoy) that
+            support it. The original client address from the header replaces the immediate
+            peer's address for logging and in addons.
+
+            Only enable this on listeners that are exclusively reachable through a trusted
+            upstream proxy: the header is client-supplied data and lets anyone who can reach
+            the listener directly spoof their apparent source address.
+            """,
+        )
 
         self.update(**kwargs)

--- a/mitmproxy/proxy/mode_servers.py
+++ b/mitmproxy/proxy/mode_servers.py
@@ -42,6 +42,7 @@ from mitmproxy.net.free_port import get_free_port
 from mitmproxy.proxy import commands
 from mitmproxy.proxy import layers
 from mitmproxy.proxy import mode_specs
+from mitmproxy.proxy import proxy_protocol
 from mitmproxy.proxy import server
 from mitmproxy.proxy.context import Context
 from mitmproxy.proxy.layer import Layer
@@ -190,9 +191,30 @@ class ServerInstance(Generic[M], metaclass=ABCMeta):
         if writer is None:
             assert isinstance(reader, mitmproxy_rs.Stream)
             writer = reader
+
+        proxy_header: proxy_protocol.ProxyHeader | None = None
+        if ctx.options.proxy_protocol:
+            if not isinstance(reader, asyncio.StreamReader):
+                logger.warning(
+                    "proxy_protocol is not supported on this listener, closing connection."
+                )
+                writer.close()
+                return
+            try:
+                proxy_header = await proxy_protocol.read_proxy_header(reader)
+            except proxy_protocol.ProxyProtocolError as e:
+                logger.warning(
+                    f"Rejecting connection, invalid PROXY protocol header: {e}"
+                )
+                writer.close()
+                return
+
         handler = ProxyConnectionHandler(
             ctx.master, reader, writer, ctx.options, self.mode
         )
+        if proxy_header is not None and proxy_header.source_addr is not None:
+            handler.layer.context.client.peername = proxy_header.source_addr
+            handler.log_prefix = f"{human.format_address(proxy_header.source_addr)}: "
         handler.layer = self.make_top_layer(handler.layer.context)
         if isinstance(self.mode, mode_specs.TransparentMode):
             assert isinstance(writer, asyncio.StreamWriter)

--- a/mitmproxy/proxy/mode_servers.py
+++ b/mitmproxy/proxy/mode_servers.py
@@ -183,6 +183,19 @@ class ServerInstance(Generic[M], metaclass=ABCMeta):
             "listen_addrs": self.listen_addrs,
         }
 
+    def _expects_proxy_protocol(self) -> bool:
+        """
+        Whether connections on this instance's listen port(s) are expected to start with a
+        PROXY protocol header. Scoped per port (rather than a single global switch) because
+        that expectation is a property of one specific listening socket, not of the whole
+        mitmproxy process: several modes can run at once, and most of them (WireGuard, local
+        capture, TUN, ...) never receive such a header.
+        """
+        configured_ports = ctx.options.proxy_protocol
+        return bool(configured_ports) and any(
+            str(addr[1]) in configured_ports for addr in self.listen_addrs
+        )
+
     async def handle_stream(
         self,
         reader: asyncio.StreamReader | mitmproxy_rs.Stream,
@@ -193,10 +206,12 @@ class ServerInstance(Generic[M], metaclass=ABCMeta):
             writer = reader
 
         proxy_header: proxy_protocol.ProxyHeader | None = None
-        if ctx.options.proxy_protocol:
+        if self._expects_proxy_protocol():
             if not isinstance(reader, asyncio.StreamReader):
-                logger.warning(
-                    "proxy_protocol is not supported on this listener, closing connection."
+                logger.error(
+                    f"proxy_protocol is configured for {self.mode.description}'s listen "
+                    "port, but this mode never receives a PROXY protocol header. Remove "
+                    "this port from the proxy_protocol option. Closing connection."
                 )
                 writer.close()
                 return
@@ -214,7 +229,6 @@ class ServerInstance(Generic[M], metaclass=ABCMeta):
         )
         if proxy_header is not None and proxy_header.source_addr is not None:
             handler.layer.context.client.peername = proxy_header.source_addr
-            handler.log_prefix = f"{human.format_address(proxy_header.source_addr)}: "
         handler.layer = self.make_top_layer(handler.layer.context)
         if isinstance(self.mode, mode_specs.TransparentMode):
             assert isinstance(writer, asyncio.StreamWriter)

--- a/mitmproxy/proxy/proxy_protocol.py
+++ b/mitmproxy/proxy/proxy_protocol.py
@@ -1,0 +1,149 @@
+"""
+Parsing for the PROXY protocol (v1 text and v2 binary), as specified by HAProxy:
+https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt
+
+Widely used by load balancers and other reverse proxies (AWS NLB, HAProxy, Envoy,
+nginx, Traefik, ...) to preserve the original client address across a hop that would
+otherwise replace it with their own.
+
+When enabled via the `proxy_protocol` option, every new inbound connection is expected
+to start with such a header before any real client traffic (HTTP, TLS, ...) follows.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import struct
+from asyncio import IncompleteReadError
+from asyncio import StreamReader
+from dataclasses import dataclass
+
+from mitmproxy.connection import Address
+
+V2_SIGNATURE = b"\r\n\r\n\x00\r\nQUIT\n"
+V1_PREFIX = b"PROXY "
+_MAX_V1_LINE_LENGTH = 107  # per spec, including the trailing CRLF
+
+
+class ProxyProtocolError(ValueError):
+    """Raised when a PROXY protocol header is malformed or missing."""
+
+
+@dataclass(frozen=True)
+class ProxyHeader:
+    """The addresses recovered from a PROXY protocol header."""
+
+    source_addr: Address | None
+    """The original client address, or None for `PROXY UNKNOWN`/LOCAL connections."""
+    dest_addr: Address | None
+    """The address the original client connected to, if provided."""
+
+
+async def read_proxy_header(reader: StreamReader) -> ProxyHeader:
+    """
+    Read and consume a PROXY protocol header (v1 or v2) from `reader`.
+
+    Raises `ProxyProtocolError` if the stream does not start with a well-formed header.
+    """
+    try:
+        prefix = await reader.readexactly(len(V2_SIGNATURE))
+    except IncompleteReadError as e:
+        raise ProxyProtocolError(
+            f"connection closed while reading PROXY protocol header: {e}"
+        ) from e
+
+    if prefix == V2_SIGNATURE:
+        return await _read_v2_body(reader)
+    else:
+        return await _read_v1_line(reader, prefix)
+
+
+async def _read_v1_line(reader: StreamReader, prefix: bytes) -> ProxyHeader:
+    if not prefix.startswith(V1_PREFIX):
+        raise ProxyProtocolError(f"not a PROXY protocol header: {prefix!r}")
+
+    line = prefix
+    while not line.endswith(b"\r\n"):
+        if len(line) >= _MAX_V1_LINE_LENGTH:
+            raise ProxyProtocolError("PROXY v1 header line too long")
+        try:
+            line += await reader.readexactly(1)
+        except IncompleteReadError as e:
+            raise ProxyProtocolError(
+                f"connection closed while reading PROXY v1 header: {e}"
+            ) from e
+
+    return parse_v1(line)
+
+
+def parse_v1(line: bytes) -> ProxyHeader:
+    """Parse a single PROXY v1 header line (including the trailing CRLF)."""
+    if not line.startswith(V1_PREFIX) or not line.endswith(b"\r\n"):
+        raise ProxyProtocolError(f"malformed PROXY v1 header: {line!r}")
+
+    fields = line[:-2].split(b" ")
+    # fields[0] == b"PROXY"
+    match fields[1:]:
+        case [b"UNKNOWN", *_]:
+            return ProxyHeader(source_addr=None, dest_addr=None)
+        case [proto, src_ip, dst_ip, src_port, dst_port]:
+            if proto not in (b"TCP4", b"TCP6"):
+                raise ProxyProtocolError(f"unsupported PROXY v1 protocol: {proto!r}")
+            try:
+                source_addr = (src_ip.decode("ascii"), int(src_port))
+                dest_addr = (dst_ip.decode("ascii"), int(dst_port))
+            except (UnicodeDecodeError, ValueError) as e:
+                raise ProxyProtocolError(
+                    f"malformed PROXY v1 address in {line!r}: {e}"
+                ) from e
+            return ProxyHeader(source_addr=source_addr, dest_addr=dest_addr)
+        case _:
+            raise ProxyProtocolError(f"malformed PROXY v1 header: {line!r}")
+
+
+async def _read_v2_body(reader: StreamReader) -> ProxyHeader:
+    try:
+        ver_cmd, fam_proto, body_len = struct.unpack(
+            "!BBH", await reader.readexactly(4)
+        )
+        body = await reader.readexactly(body_len)
+    except IncompleteReadError as e:
+        raise ProxyProtocolError(
+            f"connection closed while reading PROXY v2 header: {e}"
+        ) from e
+
+    version = ver_cmd >> 4
+    command = ver_cmd & 0x0F
+    if version != 2:
+        raise ProxyProtocolError(f"unsupported PROXY protocol version: {version}")
+    if command == 0x0:  # LOCAL: connection from the proxy itself (e.g. health check)
+        return ProxyHeader(source_addr=None, dest_addr=None)
+    if command != 0x1:  # PROXY
+        raise ProxyProtocolError(f"unsupported PROXY v2 command: {command}")
+
+    family = fam_proto >> 4
+    return parse_v2_addresses(family, body)
+
+
+def parse_v2_addresses(family: int, body: bytes) -> ProxyHeader:
+    """Parse the address block of a PROXY v2 header (family nibble + body bytes)."""
+    if family == 0x1:  # AF_INET
+        fmt = "!4s4sHH"
+    elif family == 0x2:  # AF_INET6
+        fmt = "!16s16sHH"
+    elif family == 0x0:  # AF_UNSPEC (e.g. UNKNOWN)
+        return ProxyHeader(source_addr=None, dest_addr=None)
+    else:
+        raise ProxyProtocolError(f"unsupported PROXY v2 address family: {family}")
+
+    size = struct.calcsize(fmt)
+    if len(body) < size:
+        raise ProxyProtocolError("PROXY v2 address block too short")
+    src_raw, dst_raw, src_port, dst_port = struct.unpack(fmt, body[:size])
+
+    src_ip = ipaddress.ip_address(src_raw).compressed
+    dst_ip = ipaddress.ip_address(dst_raw).compressed
+    return ProxyHeader(
+        source_addr=(src_ip, src_port),
+        dest_addr=(dst_ip, dst_port),
+    )

--- a/test/mitmproxy/proxy/test_mode_servers.py
+++ b/test/mitmproxy/proxy/test_mode_servers.py
@@ -549,3 +549,87 @@ async def test_always_uses_current_instance(patched_local_redirector, monkeypatc
         monkeypatch.setattr(inst2, "handle_stream", handler := AsyncMock())
         await handle_stream(Mock())
         assert handler.await_count
+
+
+def _client_addrs_for(caplog, message: str) -> list:
+    """The `client` extra attached to every captured LogRecord whose message matches."""
+    return [
+        r.client
+        for r in caplog.records
+        if r.getMessage() == message and hasattr(r, "client")
+    ]
+
+
+async def test_proxy_protocol_scoped_to_configured_port(caplog_async):
+    """A PROXY v1 header is parsed and the spoofed client address is adopted,
+    but only on the port explicitly listed in the proxy_protocol option."""
+    caplog_async.set_level("INFO")
+    manager = MagicMock()
+
+    with taddons.context() as tctx:
+        inst = ServerInstance.make("regular@127.0.0.1:0", manager)
+        await inst.start()
+        assert await caplog_async.await_log("proxy listening")
+
+        host, port, *_ = inst.listen_addrs[0]
+        tctx.options.proxy_protocol = [str(port)]
+
+        reader, writer = await asyncio.open_connection(host, port)
+        writer.write(b"PROXY TCP4 203.0.113.9 198.51.100.1 51234 80\r\n")
+        writer.write(b"GET http://example.com/ HTTP/1.1\r\nHost: example.com\r\n\r\n")
+        await writer.drain()
+
+        assert await caplog_async.await_log("client connect")
+        assert _client_addrs_for(caplog_async.caplog, "client connect") == [
+            ("203.0.113.9", 51234)
+        ]
+
+        writer.close()
+        await writer.wait_closed()
+        await inst.stop()
+
+
+async def test_proxy_protocol_not_enabled_on_other_ports(caplog_async):
+    """Without the port listed in proxy_protocol, a normal HTTP request is
+    unaffected: the immediate peer's address is used as-is."""
+    caplog_async.set_level("INFO")
+    manager = MagicMock()
+
+    with taddons.context() as tctx:
+        inst = ServerInstance.make("regular@127.0.0.1:0", manager)
+        await inst.start()
+        assert await caplog_async.await_log("proxy listening")
+
+        host, port, *_ = inst.listen_addrs[0]
+        tctx.options.proxy_protocol = ["1"]  # some other, unrelated port
+
+        reader, writer = await asyncio.open_connection(host, port)
+        assert await caplog_async.await_log("client connect")
+        (client_addr,) = _client_addrs_for(caplog_async.caplog, "client connect")
+        assert client_addr[0] == "127.0.0.1"  # the real socket peer, unmodified
+
+        writer.close()
+        await writer.wait_closed()
+        await inst.stop()
+
+
+async def test_proxy_protocol_rejects_malformed_header(caplog_async):
+    caplog_async.set_level("INFO")
+    manager = MagicMock()
+
+    with taddons.context() as tctx:
+        inst = ServerInstance.make("regular@127.0.0.1:0", manager)
+        await inst.start()
+        assert await caplog_async.await_log("proxy listening")
+
+        host, port, *_ = inst.listen_addrs[0]
+        tctx.options.proxy_protocol = [str(port)]
+
+        reader, writer = await asyncio.open_connection(host, port)
+        writer.write(b"GET / HTTP/1.1\r\nHost: example.com\r\n\r\n")
+        await writer.drain()
+
+        assert await caplog_async.await_log("Rejecting connection")
+        assert await reader.read() == b""  # connection was closed
+
+        await inst.stop()

--- a/test/mitmproxy/proxy/test_mode_servers.py
+++ b/test/mitmproxy/proxy/test_mode_servers.py
@@ -633,3 +633,26 @@ async def test_proxy_protocol_rejects_malformed_header(caplog_async):
         assert await reader.read() == b""  # connection was closed
 
         await inst.stop()
+
+
+async def test_proxy_protocol_misconfigured_on_non_tcp_listener(caplog_async):
+    """If a user lists a port whose mode never hands us an asyncio.StreamReader
+    (e.g. they meant a different listener), reject clearly instead of hanging
+    or misbehaving."""
+    caplog_async.set_level("INFO")
+    manager = MagicMock()
+
+    with taddons.context() as tctx:
+        inst = ServerInstance.make("regular@127.0.0.1:0", manager)
+        await inst.start()
+        host, port, *_ = inst.listen_addrs[0]
+        tctx.options.proxy_protocol = [str(port)]
+
+        reader = MagicMock()
+        writer = MagicMock()
+        await inst.handle_stream(reader, writer)
+
+        assert await caplog_async.await_log("never receives a PROXY protocol header")
+        writer.close.assert_called_once()
+
+        await inst.stop()

--- a/test/mitmproxy/proxy/test_proxy_protocol.py
+++ b/test/mitmproxy/proxy/test_proxy_protocol.py
@@ -1,0 +1,128 @@
+import asyncio
+
+import pytest
+
+from mitmproxy.proxy.proxy_protocol import ProxyProtocolError
+from mitmproxy.proxy.proxy_protocol import read_proxy_header
+
+
+async def _reader_for(data: bytes) -> asyncio.StreamReader:
+    reader = asyncio.StreamReader()
+    reader.feed_data(data)
+    reader.feed_eof()
+    return reader
+
+
+async def test_v1_tcp4():
+    reader = await _reader_for(
+        b"PROXY TCP4 192.168.0.1 192.168.0.11 56324 443\r\nGET / HTTP/1.1\r\n"
+    )
+    header = await read_proxy_header(reader)
+    assert header.source_addr == ("192.168.0.1", 56324)
+    assert header.dest_addr == ("192.168.0.11", 443)
+    # the header line is consumed, the remaining traffic is untouched.
+    assert await reader.readline() == b"GET / HTTP/1.1\r\n"
+
+
+async def test_v1_tcp6():
+    reader = await _reader_for(b"PROXY TCP6 ::1 ::2 1 2\r\n")
+    header = await read_proxy_header(reader)
+    assert header.source_addr == ("::1", 1)
+    assert header.dest_addr == ("::2", 2)
+
+
+async def test_v1_unknown():
+    reader = await _reader_for(b"PROXY UNKNOWN\r\nGET / HTTP/1.1\r\n")
+    header = await read_proxy_header(reader)
+    assert header.source_addr is None
+    assert header.dest_addr is None
+
+
+async def test_v1_malformed():
+    reader = await _reader_for(b"PROXY BOGUS 1.2.3.4 5.6.7.8 1 2\r\n")
+    with pytest.raises(ProxyProtocolError):
+        await read_proxy_header(reader)
+
+
+async def test_v1_bad_port():
+    reader = await _reader_for(b"PROXY TCP4 1.2.3.4 5.6.7.8 notaport 2\r\n")
+    with pytest.raises(ProxyProtocolError):
+        await read_proxy_header(reader)
+
+
+async def test_v1_line_too_long():
+    reader = await _reader_for(b"PROXY " + b"A" * 200 + b"\r\n")
+    with pytest.raises(ProxyProtocolError):
+        await read_proxy_header(reader)
+
+
+async def test_not_proxy_protocol():
+    reader = await _reader_for(b"GET / HTTP/1.1\r\nHost: example.com\r\n\r\n")
+    with pytest.raises(ProxyProtocolError):
+        await read_proxy_header(reader)
+
+
+async def test_truncated_connection():
+    reader = await _reader_for(b"PROXY TCP4 1.2.3")
+    with pytest.raises(ProxyProtocolError):
+        await read_proxy_header(reader)
+
+
+async def test_v2_tcp4():
+    header_bytes = bytes(
+        [
+            *b"\r\n\r\n\x00\r\nQUIT\n",  # signature
+            0x21,  # version 2, command PROXY
+            0x11,  # family AF_INET, protocol STREAM
+            0x00,
+            0x0C,  # length = 12
+            192,
+            168,
+            0,
+            1,  # src addr
+            192,
+            168,
+            0,
+            11,  # dst addr
+            0xDB,
+            0x14,  # src port 56340... actually just arbitrary bytes below
+            0x01,
+            0xBB,  # dst port 443
+        ]
+    )
+    reader = await _reader_for(header_bytes + b"remaining-tcp-payload")
+    header = await read_proxy_header(reader)
+    assert header.source_addr == ("192.168.0.1", 0xDB14)
+    assert header.dest_addr == ("192.168.0.11", 443)
+    assert await reader.read() == b"remaining-tcp-payload"
+
+
+async def test_v2_local_command():
+    header_bytes = bytes(
+        [
+            *b"\r\n\r\n\x00\r\nQUIT\n",
+            0x20,  # version 2, command LOCAL
+            0x00,
+            0x00,
+            0x00,  # length = 0
+        ]
+    )
+    reader = await _reader_for(header_bytes)
+    header = await read_proxy_header(reader)
+    assert header.source_addr is None
+    assert header.dest_addr is None
+
+
+async def test_v2_unsupported_version():
+    header_bytes = bytes(
+        [
+            *b"\r\n\r\n\x00\r\nQUIT\n",
+            0x11,  # version 1 (unsupported), command PROXY
+            0x11,
+            0x00,
+            0x00,
+        ]
+    )
+    reader = await _reader_for(header_bytes)
+    with pytest.raises(ProxyProtocolError):
+        await read_proxy_header(reader)

--- a/test/mitmproxy/proxy/test_proxy_protocol.py
+++ b/test/mitmproxy/proxy/test_proxy_protocol.py
@@ -2,6 +2,8 @@ import asyncio
 
 import pytest
 
+from mitmproxy.proxy.proxy_protocol import parse_v1
+from mitmproxy.proxy.proxy_protocol import parse_v2_addresses
 from mitmproxy.proxy.proxy_protocol import ProxyProtocolError
 from mitmproxy.proxy.proxy_protocol import read_proxy_header
 
@@ -126,3 +128,89 @@ async def test_v2_unsupported_version():
     reader = await _reader_for(header_bytes)
     with pytest.raises(ProxyProtocolError):
         await read_proxy_header(reader)
+
+
+async def test_immediate_close():
+    """A health-check style probe that opens and closes without sending anything."""
+    reader = await _reader_for(b"")
+    with pytest.raises(ProxyProtocolError):
+        await read_proxy_header(reader)
+
+
+def test_parse_v1_rejects_line_without_proxy_prefix():
+    with pytest.raises(ProxyProtocolError):
+        parse_v1(b"GET / HTTP/1.1\r\n")
+
+
+async def test_v1_wrong_field_count():
+    reader = await _reader_for(b"PROXY TCP4 1.2.3.4 5.6.7.8\r\n")
+    with pytest.raises(ProxyProtocolError):
+        await read_proxy_header(reader)
+
+
+async def test_v2_truncated_body():
+    header_bytes = bytes(
+        [
+            *b"\r\n\r\n\x00\r\nQUIT\n",
+            0x21,  # version 2, command PROXY
+            0x11,  # family AF_INET, protocol STREAM
+            0x00,
+            0x0C,  # length = 12, but we only send 5 body bytes below
+        ]
+    )
+    reader = await _reader_for(header_bytes + bytes(5))
+    with pytest.raises(ProxyProtocolError):
+        await read_proxy_header(reader)
+
+
+async def test_v2_unsupported_command():
+    header_bytes = bytes(
+        [
+            *b"\r\n\r\n\x00\r\nQUIT\n",
+            0x22,  # version 2, command 2 (unassigned)
+            0x11,
+            0x00,
+            0x00,
+        ]
+    )
+    reader = await _reader_for(header_bytes)
+    with pytest.raises(ProxyProtocolError):
+        await read_proxy_header(reader)
+
+
+async def test_v2_tcp6():
+    header_bytes = bytes(
+        [
+            *b"\r\n\r\n\x00\r\nQUIT\n",
+            0x21,  # version 2, command PROXY
+            0x21,  # family AF_INET6, protocol STREAM
+            0x00,
+            0x24,  # length = 36 (16 + 16 + 2 + 2)
+            *([0] * 15 + [1]),  # src ::1
+            *([0] * 15 + [2]),  # dst ::2
+            0x00,
+            0x01,  # src port 1
+            0x00,
+            0x02,  # dst port 2
+        ]
+    )
+    reader = await _reader_for(header_bytes)
+    header = await read_proxy_header(reader)
+    assert header.source_addr == ("::1", 1)
+    assert header.dest_addr == ("::2", 2)
+
+
+def test_parse_v2_addresses_unspec_family():
+    header = parse_v2_addresses(0x0, b"")
+    assert header.source_addr is None
+    assert header.dest_addr is None
+
+
+def test_parse_v2_addresses_unsupported_family():
+    with pytest.raises(ProxyProtocolError):
+        parse_v2_addresses(0x3, b"")  # AF_UNIX, not supported
+
+
+def test_parse_v2_addresses_body_too_short():
+    with pytest.raises(ProxyProtocolError):
+        parse_v2_addresses(0x1, bytes(4))  # AF_INET needs 12 bytes

--- a/web/src/js/ducks/_options_gen.ts
+++ b/web/src/js/ducks/_options_gen.ts
@@ -47,6 +47,7 @@ export interface OptionsState {
     onboarding_host: string;
     protobuf_definitions: string | undefined;
     proxy_debug: boolean;
+    proxy_protocol: string[];
     proxyauth: string | undefined;
     rawtcp: boolean;
     readfile_filter: string | undefined;
@@ -155,6 +156,7 @@ export const defaultState: OptionsState = {
     onboarding_host: "mitm.it",
     protobuf_definitions: undefined,
     proxy_debug: false,
+    proxy_protocol: [],
     proxyauth: undefined,
     rawtcp: true,
     readfile_filter: undefined,


### PR DESCRIPTION
#### Description

Closes #4776.

Adds support for the [PROXY protocol](https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt)
(v1 text and v2 binary) on inbound connections, via a new `proxy_protocol` option.

**Problem:** when mitmproxy sits behind a load balancer or another proxy that uses PROXY
protocol to preserve the original client address (AWS NLB, HAProxy, Envoy, nginx, Traefik,
...), that upstream hop prepends a small header to the byte stream announcing the real
client's address before the actual request. mitmproxy had no awareness of this and treated
that header as the start of the HTTP request itself, crashing with `400 Bad Request: Bad
HTTP request line: b'PROXY TCP4 ...'`.

**Fix:**
- `mitmproxy/proxy/proxy_protocol.py` (new): parses PROXY v1 (text) and v2 (binary) headers
  off an `asyncio.StreamReader`, before any real client traffic is read.
- `proxy_protocol` option: a list of listen ports expected to receive such a header (e.g.
  `--set proxy_protocol=8081`), consumed in `ServerInstance.handle_stream`. Scoped per port
  rather than a single global switch, since "is this listener behind a PROXY-protocol load
  balancer" is a property of one specific socket, not the whole process — mitmproxy can run
  several modes at once (WireGuard, local capture, TUN, DNS, ...) and none of those receive
  such a header, so a global switch would silently break them if a user enabled it for an
  unrelated listener.
- The header is parsed and discarded; the real client address it carries replaces the
  immediate peer's address (`client.peername`) for logging and in addons. Malformed headers
  close the connection with a clear log message rather than crashing.

**Security note:** the option is opt-in and documented as such — only list ports that are
exclusively reachable through a trusted upstream proxy, since the header is client-supplied
data.

#### Testing

- Unit tests for the parser (`test/mitmproxy/proxy/test_proxy_protocol.py`): v1 TCP4/TCP6,
  `UNKNOWN`, malformed/truncated input; v2 `PROXY`/`LOCAL` commands, unsupported version.
- Integration tests (`test/mitmproxy/proxy/test_mode_servers.py`) against a real
  `ServerInstance` + live socket: header is applied only on the configured port, left alone
  on other ports, and a malformed header closes the connection.
- Manually verified end-to-end against `mitmdump`: on `main`, a PROXY v1 header in front of
  a real HTTP request returns `400 Bad Request`; with this change and
  `--set proxy_protocol=<port>`, the same request returns `200 OK` and the connect log shows
  the spoofed original client address instead of the socket peer.

#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
