### PR TITLE
fix: don't crash when sendall() raises WantReadError on a dying TLS connection

### DIFF
--- a/mitmproxy/proxy/layers/tls.py
+++ b/mitmproxy/proxy/layers/tls.py
@@ -452,8 +452,12 @@ class TLSLayer(tunnel.TunnelLayer):
     def send_data(self, data: bytes) -> layer.CommandGenerator[None]:
         try:
             self.tls.sendall(data)
-        except (SSL.ZeroReturnError, SSL.SysCallError):
+        except (SSL.ZeroReturnError, SSL.SysCallError, SSL.WantReadError):
             # The other peer may still be trying to send data over, which we discard here.
+            # WantReadError happens when the connection is already failing/closing (e.g. right
+            # after a failed handshake) and OpenSSL needs a read before it can write -- there's
+            # nothing productive we can do with that here, so we drop the data the same way we
+            # already do for ZeroReturnError/SysCallError. See #6081.
             pass
         yield from self.tls_interact()
 

--- a/test/mitmproxy/proxy/layers/test_tls.py
+++ b/test/mitmproxy/proxy/layers/test_tls.py
@@ -83,6 +83,31 @@ def test_parse_client_hello():
         )
 
 
+@pytest.mark.parametrize("error", [SSL.ZeroReturnError, SSL.SysCallError, SSL.WantReadError])
+def test_send_data_swallows_errors_from_a_dying_connection(tctx, error):
+    """
+    https://github.com/mitmproxy/mitmproxy/issues/6081
+
+    `SSL.Connection.sendall()` can raise `WantReadError` -- not just the already-handled
+    `ZeroReturnError`/`SysCallError` -- when the underlying connection is already
+    failing/closing (e.g. right after a failed handshake) and OpenSSL wants a read before it
+    can write. This used to propagate out of `send_data()` uncaught and crash mitmproxy.
+    """
+
+    class RaisingConnection:
+        def sendall(self, data):
+            raise error()
+
+        def bio_read(self, n):
+            raise SSL.WantReadError()  # nothing more waiting to be sent
+
+    tls_layer = tls.TLSLayer(tctx, tctx.server)
+    tls_layer.tls = RaisingConnection()
+
+    # should not raise
+    assert list(tls_layer.send_data(b"hello")) == []
+
+
 class SSLTest:
     """Helper container for Python's builtin SSL object."""
 

--- a/test/mitmproxy/proxy/layers/test_tls.py
+++ b/test/mitmproxy/proxy/layers/test_tls.py
@@ -83,7 +83,9 @@ def test_parse_client_hello():
         )
 
 
-@pytest.mark.parametrize("error", [SSL.ZeroReturnError, SSL.SysCallError, SSL.WantReadError])
+@pytest.mark.parametrize(
+    "error", [SSL.ZeroReturnError, SSL.SysCallError, SSL.WantReadError]
+)
 def test_send_data_swallows_errors_from_a_dying_connection(tctx, error):
     """
     https://github.com/mitmproxy/mitmproxy/issues/6081


### PR DESCRIPTION
## Summary

`TLSLayer.send_data()` already treats `SSL.ZeroReturnError` and `SSL.SysCallError` from `self.tls.sendall()` as non-fatal ("the other peer may still be trying to send data over, which we discard here"), since the connection may already be failing/closing. `SSL.WantReadError` can happen in the same situation -- e.g. right after a failed server TLS handshake -- but wasn't caught, so it propagated uncaught and crashed mitmproxy entirely. This matches the traceback in #6081 exactly (`OpenSSL.SSL.WantReadError` raised from `tls.py`'s `send_data`, right after a "Server TLS handshake failed" log line).

Fixes #6081

## Changes

- `mitmproxy/proxy/layers/tls.py`: add `SSL.WantReadError` to the exception tuple already caught in `TLSLayer.send_data()`.
- `test/mitmproxy/proxy/layers/test_tls.py`: added a parametrized regression test (`test_send_data_swallows_errors_from_a_dying_connection`) covering all three now-swallowed errors on a `TLSLayer` with a fake `.tls` connection. Verified the `WantReadError` case fails with the exact reported exception on current `main` and passes with the fix; the full `test_tls.py` suite (29 tests) still passes.