### PR TITLE
fix: catch ValueError/RuntimeError from pylsqpack header encoding to prevent proxy crash

### DIFF
--- a/mitmproxy/proxy/layers/http/_http3.py
+++ b/mitmproxy/proxy/layers/http/_http3.py
@@ -133,6 +133,14 @@ class Http3Connection(HttpConnection):
                 # Http2Connection also ignores HttpEvents that violate the current stream state
                 yield commands.Log(f"Received {event!r} unexpectedly: {e}")
 
+            except (ValueError, RuntimeError) as e:
+                yield commands.Log(f"Failed to encode HTTP/3 data for {event!r}: {e}")
+                self.h3_conn.close_stream(
+                    event.stream_id,
+                    H3ErrorCode.H3_INTERNAL_ERROR.value,
+                )
+                yield from self.h3_conn.transmit()
+
             else:
                 # transmit buffered data
                 yield from self.h3_conn.transmit()


### PR DESCRIPTION
## Description

When mitmproxy is used with HTTP/3 connections, sending response headers whose name+value exceeds the `XHDR_BUF_SZ` (4096 bytes) limit in pylsqpack causes a `ValueError: the header's name and value are too long` or `RuntimeError: lsqpack_enc_start_header failed` to be raised from `aioquic.h3.connection._encode_headers`. These exceptions are not caught by the existing `except H3FrameUnexpected` handler, causing the entire proxy process to crash.

This fix catches `ValueError` and `RuntimeError` in `Http3Connection._handle_event`, closes the affected stream gracefully with `H3_INTERNAL_ERROR`, and continues processing other streams.

## Related Issue

Closes #7922 — HTTP/3: mitmproxy crashes with "ValueError: the header's name and value are too long"

## How Has This Been Tested?

- Manual code review
- The existing HTTP/3 test suite passes (test_http3.py)
- The fix follows the same pattern as `CATCH_HYPER_H2_ERRORS` in `_http2.py` (defense-in-depth against library-level exceptions)


Closes #7922
