### PR TITLE
Add graceful shutdown on SIGINT/SIGTERM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 
 ## Unreleased: mitmproxy next
 
+- Add graceful shutdown: on Ctrl+C/SIGTERM, mitmproxy now stops accepting new
+  connections immediately and waits up to the new `shutdown_timeout` option
+  (default 10s) for already-open connections to finish before closing them
+  forcibly, instead of cancelling every in-flight connection abruptly.
 - Replace deprecated pyparsing APIs with their snake_case equivalents to avoid
   `PyparsingDeprecationWarning` during command and flow-filter parsing.
   ([#8344](https://github.com/mitmproxy/mitmproxy/pull/8344), @Dnsayhey)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
   connections immediately and waits up to the new `shutdown_timeout` option
   (default 10s) for already-open connections to finish before closing them
   forcibly, instead of cancelling every in-flight connection abruptly.
+  ([#8378](https://github.com/mitmproxy/mitmproxy/pull/8378), @keshavkrishna)
 - Replace deprecated pyparsing APIs with their snake_case equivalents to avoid
   `PyparsingDeprecationWarning` during command and flow-filter parsing.
   ([#8344](https://github.com/mitmproxy/mitmproxy/pull/8344), @Dnsayhey)

--- a/mitmproxy/addons/proxyserver.py
+++ b/mitmproxy/addons/proxyserver.py
@@ -115,6 +115,8 @@ class Proxyserver(ServerManager):
     This addon runs the actual proxy server.
     """
 
+    _FORCE_CLOSE_RETRY_TIMEOUT = 5  # extra seconds done() retries closing connections
+
     connections: dict[tuple | str, ProxyConnectionHandler]
     servers: Servers
 
@@ -237,6 +239,11 @@ class Proxyserver(ServerManager):
         self.is_running = True
 
     async def done(self):
+        """
+        Stop accepting new connections, then wait for already-open ones to finish on
+        their own (up to `shutdown_timeout`) before closing them forcibly. Invoked
+        once, via DoneHook, when mitmproxy is shutting down.
+        """
         # Stop accepting new connections right away; existing ones are untouched by this.
         await self.servers.update([])
 
@@ -253,15 +260,27 @@ class Proxyserver(ServerManager):
         while self.connections and loop.time() < deadline:
             await asyncio.sleep(0.1)
 
-        if self.connections:
-            logger.warning(
-                f"{len(self.connections)} connection(s) still open after "
-                f"{timeout}s, closing forcibly."
-            )
+        if not self.connections:
+            return
+
+        logger.warning(
+            f"{len(self.connections)} connection(s) still open after {timeout}s, "
+            f"closing forcibly."
+        )
+        retry_deadline = loop.time() + self._FORCE_CLOSE_RETRY_TIMEOUT
+        while self.connections and loop.time() < retry_deadline:
             for handler in list(self.connections.values()):
                 io = handler.transports.get(handler.client)
-                if io and io.handler:
+                # io.handler is None until ClientConnectedHook finishes.
+                if io and io.handler and not io.handler.cancelled():
                     io.handler.cancel("shutdown timeout")
+            await asyncio.sleep(0.1)
+
+        if self.connections:
+            logger.warning(
+                f"{len(self.connections)} connection(s) could not be closed "
+                f"cleanly and will be terminated when the process exits."
+            )
 
     def configure(self, updated) -> None:
         if "stream_large_bodies" in updated:

--- a/mitmproxy/addons/proxyserver.py
+++ b/mitmproxy/addons/proxyserver.py
@@ -221,9 +221,47 @@ class Proxyserver(ServerManager):
             None,
             """Set the local IP address that mitmproxy should use when connecting to upstream servers.""",
         )
+        loader.add_option(
+            "shutdown_timeout",
+            int,
+            10,
+            """
+            On shutdown (Ctrl+C or SIGTERM), stop accepting new connections immediately, then wait
+            up to this many seconds for already-open connections (in-flight requests, open
+            WebSockets) to finish on their own before closing them forcibly. Set to 0 to close
+            everything immediately without waiting.
+            """,
+        )
 
     def running(self):
         self.is_running = True
+
+    async def done(self):
+        # Stop accepting new connections right away; existing ones are untouched by this.
+        await self.servers.update([])
+
+        if not self.connections:
+            return
+
+        timeout = ctx.options.shutdown_timeout
+        logger.info(
+            f"Waiting up to {timeout}s for {len(self.connections)} active "
+            f"connection(s) to finish..."
+        )
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + timeout
+        while self.connections and loop.time() < deadline:
+            await asyncio.sleep(0.1)
+
+        if self.connections:
+            logger.warning(
+                f"{len(self.connections)} connection(s) still open after "
+                f"{timeout}s, closing forcibly."
+            )
+            for handler in list(self.connections.values()):
+                io = handler.transports.get(handler.client)
+                if io and io.handler:
+                    io.handler.cancel("shutdown timeout")
 
     def configure(self, updated) -> None:
         if "stream_large_bodies" in updated:

--- a/test/mitmproxy/addons/test_proxyserver.py
+++ b/test/mitmproxy/addons/test_proxyserver.py
@@ -125,6 +125,100 @@ async def _wait_for_connection_closes(ps: Proxyserver):
     assert not ps.connections
 
 
+async def test_done_no_active_connections(caplog_async) -> None:
+    caplog_async.set_level("INFO")
+    ps = Proxyserver()
+    with taddons.context(ps) as tctx:
+        tctx.configure(ps, listen_host="127.0.0.1", listen_port=0)
+        assert await ps.setup_servers()
+        ps.running()
+        await caplog_async.await_log("HTTP(S) proxy listening at")
+        assert ps.servers
+
+        await asyncio.wait_for(ps.done(), timeout=5)
+
+        assert not ps.servers
+        assert "Waiting up to" not in caplog_async.caplog.text
+
+
+async def test_done_drains_before_timeout(caplog_async) -> None:
+    """A connection that closes on its own before shutdown_timeout elapses
+    should let done() return promptly, without waiting the full timeout."""
+    caplog_async.set_level("INFO")
+
+    async def server_handler(
+        reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+    ):
+        assert await reader.readuntil(b"\r\n\r\n") == b"GET /hello HTTP/1.1\r\n\r\n"
+        writer.write(b"HTTP/1.1 204 No Content\r\n\r\n")
+        await writer.drain()
+
+    ps = Proxyserver()
+    nl = NextLayer()
+    with taddons.context(ps, nl) as tctx:
+        tctx.configure(ps, listen_host="127.0.0.1", listen_port=0, shutdown_timeout=30)
+        async with tcp_server(server_handler) as addr:
+            assert await ps.setup_servers()
+            ps.running()
+            await caplog_async.await_log("HTTP(S) proxy listening at")
+
+            proxy_addr = ps.listen_addrs()[0]
+            reader, writer = await asyncio.open_connection(*proxy_addr)
+            req = f"GET http://{addr[0]}:{addr[1]}/hello HTTP/1.1\r\n\r\n"
+            writer.write(req.encode())
+            await reader.readuntil(b"\r\n\r\n")
+            assert ps.active_connections() == 1
+
+            async def close_soon():
+                await asyncio.sleep(0.2)
+                writer.close()
+
+            closer = asyncio.ensure_future(close_soon())
+            # If done() actually waited out the 30s timeout, this would time out first.
+            await asyncio.wait_for(ps.done(), timeout=10)
+            await closer
+
+        assert not ps.connections
+        assert "closing forcibly" not in caplog_async.caplog.text
+
+
+async def test_done_forces_close_after_timeout(caplog_async) -> None:
+    """A connection that never closes on its own gets forcibly cancelled once
+    shutdown_timeout elapses, instead of blocking shutdown forever."""
+    caplog_async.set_level("INFO")
+
+    async def server_handler(
+        reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+    ):
+        assert await reader.readuntil(b"\r\n\r\n") == b"GET /hello HTTP/1.1\r\n\r\n"
+        writer.write(b"HTTP/1.1 204 No Content\r\n\r\n")
+        await writer.drain()
+
+    ps = Proxyserver()
+    nl = NextLayer()
+    with taddons.context(ps, nl) as tctx:
+        tctx.configure(ps, listen_host="127.0.0.1", listen_port=0, shutdown_timeout=0)
+        async with tcp_server(server_handler) as addr:
+            assert await ps.setup_servers()
+            ps.running()
+            await caplog_async.await_log("HTTP(S) proxy listening at")
+
+            proxy_addr = ps.listen_addrs()[0]
+            reader, writer = await asyncio.open_connection(*proxy_addr)
+            req = f"GET http://{addr[0]}:{addr[1]}/hello HTTP/1.1\r\n\r\n"
+            writer.write(req.encode())
+            await reader.readuntil(b"\r\n\r\n")
+            assert ps.active_connections() == 1
+
+            # Client deliberately never closes its side -- done() must not hang.
+            await asyncio.wait_for(ps.done(), timeout=5)
+
+            assert await caplog_async.await_log("closing forcibly")
+            await _wait_for_connection_closes(ps)
+
+            writer.close()
+
+
 async def test_inject() -> None:
     async def server_handler(
         reader: asyncio.StreamReader, writer: asyncio.StreamWriter

--- a/test/mitmproxy/addons/test_proxyserver.py
+++ b/test/mitmproxy/addons/test_proxyserver.py
@@ -219,6 +219,74 @@ async def test_done_forces_close_after_timeout(caplog_async) -> None:
             writer.close()
 
 
+async def test_done_retries_connection_stuck_in_slow_hook(
+    caplog_async, monkeypatch
+) -> None:
+    """A connection whose ClientConnectedHook is still running when
+    shutdown_timeout elapses has no cancellable task yet; done() must retry
+    and catch it once the hook finishes, not give up on the first pass."""
+    caplog_async.set_level("INFO")
+    monkeypatch.setattr(Proxyserver, "_FORCE_CLOSE_RETRY_TIMEOUT", 2)
+
+    class SlowHook:
+        async def client_connected(self, client):
+            await asyncio.sleep(0.3)
+
+    ps = Proxyserver()
+    nl = NextLayer()
+    slow = SlowHook()
+    with taddons.context(ps, nl, slow) as tctx:
+        tctx.configure(ps, listen_host="127.0.0.1", listen_port=0, shutdown_timeout=0)
+        assert await ps.setup_servers()
+        ps.running()
+        await caplog_async.await_log("HTTP(S) proxy listening at")
+
+        proxy_addr = ps.listen_addrs()[0]
+        _, writer = await asyncio.open_connection(*proxy_addr)
+        await asyncio.sleep(0.05)  # connection registered, hook still running
+        assert ps.active_connections() == 1
+
+        await asyncio.wait_for(ps.done(), timeout=5)
+
+        assert not ps.connections
+        assert "could not be closed cleanly" not in caplog_async.caplog.text
+
+        writer.close()
+
+
+async def test_done_gives_up_after_retry_timeout(caplog_async, monkeypatch) -> None:
+    """A connection whose ClientConnectedHook never finishes in time has no
+    cancellable task at all; done() must give up after its retry grace period
+    instead of waiting forever, and say so clearly in the log."""
+    caplog_async.set_level("INFO")
+    monkeypatch.setattr(Proxyserver, "_FORCE_CLOSE_RETRY_TIMEOUT", 0.2)
+
+    class NeverConnects:
+        async def client_connected(self, client):
+            await asyncio.sleep(60)
+
+    ps = Proxyserver()
+    nl = NextLayer()
+    stuck = NeverConnects()
+    with taddons.context(ps, nl, stuck) as tctx:
+        tctx.configure(ps, listen_host="127.0.0.1", listen_port=0, shutdown_timeout=0)
+        assert await ps.setup_servers()
+        ps.running()
+        await caplog_async.await_log("HTTP(S) proxy listening at")
+
+        proxy_addr = ps.listen_addrs()[0]
+        _, writer = await asyncio.open_connection(*proxy_addr)
+        await asyncio.sleep(0.05)
+        assert ps.active_connections() == 1
+
+        await asyncio.wait_for(ps.done(), timeout=5)
+
+        assert await caplog_async.await_log("could not be closed cleanly")
+        assert ps.connections
+
+        writer.close()
+
+
 async def test_inject() -> None:
     async def server_handler(
         reader: asyncio.StreamReader, writer: asyncio.StreamWriter

--- a/web/src/js/ducks/_options_gen.ts
+++ b/web/src/js/ducks/_options_gen.ts
@@ -70,6 +70,7 @@ export interface OptionsState {
     server_replay_use_headers: string[];
     show_ignored_hosts: boolean;
     showhost: boolean;
+    shutdown_timeout: number;
     ssl_insecure: boolean;
     ssl_verify_upstream_trusted_ca: string | undefined;
     ssl_verify_upstream_trusted_confdir: string | undefined;
@@ -178,6 +179,7 @@ export const defaultState: OptionsState = {
     server_replay_use_headers: [],
     show_ignored_hosts: false,
     showhost: false,
+    shutdown_timeout: 10,
     ssl_insecure: false,
     ssl_verify_upstream_trusted_ca: undefined,
     ssl_verify_upstream_trusted_confdir: undefined,


### PR DESCRIPTION
#### Description

Closes #3895.

Adds graceful shutdown: on Ctrl+C or `SIGTERM`, mitmproxy stops accepting new
connections immediately, then waits for already-open connections (in-flight
requests, open WebSockets) to finish on their own before closing anything
forcibly.

**Problem:** `Master.shutdown()` only set an `asyncio.Event`; nothing explicit
ever closed listeners or drained connections. `Proxyserver` (the addon that
owns the actual TCP listeners and live connections) had no `DoneHook` handler
at all, so every in-flight connection was simply cancelled abruptly whenever
`asyncio.run()`'s own teardown happened to run, with no grace period and no
coordination.

**Fix:**
- `Proxyserver.done()` (new): stops all listeners immediately via the existing
  `Servers.update([])` path, then waits for `self.connections` (already
  tracked) to drain, up to a new `shutdown_timeout` option (default 10s,
  `0` = close immediately).
- After the timeout, force-cancels whatever's left via each connection's own
  client-handler task (`transports[client].handler`).
- Handles a real edge case found during review: a connection has no
  cancellable task until its `ClientConnectedHook` finishes, so one still in
  that hook when the deadline hits can't be cancelled on the first pass. The
  sweep now retries for a bounded extra window (5s) so such a connection still
  gets a clean, logged close instead of silently surviving until the
  process's own final teardown -- confirmed with an instrumented run showing
  the original one-shot version both missed the connection *and* logged
  "closing forcibly" even though nothing was actually cancelled.

#### Testing

- `test_done_no_active_connections`: no active connections, `done()` returns
  immediately and stops all listeners.
- `test_done_drains_before_timeout`: a connection that closes on its own
  before the timeout lets `done()` return promptly rather than waiting it out.
- `test_done_forces_close_after_timeout`: a connection that never closes gets
  forcibly cancelled once `shutdown_timeout` elapses.
- `test_done_retries_connection_stuck_in_slow_hook`: a connection whose
  `ClientConnectedHook` is still running when the timeout hits gets caught on
  a later retry pass, not lost.
- `test_done_gives_up_after_retry_timeout`: a connection that never finishes
  its hook at all is given up on cleanly, with an honest log message, instead
  of blocking shutdown forever.
- Manually verified end-to-end against real `mitmdump` processes: on `main`,
  `SIGTERM` with an open connection exits in ~7ms with no drain; on this
  branch with `--set shutdown_timeout=2`, it waits ~2.3s and logs the wait
  before force-closing; if the client closes early, shutdown returns promptly
  without waiting out the full timeout.

#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
