### PR TITLE
fix(tls): honor show_ignored_hosts for connections ignored via tls_clienthello

### DIFF
--- a/mitmproxy/proxy/layers/tls.py
+++ b/mitmproxy/proxy/layers/tls.py
@@ -594,10 +594,15 @@ class ClientTLSLayer(TLSLayer):
                 parent_layer.conn = parent_layer.tunnel_connection = connection.Server(
                     address=None
                 )
+            # Respect show_ignored_hosts here too, just like the --ignore/--allow path in
+            # next_layer.py: `ignore=True` hides the flow entirely, so hardcoding it means
+            # connections ignored via a `tls_clienthello` hook never show up regardless of
+            # this option.
+            show = self.context.options.show_ignored_hosts
             if self.is_dtls:
-                self.child_layer = udp.UDPLayer(self.context, ignore=True)
+                self.child_layer = udp.UDPLayer(self.context, ignore=not show)
             else:
-                self.child_layer = tcp.TCPLayer(self.context, ignore=True)
+                self.child_layer = tcp.TCPLayer(self.context, ignore=not show)
             yield from self.event_to_child(
                 events.DataReceived(self.context.client, bytes(self.recv_buffer))
             )

--- a/test/mitmproxy/proxy/layers/test_tls.py
+++ b/test/mitmproxy/proxy/layers/test_tls.py
@@ -14,6 +14,7 @@ from mitmproxy.proxy import commands
 from mitmproxy.proxy import context
 from mitmproxy.proxy import events
 from mitmproxy.proxy import layer
+from mitmproxy.proxy.layers import tcp
 from mitmproxy.proxy.layers import tls
 from mitmproxy.tls import ClientHelloData
 from mitmproxy.tls import TlsData
@@ -670,6 +671,42 @@ class TestClientTLS:
             )  # and the same for the serverhello.
             << commands.SendData(tctx.client, b"ServerHello")
         )
+
+    @pytest.mark.parametrize("show_ignored_hosts", [False, True])
+    def test_passthrough_from_clienthello_show_ignored_hosts(
+        self, tctx, show_ignored_hosts
+    ):
+        """
+        A connection passed through via the tls_clienthello hook's ignore_connection flag
+        should honor show_ignored_hosts just like the --ignore/--allow path in next_layer.py
+        does, instead of always suppressing the flow.
+        """
+        tctx.options.show_ignored_hosts = show_ignored_hosts
+        playbook, client_layer, tssl_client = make_client_tls_layer(tctx, alpn=["quux"])
+
+        def make_passthrough(client_hello: ClientHelloData) -> None:
+            client_hello.ignore_connection = True
+
+        client_hello = tssl_client.bio_read()
+        (
+            playbook
+            >> events.DataReceived(tctx.client, client_hello)
+            << tls.TlsClienthelloHook(tutils.Placeholder())
+            >> tutils.reply(side_effect=make_passthrough)
+        )
+        if show_ignored_hosts:
+            # only a non-ignored (i.e. shown) TCPLayer has a flow, and thus fires these hooks.
+            playbook << tcp.TcpStartHook(tutils.Placeholder())
+            playbook >> tutils.reply()
+        playbook << commands.OpenConnection(tctx.server)
+        playbook >> tutils.reply(None)
+        if show_ignored_hosts:
+            playbook << tcp.TcpMessageHook(tutils.Placeholder())
+            playbook >> tutils.reply()
+        assert playbook << commands.SendData(tctx.server, client_hello)
+
+        # TCPLayer only creates (and hooks/shows) a flow when it isn't told to fully ignore.
+        assert (client_layer.child_layer.flow is not None) == show_ignored_hosts
 
     def test_cannot_parse_clienthello(self, tctx: context.Context):
         """Test the scenario where we cannot parse the ClientHello"""


### PR DESCRIPTION
## Summary

`--show-ignored-hosts` works when a connection is ignored via `--ignore-host`/`--allow-hosts`, but not when it's ignored programmatically by setting `data.ignore_connection = True` in a `tls_clienthello` hook — such connections never show up in the Flows list regardless of the option.

Fixes #7577

## Root cause

`next_layer.py`'s `--ignore`/`--allow` path already threads the option through:

```python
layers.TCPLayer(context, ignore=not ctx.options.show_ignored_hosts)
```

But `ClientTLSLayer.receive_handshake_data`'s `ignore_connection` branch (triggered by the `tls_clienthello` hook) hardcodes `ignore=True` for both the TCP and DTLS/UDP child layers, so `TCPLayer`/`UDPLayer` never create a flow (and thus never fire `TcpStartHook`/etc.) for hook-ignored connections, independent of `show_ignored_hosts`.

## Changes

- `mitmproxy/proxy/layers/tls.py`: both child-layer constructions in the `ignore_connection` branch now pass `ignore=not self.context.options.show_ignored_hosts`, matching `next_layer.py`'s existing behavior for the CLI-based ignore path.
- `test/mitmproxy/proxy/layers/test_tls.py`: added `test_passthrough_from_clienthello_show_ignored_hosts`, parametrized over `show_ignored_hosts`, asserting the resulting `TCPLayer` only gets a (hooked/visible) flow when the option is set. Verified fails on the `True` case pre-fix (via `git stash` on just the source file) and passes post-fix; full `test_tls.py` (107 tests) and `test_next_layer.py` still green.