### PR TITLE
Use ANSI-C quoting for curl and httpie export bodies with control characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 - Fix the curl and httpie export of request bodies with control characters: `%`, backslashes
   and a trailing newline were changed by `printf`. The body is now quoted with `$'...'`.
+  ([#8426](https://github.com/mitmproxy/mitmproxy/pull/8426), @monasco)
 - Replace deprecated pyparsing APIs with their snake_case equivalents to avoid
   `PyparsingDeprecationWarning` during command and flow-filter parsing.
   ([#8344](https://github.com/mitmproxy/mitmproxy/pull/8344), @Dnsayhey)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 ## Unreleased: mitmproxy next
 
+- Fix the curl and httpie export of request bodies with control characters: `%`, backslashes
+  and a trailing newline were changed by `printf`. The body is now quoted with `$'...'`.
 - Replace deprecated pyparsing APIs with their snake_case equivalents to avoid
   `PyparsingDeprecationWarning` during command and flow-filter parsing.
   ([#8344](https://github.com/mitmproxy/mitmproxy/pull/8344), @Dnsayhey)

--- a/mitmproxy/addons/export.py
+++ b/mitmproxy/addons/export.py
@@ -51,13 +51,23 @@ def request_content_for_console(request: http.Request) -> str:
         # shlex.quote doesn't support a bytes object
         # see https://github.com/python/cpython/pull/10871
         raise exceptions.CommandError("Request content must be valid unicode")
-    escape_control_chars = {chr(i): f"\\x{i:02x}" for i in range(32)}
-    escaped_text = "".join(escape_control_chars.get(x, x) for x in text)
-    if any(char in escape_control_chars for char in text):
-        # Escaped chars need to be unescaped by the shell to be properly inperpreted by curl and httpie
-        return f'"$(printf {shlex.quote(escaped_text)})"'
+    if not any(ord(char) < 32 for char in text):
+        return shlex.quote(text)
 
-    return shlex.quote(escaped_text)
+    # Control characters must be unescaped by the shell. ANSI-C quoting ($'...')
+    # does that byte for byte. printf would treat "%" and "\\" as format
+    # directives, and $(...) would strip trailing newlines.
+    escaped = []
+    for char in text:
+        if char == "\\":
+            escaped.append("\\\\")
+        elif char == "'":
+            escaped.append("\\'")
+        elif ord(char) < 32:
+            escaped.append(f"\\x{ord(char):02x}")
+        else:
+            escaped.append(char)
+    return "$'" + "".join(escaped) + "'"
 
 
 def curl_command(f: flow.Flow) -> str:

--- a/test/mitmproxy/addons/test_export.py
+++ b/test/mitmproxy/addons/test_export.py
@@ -124,8 +124,24 @@ class TestExportCurlCommand:
 
     def test_expand_escaped(self, export_curl, post_request):
         post_request.request.content = b"foo\nbar"
-        result = "curl -X POST http://address:22/path -d \"$(printf 'foo\\x0abar')\""
+        result = "curl -X POST http://address:22/path -d $'foo\\x0abar'"
         assert export_curl(post_request) == result
+
+    @pytest.mark.parametrize(
+        "content,quoted",
+        [
+            (b"foo\n", "$'foo\\x0a'"),
+            (b"a=100%\nb=2", "$'a=100%\\x0ab=2'"),
+            (b"C:\\new\\temp\nx", "$'C:\\\\new\\\\temp\\x0ax'"),
+            (b"it's\ta tab", "$'it\\'s\\x09a tab'"),
+        ],
+    )
+    def test_escaped_keeps_bytes(self, export_curl, post_request, content, quoted):
+        post_request.request.content = content
+        assert (
+            export_curl(post_request)
+            == f"curl -X POST http://address:22/path -d {quoted}"
+        )
 
     def test_no_expand_when_no_escaped(self, export_curl, post_request):
         post_request.request.content = b"foobar"
@@ -200,6 +216,11 @@ class TestExportHttpieCommand:
         command = export.httpie_command(request)
         assert shlex.split(command)[-2] == "<<<"
         assert shlex.split(command)[-1] == "'&#"
+
+    def test_expand_escaped(self, post_request):
+        post_request.request.content = b"a=100%\nb=2"
+        result = "http POST http://address:22/path <<< $'a=100%\\x0ab=2'"
+        assert export.httpie_command(post_request) == result
 
     # See comment in `TestExportCurlCommand.test_correct_host_used`. httpie
     # currently doesn't have a way of forcing connection to a particular IP, so


### PR DESCRIPTION
#### Description

The curl and httpie export passed bodies with control characters as `"$(printf '...')"`. `printf` treats `%` and backslash sequences as format directives, and `$(...)` strips newlines at the end. So a body like `{"a":1}` plus newline was sent without the newline, and `a=100%` plus newline was cut to `a=100`.

The body is now quoted with ANSI-C quoting (`$'...'`). Backslashes and single quotes are escaped, control characters become `\xNN`. I ran the exported commands in bash and zsh against a local server, the bodies arrive byte for byte.

Bodies without control characters still use `shlex.quote`, nothing changes for them.

Fixes #8425

#### Checklist

 - [x] I have updated tests where applicable.
 - [x] I have added an entry to the CHANGELOG.
