### PR TITLE
Send TLS close_notify before closing established connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ## Unreleased: mitmproxy next
 
 - Send TLS `close_notify` alerts before closing established connections.
+  ([#8400](https://github.com/mitmproxy/mitmproxy/pull/8400), @kote-openai)
 - Replace deprecated pyparsing APIs with their snake_case equivalents to avoid
   `PyparsingDeprecationWarning` during command and flow-filter parsing.
   ([#8344](https://github.com/mitmproxy/mitmproxy/pull/8344), @Dnsayhey)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ## Unreleased: mitmproxy next
 
+- Send TLS `close_notify` alerts before closing established connections.
 - Replace deprecated pyparsing APIs with their snake_case equivalents to avoid
   `PyparsingDeprecationWarning` during command and flow-filter parsing.
   ([#8344](https://github.com/mitmproxy/mitmproxy/pull/8344), @Dnsayhey)

--- a/mitmproxy/proxy/layers/tls.py
+++ b/mitmproxy/proxy/layers/tls.py
@@ -242,6 +242,7 @@ class TlsFailedServerHook(StartHook):
 class TLSLayer(tunnel.TunnelLayer):
     tls: SSL.Connection = None  # type: ignore
     """The OpenSSL connection object"""
+    _tls_failed: bool = False
 
     def __init__(self, context: context.Context, conn: connection.Connection):
         super().__init__(
@@ -425,6 +426,7 @@ class TLSLayer(tunnel.TunnelLayer):
                 # which upon mistrusting a certificate still completes the handshake
                 # and then sends an alert in the next packet. At this point we have unfortunately
                 # already fired out `tls_established_client` hook.
+                self._tls_failed = True
                 yield commands.Log(f"TLS Error: {e}", WARNING)
                 break
 
@@ -450,6 +452,8 @@ class TLSLayer(tunnel.TunnelLayer):
             yield from super().receive_close()
 
     def send_data(self, data: bytes) -> layer.CommandGenerator[None]:
+        if self._tls_failed:
+            return
         try:
             self.tls.sendall(data)
         except (SSL.ZeroReturnError, SSL.SysCallError):
@@ -462,6 +466,7 @@ class TLSLayer(tunnel.TunnelLayer):
     ) -> layer.CommandGenerator[None]:
         if (
             self.tls is not None
+            and not self._tls_failed
             and self.tunnel_state is tunnel.TunnelState.OPEN
             and not self.tls.get_shutdown() & SSL.SENT_SHUTDOWN
         ):

--- a/mitmproxy/proxy/layers/tls.py
+++ b/mitmproxy/proxy/layers/tls.py
@@ -460,7 +460,17 @@ class TLSLayer(tunnel.TunnelLayer):
     def send_close(
         self, command: commands.CloseConnection
     ) -> layer.CommandGenerator[None]:
-        # We should probably shutdown the TLS connection properly here.
+        if (
+            self.tls is not None
+            and self.tunnel_state is tunnel.TunnelState.OPEN
+            and not self.tls.get_shutdown() & SSL.SENT_SHUTDOWN
+        ):
+            try:
+                self.tls.shutdown()
+            except SSL.Error as e:
+                # A fatal TLS error may leave the tunnel open but prevent shutdown.
+                yield commands.Log(f"{self.proto_name} shutdown failed: {e}", WARNING)
+            yield from self.tls_interact()
         yield from super().send_close(command)
 
 

--- a/mitmproxy/proxy/layers/tls.py
+++ b/mitmproxy/proxy/layers/tls.py
@@ -242,6 +242,8 @@ class TlsFailedServerHook(StartHook):
 class TLSLayer(tunnel.TunnelLayer):
     tls: SSL.Connection = None  # type: ignore
     """The OpenSSL connection object"""
+    # Nested TLS layers share Connection metadata, but not handshake state.
+    _handshake_complete: bool = False
     _tls_failed: bool = False
 
     def __init__(self, context: context.Context, conn: connection.Connection):
@@ -354,6 +356,7 @@ class TLSLayer(tunnel.TunnelLayer):
                 err = f"OpenSSL {e!r}"
             return False, err
         else:
+            self._handshake_complete = True
             # Here we set all attributes that are only known *after* the handshake.
 
             # Get all peer certificates.
@@ -465,9 +468,8 @@ class TLSLayer(tunnel.TunnelLayer):
         self, command: commands.CloseConnection
     ) -> layer.CommandGenerator[None]:
         if (
-            self.tls is not None
+            self._handshake_complete
             and not self._tls_failed
-            and self.tunnel_state is tunnel.TunnelState.OPEN
             and not self.tls.get_shutdown() & SSL.SENT_SHUTDOWN
         ):
             try:

--- a/test/mitmproxy/proxy/layers/test_tls.py
+++ b/test/mitmproxy/proxy/layers/test_tls.py
@@ -674,6 +674,7 @@ class TestClientTLS:
             ],
         )
         assert sent[-1] is close
+        assert close.half_close == half_close
         assert list(client_layer.send_close(close)) == [close]
 
         if half_close:

--- a/test/mitmproxy/proxy/layers/test_tls.py
+++ b/test/mitmproxy/proxy/layers/test_tls.py
@@ -620,8 +620,12 @@ class TestClientTLS:
                 >> events.DataReceived(tctx.client, bytes(ciphertext))
                 << commands.Log(StrMatching("TLS Error: .*bad record mac"), WARNING)
                 << commands.SendData(tctx.client, Placeholder(bytes))
+            )
+            # A nested TLS layer may still send its shutdown alert through us.
+            assert list(client_layer.send_data(b"nested close_notify")) == []
+            assert (
+                playbook
                 >> events.ConnectionClosed(tctx.client)
-                << commands.Log(StrMatching("TLS shutdown failed:"), WARNING)
                 << commands.CloseConnection(tctx.client)
             )
             return

--- a/test/mitmproxy/proxy/layers/test_tls.py
+++ b/test/mitmproxy/proxy/layers/test_tls.py
@@ -170,7 +170,10 @@ class TlsEchoLayer(tutils.EchoLayer):
 
 
 def finish_handshake(
-    playbook: tutils.Playbook, conn: connection.Connection, tssl: SSLTest
+    playbook: tutils.Playbook,
+    conn: connection.Connection,
+    tssl: SSLTest,
+    expect_data: bool = True,
 ):
     data = tutils.Placeholder(bytes)
     tls_hook_data = tutils.Placeholder(TlsData)
@@ -178,29 +181,33 @@ def finish_handshake(
         established_hook = tls.TlsEstablishedClientHook(tls_hook_data)
     else:
         established_hook = tls.TlsEstablishedServerHook(tls_hook_data)
-    assert (
+    (
         playbook
         >> events.DataReceived(conn, tssl.bio_read())
         << established_hook
         >> tutils.reply()
-        << commands.SendData(conn, data)
     )
+    if expect_data:
+        playbook << commands.SendData(conn, data)
+    assert playbook
     assert tls_hook_data().conn.error is None
-    tssl.bio_write(data())
+    if expect_data:
+        tssl.bio_write(data())
 
 
-def reply_tls_start_client(alpn: bytes | None = None, *args, **kwargs) -> tutils.reply:
+def reply_tls_start_client(
+    alpn: bytes | None = None,
+    *args,
+    min_ver: ssl.TLSVersion = ssl.TLSVersion.TLSv1_3,
+    **kwargs,
+) -> tutils.reply:
     """
     Helper function to simplify the syntax for tls_start_client hooks.
     """
 
     def make_client_conn(tls_start: TlsData) -> None:
-        # ssl_context = SSL.Context(Method.TLS_METHOD)
-        # ssl_context.set_min_proto_version(SSL.TLS1_3_VERSION)
-        ssl_context = SSL.Context(SSL.SSLv23_METHOD)
-        ssl_context.set_options(
-            SSL.OP_NO_SSLv3 | SSL.OP_NO_TLSv1 | SSL.OP_NO_TLSv1_1 | SSL.OP_NO_TLSv1_2
-        )
+        ssl_context = SSL.Context(SSL.TLS_METHOD)
+        ssl_context.set_min_proto_version(min_ver)
         ssl_context.use_privatekey_file(
             tlsdata.path("../../net/data/verificationcerts/trusted-leaf.key")
         )
@@ -217,19 +224,19 @@ def reply_tls_start_client(alpn: bytes | None = None, *args, **kwargs) -> tutils
 
 
 def reply_tls_start_server(
-    alpn: bytes | None = None, client_cert: bool = False, *args, **kwargs
+    alpn: bytes | None = None,
+    client_cert: bool = False,
+    *args,
+    min_ver: ssl.TLSVersion = ssl.TLSVersion.TLSv1_3,
+    **kwargs,
 ) -> tutils.reply:
     """
     Helper function to simplify the syntax for tls_start_server hooks.
     """
 
     def make_server_conn(tls_start: TlsData) -> None:
-        # ssl_context = SSL.Context(Method.TLS_METHOD)
-        # ssl_context.set_min_proto_version(SSL.TLS1_3_VERSION)
-        ssl_context = SSL.Context(SSL.SSLv23_METHOD)
-        ssl_context.set_options(
-            SSL.OP_NO_SSLv3 | SSL.OP_NO_TLSv1 | SSL.OP_NO_TLSv1_1 | SSL.OP_NO_TLSv1_2
-        )
+        ssl_context = SSL.Context(SSL.TLS_METHOD)
+        ssl_context.set_min_proto_version(min_ver)
         ssl_context.load_verify_locations(
             cafile=tlsdata.path("../../net/data/verificationcerts/trusted-root.crt")
         )
@@ -286,28 +293,46 @@ class TestServerTLS:
             << commands.SendData(tctx.client, b"hello world")
         )
 
-    def test_simple(self, tctx):
+    @pytest.mark.parametrize(
+        "tls_version", [ssl.TLSVersion.TLSv1_2, ssl.TLSVersion.TLSv1_3]
+    )
+    def test_simple(self, tctx, tls_version):
         playbook = tutils.Playbook(tls.ServerTLSLayer(tctx))
         tctx.server.address = ("example.mitmproxy.org", 443)
         tctx.server.state = ConnectionState.OPEN
         tctx.server.sni = "example.mitmproxy.org"
 
-        tssl = SSLTest(server_side=True)
+        tssl = SSLTest(server_side=True, max_ver=tls_version)
 
         # send ClientHello, receive ClientHello
         data = tutils.Placeholder(bytes)
         assert (
             playbook
             << tls.TlsStartServerHook(tutils.Placeholder())
-            >> reply_tls_start_server()
+            >> reply_tls_start_server(min_ver=tls_version)
             << commands.SendData(tctx.server, data)
         )
         tssl.bio_write(data())
         with pytest.raises(ssl.SSLWantReadError):
             tssl.do_handshake()
 
+        if tls_version == ssl.TLSVersion.TLSv1_2:
+            data = tutils.Placeholder(bytes)
+            assert (
+                playbook
+                >> events.DataReceived(tctx.server, tssl.bio_read())
+                << commands.SendData(tctx.server, data)
+            )
+            tssl.bio_write(data())
+            tssl.do_handshake()
+
         # finish handshake (mitmproxy)
-        finish_handshake(playbook, tctx.server, tssl)
+        finish_handshake(
+            playbook,
+            tctx.server,
+            tssl,
+            expect_data=tls_version == ssl.TLSVersion.TLSv1_3,
+        )
 
         # finish handshake (locally)
         tssl.do_handshake()
@@ -316,6 +341,7 @@ class TestServerTLS:
         assert playbook
 
         assert tctx.server.tls_established
+        assert tssl.obj.version() == tls_version.name.replace("_", ".")
 
         # Echo
         assert (
@@ -329,13 +355,17 @@ class TestServerTLS:
 
         with pytest.raises(ssl.SSLWantReadError):
             tssl.obj.unwrap()
+        close_notify = tutils.Placeholder(bytes)
         assert (
             playbook
             >> events.DataReceived(tctx.server, tssl.bio_read())
+            << commands.SendData(tctx.server, close_notify)
             << commands.CloseConnection(tctx.server)
             >> events.ConnectionClosed(tctx.server)
             << None
         )
+        tssl.bio_write(close_notify())
+        tssl.obj.unwrap()
 
     def test_untrusted_cert(self, tctx):
         """If the certificate is not trusted, we should fail."""
@@ -534,9 +564,15 @@ def make_client_tls_layer(
 
 
 class TestClientTLS:
-    def test_client_only(self, tctx: context.Context):
+    @pytest.mark.parametrize(
+        "tls_version", [ssl.TLSVersion.TLSv1_2, ssl.TLSVersion.TLSv1_3]
+    )
+    @pytest.mark.parametrize("close_mode", ["full", "half", "bad_record"])
+    def test_client_only(self, tctx: context.Context, tls_version, close_mode):
         """Test TLS with client only"""
-        playbook, client_layer, tssl_client = make_client_tls_layer(tctx)
+        playbook, client_layer, tssl_client = make_client_tls_layer(
+            tctx, max_ver=tls_version
+        )
         client_layer.debug = "  "
         assert not tctx.client.tls_established
 
@@ -548,16 +584,22 @@ class TestClientTLS:
             << tls.TlsClienthelloHook(tutils.Placeholder())
             >> tutils.reply()
             << tls.TlsStartClientHook(tutils.Placeholder())
-            >> reply_tls_start_client()
+            >> reply_tls_start_client(min_ver=tls_version)
             << commands.SendData(tctx.client, data)
         )
         tssl_client.bio_write(data())
-        tssl_client.do_handshake()
+        if tls_version == ssl.TLSVersion.TLSv1_2:
+            with pytest.raises(ssl.SSLWantReadError):
+                tssl_client.do_handshake()
+        else:
+            tssl_client.do_handshake()
         # Finish Handshake
         finish_handshake(playbook, tctx.client, tssl_client)
+        tssl_client.do_handshake()
 
         assert tssl_client.obj.getpeercert(True)
         assert tctx.client.tls_established
+        assert tssl_client.obj.version() == tls_version.name.replace("_", ".")
 
         # Echo
         _test_echo(playbook, tssl_client, tctx.client)
@@ -567,6 +609,71 @@ class TestClientTLS:
             >> events.DataReceived(other_server, b"Plaintext")
             << commands.SendData(other_server, b"plaintext")
         )
+
+        if close_mode == "bad_record":
+            client_layer.debug = None
+            tssl_client.obj.write(b"bad record")
+            ciphertext = bytearray(tssl_client.bio_read())
+            ciphertext[-1] ^= 1
+            assert (
+                playbook
+                >> events.DataReceived(tctx.client, bytes(ciphertext))
+                << commands.Log(StrMatching("TLS Error: .*bad record mac"), WARNING)
+                << commands.SendData(tctx.client, Placeholder(bytes))
+                >> events.ConnectionClosed(tctx.client)
+                << commands.Log(StrMatching("TLS shutdown failed:"), WARNING)
+                << commands.CloseConnection(tctx.client)
+            )
+            return
+
+        half_close = close_mode == "half"
+        data = Placeholder(bytes)
+        close_notify = Placeholder(bytes)
+        close = commands.CloseTcpConnection(tctx.client, half_close=half_close)
+        sent = [*client_layer.send_data(b"goodbye"), *client_layer.send_close(close)]
+        assert tutils.eq(
+            sent,
+            [
+                commands.SendData(tctx.client, data),
+                commands.SendData(tctx.client, close_notify),
+                close,
+            ],
+        )
+        assert sent[-1] is close
+        assert list(client_layer.send_close(close)) == [close]
+
+        if half_close:
+            recorder = tutils.RecordLayer(tctx)
+            client_layer.child_layer = recorder
+            tssl_client.obj.write(b"in-flight data")
+            assert playbook >> events.DataReceived(tctx.client, tssl_client.bio_read())
+            assert tutils.eq(
+                recorder.event_log,
+                [events.DataReceived(tctx.client, b"in-flight data")],
+            )
+
+        tssl_client.bio_write(data() + close_notify())
+        tssl_client.inc.write_eof()
+        assert tssl_client.obj.read() == b"goodbye"
+        assert tssl_client.obj.read() == b""
+
+    @pytest.mark.parametrize("started", [False, True])
+    def test_close_before_handshake(self, tctx: context.Context, started):
+        playbook, client_layer, tssl_client = make_client_tls_layer(tctx)
+        if started:
+            assert (
+                playbook
+                >> events.DataReceived(tctx.client, tssl_client.bio_read())
+                << tls.TlsClienthelloHook(Placeholder())
+                >> tutils.reply()
+                << tls.TlsStartClientHook(Placeholder())
+                >> reply_tls_start_client()
+                << commands.SendData(tctx.client, Placeholder(bytes))
+            )
+        else:
+            assert playbook
+        close = commands.CloseConnection(tctx.client)
+        assert list(client_layer.send_close(close)) == [close]
 
     @pytest.mark.parametrize("server_state", ["open", "closed"])
     def test_server_required(self, tctx, server_state):

--- a/test/mitmproxy/proxy/layers/test_tls.py
+++ b/test/mitmproxy/proxy/layers/test_tls.py
@@ -585,7 +585,7 @@ class TestClientTLS:
         "tls_version", [ssl.TLSVersion.TLSv1_2, ssl.TLSVersion.TLSv1_3]
     )
     @pytest.mark.parametrize(
-        "close_mode", ["full", "half", "bad_record", "shutdown_error"]
+        "close_mode", ["full", "half", "nested", "bad_record", "shutdown_error"]
     )
     def test_client_only(self, tctx: context.Context, tls_version, close_mode):
         """Test TLS with client only"""
@@ -659,6 +659,11 @@ class TestClientTLS:
                     [commands.Log("TLS shutdown failed: test error", WARNING), close],
                 )
             return
+
+        if close_mode == "nested":
+            # An inner TLS layer resets metadata shared with the outer layer.
+            client_layer.child_layer = tls.ClientTLSLayer(client_layer.context)
+            assert not tctx.client.tls_established
 
         half_close = close_mode == "half"
         data = Placeholder(bytes)

--- a/test/mitmproxy/proxy/layers/test_tls.py
+++ b/test/mitmproxy/proxy/layers/test_tls.py
@@ -3,6 +3,7 @@ import sys
 import time
 from logging import DEBUG
 from logging import WARNING
+from unittest.mock import patch
 
 import pytest
 from OpenSSL import SSL
@@ -583,7 +584,9 @@ class TestClientTLS:
     @pytest.mark.parametrize(
         "tls_version", [ssl.TLSVersion.TLSv1_2, ssl.TLSVersion.TLSv1_3]
     )
-    @pytest.mark.parametrize("close_mode", ["full", "half", "bad_record"])
+    @pytest.mark.parametrize(
+        "close_mode", ["full", "half", "bad_record", "shutdown_error"]
+    )
     def test_client_only(self, tctx: context.Context, tls_version, close_mode):
         """Test TLS with client only"""
         playbook, client_layer, tssl_client = make_client_tls_layer(
@@ -644,6 +647,17 @@ class TestClientTLS:
                 >> events.ConnectionClosed(tctx.client)
                 << commands.CloseConnection(tctx.client)
             )
+            return
+
+        if close_mode == "shutdown_error":
+            close = commands.CloseConnection(tctx.client)
+            with patch.object(
+                client_layer.tls, "shutdown", side_effect=SSL.Error("test error")
+            ):
+                assert tutils.eq(
+                    list(client_layer.send_close(close)),
+                    [commands.Log("TLS shutdown failed: test error", WARNING), close],
+                )
             return
 
         half_close = close_mode == "half"

--- a/test/mitmproxy/proxy/layers/test_tls.py
+++ b/test/mitmproxy/proxy/layers/test_tls.py
@@ -296,8 +296,10 @@ class TestServerTLS:
     @pytest.mark.parametrize(
         "tls_version", [ssl.TLSVersion.TLSv1_2, ssl.TLSVersion.TLSv1_3]
     )
-    def test_simple(self, tctx, tls_version):
-        playbook = tutils.Playbook(tls.ServerTLSLayer(tctx))
+    @pytest.mark.parametrize("close_after_eof", [False, True])
+    def test_simple(self, tctx, tls_version, close_after_eof):
+        server_layer = tls.ServerTLSLayer(tctx)
+        playbook = tutils.Playbook(server_layer)
         tctx.server.address = ("example.mitmproxy.org", 443)
         tctx.server.state = ConnectionState.OPEN
         tctx.server.sni = "example.mitmproxy.org"
@@ -356,14 +358,28 @@ class TestServerTLS:
         with pytest.raises(ssl.SSLWantReadError):
             tssl.obj.unwrap()
         close_notify = tutils.Placeholder(bytes)
-        assert (
-            playbook
-            >> events.DataReceived(tctx.server, tssl.bio_read())
-            << commands.SendData(tctx.server, close_notify)
-            << commands.CloseConnection(tctx.server)
-            >> events.ConnectionClosed(tctx.server)
-            << None
-        )
+        if close_after_eof:
+            server_layer.child_layer = tutils.RecordLayer(tctx)
+            assert (
+                playbook
+                >> events.DataReceived(tctx.server, tssl.bio_read())
+                >> events.ConnectionClosed(tctx.server)
+            )
+            assert tctx.server.state is ConnectionState.CAN_WRITE
+            close = commands.CloseConnection(tctx.server)
+            assert tutils.eq(
+                list(server_layer.send_close(close)),
+                [commands.SendData(tctx.server, close_notify), close],
+            )
+        else:
+            assert (
+                playbook
+                >> events.DataReceived(tctx.server, tssl.bio_read())
+                << commands.SendData(tctx.server, close_notify)
+                << commands.CloseConnection(tctx.server)
+                >> events.ConnectionClosed(tctx.server)
+                << None
+            )
         tssl.bio_write(close_notify())
         tssl.obj.unwrap()
 


### PR DESCRIPTION
#### Description

Addresses #7476, following @makrinaemad's work in #7781.

Send `close_notify` from `TLSLayer.send_close` before closing the transport, so strict TLS peers receive a clean EOF instead of reporting truncation. Flush pending TLS output and preserve the original close command, including TCP half-close, without waiting for the peer's response.

Track completed handshakes and fatal read errors per TLS layer. This keeps shutdown working after TCP read EOF and prevents a nested TLS layer's shutdown data from being written through a failed outer TLS session. Nested layers share connection metadata, so that metadata cannot reliably track each handshake. OpenSSL's shutdown flag prevents duplicate alerts; failures still allow transport closure.

The existing SSLTest/Playbook cases cover TLS 1.2/1.3, peer-first shutdown, complete payload plus strict EOF, delayed closure after peer EOF, half-close flags and reads, nested TLS metadata resets, repeated close, corrupted records with late child writes, shutdown errors, and pre-handshake closure. The late-write and delayed-close regressions fail before their respective fixes. All 51 focused TLS/tunnel cases and 450 broader proxy-layer, tunnel, net-TLS, and TLSConfig cases pass. Whole-repo Ruff and focused mypy 1.20.2 checks also pass.

Local tests ran through `uv run --offline --no-sync` with an existing Python 3.12 environment; the repository's configured tox matrix runs in CI. No dependency or lockfile changes are included.

#### Checklist

- [x] I have updated tests where applicable.
- [x] I have added an entry to the CHANGELOG.
